### PR TITLE
Use new sedona_internal_err to avoid misleading datafusion internal err

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4863,6 +4863,7 @@ dependencies = [
  "datafusion-expr",
  "datafusion-physical-expr",
  "geo-traits 0.2.0",
+ "sedona-common",
  "sedona-geometry",
  "sedona-schema",
  "sedona-testing",
@@ -4974,6 +4975,7 @@ dependencies = [
  "geo-traits 0.2.0",
  "object_store",
  "parquet",
+ "sedona-common",
  "sedona-expr",
  "sedona-geometry",
  "sedona-schema",
@@ -5060,6 +5062,7 @@ dependencies = [
  "arrow-schema",
  "datafusion-common",
  "datafusion-expr",
+ "sedona-common",
  "serde_json",
 ]
 
@@ -5118,6 +5121,7 @@ dependencies = [
  "parquet",
  "rand 0.8.5",
  "rstest",
+ "sedona-common",
  "sedona-expr",
  "sedona-geometry",
  "sedona-schema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4883,6 +4883,7 @@ dependencies = [
  "datafusion-expr",
  "geo-traits 0.2.0",
  "rstest",
+ "sedona-common",
  "sedona-expr",
  "sedona-geometry",
  "sedona-schema",

--- a/rust/sedona-common/src/error.rs
+++ b/rust/sedona-common/src/error.rs
@@ -8,10 +8,10 @@ macro_rules! sedona_internal_err {
             Please help us to resolve this by filing a bug report in our issue tracker: \
             https://github.com/apache/sedona-db/issues",
             std::format!($($args),*),
-            DataFusionError::get_back_trace(),
+            datafusion_common::DataFusionError::get_back_trace(),
         );
         // We avoid using Internal to avoid the message suggesting it's internal to DataFusion
-        Err(DataFusionError::External(msg.into()))
+        Err(datafusion_common::DataFusionError::External(msg.into()))
     }};
 }
 

--- a/rust/sedona-common/src/error.rs
+++ b/rust/sedona-common/src/error.rs
@@ -1,0 +1,34 @@
+/// Macro to create Sedona Internal Error that avoids the misleading error message from
+/// DataFusionError::Internal.
+#[macro_export]
+macro_rules! sedona_internal_err {
+    ($($args:expr),*) => {{
+        let msg = std::format!(
+            "SedonaDB internal error: {}{}.\nThis issue was likely caused by a bug in SedonaDB's code. \
+            Please help us to resolve this by filing a bug report in our issue tracker: \
+            https://github.com/apache/sedona-db/issues",
+            std::format!($($args),*),
+            DataFusionError::get_back_trace(),
+        );
+        // We avoid using Internal to avoid the message suggesting it's internal to DataFusion
+        Err(DataFusionError::External(msg.into()))
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion_common::DataFusionError;
+
+    #[test]
+    fn test_sedona_internal_err() {
+        let result: Result<(), DataFusionError> = sedona_internal_err!("Test error: {}", "details");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let err_string = err.to_string();
+        assert!(err_string.contains("SedonaDB internal error: Test error: details"));
+
+        // Ensure the message doesn't contain the 'DataFusion'-specific messages
+        assert!(!err_string.contains("DataFusion's code"));
+        assert!(!err_string.contains("https://github.com/apache/datafusion/issues"));
+    }
+}

--- a/rust/sedona-common/src/lib.rs
+++ b/rust/sedona-common/src/lib.rs
@@ -3,6 +3,7 @@
 //! This crate contains shared components that are used across multiple
 //! Sedona modules, including configuration options and common data structures.
 
+pub mod error;
 pub mod option;
 
 pub use option::*;

--- a/rust/sedona-expr/Cargo.toml
+++ b/rust/sedona-expr/Cargo.toml
@@ -21,6 +21,7 @@ datafusion-common = { workspace = true }
 datafusion-expr = { workspace = true }
 datafusion-physical-expr = { workspace = true }
 geo-traits = { workspace = true }
+sedona-common = { path = "../sedona-common" }
 sedona-geometry = { path = "../sedona-geometry" }
 sedona-schema = { path = "../sedona-schema" }
 serde = { workspace = true }

--- a/rust/sedona-expr/src/function_set.rs
+++ b/rust/sedona-expr/src/function_set.rs
@@ -249,10 +249,9 @@ mod tests {
         let err = functions
             .add_aggregate_udf_kernel("function that does not exist", kernel.clone())
             .unwrap_err();
-        assert_eq!(
-            err.message().lines().next().unwrap(),
+        assert!(err.message().lines().next().unwrap().contains(
             "Can't register aggregate kernel for function 'function that does not exist'."
-        );
+        ));
 
         let udaf2 = SedonaAggregateUDF::new(
             "simple_udaf2",

--- a/rust/sedona-expr/src/function_set.rs
+++ b/rust/sedona-expr/src/function_set.rs
@@ -2,8 +2,9 @@ use crate::{
     aggregate_udf::{SedonaAccumulatorRef, SedonaAggregateUDF},
     scalar_udf::{ScalarKernelRef, SedonaScalarUDF},
 };
-use datafusion_common::{error::Result, internal_err};
+use datafusion_common::error::Result;
 use datafusion_expr::{AggregateUDFImpl, ScalarUDFImpl};
+use sedona_common::sedona_internal_err;
 use std::collections::HashMap;
 
 /// Helper for managing groups of functions
@@ -110,7 +111,7 @@ impl FunctionSet {
             function.add_kernel(kernel);
             Ok(self.aggregate_udf(name).unwrap())
         } else {
-            internal_err!("Can't register aggregate kernel for function '{}'", name)
+            sedona_internal_err!("Can't register aggregate kernel for function '{}'", name)
         }
     }
 }

--- a/rust/sedona-expr/src/scalar_udf.rs
+++ b/rust/sedona-expr/src/scalar_udf.rs
@@ -3,11 +3,12 @@ use std::sync::Arc;
 use std::{any::Any, fmt::Debug};
 
 use arrow_schema::{DataType, Field, FieldRef};
-use datafusion_common::{internal_err, not_impl_err, plan_err, Result, ScalarValue};
+use datafusion_common::{not_impl_err, plan_err, Result, ScalarValue};
 use datafusion_expr::{
     ColumnarValue, Documentation, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl, Signature,
     Volatility,
 };
+use sedona_common::sedona_internal_err;
 use sedona_schema::datatypes::{Edges, SedonaType};
 
 pub type ScalarKernelRef = Arc<dyn SedonaScalarKernel + Send + Sync>;
@@ -121,7 +122,7 @@ impl ArgMatcher {
                     (Some(lhs_crs), Some(rhs_crs)) => {
                         plan_err!("Mismatched CRS arguments: {lhs_crs} vs {rhs_crs}\n{hint}")
                     }
-                    _ => internal_err!("None vs. None should be considered equal"),
+                    _ => sedona_internal_err!("None vs. None should be considered equal"),
                 };
             }
         }
@@ -876,13 +877,13 @@ mod tests {
                 }
             }
 
-            internal_err!("unrecognized target value")
+            sedona_internal_err!("unrecognized target value")
         }
     }
 
     impl SedonaScalarKernel for SimpleCast {
         fn return_type(&self, _args: &[SedonaType]) -> Result<Option<SedonaType>> {
-            internal_err!("Should not be called")
+            sedona_internal_err!("Should not be called")
         }
 
         fn return_type_from_args_and_scalars(

--- a/rust/sedona-expr/src/spatial_filter.rs
+++ b/rust/sedona-expr/src/spatial_filter.rs
@@ -1,12 +1,13 @@
 use std::sync::Arc;
 
-use datafusion_common::{internal_err, DataFusionError, Result, ScalarValue};
+use datafusion_common::{DataFusionError, Result, ScalarValue};
 use datafusion_expr::Operator;
 use datafusion_physical_expr::{
     expressions::{BinaryExpr, Column, Literal},
     PhysicalExpr, ScalarFunctionExpr,
 };
 use geo_traits::Dimensions;
+use sedona_common::sedona_internal_err;
 use sedona_geometry::{bounding_box::BoundingBox, bounds::wkb_bounds_xy, interval::IntervalTrait};
 use sedona_schema::datatypes::SedonaType;
 
@@ -107,7 +108,9 @@ impl SpatialFilter {
             match scalar_fun.fun().name() {
                 "st_intersects" => {
                     if args.len() != 2 {
-                        return internal_err!("unexpected argument count in filter evaluation");
+                        return sedona_internal_err!(
+                            "unexpected argument count in filter evaluation"
+                        );
                     }
 
                     match (&args[0], &args[1]) {
@@ -126,7 +129,9 @@ impl SpatialFilter {
                 }
                 "st_hasz" => {
                     if args.len() != 1 {
-                        return internal_err!("unexpected argument count in filter evaluation");
+                        return sedona_internal_err!(
+                            "unexpected argument count in filter evaluation"
+                        );
                     }
 
                     match &args[0] {
@@ -191,7 +196,7 @@ fn literal_bounds(literal: &Literal) -> Result<BoundingBox> {
         _ => {}
     }
 
-    internal_err!("Unexpected scalar type in filter expression")
+    sedona_internal_err!("Unexpected scalar type in filter expression")
 }
 
 fn parse_args(args: &[Arc<dyn PhysicalExpr>]) -> Vec<ArgRef<'_>> {

--- a/rust/sedona-functions/Cargo.toml
+++ b/rust/sedona-functions/Cargo.toml
@@ -25,6 +25,7 @@ arrow-array = { workspace = true }
 datafusion-common = { workspace = true }
 datafusion-expr = { workspace = true }
 geo-traits = { workspace = true }
+sedona-common = { path = "../sedona-common" }
 sedona-expr = { path = "../sedona-expr" }
 sedona-geometry = { path = "../sedona-geometry" }
 sedona-schema = { path = "../sedona-schema" }

--- a/rust/sedona-functions/src/executor.rs
+++ b/rust/sedona-functions/src/executor.rs
@@ -3,8 +3,9 @@ use std::iter::zip;
 use arrow_array::ArrayRef;
 use datafusion_common::cast::{as_binary_array, as_binary_view_array};
 use datafusion_common::error::Result;
-use datafusion_common::{internal_err, DataFusionError, ScalarValue};
+use datafusion_common::{DataFusionError, ScalarValue};
 use datafusion_expr::ColumnarValue;
+use sedona_common::sedona_internal_err;
 use sedona_schema::datatypes::SedonaType;
 use wkb::reader::Wkb;
 
@@ -300,7 +301,7 @@ impl IterGeo for ArrayRef {
         func: F,
     ) -> Result<()> {
         if num_iterations != self.len() {
-            return internal_err!(
+            return sedona_internal_err!(
                 "Expected {num_iterations} items but got Array with {} items",
                 self.len()
             );
@@ -313,7 +314,7 @@ impl IterGeo for ArrayRef {
                 // We could cast here as a fallback, iterate and cast per-element, or
                 // implement iter_as_something_else()/supports_iter_xxx() when more geo array types
                 // are supported.
-                internal_err!("Can't iterate over {:?} as Wkb", sedona_type)
+                sedona_internal_err!("Can't iterate over {:?} as Wkb", sedona_type)
             }
         }
     }
@@ -326,7 +327,7 @@ impl ScalarGeo for ScalarValue {
             | ScalarValue::BinaryView(maybe_item)
             | ScalarValue::LargeBinary(maybe_item) => Ok(maybe_item.as_deref()),
             ScalarValue::Null => Ok(None),
-            _ => internal_err!("Can't iterate over {:?} ScalarValue as &[u8]", self),
+            _ => sedona_internal_err!("Can't iterate over {:?} ScalarValue as &[u8]", self),
         }
     }
 }
@@ -379,7 +380,7 @@ fn iter_wkb_wkb_array<
         _ => {
             // We could do casting of one or both sides to support other cases as they
             // arise to manage the complexity/performance balance
-            internal_err!(
+            sedona_internal_err!(
                 "Can't iterate over {:?} and {:?} arrays as a pair of Wkb scalars",
                 types.0,
                 types.1

--- a/rust/sedona-functions/src/st_dimension.rs
+++ b/rust/sedona-functions/src/st_dimension.rs
@@ -3,11 +3,12 @@ use std::sync::Arc;
 use crate::executor::WkbExecutor;
 use arrow_array::builder::Int8Builder;
 use arrow_schema::DataType;
-use datafusion_common::{error::Result, internal_err};
+use datafusion_common::error::Result;
 use datafusion_expr::{
     scalar_doc_sections::DOC_SECTION_OTHER, ColumnarValue, Documentation, Volatility,
 };
 use geo_traits::{GeometryCollectionTrait, GeometryTrait, GeometryType};
+use sedona_common::sedona_internal_err;
 use sedona_expr::scalar_udf::{ArgMatcher, SedonaScalarKernel, SedonaScalarUDF};
 use sedona_schema::datatypes::SedonaType;
 use wkb::reader::Wkb;
@@ -76,7 +77,7 @@ fn invoke_scalar(item: &Wkb) -> Result<i8> {
             }
             Ok(highest_dim)
         }
-        _ => internal_err!("Invalid geometry type"),
+        _ => sedona_internal_err!("Invalid geometry type"),
     }
 }
 

--- a/rust/sedona-functions/src/st_envelope_aggr.rs
+++ b/rust/sedona-functions/src/st_envelope_aggr.rs
@@ -6,11 +6,12 @@ use arrow_array::ArrayRef;
 use arrow_schema::FieldRef;
 use datafusion_common::{
     error::{DataFusionError, Result},
-    internal_err, ScalarValue,
+    ScalarValue,
 };
 use datafusion_expr::{
     scalar_doc_sections::DOC_SECTION_OTHER, Accumulator, ColumnarValue, Documentation, Volatility,
 };
+use sedona_common::sedona_internal_err;
 use sedona_expr::{
     aggregate_udf::{SedonaAccumulator, SedonaAggregateUDF},
     scalar_udf::ArgMatcher,
@@ -108,7 +109,7 @@ impl BoundsAccumulator2D {
             )));
         }
         if input.len() != expected {
-            return internal_err!(
+            return sedona_internal_err!(
                 "Unexpected input length in {} (expected {}, got {})",
                 context,
                 expected,

--- a/rust/sedona-functions/src/st_geometrytype.rs
+++ b/rust/sedona-functions/src/st_geometrytype.rs
@@ -3,11 +3,12 @@ use std::sync::Arc;
 use crate::executor::WkbExecutor;
 use arrow_array::builder::StringBuilder;
 use arrow_schema::DataType;
-use datafusion_common::{error::Result, internal_err};
+use datafusion_common::error::Result;
 use datafusion_expr::{
     scalar_doc_sections::DOC_SECTION_OTHER, ColumnarValue, Documentation, Volatility,
 };
 use geo_traits::GeometryTrait;
+use sedona_common::sedona_internal_err;
 use sedona_expr::scalar_udf::{ArgMatcher, SedonaScalarKernel, SedonaScalarUDF};
 use sedona_schema::datatypes::SedonaType;
 use wkb::reader::Wkb;
@@ -80,7 +81,7 @@ fn invoke_scalar(item: &Wkb) -> Result<Option<String>> {
         }
 
         // Other geometry types in geo that we should not get here: Rect, Triangle, Line
-        _ => internal_err!("unexpected geometry type"),
+        _ => sedona_internal_err!("unexpected geometry type"),
     }
 }
 

--- a/rust/sedona-functions/src/st_haszm.rs
+++ b/rust/sedona-functions/src/st_haszm.rs
@@ -3,11 +3,12 @@ use std::sync::Arc;
 use crate::executor::WkbExecutor;
 use arrow_array::builder::BooleanBuilder;
 use arrow_schema::DataType;
-use datafusion_common::{error::Result, internal_err};
+use datafusion_common::error::Result;
 use datafusion_expr::{
     scalar_doc_sections::DOC_SECTION_OTHER, ColumnarValue, Documentation, Volatility,
 };
 use geo_traits::{Dimensions, GeometryTrait};
+use sedona_common::sedona_internal_err;
 use sedona_expr::scalar_udf::{ArgMatcher, SedonaScalarKernel, SedonaScalarUDF};
 use sedona_schema::datatypes::SedonaType;
 use wkb::reader::Wkb;
@@ -108,7 +109,7 @@ fn invoke_scalar(item: &Wkb, dim_index: usize) -> Result<Option<bool>> {
             match dim_index {
                 2 => Ok(Some(matches!(geom_dim, Dimensions::Xyz | Dimensions::Xyzm))),
                 3 => Ok(Some(matches!(geom_dim, Dimensions::Xym | Dimensions::Xyzm))),
-                _ => internal_err!("unexpected dim_index"),
+                _ => sedona_internal_err!("unexpected dim_index"),
             }
         }
     }

--- a/rust/sedona-functions/src/st_isempty.rs
+++ b/rust/sedona-functions/src/st_isempty.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::executor::WkbExecutor;
 use arrow_array::builder::BooleanBuilder;
 use arrow_schema::DataType;
-use datafusion_common::{error::Result, internal_err};
+use datafusion_common::error::Result;
 use datafusion_expr::{
     scalar_doc_sections::DOC_SECTION_OTHER, ColumnarValue, Documentation, Volatility,
 };
@@ -11,6 +11,7 @@ use geo_traits::{
     GeometryCollectionTrait, GeometryTrait, LineStringTrait, MultiLineStringTrait, MultiPointTrait,
     MultiPolygonTrait, PointTrait, PolygonTrait,
 };
+use sedona_common::sedona_internal_err;
 use sedona_expr::scalar_udf::{ArgMatcher, SedonaScalarKernel, SedonaScalarUDF};
 use sedona_schema::datatypes::SedonaType;
 use wkb::reader::Wkb;
@@ -87,7 +88,7 @@ fn invoke_scalar(item: &Wkb) -> Result<bool> {
         geo_traits::GeometryType::GeometryCollection(geometrycollection) => {
             Ok(geometrycollection.num_geometries() == 0)
         }
-        _ => internal_err!("Invalid geometry type"),
+        _ => sedona_internal_err!("Invalid geometry type"),
     }
 }
 

--- a/rust/sedona-functions/src/st_setsrid.rs
+++ b/rust/sedona-functions/src/st_setsrid.rs
@@ -1,10 +1,11 @@
 use std::{sync::Arc, vec};
 
 use arrow_schema::DataType;
-use datafusion_common::{error::Result, internal_err, DataFusionError, ScalarValue};
+use datafusion_common::{error::Result, DataFusionError, ScalarValue};
 use datafusion_expr::{
     scalar_doc_sections::DOC_SECTION_OTHER, ColumnarValue, Documentation, Volatility,
 };
+use sedona_common::sedona_internal_err;
 use sedona_expr::scalar_udf::{ArgMatcher, SedonaScalarKernel, SedonaScalarUDF};
 use sedona_geometry::transform::CrsEngine;
 use sedona_schema::{crs::deserialize_crs, datatypes::SedonaType};
@@ -87,7 +88,7 @@ impl SedonaScalarKernel for STSetSRID {
             }
         }
 
-        internal_err!("Unexpected argument types: {}, {}", args[0], args[1])
+        sedona_internal_err!("Unexpected argument types: {}, {}", args[0], args[1])
     }
 
     fn invoke_batch(
@@ -99,7 +100,7 @@ impl SedonaScalarKernel for STSetSRID {
     }
 
     fn return_type(&self, _args: &[SedonaType]) -> Result<Option<SedonaType>> {
-        internal_err!(
+        sedona_internal_err!(
             "Should not be called because return_type_from_args_and_scalars() is implemented"
         )
     }

--- a/rust/sedona-functions/src/st_xyzm.rs
+++ b/rust/sedona-functions/src/st_xyzm.rs
@@ -3,10 +3,7 @@ use std::{sync::Arc, vec};
 use crate::executor::WkbExecutor;
 use arrow_array::builder::Float64Builder;
 use arrow_schema::DataType;
-use datafusion_common::{
-    error::{DataFusionError, Result},
-    internal_err,
-};
+use datafusion_common::error::{DataFusionError, Result};
 use datafusion_expr::{
     scalar_doc_sections::DOC_SECTION_OTHER, ColumnarValue, Documentation, Volatility,
 };
@@ -14,6 +11,7 @@ use geo_traits::{
     CoordTrait, Dimensions, GeometryCollectionTrait, GeometryTrait, LineStringTrait,
     MultiLineStringTrait, MultiPointTrait, MultiPolygonTrait, PointTrait, PolygonTrait,
 };
+use sedona_common::sedona_internal_err;
 use sedona_expr::scalar_udf::{ArgMatcher, SedonaScalarKernel, SedonaScalarUDF};
 use sedona_schema::datatypes::SedonaType;
 use wkb::reader::Wkb;
@@ -108,7 +106,7 @@ impl SedonaScalarKernel for STXyzm {
             "y" => 1,
             "z" => 2,
             "m" => 3,
-            _ => internal_err!("unexpected dimension")?,
+            _ => sedona_internal_err!("unexpected dimension")?,
         };
 
         let executor = WkbExecutor::new(arg_types, args);
@@ -209,7 +207,7 @@ where
             }
             _ => {}
         },
-        _ => internal_err!("unexpected dimension index")?,
+        _ => sedona_internal_err!("unexpected dimension index")?,
     }
     Ok(None)
 }

--- a/rust/sedona-functions/src/st_xyzm_minmax.rs
+++ b/rust/sedona-functions/src/st_xyzm_minmax.rs
@@ -3,11 +3,12 @@ use std::sync::Arc;
 use crate::executor::WkbExecutor;
 use arrow_array::builder::Float64Builder;
 use arrow_schema::DataType;
-use datafusion_common::{error::Result, internal_err, DataFusionError};
+use datafusion_common::{error::Result, DataFusionError};
 use datafusion_expr::{
     scalar_doc_sections::DOC_SECTION_OTHER, ColumnarValue, Documentation, Volatility,
 };
 use geo_traits::GeometryTrait;
+use sedona_common::sedona_internal_err;
 use sedona_expr::scalar_udf::{ArgMatcher, SedonaScalarKernel, SedonaScalarUDF};
 use sedona_geometry::{
     bounds::{geo_traits_bounds_m, geo_traits_bounds_xy, geo_traits_bounds_z},
@@ -197,7 +198,7 @@ fn invoke_scalar(
                 .map_err(|e| DataFusionError::Internal(format!("Error updating bounds: {}", e)))?;
             m_bounds
         }
-        _ => internal_err!("unexpected dim index")?,
+        _ => sedona_internal_err!("unexpected dim index")?,
     };
 
     if interval.is_empty() {

--- a/rust/sedona-geoparquet/Cargo.toml
+++ b/rust/sedona-geoparquet/Cargo.toml
@@ -35,6 +35,7 @@ geo-traits = { workspace = true }
 futures = { workspace = true }
 object_store = { workspace = true }
 parquet = { workspace = true }
+sedona-common = { path = "../sedona-common" }
 sedona-expr = { path = "../sedona-expr" }
 sedona-geometry = { path = "../sedona-geometry" }
 sedona-schema = { path = "../sedona-schema" }

--- a/rust/sedona-geoparquet/src/format.rs
+++ b/rust/sedona-geoparquet/src/format.rs
@@ -16,7 +16,7 @@ use datafusion::{
     },
 };
 use datafusion_catalog::{memory::DataSourceExec, Session};
-use datafusion_common::{internal_err, not_impl_err, plan_err, GetExt, Result, Statistics};
+use datafusion_common::{not_impl_err, plan_err, GetExt, Result, Statistics};
 use datafusion_physical_expr::{LexRequirement, PhysicalExpr};
 use datafusion_physical_plan::{
     filter_pushdown::FilterPushdownPropagation, metrics::ExecutionPlanMetricsSet,
@@ -25,6 +25,7 @@ use datafusion_physical_plan::{
 use futures::{StreamExt, TryStreamExt};
 use object_store::{ObjectMeta, ObjectStore};
 
+use sedona_common::sedona_internal_err;
 use sedona_expr::projection::wrap_physical_expressions;
 
 use sedona_schema::{
@@ -76,7 +77,7 @@ impl FileFormatFactory for GeoParquetFormatFactory {
         if let Some(parquet_format) = inner_format.as_any().downcast_ref::<ParquetFormat>() {
             Ok(Arc::new(GeoParquetFormat::new(parquet_format)))
         } else {
-            internal_err!(
+            sedona_internal_err!(
                 "Unexpected format from ParquetFormatFactory: {:?}",
                 inner_format
             )
@@ -376,7 +377,7 @@ impl GeoParquetFileSource {
                 predicate: new_predicate,
             })
         } else {
-            internal_err!("GeoParquetFileSource constructed from non-ParquetSource")
+            sedona_internal_err!("GeoParquetFileSource constructed from non-ParquetSource")
         }
     }
 

--- a/rust/sedona-schema/Cargo.toml
+++ b/rust/sedona-schema/Cargo.toml
@@ -16,4 +16,5 @@ arrow-schema = { workspace = true }
 arrow-array = { workspace = true }
 datafusion-common = { workspace = true }
 datafusion-expr = { workspace = true }
+sedona-common = { path = "../sedona-common" }
 serde_json = { workspace = true }

--- a/rust/sedona-schema/src/extension_type.rs
+++ b/rust/sedona-schema/src/extension_type.rs
@@ -3,9 +3,9 @@ use std::{collections::HashMap, sync::Arc};
 use arrow_array::{ArrayRef, StructArray};
 use arrow_schema::{DataType, Field, Fields};
 use datafusion_common::error::Result;
-use datafusion_common::internal_err;
 use datafusion_common::scalar::ScalarValue;
 use datafusion_expr::ColumnarValue;
+use sedona_common::sedona_internal_err;
 
 /// Parsed representation of an Arrow extension type
 ///
@@ -96,7 +96,7 @@ impl ExtensionType {
     /// Wrap storage array as a StructArray
     pub fn wrap_array(&self, array: ArrayRef) -> Result<ArrayRef> {
         if array.data_type() != &self.storage_type {
-            return internal_err!(
+            return sedona_internal_err!(
                 "Type to wrap ({}) does not match storage type ({})",
                 array.data_type(),
                 &self.storage_type

--- a/rust/sedona-spatial-join/src/optimizer.rs
+++ b/rust/sedona-spatial-join/src/optimizer.rs
@@ -12,7 +12,6 @@ use datafusion::{
 };
 use datafusion_common::ScalarValue;
 use datafusion_common::{
-    internal_err,
     tree_node::{Transformed, TreeNode},
     JoinSide,
 };
@@ -24,7 +23,7 @@ use datafusion_physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion_physical_plan::joins::utils::ColumnIndex;
 use datafusion_physical_plan::joins::{HashJoinExec, NestedLoopJoinExec};
 use datafusion_physical_plan::{joins::utils::JoinFilter, ExecutionPlan};
-use sedona_common::option::SedonaOptions;
+use sedona_common::{option::SedonaOptions, sedona_internal_err};
 
 /// Physical planner extension for spatial joins
 ///
@@ -362,7 +361,7 @@ impl SpatialJoinOptimizer {
             }
 
             if !found {
-                return internal_err!(
+                return sedona_internal_err!(
                     "Cannot find matching field for '{}' ({:?}) at position {} in spatial join output. \
                      Please check column name mappings and schema compatibility between HashJoinExec and SpatialJoinExec.",
                     expected_field.name(),

--- a/rust/sedona-spatial-join/src/refine/geo.rs
+++ b/rust/sedona-spatial-join/src/refine/geo.rs
@@ -1,8 +1,8 @@
 use std::sync::{Arc, OnceLock};
 
-use datafusion_common::{internal_err, Result};
+use datafusion_common::Result;
 use geo_generic_alg::{Contains, Distance, Euclidean, Intersects, Relate, Within};
-use sedona_common::{ExecutionMode, SpatialJoinOptions};
+use sedona_common::{sedona_internal_err, ExecutionMode, SpatialJoinOptions};
 use sedona_expr::statistics::GeoStatistics;
 use sedona_geo::to_geo::item_to_geometry;
 use wkb::reader::Wkb;
@@ -150,7 +150,7 @@ impl IndexQueryResultRefiner for GeoRefiner {
             }
             ExecutionMode::PrepareProbe => self.refine_prepare_probe(probe, index_query_results),
             ExecutionMode::Speculative(_) => {
-                internal_err!(
+                sedona_internal_err!(
                     "Speculative execution mode should be translated to other execution modes"
                 )
             }

--- a/rust/sedona-spatial-join/src/refine/geos.rs
+++ b/rust/sedona-spatial-join/src/refine/geos.rs
@@ -3,10 +3,10 @@ use std::sync::{
     Arc, OnceLock,
 };
 
-use datafusion_common::{internal_err, DataFusionError, Result};
+use datafusion_common::{DataFusionError, Result};
 use geos::{Geom, PreparedGeometry};
 use parking_lot::Mutex;
-use sedona_common::{ExecutionMode, SpatialJoinOptions};
+use sedona_common::{sedona_internal_err, ExecutionMode, SpatialJoinOptions};
 use sedona_expr::statistics::GeoStatistics;
 use wkb::reader::{to_geos::GEOSWkbFactory, Wkb};
 
@@ -316,7 +316,7 @@ impl IndexQueryResultRefiner for GeosRefiner {
             ExecutionMode::PrepareBuild => self.refine_prepare_build(probe, index_query_results),
             ExecutionMode::PrepareProbe => self.refine_prepare_probe(probe, index_query_results),
             ExecutionMode::Speculative(_) => {
-                internal_err!(
+                sedona_internal_err!(
                     "Speculative execution mode should be translated to other execution modes"
                 )
             }

--- a/rust/sedona-spatial-join/src/refine/tg.rs
+++ b/rust/sedona-spatial-join/src/refine/tg.rs
@@ -6,8 +6,8 @@ use std::{
     },
 };
 
-use datafusion_common::{internal_err, DataFusionError, Result};
-use sedona_common::{ExecutionMode, SpatialJoinOptions, TgIndexType};
+use datafusion_common::{DataFusionError, Result};
+use sedona_common::{sedona_internal_err, ExecutionMode, SpatialJoinOptions, TgIndexType};
 use sedona_expr::statistics::GeoStatistics;
 use sedona_tg::tg::{self, BinaryPredicate};
 use wkb::reader::Wkb;
@@ -244,7 +244,7 @@ impl IndexQueryResultRefiner for TgRefiner {
                 self.refine_not_prepare_build(probe, index_query_results, self.index_type)
             }
             ExecutionMode::Speculative(_) => {
-                internal_err!(
+                sedona_internal_err!(
                     "Speculative execution mode should be translated to other execution modes"
                 )
             }

--- a/rust/sedona-spatial-join/src/stream.rs
+++ b/rust/sedona-spatial-join/src/stream.rs
@@ -1,7 +1,7 @@
 use arrow::array::BooleanBufferBuilder;
 use arrow::compute::interleave_record_batch;
 use arrow_array::{UInt32Array, UInt64Array};
-use datafusion_common::{internal_err, JoinSide, Result};
+use datafusion_common::{JoinSide, Result};
 use datafusion_expr::JoinType;
 use datafusion_physical_plan::joins::utils::StatefulStreamResult;
 use datafusion_physical_plan::joins::utils::{ColumnIndex, JoinFilter};
@@ -10,6 +10,7 @@ use datafusion_physical_plan::{handle_state, RecordBatchStream, SendableRecordBa
 use futures::stream::StreamExt;
 use futures::{ready, task::Poll};
 use parking_lot::Mutex;
+use sedona_common::sedona_internal_err;
 use sedona_functions::st_analyze_aggr::AnalyzeAccumulator;
 use sedona_schema::datatypes::WKB_GEOMETRY;
 use std::collections::HashMap;
@@ -276,7 +277,9 @@ impl SpatialJoinStream {
         &mut self,
     ) -> Poll<Result<StatefulStreamResult<Option<RecordBatch>>>> {
         let Some(spatial_index) = self.spatial_index.as_ref() else {
-            return Poll::Ready(internal_err!("Expected spatial index to be available"));
+            return Poll::Ready(sedona_internal_err!(
+                "Expected spatial index to be available"
+            ));
         };
 
         let is_last_stream = spatial_index.report_probe_completed();
@@ -339,7 +342,7 @@ impl SpatialJoinStream {
                 (batch_opt, is_complete)
             }
             _ => {
-                return Poll::Ready(internal_err!(
+                return Poll::Ready(sedona_internal_err!(
                     "process_unmatched_build_batch called with invalid state"
                 ))
             }
@@ -845,7 +848,7 @@ impl UnmatchedBuildBatchIterator {
     ) -> Result<Self> {
         let visited_left_side = spatial_index.visited_left_side();
         let Some(vec_visited_left_side) = visited_left_side else {
-            return internal_err!("The bitmap for visited left side is not created");
+            return sedona_internal_err!("The bitmap for visited left side is not created");
         };
 
         let total_batches = {
@@ -872,7 +875,7 @@ impl UnmatchedBuildBatchIterator {
         while self.current_batch_idx < self.total_batches && !self.is_complete {
             let visited_left_side = self.spatial_index.visited_left_side();
             let Some(vec_visited_left_side) = visited_left_side else {
-                return internal_err!("The bitmap for visited left side is not created");
+                return sedona_internal_err!("The bitmap for visited left side is not created");
             };
 
             let batch = {

--- a/rust/sedona-testing/Cargo.toml
+++ b/rust/sedona-testing/Cargo.toml
@@ -30,6 +30,7 @@ geo-traits = { workspace = true }
 geo-types = { workspace = true }
 parquet = { workspace = true, features = ["arrow", "snap", "zstd"] }
 rand = { workspace = true }
+sedona-common = { path = "../sedona-common" }
 sedona-geometry = { path = "../sedona-geometry" }
 sedona-expr = { path = "../sedona-expr" }
 sedona-schema = { path = "../sedona-schema" }

--- a/rust/sedona-testing/src/benchmark_util.rs
+++ b/rust/sedona-testing/src/benchmark_util.rs
@@ -3,11 +3,12 @@ use std::{fmt::Debug, sync::Arc, vec};
 use arrow_array::{ArrayRef, Float64Array};
 use arrow_schema::DataType;
 
-use datafusion_common::{internal_err, Result, ScalarValue};
+use datafusion_common::{Result, ScalarValue};
 use datafusion_expr::{AggregateUDF, ScalarUDF};
 use geo_types::Rect;
 use rand::{distributions::Uniform, rngs::StdRng, Rng, SeedableRng};
 
+use sedona_common::sedona_internal_err;
 use sedona_geometry::types::GeometryTypeId;
 use sedona_schema::datatypes::{SedonaType, WKB_GEOMETRY};
 
@@ -392,7 +393,10 @@ impl BenchmarkData {
     /// Invoke an aggregate function on this data
     pub fn invoke_aggregate(&self, udf: &AggregateUDF) -> Result<ScalarValue> {
         if !matches!(self.config, BenchmarkArgs::Array(_)) {
-            return internal_err!("invoke_aggregate() not implemented for {:?}", self.config);
+            return sedona_internal_err!(
+                "invoke_aggregate() not implemented for {:?}",
+                self.config
+            );
         }
 
         let tester = AggregateUdfTester::new(udf.clone(), self.config.sedona_types().clone());

--- a/rust/sedona-testing/src/data.rs
+++ b/rust/sedona-testing/src/data.rs
@@ -1,6 +1,7 @@
 use std::{env, fs};
 
-use datafusion_common::{internal_err, Result};
+use datafusion_common::Result;
+use sedona_common::sedona_internal_err;
 
 /// Find the most likely path to the test GeoParquet file
 ///
@@ -16,7 +17,7 @@ pub fn test_geoparquet(group: &str, name: &str) -> Result<String> {
         }
     }
 
-    internal_err!(
+    sedona_internal_err!(
         "geoarrow-data test file '{path}' does not exist.\n{}\n{}",
         "You may need to check the value of the SEDONA_GEOARROW_DATA_DIR environment variable,",
         "run submodules/download-assets.py, or check the name of the file you requested"
@@ -34,7 +35,7 @@ pub fn geoarrow_data_dir() -> Result<String> {
         if fs::exists(&from_env)? {
             return Ok(from_env);
         } else {
-            return internal_err!(
+            return sedona_internal_err!(
                 "{}\n{}{}{}",
                 "Can't resolve geoarrow-data from the current working directory because",
                 "the value of the SEDONA_GEOARROW_DATA_DIR (",
@@ -59,7 +60,7 @@ pub fn geoarrow_data_dir() -> Result<String> {
         }
     }
 
-    internal_err!(
+    sedona_internal_err!(
         "{}\n{}\n{}",
         "Can't resolve geoarrow-data from the current working directory",
         "You may need to run `git submodule init && git submodule update --recursive` or",

--- a/rust/sedona-testing/src/read.rs
+++ b/rust/sedona-testing/src/read.rs
@@ -1,8 +1,9 @@
 use std::fs::File;
 
 use arrow_array::{ArrayRef, RecordBatchReader};
-use datafusion_common::{internal_err, DataFusionError, Result};
+use datafusion_common::{DataFusionError, Result};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReader;
+use sedona_common::sedona_internal_err;
 use sedona_schema::datatypes::SedonaType;
 
 use crate::data::test_geoparquet;
@@ -59,7 +60,7 @@ pub fn read_geoarrow_data_geometry(
         .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
     if reader.schema().fields().is_empty() {
-        return internal_err!("Unexpected schema: zero columns");
+        return sedona_internal_err!("Unexpected schema: zero columns");
     }
 
     // True for all geoarrow-data files

--- a/rust/sedona-testing/src/testers.rs
+++ b/rust/sedona-testing/src/testers.rs
@@ -2,12 +2,13 @@ use std::{iter::zip, sync::Arc};
 
 use arrow_array::{ArrayRef, RecordBatch};
 use arrow_schema::{DataType, Field, FieldRef, Schema};
-use datafusion_common::{internal_err, Result, ScalarValue};
+use datafusion_common::{Result, ScalarValue};
 use datafusion_expr::{
     function::{AccumulatorArgs, StateFieldsArgs},
     Accumulator, AggregateUDF, ColumnarValue, Expr, Literal, ScalarFunctionArgs, ScalarUDF,
 };
 use datafusion_physical_expr::{expressions::Column, PhysicalExpr};
+use sedona_common::sedona_internal_err;
 use sedona_schema::datatypes::SedonaType;
 
 use crate::{
@@ -195,7 +196,7 @@ impl ScalarUdfTester {
         if let ColumnarValue::Scalar(scalar) = self.invoke(args)? {
             Ok(scalar)
         } else {
-            internal_err!("Expected scalar result from scalar invoke")
+            sedona_internal_err!("Expected scalar result from scalar invoke")
         }
     }
 
@@ -218,7 +219,7 @@ impl ScalarUdfTester {
         if let ColumnarValue::Scalar(scalar) = self.invoke(args)? {
             Ok(scalar)
         } else {
-            internal_err!("Expected scalar result from binary scalar invoke")
+            sedona_internal_err!("Expected scalar result from binary scalar invoke")
         }
     }
 
@@ -238,7 +239,7 @@ impl ScalarUdfTester {
         if let ColumnarValue::Scalar(scalar) = self.invoke(args)? {
             Ok(scalar)
         } else {
-            internal_err!("Expected scalar result from binary scalar invoke")
+            sedona_internal_err!("Expected scalar result from binary scalar invoke")
         }
     }
 
@@ -309,7 +310,7 @@ impl ScalarUdfTester {
         if let ColumnarValue::Array(array) = self.invoke(args)? {
             Ok(array)
         } else {
-            internal_err!("Expected array result from scalar/array invoke")
+            sedona_internal_err!("Expected array result from scalar/array invoke")
         }
     }
 
@@ -325,7 +326,7 @@ impl ScalarUdfTester {
         if let ColumnarValue::Array(array) = self.invoke(args)? {
             Ok(array)
         } else {
-            internal_err!("Expected array result from array/scalar invoke")
+            sedona_internal_err!("Expected array result from array/scalar invoke")
         }
     }
 
@@ -347,7 +348,7 @@ impl ScalarUdfTester {
         if let ColumnarValue::Array(array) = self.invoke(args)? {
             Ok(array)
         } else {
-            internal_err!("Expected array result from array/scalar invoke")
+            sedona_internal_err!("Expected array result from array/scalar invoke")
         }
     }
 
@@ -361,7 +362,7 @@ impl ScalarUdfTester {
         if let ColumnarValue::Array(array) = self.invoke(args)? {
             Ok(array)
         } else {
-            internal_err!("Expected array result from array invoke")
+            sedona_internal_err!("Expected array result from array invoke")
         }
     }
 
@@ -406,13 +407,13 @@ impl ScalarUdfTester {
                 } else if scalar.is_null() {
                     Ok(create_scalar(None, sedona_type))
                 } else {
-                    internal_err!("Can't interpret scalar {scalar} as type {sedona_type}")
+                    sedona_internal_err!("Can't interpret scalar {scalar} as type {sedona_type}")
                 }
             } else {
                 scalar.cast_to(&sedona_type.data_type())
             }
         } else {
-            internal_err!("Can't use test scalar invoke where .lit() returns non-literal")
+            sedona_internal_err!("Can't use test scalar invoke where .lit() returns non-literal")
         }
     }
 

--- a/rust/sedona/src/ffi.rs
+++ b/rust/sedona/src/ffi.rs
@@ -3,7 +3,7 @@ use std::{any::Any, sync::Arc};
 use abi_stable::StableAbi;
 use arrow_schema::{DataType, Field, FieldRef, Schema};
 use datafusion::physical_plan::{expressions::Column, PhysicalExpr};
-use datafusion_common::{internal_err, DataFusionError, Result, ScalarValue};
+use datafusion_common::{DataFusionError, Result, ScalarValue};
 use datafusion_expr::{
     function::{AccumulatorArgs, StateFieldsArgs},
     Accumulator, AggregateUDF, AggregateUDFImpl, ColumnarValue, ReturnFieldArgs,
@@ -13,6 +13,7 @@ use datafusion_ffi::{
     udaf::{FFI_AggregateUDF, ForeignAggregateUDF},
     udf::{FFI_ScalarUDF, ForeignScalarUDF},
 };
+use sedona_common::sedona_internal_err;
 use sedona_schema::datatypes::SedonaType;
 
 use sedona_expr::{
@@ -96,7 +97,7 @@ impl ScalarUDFImpl for ExportedScalarKernel {
     }
 
     fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
-        internal_err!("should not be called")
+        sedona_internal_err!("should not be called")
     }
 
     fn return_field_from_args(&self, args: ReturnFieldArgs) -> Result<FieldRef> {

--- a/rust/sedona/src/record_batch_reader_provider.rs
+++ b/rust/sedona/src/record_batch_reader_provider.rs
@@ -16,7 +16,8 @@ use datafusion::{
     physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties},
     prelude::Expr,
 };
-use datafusion_common::{internal_err, DataFusionError};
+use datafusion_common::DataFusionError;
+use sedona_common::sedona_internal_err;
 use sedona_expr::projection::wrap_batch;
 use sedona_schema::projection::wrap_schema;
 
@@ -79,7 +80,7 @@ impl TableProvider for RecordBatchReaderProvider {
         if let Some(reader) = writable_reader.take() {
             Ok(Arc::new(RecordBatchReaderExec::new(reader, limit)))
         } else {
-            internal_err!("Can't scan RecordBatchReader provider more than once")
+            sedona_internal_err!("Can't scan RecordBatchReader provider more than once")
         }
     }
 }
@@ -169,7 +170,7 @@ impl ExecutionPlan for RecordBatchReaderExec {
         let reader = if let Some(reader) = writable_reader.take() {
             reader
         } else {
-            return internal_err!("Can't scan RecordBatchReader provider more than once");
+            return sedona_internal_err!("Can't scan RecordBatchReader provider more than once");
         };
 
         let limit = self.limit;


### PR DESCRIPTION
I've found the use of Datafusion's `internal_err!` to be very misleading during development because it suggests the error is DataFusion's and not Sedona's (see the example texts). This PR adds a new macro to use instead.

Example (code was modified to intentionally trigger this internal error):

Before:
```sql
> select st_m(st_geomfromtext('point (1 1)'));
Internal error: unexpected dimension.
This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
```

Now:
```sql
> select st_m(st_geomfromtext('point (1 1)'));
External error: SedonaDB internal error: unexpected dimension.
This issue was likely caused by a bug in SedonaDB's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/sedona-db/issues
```

It would be nice to avoid the "External error:" prepending the message, but that seems to be the most reasonable of the available options without making an upstream change.