### PR TITLE
Add 'platform: linux/amd64' to postgis compose.yml

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,6 @@
 services:
   postgis:
+    platform: linux/amd64
     image: postgis/postgis:latest
     ports:
       - "5432:5432"


### PR DESCRIPTION
When running `docker compose up -d` on a mac, I get the following message since my machine is not amd64. I've been manually adding it to the file each time I need to use it, but it would be nice to just have it already there. It looks like [amd64 is the only architecture they support](https://hub.docker.com/r/postgis/postgis/#:~:text=Supported%20architecture%3A%20amd64%20(also%20known%20as%20X86%2D64)%22), so I think it's safe to explicitly include for everyone.

```bash
docker compose up -d
[+] Running 3/3
 ✔ Network sedona-db_default                                                                                                                              Created                                                                                               0.0s 
 ✔ Container sedona-db-postgis-1                                                                                                                          Started                                                                                               0.1s 
 ! postgis The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
```