### PR TITLE
chore(python/sedonadb): Add integration tests for GeoParquet reader

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 name: python
 
 on:
@@ -73,14 +74,18 @@ jobs:
         run: |
           pip install -e "python/sedonadb/[test]" -vv
 
+      - name: Download minimal geoarrow-data assets
+        run: |
+          python submodules/download-assets.py "*water-junc*" "*water-point*"
+
       - name: Start PostGIS
         run: |
           docker compose up --wait --detach postgis
 
       - name: Run tests
         env:
-          # Ensure that there are no skips for PostGIS or duckdb not available
-          SEDONADB_PYTHON_ENSURE_ALL_ENGINES: "true"
+          # Ensure that we don't skip tests that we didn't intend to
+          SEDONADB_PYTHON_NO_SKIP_TESTS: "true"
         run: |
           cd python
           python -m pytest -vv

--- a/.gitmodules
+++ b/.gitmodules
@@ -23,3 +23,6 @@
 [submodule "c/sedona-s2geography/s2geometry"]
 	path = c/sedona-s2geography/s2geometry
 	url = https://github.com/google/s2geometry.git
+[submodule "submodules/sedona-testing"]
+	path = submodules/sedona-testing
+	url = https://github.com/apache/sedona-testing.git

--- a/python/sedonadb/python/sedonadb/testing.py
+++ b/python/sedonadb/python/sedonadb/testing.py
@@ -1,5 +1,6 @@
 import os
 import warnings
+from pathlib import Path
 from typing import TYPE_CHECKING, List, Tuple
 
 import geoarrow.pyarrow as ga
@@ -9,6 +10,29 @@ if TYPE_CHECKING:
     import pandas
 
     import sedonadb
+
+
+def skip_if_not_exists(path: Path):
+    """Skip a test using pytest.skip() if path does not exist
+
+    If SEDONADB_PYTHON_NO_SKIP_TESTS is set, this function will never skip to
+    avoid accidentally skipping tests on CI.
+    """
+    if _env_no_skip():
+        return
+
+    if not path.exists():
+        import pytest
+
+        pytest.skip(
+            f"Test asset '{path}' not found. "
+            "Run submodules/download-assets.py to test with submodule assets"
+        )
+
+
+def _env_no_skip():
+    env_no_skip = os.environ.get("SEDONADB_PYTHON_NO_SKIP_TESTS", "false")
+    return env_no_skip in ("true", "1")
 
 
 class DBEngine:
@@ -43,12 +67,14 @@ class DBEngine:
         This is the constructor that should be used in tests to ensure that integration
         style tests don't cause failure for contributors working on Python-only
         behaviour.
+
+        If SEDONADB_PYTHON_NO_SKIP_TESTS is set, this function will never skip to
+        avoid accidentally skipping tests on CI.
         """
         import pytest
 
         # Ensure we can force this to succeed (or fail in CI)
-        env_no_skip = os.environ.get("SEDONADB_PYTHON_ENSURE_ALL_ENGINES", "false")
-        if env_no_skip in ("true", "1"):
+        if _env_no_skip():
             return cls(*args, **kwargs)
 
         # By default, allow construction to fail (e.g., for contributors running

--- a/python/sedonadb/python/sedonadb/testing.py
+++ b/python/sedonadb/python/sedonadb/testing.py
@@ -267,7 +267,8 @@ class SedonaDB(DBEngine):
         return self
 
     def execute_and_collect(self, query) -> "sedonadb.dataframe.DataFrame":
-        return self.con.sql(query).collect()
+        # Use to_arrow_table() to maintain ordering of the input table
+        return self.con.sql(query).to_arrow_table()
 
 
 class DuckDB(DBEngine):

--- a/python/sedonadb/tests/conftest.py
+++ b/python/sedonadb/tests/conftest.py
@@ -17,3 +17,8 @@ def con():
 @pytest.fixture()
 def geoarrow_data():
     return HERE.parent.parent.parent / "submodules" / "geoarrow-data"
+
+
+@pytest.fixture()
+def sedona_testing():
+    return HERE.parent.parent.parent / "submodules" / "sedona-testing"

--- a/python/sedonadb/tests/io/test_parquet.py
+++ b/python/sedonadb/tests/io/test_parquet.py
@@ -103,11 +103,13 @@ def test_read_geoparquet_pruned(geoarrow_data, name):
         )
 
         eng.create_view_parquet("tab", tmp_parquet)
-        result = eng.execute_and_collect(f"""
+        result = eng.execute_and_collect(
+            f"""
             SELECT "OBJECTID", geometry FROM tab
             WHERE ST_Intersects(geometry, ST_SetSRID({geom_or_null(wkt_filter)}, '{gdf.crs.to_json()}'))
             ORDER BY "OBJECTID";
-        """)
+        """
+        )
         eng.assert_result(result, gdf)
 
         # Write a dataset with one file per row group to check file pruning correctness
@@ -126,9 +128,11 @@ def test_read_geoparquet_pruned(geoarrow_data, name):
         # Check a query against the same dataset without the bbox column but with file-level
         # geoparquet metadata bounding boxes
         eng.create_view_parquet("tab_dataset", ds_paths)
-        result = eng.execute_and_collect(f"""
+        result = eng.execute_and_collect(
+            f"""
             SELECT * FROM tab_dataset
             WHERE ST_Intersects(geometry, ST_SetSRID({geom_or_null(wkt_filter)}, '{gdf.crs.to_json()}'))
             ORDER BY "OBJECTID";
-        """)
+        """
+        )
         eng.assert_result(result, gdf)

--- a/python/sedonadb/tests/io/test_parquet.py
+++ b/python/sedonadb/tests/io/test_parquet.py
@@ -1,0 +1,93 @@
+import pytest
+import tempfile
+import shapely
+import geopandas
+from pathlib import Path
+from sedonadb.testing import geom_or_null, SedonaDB, DuckDB
+
+
+@pytest.mark.parametrize("name", ["water-junc", "water-point"])
+def test_read_whole_geoparquet(geoarrow_data, name):
+    # Checks a read of some non-trivial files and ensures we match a GeoPandas read
+    eng = SedonaDB()
+    path = geoarrow_data / "ns-water" / "files" / f"ns-water_{name}_geo.parquet"
+    gdf = geopandas.read_parquet(path).sort_values(by="OBJECTID").reset_index(drop=True)
+
+    eng.create_view_parquet("tab", path)
+    result = eng.execute_and_collect("""SELECT * FROM tab ORDER BY "OBJECTID";""")
+    eng.assert_result(result, gdf)
+
+
+@pytest.mark.parametrize(
+    "name", ["geoparquet-1.0.0", "geoparquet-1.1.0", "overature-bbox", "plain"]
+)
+def test_read_sedona_testing(sedona_testing, name):
+    # Checks a read of trivial files (some GeoParquet and some not) against a DuckDB read
+    duckdb = DuckDB.create_or_skip()
+    sedonadb = SedonaDB()
+    path = sedona_testing / "data" / "parquet" / f"{name}.parquet"
+    if not path.exists():
+        pytest.skip("submodules/sedona-testing not present or not initialized")
+
+    duckdb.create_view_parquet("tab", path)
+    result_duckdb = duckdb.execute_and_collect("SELECT * FROM tab")
+    df_duckdb = duckdb.result_to_pandas(result_duckdb)
+
+    # DuckDB never returns CRSes
+    kwargs = {}
+    if isinstance(df_duckdb, geopandas.GeoDataFrame):
+        kwargs["check_crs"] = False
+
+    sedonadb.create_view_parquet("tab", path)
+    sedonadb.assert_query_result("SELECT * FROM tab", df_duckdb, **kwargs)
+
+
+@pytest.mark.parametrize("name", ["water-junc", "water-point"])
+def test_read_geoparquet_pruned(geoarrow_data, name):
+    # Note that this doesn't check that pruning actually occurred, just that
+    # for a query where we should be pruning automatically that we don't omit results.
+    eng = SedonaDB()
+    path = geoarrow_data / "ns-water" / "files" / f"ns-water_{name}_geo.parquet"
+    if not path.exists():
+        pytest.skip(
+            "submodules/geoarrow-data not present or submodules/download-assets.py not run"
+        )
+
+    # Roughly a diamond around Gaspereau Lake, Nova Scotia, in UTM zone 20
+    wkt_filter = """
+        POLYGON ((
+            371000 4978000, 376000 4972000, 381000 4978000,
+            376000 4983000, 371000 4978000
+        ))
+    """
+    poly_filter = shapely.from_wkt(wkt_filter)
+
+    gdf = geopandas.read_parquet(path)
+    gdf = (
+        gdf[gdf.geometry.intersects(poly_filter)]
+        .sort_values(by="OBJECTID")
+        .reset_index(drop=True)
+    )
+    gdf = gdf[["OBJECTID", "geometry"]]
+
+    with tempfile.TemporaryDirectory() as td:
+        # Write using GeoPandas, which implements GeoParquet 1.1 bbox covering
+        # Write tiny row groups so that many bounding boxes have to be checked
+        tmp_parquet = Path(td) / f"{name}.parquet"
+        geopandas.read_parquet(path).to_parquet(
+            tmp_parquet,
+            schema_version="1.1.0",
+            write_covering_bbox=True,
+            row_group_size=1024,
+        )
+
+        eng.create_view_parquet("tab", tmp_parquet)
+        result = eng.execute_and_collect(f"""
+            SELECT "OBJECTID", geometry FROM tab
+            WHERE ST_Intersects(geometry, ST_SetSRID({geom_or_null(wkt_filter)}, '{gdf.crs.to_json()}'))
+            ORDER BY "OBJECTID";
+        """)
+        eng.assert_result(result, gdf)
+
+        # Also check that this isn't a bogus test
+        assert len(gdf) > 0

--- a/python/sedonadb/tests/io/test_parquet.py
+++ b/python/sedonadb/tests/io/test_parquet.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 import pytest
 import tempfile
 import shapely


### PR DESCRIPTION
Adds a basic suite of tests to check metadata, pruning, and spatialness of Parquet reads. Notably, this includes realistic checks of a multi-file dataset single GeoParquet 1.1 file with row groups to ensure correctness of queries we should be pruning.