### PR TITLE
Fix docs for building documentation using mkdocs, add docstring for `create_data_frame`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@
 SedonaDB's documentation is powered by [mkdocs.org](https://www.mkdocs.org) and [mkdocs-material](https://squidfunk.github.io/mkdocs-material/reference/). To build the documentation locally, clone the repo, install the Python requirements, and use the `mkdocs` command-line tool to build or serve the documentation.
 
 ```shell
+pip install -e "python/sedonadb/[test]" -vv # OPTIONAL: build the doc for the latest dev version of sedona-db
 git clone https://github.com/apache/sedona-db.git && cd sedona-db
 pip install -r docs/requirements.txt
 ```

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,4 @@ mkdocstrings[python]
 ruff
 ipykernel
 notebook
+sedonadb[geopandas]

--- a/python/sedonadb/python/sedonadb/context.py
+++ b/python/sedonadb/python/sedonadb/context.py
@@ -35,6 +35,34 @@ class SedonaContext:
         self._impl = InternalContext()
 
     def create_data_frame(self, obj, schema=None) -> DataFrame:
+        """Create a DataFrame from an in-memory or protocol-enabled object.
+
+        Converts supported Python objects into a SedonaDB DataFrame so you
+        can run SQL and spatial operations on them.
+
+        Args:
+            obj: A supported object:
+                - pandas DataFrame
+                - GeoPandas DataFrame
+                - Polars DataFrame
+                - pyarrow Table
+            schema: Optional object implementing ``__arrow_schema__`` for providing an Arrow schema.
+
+        Returns:
+            DataFrame: A SedonaDB DataFrame.
+
+        Examples:
+
+            >>> import sedonadb, pandas as pd
+            >>> con = sedonadb.connect()
+            >>> con.create_data_frame(pd.DataFrame({"x": [1, 2]})).head(1).show()
+            ┌───────┐
+            │   x   │
+            │ int64 │
+            ╞═══════╡
+            │     1 │
+            └───────┘
+        """
         return _create_data_frame(self._impl, obj, schema)
 
     def view(self, name: str) -> DataFrame:


### PR DESCRIPTION
`sedonadb` package must be installed to build documentation using mkdocs. I have added `sedonadb[geopandas]` to the requirements.txt file although it is not published to PyPI for now. The package name was taken from https://github.com/apache/sedona/pull/2328.

I wrote the docstring for `create_data_frame` according to my understanding of the code. Feel free to point out any problem.