### PR TITLE
Use spatial predicates defined by TG when tg feature is enabled

### DIFF
--- a/python/sedonadb/tests/functions/test_predicates.py
+++ b/python/sedonadb/tests/functions/test_predicates.py
@@ -330,7 +330,7 @@ def test_st_within(eng, geom1, geom2, expected):
     )
 
 
-@pytest.mark.skip("Skipping test for ST_Within with GeometryCollection")
+@pytest.mark.xfail(reason="https://github.com/tidwall/tg/issues/20")
 @pytest.mark.parametrize("eng", [SedonaDB, PostGIS])
 @pytest.mark.parametrize(
     ("geom1", "geom2", "expected"),

--- a/python/sedonadb/tests/functions/test_predicates.py
+++ b/python/sedonadb/tests/functions/test_predicates.py
@@ -312,11 +312,6 @@ def test_st_touches(eng, geom1, geom2, expected):
             "MULTIPOLYGON (((0 0, 1 0, 1 1, 0 1, 0 0)), ((0 0, 1 0, 1 1, 0 1, 0 0)))",
             True,
         ),
-        (
-            "POINT (0 0)",
-            "GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (0 0, 1 1), POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)))",
-            False,
-        ),
         # Identical geometries are not considered within each other
         ("POINT (0 0)", "POINT (0 0)", True),
         (
@@ -328,6 +323,35 @@ def test_st_touches(eng, geom1, geom2, expected):
     ],
 )
 def test_st_within(eng, geom1, geom2, expected):
+    eng = eng.create_or_skip()
+    eng.assert_query_result(
+        f"SELECT ST_Within({geom_or_null(geom1)}, {geom_or_null(geom2)})",
+        expected,
+    )
+
+
+@pytest.mark.skip("Skipping test for ST_Within with GeometryCollection")
+@pytest.mark.parametrize("eng", [SedonaDB, PostGIS])
+@pytest.mark.parametrize(
+    ("geom1", "geom2", "expected"),
+    [
+        # These cases demonstrates the weirdness of ST_Contains:
+        # Both POINT(0 0) and GEOMETRYCOLLECTION (POINT (0 0)) contains POINT (0 0),
+        # but GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (0 0, 1 1)) does not contain POINT (0 0).
+        # See https://lin-ear-th-inking.blogspot.com/2007/06/subtleties-of-ogc-covers-spatial.html
+        (
+            "POINT (0 0)",
+            "GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (0 0, 1 1))",
+            False,
+        ),
+        (
+            "POINT (0 0)",
+            "GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (0 0, 1 1), POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)))",
+            False,
+        ),
+    ],
+)
+def test_st_within_skipped(eng, geom1, geom2, expected):
     eng = eng.create_or_skip()
     eng.assert_query_result(
         f"SELECT ST_Within({geom_or_null(geom1)}, {geom_or_null(geom2)})",

--- a/rust/sedona-common/src/option.rs
+++ b/rust/sedona-common/src/option.rs
@@ -53,7 +53,7 @@ config_namespace! {
         pub enable: bool, default = true
 
         /// Spatial library to use for spatial join
-        pub spatial_library: SpatialLibrary, default = SpatialLibrary::Geo
+        pub spatial_library: SpatialLibrary, default = SpatialLibrary::Tg
 
         /// Options for configuring the GEOS spatial library
         pub geos: GeosOptions, default = GeosOptions::default()

--- a/rust/sedona/src/context.rs
+++ b/rust/sedona/src/context.rs
@@ -138,6 +138,9 @@ impl SedonaContext {
         #[cfg(feature = "geo")]
         out.register_scalar_kernels(sedona_geo::register::scalar_kernels().into_iter())?;
 
+        #[cfg(feature = "tg")]
+        out.register_scalar_kernels(sedona_tg::register::scalar_kernels().into_iter())?;
+
         // Register geo aggregate kernels if built with geo support
         #[cfg(feature = "geo")]
         out.register_aggregate_kernels(sedona_geo::register::aggregate_kernels().into_iter())?;


### PR DESCRIPTION
This patch uses TG as the default library for evaluating spatial predicates. TG has better overall performance compared to GEOS, but it does not always produce the same result as GEOS. See the skipped python test for an example.

Here are the benchmark results of ST_Contains.

After switching to TG:

```
------------------------------------------------------------------------------------------ benchmark 'table=polygons_complex': 6 tests -------------------------------------------------------------------------------------------
Name (time in ms)                                       Min                    Max                   Mean              StdDev                 Median                 IQR            Outliers     OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_st_contains[polygons_complex-SedonaDB]     14,967.6217 (113.62)   15,101.0815 (112.21)   15,034.7782 (113.08)    58.7428 (44.96)    15,053.5245 (113.73)   103.6030 (44.66)         2;0  0.0665 (0.01)          5           1
test_st_contains[polygons_complex-PostGIS]      18,754.5553 (142.37)   18,947.6443 (140.79)   18,810.6307 (141.47)    77.8565 (59.60)    18,784.8336 (141.92)    60.9839 (26.29)         1;1  0.0532 (0.01)          5           1
test_st_contains[polygons_complex-DuckDB]       41,355.0608 (313.93)   41,757.0877 (310.27)   41,485.6860 (312.01)   158.4599 (121.29)   41,460.6061 (313.24)   152.4081 (65.69)         1;0  0.0241 (0.00)          5           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------------------------------------- benchmark 'table=polygons_simple': 6 tests ----------------------------------------------------------------------------------------
Name (time in ms)                                     Min                   Max                  Mean             StdDev                Median                IQR            Outliers      OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_st_contains[polygons_simple-SedonaDB]        51.7848 (4.95)        53.2945 (4.59)        52.0883 (4.88)      0.3806 (1.78)        51.9682 (4.89)      0.2382 (1.07)          2;2  19.1982 (0.21)         15           1
test_st_contains[polygons_simple-PostGIS]        503.0724 (48.12)      504.4988 (43.48)      503.9603 (47.18)     0.5745 (2.68)       504.0978 (47.39)     0.8316 (3.72)          1;0   1.9843 (0.02)          5           1
test_st_contains[polygons_simple-DuckDB]       1,028.6870 (98.39)    1,052.6184 (90.72)    1,038.6616 (97.23)    11.0858 (51.76)    1,032.6861 (97.09)    19.3825 (86.66)         1;0   0.9628 (0.01)          5           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

Before switching to TG (using GEOS):

```
-------------------------------------------------------------------------------- benchmark 'table=polygons_complex': 3 tests ---------------------------------------------------------------------------------
Name (time in s)                                    Min                Max               Mean            StdDev             Median               IQR            Outliers     OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_st_contains[polygons_complex-PostGIS]      19.1494 (1.0)      19.4207 (1.0)      19.2242 (1.0)      0.1130 (1.43)     19.1802 (1.0)      0.1146 (1.07)          1;0  0.0520 (1.0)           5           1
test_st_contains[polygons_complex-DuckDB]       41.3088 (2.16)     41.5109 (2.14)     41.4314 (2.16)     0.0791 (1.0)      41.4345 (2.16)     0.1074 (1.0)           2;0  0.0241 (0.46)          5           1
test_st_contains[polygons_complex-SedonaDB]     45.8714 (2.40)     46.2991 (2.38)     46.0659 (2.40)     0.1825 (2.31)     46.0117 (2.40)     0.3136 (2.92)          2;0  0.0217 (0.42)          5           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------------------------------------- benchmark 'table=polygons_simple': 3 tests ---------------------------------------------------------------------------------------
Name (time in ms)                                     Min                   Max                  Mean             StdDev                Median                IQR            Outliers     OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_st_contains[polygons_simple-PostGIS]        505.0895 (1.0)        508.2328 (1.0)        505.9608 (1.0)       1.3032 (1.0)        505.3185 (1.0)       1.2252 (1.0)           1;0  1.9764 (1.0)           5           1
test_st_contains[polygons_simple-DuckDB]       1,041.7832 (2.06)     1,095.9742 (2.16)     1,058.1268 (2.09)     22.6935 (17.41)    1,048.8662 (2.08)     28.5375 (23.29)         1;0  0.9451 (0.48)          5           1
test_st_contains[polygons_simple-SedonaDB]     1,149.4455 (2.28)     1,176.6984 (2.32)     1,163.5871 (2.30)     11.7818 (9.04)     1,168.0510 (2.31)     20.1257 (16.43)         2;0  0.8594 (0.43)          5           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```