### PR TITLE
bug: Support read_parquet glob file paths

### DIFF
--- a/python/sedonadb/tests/test_context.py
+++ b/python/sedonadb/tests/test_context.py
@@ -35,6 +35,24 @@ def test_read_parquet(con, geoarrow_data):
     assert len(tab) == 244
 
 
+def test_read_parquet_local_glob(con, geoarrow_data):
+    # The above test uses .glob() method, this test uses the raw string
+    # Check one file
+    tab = con.read_parquet(
+        geoarrow_data / "example/files/*_geo.parquet"
+    ).to_arrow_table()
+    assert tab["geometry"].type.extension_name == "geoarrow.wkb"
+
+    # Check many files
+    assert tab["geometry"].type.extension_name == "geoarrow.wkb"
+    assert len(tab) == 244
+
+    tab = con.read_parquet(
+        geoarrow_data / "example/files/example_polygon-*geo.parquet"
+    ).to_arrow_table()
+    assert len(tab) == 12
+
+
 def test_read_parquet_error(con):
     with pytest.raises(sedonadb._lib.SedonaError, match="No table paths were provided"):
         con.read_parquet([])

--- a/python/sedonadb/tests/test_context.py
+++ b/python/sedonadb/tests/test_context.py
@@ -37,13 +37,9 @@ def test_read_parquet(con, geoarrow_data):
 
 def test_read_parquet_local_glob(con, geoarrow_data):
     # The above test uses .glob() method, this test uses the raw string
-    # Check one file
     tab = con.read_parquet(
         geoarrow_data / "example/files/*_geo.parquet"
     ).to_arrow_table()
-    assert tab["geometry"].type.extension_name == "geoarrow.wkb"
-
-    # Check many files
     assert tab["geometry"].type.extension_name == "geoarrow.wkb"
     assert len(tab) == 244
 


### PR DESCRIPTION
This one was pretty annoying to debug. Here's what was going on. We were calling `.to_urls()` in twice: once in `geoparquet_listing_table` and once in here in `context.rs`'s read_parquet:
https://github.com/apache/sedona-db/blob/5d3cfba252ffdb0d1a8ac1fd2126fb829ca459df/rust/sedona/src/context.rs#L229-L235

The second call was causing the `ListingTableUrl`'s glob attribute to being removed. I fixed this my removing one of the calls.

Note: globbing with the `*` operations still does NOT work on AWS s3 paths. That would need an additional fix / feature. It looks like Datafusion doesn't support globbing s3 paths yet either: It looks like DataFusion doesn't support globbing s3 paths yet either: https://github.com/apache/datafusion/issues/16303