### PR TITLE
Push down all spatial predicates when reading GeoParquet files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4993,6 +4993,7 @@ dependencies = [
  "geo-traits 0.2.0",
  "object_store",
  "parquet",
+ "rstest",
  "sedona-common",
  "sedona-expr",
  "sedona-geometry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4880,6 +4880,7 @@ dependencies = [
  "datafusion-expr",
  "datafusion-physical-expr",
  "geo-traits 0.2.0",
+ "rstest",
  "sedona-common",
  "sedona-geometry",
  "sedona-schema",

--- a/rust/sedona-expr/Cargo.toml
+++ b/rust/sedona-expr/Cargo.toml
@@ -29,6 +29,7 @@ result_large_err = "allow"
 
 [dev-dependencies]
 sedona-testing = { path = "../sedona-testing" }
+rstest = { workspace = true }
 
 [dependencies]
 arrow-array = { workspace = true }

--- a/rust/sedona-expr/src/lib.rs
+++ b/rust/sedona-expr/src/lib.rs
@@ -19,3 +19,4 @@ pub mod function_set;
 pub mod scalar_udf;
 pub mod spatial_filter;
 pub mod statistics;
+pub mod utils;

--- a/rust/sedona-expr/src/spatial_filter.rs
+++ b/rust/sedona-expr/src/spatial_filter.rs
@@ -87,7 +87,7 @@ impl SpatialFilter {
 
     fn evaluate_covered_by_bbox(column_stats: &GeoStatistics, bounds: &BoundingBox) -> bool {
         if let Some(bbox) = column_stats.bbox() {
-            bounds.contains(&bbox)
+            bounds.contains(bbox)
         } else {
             true
         }

--- a/rust/sedona-expr/src/utils.rs
+++ b/rust/sedona-expr/src/utils.rs
@@ -1,0 +1,62 @@
+use std::sync::Arc;
+
+use datafusion_expr::Operator;
+use datafusion_physical_expr::{expressions::BinaryExpr, PhysicalExpr, ScalarFunctionExpr};
+
+pub struct ParsedDistancePredicate {
+    pub arg0: Arc<dyn PhysicalExpr>,
+    pub arg1: Arc<dyn PhysicalExpr>,
+    pub arg_distance: Arc<dyn PhysicalExpr>,
+}
+
+pub fn parse_distance_predicate(expr: &Arc<dyn PhysicalExpr>) -> Option<ParsedDistancePredicate> {
+    // There are 3 forms of distance predicates:
+    // 1. st_dwithin(geom1, geom2, distance)
+    // 2. st_distance(geom1, geom2) <= distance or st_distance(geom1, geom2) < distance
+    // 3. distance >= st_distance(geom1, geom2) or distance > st_distance(geom1, geom2)
+    if let Some(binary_expr) = expr.as_any().downcast_ref::<BinaryExpr>() {
+        // handle case 2. and 3.
+        let left = binary_expr.left();
+        let right = binary_expr.right();
+        let (st_distance_expr, distance_bound_expr) = match *binary_expr.op() {
+            Operator::Lt | Operator::LtEq => (left, right),
+            Operator::Gt | Operator::GtEq => (right, left),
+            _ => return None,
+        };
+
+        if let Some(st_distance_expr) = st_distance_expr
+            .as_any()
+            .downcast_ref::<ScalarFunctionExpr>()
+        {
+            if st_distance_expr.fun().name() != "st_distance" {
+                return None;
+            }
+
+            let args = st_distance_expr.args();
+            assert!(args.len() >= 2);
+            Some(ParsedDistancePredicate {
+                arg0: Arc::clone(&args[0]),
+                arg1: Arc::clone(&args[1]),
+                arg_distance: Arc::clone(distance_bound_expr),
+            })
+        } else {
+            None
+        }
+    } else if let Some(st_dwithin_expr) = expr.as_any().downcast_ref::<ScalarFunctionExpr>() {
+        // handle case 1.
+        if st_dwithin_expr.fun().name() != "st_dwithin" {
+            return None;
+        }
+
+        let args = st_dwithin_expr.args();
+        assert!(args.len() >= 3);
+        // Some((&args[0], &args[1], &args[2]))
+        Some(ParsedDistancePredicate {
+            arg0: Arc::clone(&args[0]),
+            arg1: Arc::clone(&args[1]),
+            arg_distance: Arc::clone(&args[2]),
+        })
+    } else {
+        None
+    }
+}

--- a/rust/sedona-expr/src/utils.rs
+++ b/rust/sedona-expr/src/utils.rs
@@ -3,19 +3,62 @@ use std::sync::Arc;
 use datafusion_expr::Operator;
 use datafusion_physical_expr::{expressions::BinaryExpr, PhysicalExpr, ScalarFunctionExpr};
 
+/// Represents a parsed distance predicate with its constituent parts.
+///
+/// Distance predicates are spatial operations that determine whether two geometries
+/// are within a specified distance of each other. This struct holds the parsed
+/// components of such predicates for further processing.
+///
+/// ## Supported Distance Predicate Forms
+///
+/// This struct can represent the parsed components from any of these distance predicate forms:
+///
+/// 1. **Direct distance function**:
+///    - `st_dwithin(geom1, geom2, distance)` - Returns true if geometries are within the distance
+///
+/// 2. **Distance comparison (left-to-right)**:
+///    - `st_distance(geom1, geom2) <= distance` - Distance is less than or equal to threshold
+///    - `st_distance(geom1, geom2) < distance` - Distance is strictly less than threshold
+///
+/// 3. **Distance comparison (right-to-left)**:
+///    - `distance >= st_distance(geom1, geom2)` - Threshold is greater than or equal to distance
+///    - `distance > st_distance(geom1, geom2)` - Threshold is strictly greater than distance
+///
+/// All forms are logically equivalent but may appear differently in SQL queries. The parser
+/// normalizes them into this common structure for uniform processing.
 pub struct ParsedDistancePredicate {
+    /// The first geometry argument in the distance predicate
     pub arg0: Arc<dyn PhysicalExpr>,
+    /// The second geometry argument in the distance predicate
     pub arg1: Arc<dyn PhysicalExpr>,
+    /// The distance threshold argument (as a physical expression)
     pub arg_distance: Arc<dyn PhysicalExpr>,
 }
 
+/// Parses a physical expression to extract distance predicate components.
+///
+/// This function recognizes and parses distance predicates in spatial queries.
+/// See [`ParsedDistancePredicate`] documentation for details on the supported
+/// distance predicate forms.
+///
+/// # Arguments
+///
+/// * `expr` - A physical expression that potentially represents a distance predicate
+///
+/// # Returns
+///
+/// * `Some(ParsedDistancePredicate)` - If the expression is a recognized distance predicate,
+///   returns the parsed components (two geometry arguments and the distance threshold)
+/// * `None` - If the expression is not a distance predicate or cannot be parsed
+///
+/// # Examples
+///
+/// The function can parse expressions like:
+/// - `st_dwithin(geometry_column, POINT(0 0), 100.0)`
+/// - `st_distance(geom_a, geom_b) <= 50.0`
+/// - `25.0 >= st_distance(geom_x, geom_y)`
 pub fn parse_distance_predicate(expr: &Arc<dyn PhysicalExpr>) -> Option<ParsedDistancePredicate> {
-    // There are 3 forms of distance predicates:
-    // 1. st_dwithin(geom1, geom2, distance)
-    // 2. st_distance(geom1, geom2) <= distance or st_distance(geom1, geom2) < distance
-    // 3. distance >= st_distance(geom1, geom2) or distance > st_distance(geom1, geom2)
     if let Some(binary_expr) = expr.as_any().downcast_ref::<BinaryExpr>() {
-        // handle case 2. and 3.
         let left = binary_expr.left();
         let right = binary_expr.right();
         let (st_distance_expr, distance_bound_expr) = match *binary_expr.op() {
@@ -43,14 +86,12 @@ pub fn parse_distance_predicate(expr: &Arc<dyn PhysicalExpr>) -> Option<ParsedDi
             None
         }
     } else if let Some(st_dwithin_expr) = expr.as_any().downcast_ref::<ScalarFunctionExpr>() {
-        // handle case 1.
         if st_dwithin_expr.fun().name() != "st_dwithin" {
             return None;
         }
 
         let args = st_dwithin_expr.args();
         assert!(args.len() >= 3);
-        // Some((&args[0], &args[1], &args[2]))
         Some(ParsedDistancePredicate {
             arg0: Arc::clone(&args[0]),
             arg1: Arc::clone(&args[1]),

--- a/rust/sedona-geometry/src/bounding_box.rs
+++ b/rust/sedona-geometry/src/bounding_box.rs
@@ -127,6 +127,20 @@ impl BoundingBox {
         contains_xy && may_contain_z && may_contain_m
     }
 
+    /// Expand this BoundingBox by a given distance in x and y dimensions only
+    ///
+    /// Returns a new BoundingBox where x and y intervals are expanded by the given distance.
+    /// The x dimension (which may wrap around) is handled correctly.
+    /// Z and M dimensions are left unchanged.
+    pub fn expand_by(&self, distance: f64) -> Self {
+        Self {
+            x: self.x.expand_by(distance),
+            y: self.y.expand_by(distance),
+            z: self.z,
+            m: self.m,
+        }
+    }
+
     /// Update this BoundingBox to include the bounds of another
     ///
     /// This method will propagate missingness of Z or M dimensions from the two boxes
@@ -399,5 +413,59 @@ mod test {
         assert!(bbox_nan2.x().hi().is_nan());
         assert!(bbox_nan2.y().lo().is_nan());
         assert!(bbox_nan2.y().hi().is_nan());
+    }
+
+    #[test]
+    fn bounding_box_expand_by() {
+        let xyzm = BoundingBox::xyzm(
+            (10, 20),
+            (30, 40),
+            Some((50, 60).into()),
+            Some((70, 80).into()),
+        );
+
+        // Expand by a positive distance - only x and y should change
+        let expanded = xyzm.expand_by(5.0);
+        assert_eq!(expanded.x(), &WraparoundInterval::new(5.0, 25.0));
+        assert_eq!(expanded.y(), &Interval::new(25.0, 45.0));
+        assert_eq!(expanded.z(), &Some(Interval::new(50.0, 60.0))); // unchanged
+        assert_eq!(expanded.m(), &Some(Interval::new(70.0, 80.0))); // unchanged
+
+        // Expand by zero does nothing
+        let unchanged = xyzm.expand_by(0.0);
+        assert_eq!(unchanged, xyzm);
+
+        // Expand by negative distance does nothing
+        let unchanged_neg = xyzm.expand_by(-2.0);
+        assert_eq!(unchanged_neg, xyzm);
+
+        // Expand by NaN does nothing
+        let unchanged_nan = xyzm.expand_by(f64::NAN);
+        assert_eq!(unchanged_nan, xyzm);
+
+        // Test with missing z and m dimensions
+        let xy_only = BoundingBox::xy((10, 20), (30, 40));
+        let expanded_xy = xy_only.expand_by(3.0);
+        assert_eq!(expanded_xy.x(), &WraparoundInterval::new(7.0, 23.0));
+        assert_eq!(expanded_xy.y(), &Interval::new(27.0, 43.0));
+        assert!(expanded_xy.z().is_none());
+        assert!(expanded_xy.m().is_none());
+
+        // Test with empty intervals
+        let bbox_with_empty = BoundingBox::xy((10, 20), Interval::empty());
+        let expanded_empty = bbox_with_empty.expand_by(5.0);
+        assert_eq!(expanded_empty.x(), &WraparoundInterval::new(5.0, 25.0));
+        assert_eq!(expanded_empty.y(), &Interval::empty());
+
+        // Test with wraparound x interval
+        let wraparound_x = BoundingBox::xy(WraparoundInterval::new(170.0, -170.0), (30, 40));
+        let expanded_wraparound = wraparound_x.expand_by(10.0);
+        // Original excludes (-170, 170), expanding by 10 should exclude (-160, 160)
+        // So the new interval should be (160, -160)
+        assert_eq!(
+            expanded_wraparound.x(),
+            &WraparoundInterval::new(160.0, -160.0)
+        );
+        assert_eq!(expanded_wraparound.y(), &Interval::new(20.0, 50.0));
     }
 }

--- a/rust/sedona-geometry/src/bounding_box.rs
+++ b/rust/sedona-geometry/src/bounding_box.rs
@@ -108,6 +108,25 @@ impl BoundingBox {
         intersects_xy && may_intersect_z && may_intersect_m
     }
 
+    /// Calculate whether this bounding box contains another BoundingBox
+    ///
+    /// Returns true if this bounding box contains other or false otherwise.
+    /// This method will consider Z and M dimension if and only if those dimensions are present
+    /// in both bounding boxes.
+    pub fn contains(&self, other: &Self) -> bool {
+        let contains_xy = self.x.contains_interval(&other.x) && self.y.contains_interval(&other.y);
+        let may_contain_z = match (self.z, other.z) {
+            (Some(z), Some(other_z)) => z.contains_interval(&other_z),
+            _ => true,
+        };
+        let may_contain_m = match (self.m, other.m) {
+            (Some(m), Some(other_m)) => m.contains_interval(&other_m),
+            _ => true,
+        };
+
+        contains_xy && may_contain_z && may_contain_m
+    }
+
     /// Update this BoundingBox to include the bounds of another
     ///
     /// This method will propagate missingness of Z or M dimensions from the two boxes

--- a/rust/sedona-geometry/src/bounding_box.rs
+++ b/rust/sedona-geometry/src/bounding_box.rs
@@ -208,6 +208,88 @@ mod test {
     }
 
     #[test]
+    fn bounding_box_contains() {
+        let xyzm = BoundingBox::xyzm(
+            (10, 20),
+            (30, 40),
+            Some((50, 60).into()),
+            Some((70, 80).into()),
+        );
+
+        // Should contain a smaller box completely within bounds
+        assert!(xyzm.contains(&BoundingBox::xy((14, 16), (34, 36))));
+
+        // Should contain itself
+        assert!(xyzm.contains(&xyzm));
+
+        // Should contain a box without z or m information if xy is contained
+        assert!(xyzm.contains(&BoundingBox::xy((12, 18), (32, 38))));
+
+        // Should contain without z information but with contained m
+        assert!(xyzm.contains(&BoundingBox::xyzm(
+            (14, 16),
+            (34, 36),
+            None,
+            Some((74, 76).into())
+        )));
+
+        // Should contain without m information but with contained z
+        assert!(xyzm.contains(&BoundingBox::xyzm(
+            (14, 16),
+            (34, 36),
+            Some((54, 56).into()),
+            None,
+        )));
+
+        // Should contain boxes that touch the boundaries
+        assert!(xyzm.contains(&BoundingBox::xy((10, 20), (30, 40))));
+        assert!(xyzm.contains(&BoundingBox::xy((10, 15), (30, 35))));
+        assert!(xyzm.contains(&BoundingBox::xy((15, 20), (35, 40))));
+
+        // Should *not* contain if x or y extends beyond bounds
+        assert!(!xyzm.contains(&BoundingBox::xy((4, 16), (34, 36)))); // x extends below
+        assert!(!xyzm.contains(&BoundingBox::xy((14, 26), (34, 36)))); // x extends above
+        assert!(!xyzm.contains(&BoundingBox::xy((14, 16), (24, 36)))); // y extends below
+        assert!(!xyzm.contains(&BoundingBox::xy((14, 16), (34, 46)))); // y extends above
+
+        // Should *not* contain if z is provided but extends beyond bounds
+        assert!(!xyzm.contains(&BoundingBox::xyzm(
+            (14, 16),
+            (34, 36),
+            Some((44, 56).into()), // z extends below
+            None
+        )));
+
+        assert!(!xyzm.contains(&BoundingBox::xyzm(
+            (14, 16),
+            (34, 36),
+            Some((54, 66).into()), // z extends above
+            None
+        )));
+
+        // Should *not* contain if m is provided but extends beyond bounds
+        assert!(!xyzm.contains(&BoundingBox::xyzm(
+            (14, 16),
+            (34, 36),
+            None,
+            Some((64, 76).into()) // m extends below
+        )));
+
+        assert!(!xyzm.contains(&BoundingBox::xyzm(
+            (14, 16),
+            (34, 36),
+            None,
+            Some((74, 86).into()) // m extends above
+        )));
+
+        // Should *not* contain boxes that are completely outside
+        assert!(!xyzm.contains(&BoundingBox::xy((0, 5), (30, 40)))); // x completely below
+        assert!(!xyzm.contains(&BoundingBox::xy((25, 30), (30, 40)))); // x completely above
+        assert!(!xyzm.contains(&BoundingBox::xy((10, 20), (0, 25)))); // y completely below
+        assert!(!xyzm.contains(&BoundingBox::xy((10, 20), (45, 50)))); // y completely above
+    }
+
+    #[test]
     fn bounding_box_update() {
         let xyzm = BoundingBox::xyzm(
             (10, 20),

--- a/rust/sedona-geometry/src/interval.rs
+++ b/rust/sedona-geometry/src/interval.rs
@@ -73,6 +73,15 @@ pub trait IntervalTrait: std::fmt::Debug + PartialEq {
     /// `is_wraparound()` when not required for an implementation.
     fn intersects_interval(&self, other: &Self) -> bool;
 
+    /// Check for potential containment of an interval
+    ///
+    /// Note that intervals always contain their endpoints (for both the wraparound and
+    /// non-wraparound case).
+    ///
+    /// This method accepts Self for performance reasons to prevent unnecessary checking of
+    /// `is_wraparound()` when not required for an implementation.
+    fn contains_interval(&self, other: &Self) -> bool;
+
     /// The width of the interval
     ///
     /// For the non-wraparound case, this is the distance between lo and hi. For the wraparound
@@ -204,6 +213,10 @@ impl IntervalTrait for Interval {
         self.lo <= other.hi && other.lo <= self.hi
     }
 
+    fn contains_interval(&self, other: &Self) -> bool {
+        self.lo <= other.lo && self.hi >= other.hi
+    }
+
     fn width(&self) -> f64 {
         self.hi - self.lo
     }
@@ -314,6 +327,12 @@ impl IntervalTrait for WraparoundInterval {
             || left.intersects_interval(&other_right)
             || right.intersects_interval(&other_left)
             || right.intersects_interval(&other_right)
+    }
+
+    fn contains_interval(&self, other: &Self) -> bool {
+        let (left, right) = self.split();
+        let (other_left, other_right) = other.split();
+        left.contains_interval(&other_left) && right.contains_interval(&other_right)
     }
 
     fn width(&self) -> f64 {

--- a/rust/sedona-geoparquet/Cargo.toml
+++ b/rust/sedona-geoparquet/Cargo.toml
@@ -33,6 +33,7 @@ default = []
 [dev-dependencies]
 sedona-testing = { path = "../sedona-testing" }
 url = { workspace = true }
+rstest = { workspace = true }
 
 [dependencies]
 async-trait = { workspace = true }

--- a/rust/sedona-geoparquet/src/format.rs
+++ b/rust/sedona-geoparquet/src/format.rs
@@ -352,7 +352,7 @@ impl GeoParquetFileSource {
         if let Some(parquet_source) = inner.as_any().downcast_ref::<ParquetSource>() {
             let mut parquet_source = parquet_source.clone();
 
-            // Extract the precicate from the existing source if it exists so we can keep a copy of it
+            // Extract the predicate from the existing source if it exists so we can keep a copy of it
             let new_predicate = match (parquet_source.predicate().cloned(), predicate) {
                 (None, None) => None,
                 (None, Some(specified_predicate)) => Some(specified_predicate),

--- a/rust/sedona-geoparquet/src/format.rs
+++ b/rust/sedona-geoparquet/src/format.rs
@@ -530,6 +530,7 @@ mod test {
     use datafusion_physical_expr::expressions::{BinaryExpr, Column, Literal};
     use datafusion_physical_expr::PhysicalExpr;
 
+    use rstest::rstest;
     use sedona_schema::crs::lnglat;
     use sedona_schema::datatypes::{Edges, SedonaType, WKB_GEOMETRY};
     use sedona_testing::create::create_scalar;
@@ -675,21 +676,24 @@ mod test {
         assert_eq!(total_size, 244);
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn pruning_geoparquet_metadata() {
+    async fn pruning_geoparquet_metadata(#[values("st_intersects", "st_within")] udf_name: &str) {
         let data_dir = geoarrow_data_dir().unwrap();
         let ctx = setup_context();
 
         let udf: ScalarUDF = SimpleScalarUDF::new_with_signature(
-            "st_intersects",
+            udf_name,
             Signature::any(2, Volatility::Immutable),
             DataType::Boolean,
             Arc::new(|_args| Ok(ScalarValue::Boolean(Some(true)).into())),
         )
         .into();
 
-        let definitely_non_intersecting_scalar =
-            create_scalar(Some("POINT (100 200)"), &WKB_GEOMETRY);
+        let definitely_non_intersecting_scalar = create_scalar(
+            Some("POLYGON ((100 200), (100 300), (200 300), (100 200))"),
+            &WKB_GEOMETRY,
+        );
         let storage_field = WKB_GEOMETRY.to_storage_field("", true).unwrap();
 
         let df = ctx
@@ -708,7 +712,10 @@ mod test {
         let batches_out = df.collect().await.unwrap();
         assert!(batches_out.is_empty());
 
-        let definitely_intersecting_scalar = create_scalar(Some("POINT (30 10)"), &WKB_GEOMETRY);
+        let definitely_intersecting_scalar = create_scalar(
+            Some("POLYGON ((30 10), (30 20), (40 20), (40 10), (30 10))"),
+            &WKB_GEOMETRY,
+        );
         let df = ctx
             .table(format!("{data_dir}/example/files/*_geo.parquet"))
             .await

--- a/rust/sedona-spatial-join/src/operand_evaluator.rs
+++ b/rust/sedona-spatial-join/src/operand_evaluator.rs
@@ -241,6 +241,7 @@ impl DistanceOperandEvaluator {
 
         // Expand the vec by distance
         let distance_columnar_value = self.inner.distance.evaluate(batch)?;
+        // No timezone conversion needed for distance; pass None as cast_options explicitly.
         let distance_columnar_value = distance_columnar_value.cast_to(&DataType::Float64, None)?;
         match &distance_columnar_value {
             ColumnarValue::Scalar(ScalarValue::Float64(Some(distance))) => {

--- a/rust/sedona-spatial-join/src/operand_evaluator.rs
+++ b/rust/sedona-spatial-join/src/operand_evaluator.rs
@@ -18,6 +18,7 @@ use core::fmt;
 use std::{mem::transmute, sync::Arc};
 
 use arrow_array::{Array, ArrayRef, Float64Array, RecordBatch};
+use arrow_schema::DataType;
 use datafusion_common::{
     utils::proxy::VecAllocExt, DataFusionError, JoinSide, Result, ScalarValue,
 };
@@ -240,6 +241,7 @@ impl DistanceOperandEvaluator {
 
         // Expand the vec by distance
         let distance_columnar_value = self.inner.distance.evaluate(batch)?;
+        let distance_columnar_value = distance_columnar_value.cast_to(&DataType::Float64, None)?;
         match &distance_columnar_value {
             ColumnarValue::Scalar(ScalarValue::Float64(Some(distance))) => {
                 result.rects.iter_mut().for_each(|(_, rect)| {


### PR DESCRIPTION
This patch pushes all spatial predicates when reading GeoParquet files, including distance predicate and all spatial relation operators such as `ST_Contains`, `ST_Within`, etc. To implement this, we have added the following methods to `BoundingBox`:

* `contains`: Check for bounding box containment
* `expand_by`: Expand the bounding box by the specified distance

The interval types also have corresponding functions implemented to work with 1-D plain and wrapping-around intervals.

Currently GeoParquet predicate pushdown only work with planar geometries correctly. This limitation already exists prior to developing this patch. I suggest that we submit another PR to disable spatial predicate pushdown for GeoParquet files containing spherical geography objects.