### PR TITLE
chore(python/sedonadb): Add geopandas extra

### DIFF
--- a/python/sedonadb/pyproject.toml
+++ b/python/sedonadb/pyproject.toml
@@ -39,6 +39,11 @@ test = [
     "pandas",
     "pytest",
 ]
+geopandas = [
+    "adbc-driver-manager[dbapi]",
+    "geoarrow-pyarrow",
+    "geopandas",
+]
 
 [tool.maturin]
 features = ["pyo3/extension-module"]


### PR DESCRIPTION
In Sedona Python we have it installing `sedonadb[geopandas]` but we haven't added the extra yet!

This extra installs a few extra packages to make sure everything required for geopandas interop is there. One could also call this "reccomended" but that's hard to remember how to spell (for me).

Can be run locally with:

```
pip install "python/sedonadb/[geopandas]"
```