### PR TITLE
feat(rust/sedona-geoparquet): Add GeoParquet writer for non-spatial output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4987,6 +4987,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tempfile",
  "tokio",
  "url",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4810,6 +4810,7 @@ dependencies = [
  "sedona-tg",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "url",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5167,6 +5167,7 @@ dependencies = [
  "async-trait",
  "datafusion",
  "datafusion-common",
+ "datafusion-expr",
  "datafusion-ffi",
  "futures",
  "libmimalloc-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ rstest = "0.24.0"
 serde = { version = "1" }
 serde_json = { version = "1" }
 serde_with = { version = "1" }
+tempfile = { version = "3"}
 thiserror = { version = "2" }
 tokio = { version = "1.44" }
 url = "2.5.4"

--- a/python/sedonadb/Cargo.toml
+++ b/python/sedonadb/Cargo.toml
@@ -36,6 +36,7 @@ arrow-array = { workspace = true }
 async-trait = { workspace = true }
 datafusion = { workspace = true }
 datafusion-common = { workspace = true }
+datafusion-expr = { workspace = true }
 datafusion-ffi = { workspace = true }
 futures = { workspace = true }
 pyo3 = { version = "0.25.1" }

--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -269,8 +269,8 @@ class DataFrame:
         self,
         path: Union[str, Path],
         *,
-        partition_by: Optional[Iterable[str]] = None,
-        sort_by: Optional[Iterable[str]] = None,
+        partition_by: Optional[Union[str, Iterable[str]]] = None,
+        sort_by: Optional[Union[str, Iterable[str]]] = None,
         single_file_output: Optional[bool] = None,
     ):
         path = Path(path)
@@ -278,12 +278,16 @@ class DataFrame:
         if single_file_output is None:
             single_file_output = partition_by is None and str(path).endswith(".parquet")
 
-        if partition_by is not None:
+        if isinstance(partition_by, str):
+            partition_by = [partition_by]
+        elif partition_by is not None:
             partition_by = list(partition_by)
         else:
             partition_by = []
 
-        if sort_by is not None:
+        if isinstance(sort_by, str):
+            sort_by = [sort_by]
+        elif sort_by is not None:
             sort_by = list(sort_by)
         else:
             sort_by = []

--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -14,7 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import TYPE_CHECKING, Union, Optional, Any
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Union, Optional, Any, Iterable
 
 from sedonadb._options import global_options
 
@@ -262,6 +264,33 @@ class DataFrame:
             return GeoDataFrame.from_arrow(table, geometry=geometry)
         else:
             return table.to_pandas()
+
+    def to_parquet(
+        self,
+        path: Union[str, Path],
+        *,
+        partition_by: Optional[Iterable[str]] = None,
+        sort_by: Optional[Iterable[str]] = None,
+        single_file_output: Optional[bool] = None,
+    ):
+        path = Path(path)
+
+        if single_file_output is None:
+            single_file_output = partition_by is None and str(path).endswith(".parquet")
+
+        if partition_by is not None:
+            partition_by = list(partition_by)
+        else:
+            partition_by = []
+
+        if sort_by is not None:
+            sort_by = list(sort_by)
+        else:
+            sort_by = []
+
+        self._impl.to_parquet(
+            self._ctx, str(path), partition_by, sort_by, single_file_output
+        )
 
     def show(
         self,

--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -273,6 +273,35 @@ class DataFrame:
         sort_by: Optional[Union[str, Iterable[str]]] = None,
         single_file_output: Optional[bool] = None,
     ):
+        """Write this DataFrame to one or more (Geo)Parquet files
+
+        For input that contains geometry columns, GeoParquet metadata is written
+        such that suitable readers can recreate Geometry/Geography types when
+        reading the output.
+
+
+        Args:
+            path: A filename or directory to which parquet file(s) should be written.
+            partition_by: A vector of column names to partition by. If non-empty,
+                applies hive-style partitioning to the output.
+            sort_by: A vector of column names to sort by. Currently only ascending
+                sort is supported.
+            single_file_output: Use True or False to force writing a single Parquet
+                file vs. writing one file per partition to a directory. By default,
+                a single file is written if `partition_by` is unspecified and
+                `path` ends with `.parquet`.
+
+        Examples:
+
+            >>> import sedonadb
+            >>> import tempfile
+            >>> con = sedonadb.connect()
+            >>> td = tempfile.TemporaryDirectory()
+            >>> url = "https://github.com/apache/sedona-testing/raw/refs/heads/main/data/parquet/geoparquet-1.1.0.parquet"
+            >>> con.read_parquet(url).to_parquet(f"{td.name}/tmp.parquet")
+
+        """
+
         path = Path(path)
 
         if single_file_output is None:

--- a/python/sedonadb/src/dataframe.rs
+++ b/python/sedonadb/src/dataframe.rs
@@ -22,12 +22,16 @@ use arrow_array::ffi_stream::FFI_ArrowArrayStream;
 use arrow_array::RecordBatchReader;
 use arrow_schema::Schema;
 use datafusion::catalog::MemTable;
+use datafusion::logical_expr::SortExpr;
 use datafusion::prelude::DataFrame;
+use datafusion_common::Column;
+use datafusion_expr::Expr;
 use datafusion_ffi::table_provider::FFI_TableProvider;
 use pyo3::prelude::*;
 use pyo3::types::PyCapsule;
-use sedona::context::SedonaDataFrame;
+use sedona::context::{SedonaDataFrame, SedonaWriteOptions};
 use sedona::show::{DisplayMode, DisplayTableOptions};
+use sedona_geoparquet::writer::TableGeoParquetOptions;
 use sedona_schema::schema::SedonaSchema;
 use tokio::runtime::Runtime;
 
@@ -117,6 +121,41 @@ impl InternalDataFrame {
             ctx.inner.ctx.read_table(Arc::new(provider))?,
             self.runtime.clone(),
         ))
+    }
+
+    fn to_parquet<'py>(
+        &self,
+        py: Python<'py>,
+        ctx: &InternalContext,
+        path: String,
+        partition_by: Vec<String>,
+        sort_by: Vec<String>,
+        single_file_output: bool,
+    ) -> Result<(), PySedonaError> {
+        // sort_by needs to be SortExpr. A Vec<String> can unambiguously be interpreted as
+        // field names (ascending), but other types of expressions aren't supported here yet.
+        let sort_by_expr = sort_by
+            .into_iter()
+            .map(|name| {
+                let column = Expr::Column(Column::new_unqualified(name));
+                SortExpr::new(column, true, false)
+            })
+            .collect::<Vec<_>>();
+
+        let options = SedonaWriteOptions::new()
+            .with_partition_by(partition_by)
+            .with_sort_by(sort_by_expr)
+            .with_single_file_output(single_file_output);
+        let writer_options = TableGeoParquetOptions::default();
+
+        wait_for_future(
+            py,
+            &self.runtime,
+            self.inner
+                .clone()
+                .write_geoparquet(&ctx.inner, &path, options, Some(writer_options)),
+        )??;
+        Ok(())
     }
 
     fn show<'py>(

--- a/python/sedonadb/src/dataframe.rs
+++ b/python/sedonadb/src/dataframe.rs
@@ -31,7 +31,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyCapsule;
 use sedona::context::{SedonaDataFrame, SedonaWriteOptions};
 use sedona::show::{DisplayMode, DisplayTableOptions};
-use sedona_geoparquet::writer::TableGeoParquetOptions;
+use sedona_geoparquet::options::TableGeoParquetOptions;
 use sedona_schema::schema::SedonaSchema;
 use tokio::runtime::Runtime;
 

--- a/rust/sedona-geoparquet/Cargo.toml
+++ b/rust/sedona-geoparquet/Cargo.toml
@@ -34,6 +34,8 @@ default = []
 sedona-testing = { path = "../sedona-testing" }
 url = { workspace = true }
 rstest = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }
 
 [dependencies]
 async-trait = { workspace = true }
@@ -59,4 +61,3 @@ sedona-schema = { path = "../sedona-schema" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
-tokio = { workspace = true }

--- a/rust/sedona-geoparquet/src/format.rs
+++ b/rust/sedona-geoparquet/src/format.rs
@@ -571,14 +571,11 @@ mod test {
             ["wkt", "geometry"]
         );
 
-        let sedona_types: Result<Vec<_>> = df
+        let sedona_types = df
             .schema()
-            .as_arrow()
-            .fields()
-            .iter()
-            .map(|f| SedonaType::from_storage_field(f))
-            .collect();
-        let sedona_types = sedona_types.unwrap();
+            .sedona_types()
+            .collect::<Result<Vec<_>>>()
+            .unwrap();
         assert_eq!(sedona_types.len(), 2);
         assert_eq!(sedona_types[0], SedonaType::Arrow(DataType::Utf8View));
         assert_eq!(
@@ -590,13 +587,11 @@ mod test {
         // the correct schema
         let batches = df.collect().await.unwrap();
         assert_eq!(batches.len(), 1);
-        let sedona_types: Result<Vec<_>> = batches[0]
+        let sedona_types = batches[0]
             .schema()
-            .fields()
-            .iter()
-            .map(|f| SedonaType::from_storage_field(f))
-            .collect();
-        let sedona_types = sedona_types.unwrap();
+            .sedona_types()
+            .collect::<Result<Vec<_>>>()
+            .unwrap();
         assert_eq!(sedona_types.len(), 2);
         assert_eq!(sedona_types[0], SedonaType::Arrow(DataType::Utf8View));
         assert_eq!(
@@ -644,14 +639,11 @@ mod test {
             .select(vec![col("wkt")])
             .unwrap();
 
-        let sedona_types: Result<Vec<_>> = df
+        let sedona_types = df
             .schema()
-            .as_arrow()
-            .fields()
-            .iter()
-            .map(|f| SedonaType::from_storage_field(f))
-            .collect();
-        let sedona_types = sedona_types.unwrap();
+            .sedona_types()
+            .collect::<Result<Vec<_>>>()
+            .unwrap();
         assert_eq!(sedona_types.len(), 1);
         assert_eq!(sedona_types[0], SedonaType::Arrow(DataType::Utf8View));
     }
@@ -665,14 +657,11 @@ mod test {
             .await
             .unwrap();
 
-        let sedona_types: Result<Vec<_>> = df
+        let sedona_types = df
             .schema()
-            .as_arrow()
-            .fields()
-            .iter()
-            .map(|f| SedonaType::from_storage_field(f))
-            .collect();
-        let sedona_types = sedona_types.unwrap();
+            .sedona_types()
+            .collect::<Result<Vec<_>>>()
+            .unwrap();
         assert_eq!(sedona_types.len(), 2);
         assert_eq!(sedona_types[0], SedonaType::Arrow(DataType::Utf8View));
         assert_eq!(

--- a/rust/sedona-geoparquet/src/format.rs
+++ b/rust/sedona-geoparquet/src/format.rs
@@ -94,9 +94,9 @@ impl FileFormatFactory for GeoParquetFormatFactory {
         options_mut.geoparquet_version =
             if let Some(version_string) = format_options_mut.remove("geoparquet_version") {
                 match version_string.as_str() {
-                    "1.0.0" => GeoParquetVersion::V1_0,
-                    "1.1.0" => GeoParquetVersion::V1_1,
-                    "2.0.0" => GeoParquetVersion::V2_0,
+                    "1.0" => GeoParquetVersion::V1_0,
+                    "1.1" => GeoParquetVersion::V1_1,
+                    "2.0" => GeoParquetVersion::V2_0,
                     _ => GeoParquetVersion::default(),
                 }
             } else {

--- a/rust/sedona-geoparquet/src/format.rs
+++ b/rust/sedona-geoparquet/src/format.rs
@@ -105,10 +105,10 @@ impl FileFormatFactory for GeoParquetFormatFactory {
                     "1.0.0" => GeoParquetVersion::V1_0,
                     "1.1.0" => GeoParquetVersion::V1_1,
                     "2.0.0" => GeoParquetVersion::V2_0,
-                    _ => GeoParquetVersion::Auto,
+                    _ => GeoParquetVersion::default(),
                 }
             } else {
-                GeoParquetVersion::Auto
+                GeoParquetVersion::default()
             };
 
         let inner_format = self.inner.create(state, &format_options_mut)?;

--- a/rust/sedona-geoparquet/src/lib.rs
+++ b/rust/sedona-geoparquet/src/lib.rs
@@ -17,5 +17,5 @@
 mod file_opener;
 pub mod format;
 mod metadata;
+pub mod options;
 pub mod provider;
-pub mod writer;

--- a/rust/sedona-geoparquet/src/lib.rs
+++ b/rust/sedona-geoparquet/src/lib.rs
@@ -18,3 +18,4 @@ mod file_opener;
 pub mod format;
 mod metadata;
 pub mod provider;
+pub mod writer;

--- a/rust/sedona-geoparquet/src/lib.rs
+++ b/rust/sedona-geoparquet/src/lib.rs
@@ -19,3 +19,4 @@ pub mod format;
 mod metadata;
 pub mod options;
 pub mod provider;
+mod writer;

--- a/rust/sedona-geoparquet/src/metadata.rs
+++ b/rust/sedona-geoparquet/src/metadata.rs
@@ -63,6 +63,12 @@ pub enum GeoParquetColumnEncoding {
     MultiPolygon,
 }
 
+impl Default for GeoParquetColumnEncoding {
+    fn default() -> Self {
+        Self::WKB
+    }
+}
+
 impl Display for GeoParquetColumnEncoding {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use GeoParquetColumnEncoding::*;
@@ -276,8 +282,18 @@ pub struct GeoParquetMetadata {
     pub columns: HashMap<String, GeoParquetColumnMetadata>,
 }
 
+impl Default for GeoParquetMetadata {
+    fn default() -> Self {
+        Self {
+            version: "1.0.0".to_string(),
+            primary_column: Default::default(),
+            columns: Default::default(),
+        }
+    }
+}
+
 /// GeoParquet column metadata
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct GeoParquetColumnMetadata {
     /// Name of the geometry encoding format. As of GeoParquet 1.1, `"WKB"`, `"point"`,
     /// `"linestring"`, `"polygon"`, `"multipoint"`, `"multilinestring"`, and `"multipolygon"` are

--- a/rust/sedona-geoparquet/src/options.rs
+++ b/rust/sedona-geoparquet/src/options.rs
@@ -1,0 +1,32 @@
+use datafusion::config::TableParquetOptions;
+
+/// [TableParquetOptions] wrapper with GeoParquet-specific options
+#[derive(Debug, Default, Clone)]
+pub struct TableGeoParquetOptions {
+    pub inner: TableParquetOptions,
+    pub geoparquet_version: GeoParquetVersion,
+}
+
+impl From<TableParquetOptions> for TableGeoParquetOptions {
+    fn from(value: TableParquetOptions) -> Self {
+        Self {
+            inner: value,
+            geoparquet_version: GeoParquetVersion::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum GeoParquetVersion {
+    Auto,
+    V1_0,
+    V1_1,
+    V2_0,
+    Omitted,
+}
+
+impl Default for GeoParquetVersion {
+    fn default() -> Self {
+        Self::Auto
+    }
+}

--- a/rust/sedona-geoparquet/src/options.rs
+++ b/rust/sedona-geoparquet/src/options.rs
@@ -18,16 +18,13 @@ impl From<TableParquetOptions> for TableGeoParquetOptions {
     }
 }
 
-/// The GeoParquet Version to use
+/// The GeoParquet Version to write for output with spatial columns
 #[derive(Debug, Clone, Copy)]
 pub enum GeoParquetVersion {
-    /// Automatically determine which GeoParquet version to use on write
-    ///
-    /// The heurisitc is currently to include GeoParquet 1.0 if a table contains
-    /// a spatial type, or Omitted otherwise.
-    Auto,
-
     /// Write GeoParquet 1.0 metadata
+    ///
+    /// GeoParquet 1.0 has the widest support among readers and writers; however
+    /// it does not include row-group level statistics.
     V1_0,
 
     /// Write GeoParquet 1.1 metadata and optional bounding box column
@@ -56,6 +53,6 @@ pub enum GeoParquetVersion {
 
 impl Default for GeoParquetVersion {
     fn default() -> Self {
-        Self::Auto
+        Self::V1_0
     }
 }

--- a/rust/sedona-geoparquet/src/options.rs
+++ b/rust/sedona-geoparquet/src/options.rs
@@ -3,7 +3,9 @@ use datafusion::config::TableParquetOptions;
 /// [TableParquetOptions] wrapper with GeoParquet-specific options
 #[derive(Debug, Default, Clone)]
 pub struct TableGeoParquetOptions {
+    /// Inner [TableParquetOptions]
     pub inner: TableParquetOptions,
+    /// [GeoParquetVersion] to use when writing GeoParquet files
     pub geoparquet_version: GeoParquetVersion,
 }
 
@@ -16,12 +18,39 @@ impl From<TableParquetOptions> for TableGeoParquetOptions {
     }
 }
 
+/// The GeoParquet Version to use
 #[derive(Debug, Clone, Copy)]
 pub enum GeoParquetVersion {
+    /// Automatically determine which GeoParquet version to use on write
+    ///
+    /// The heurisitc is currently to include GeoParquet 1.0 if a table contains
+    /// a spatial type, or Omitted otherwise.
     Auto,
+
+    /// Write GeoParquet 1.0 metadata
     V1_0,
+
+    /// Write GeoParquet 1.1 metadata and optional bounding box column
+    ///
+    /// A bbox column will be included for any column where the Parquet options would
+    /// have otherwise written statistics (which it will by default).
+    /// This option may be more computationally expensive; however, will result in
+    /// row-group level statistics that some readers (e.g., SedonaDB) can use to prune
+    /// row groups on read.
     V1_1,
+
+    /// Write GeoParquet 2.0
+    ///
+    /// The GeoParquet 2.0 options is identical to GeoParquet 1.0 except the underlying storage
+    /// of spatial columns is Parquet native geometry, where the Parquet writer will include
+    /// native statistics according to the underlying Parquet options. Some readers
+    /// (e.g., SedonaDB) can use these statistics to prune row groups on read.
     V2_0,
+
+    /// Do not write GeoParquet metadata
+    ///
+    /// This option suppresses GeoParquet metadata; however, spatial types will be written as
+    /// Parquet native Geometry/Geography when this is supported by the underlying writer.
     Omitted,
 }
 

--- a/rust/sedona-geoparquet/src/provider.rs
+++ b/rust/sedona-geoparquet/src/provider.rs
@@ -173,7 +173,8 @@ impl ReadOptions<'_> for GeoParquetReadOptions<'_> {
 
         let mut options = self.inner.to_listing_options(config, table_options);
         if let Some(parquet_format) = options.format.as_any().downcast_ref::<ParquetFormat>() {
-            options.format = Arc::new(GeoParquetFormat::new(parquet_format));
+            let geoparquet_options = parquet_format.options().clone().into();
+            options.format = Arc::new(GeoParquetFormat::new(geoparquet_options));
             return options;
         }
 

--- a/rust/sedona-geoparquet/src/writer.rs
+++ b/rust/sedona-geoparquet/src/writer.rs
@@ -1,5 +1,6 @@
 use datafusion::config::TableParquetOptions;
 
+#[derive(Debug, Default)]
 pub struct TableGeoParquetOptions {
     pub inner: TableParquetOptions,
 }

--- a/rust/sedona-geoparquet/src/writer.rs
+++ b/rust/sedona-geoparquet/src/writer.rs
@@ -1,0 +1,135 @@
+use std::sync::Arc;
+
+use datafusion::{
+    config::TableParquetOptions,
+    datasource::{
+        file_format::parquet::ParquetSink, physical_plan::FileSinkConfig, sink::DataSinkExec,
+    },
+};
+use datafusion_common::{exec_datafusion_err, exec_err, not_impl_err, Result};
+use datafusion_expr::dml::InsertOp;
+use datafusion_physical_expr::LexRequirement;
+use datafusion_physical_plan::ExecutionPlan;
+use sedona_common::sedona_internal_err;
+use sedona_schema::{
+    crs::lnglat,
+    datatypes::{Edges, SedonaType},
+    schema::SedonaSchema,
+};
+
+use crate::{
+    metadata::{GeoParquetColumnMetadata, GeoParquetMetadata},
+    options::{GeoParquetVersion, TableGeoParquetOptions},
+};
+
+pub fn create_geoparquet_writer_physical_plan(
+    input: Arc<dyn ExecutionPlan>,
+    conf: FileSinkConfig,
+    order_requirements: Option<LexRequirement>,
+    options: &TableGeoParquetOptions,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    if conf.insert_op != InsertOp::Append {
+        return not_impl_err!("Overwrites are not implemented yet for Parquet");
+    }
+
+    // If there is no geometry, just use the inner implementation
+    let output_geometry_column_indices = conf.output_schema().geometry_column_indices()?;
+    if output_geometry_column_indices.is_empty() {
+        return create_inner_writer(input, conf, order_requirements, options.inner.clone());
+    }
+
+    // We have geometry and/or geography! Collect the GeoParquetMetadata we'll need to write
+    let mut metadata = GeoParquetMetadata::default();
+
+    // Check the version
+    match options.geoparquet_version {
+        GeoParquetVersion::V1_0 => {
+            metadata.version = "1.0.0".to_string();
+        }
+        _ => {
+            return not_impl_err!(
+                "GeoParquetVersion {:?} is not yet supported",
+                options.geoparquet_version
+            );
+        }
+    };
+
+    let field_names = conf
+        .output_schema()
+        .fields()
+        .iter()
+        .map(|f| f.name())
+        .collect::<Vec<_>>();
+
+    // Apply primary column
+    if let Some(output_geometry_primary) = conf.output_schema().primary_geometry_column_index()? {
+        metadata.primary_column = field_names[output_geometry_primary].clone();
+    }
+
+    // Apply all columns
+    for i in output_geometry_column_indices {
+        let f = conf.output_schema().field(i);
+        let sedona_type = SedonaType::from_storage_field(f)?;
+        let mut column_metadata = GeoParquetColumnMetadata::default();
+
+        let (edge_type, crs) = match sedona_type {
+            SedonaType::Wkb(edge_type, crs) | SedonaType::WkbView(edge_type, crs) => {
+                (edge_type, crs)
+            }
+            _ => return sedona_internal_err!("Unexpected type: {sedona_type}"),
+        };
+
+        // Assign edge type if needed
+        match edge_type {
+            Edges::Planar => {}
+            Edges::Spherical => {
+                column_metadata.edges = Some("spherical".to_string());
+            }
+        }
+
+        // Assign crs
+        if crs == lnglat() {
+            // Do nothing, lnglat is the meaning of an omitted CRS
+        } else if let Some(crs) = crs {
+            column_metadata.crs = Some(crs.to_json().parse().map_err(|e| {
+                exec_datafusion_err!("Failed to parse CRS for column '{}'{e}", f.name())
+            })?);
+        } else {
+            return exec_err!(
+                "Can't write GeoParquet from null CRS\nUse ST_SetSRID({}, ...) to assign it one",
+                f.name()
+            );
+        }
+
+        // Add to metadata
+        metadata
+            .columns
+            .insert(f.name().to_string(), column_metadata);
+    }
+
+    // Apply to the Parquet options
+    let mut parquet_options = options.inner.clone();
+    parquet_options.key_value_metadata.insert(
+        "geo".to_string(),
+        Some(
+            serde_json::to_string(&metadata).map_err(|e| {
+                exec_datafusion_err!("Failed to serialize GeoParquet metadata: {e}")
+            })?,
+        ),
+    );
+
+    // Create the sink
+    let sink = Arc::new(ParquetSink::new(conf, parquet_options));
+    Ok(Arc::new(DataSinkExec::new(input, sink, order_requirements)) as _)
+}
+
+fn create_inner_writer(
+    input: Arc<dyn ExecutionPlan>,
+    conf: FileSinkConfig,
+    order_requirements: Option<LexRequirement>,
+    options: TableParquetOptions,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    // Create the sink
+    let sink = Arc::new(ParquetSink::new(conf, options));
+    Ok(Arc::new(DataSinkExec::new(input, sink, order_requirements)) as _)
+}

--- a/rust/sedona-geoparquet/src/writer.rs
+++ b/rust/sedona-geoparquet/src/writer.rs
@@ -1,0 +1,46 @@
+
+pub async fn write_parquet(
+        self,
+        path: &str,
+        options: DataFrameWriteOptions,
+        writer_options: Option<TableParquetOptions>,
+    ) -> Result<Vec<RecordBatch>, DataFusionError> {
+        if options.insert_op != InsertOp::Append {
+            return not_impl_err!(
+                "{} is not implemented for DataFrame::write_parquet.",
+                options.insert_op
+            );
+        }
+
+        let format = if let Some(parquet_opts) = writer_options {
+            Arc::new(ParquetFormatFactory::new_with_options(parquet_opts))
+        } else {
+            Arc::new(ParquetFormatFactory::new())
+        };
+
+        let file_type = format_as_file_type(format);
+
+        let plan = if options.sort_by.is_empty() {
+            self.plan
+        } else {
+            LogicalPlanBuilder::from(self.plan)
+                .sort(options.sort_by)?
+                .build()?
+        };
+
+        let plan = LogicalPlanBuilder::copy_to(
+            plan,
+            path.into(),
+            file_type,
+            Default::default(),
+            options.partition_by,
+        )?
+        .build()?;
+        DataFrame {
+            session_state: self.session_state,
+            plan,
+            projection_requires_validation: self.projection_requires_validation,
+        }
+        .collect()
+        .await
+    }

--- a/rust/sedona-geoparquet/src/writer.rs
+++ b/rust/sedona-geoparquet/src/writer.rs
@@ -1,46 +1,5 @@
+use datafusion::config::TableParquetOptions;
 
-pub async fn write_parquet(
-        self,
-        path: &str,
-        options: DataFrameWriteOptions,
-        writer_options: Option<TableParquetOptions>,
-    ) -> Result<Vec<RecordBatch>, DataFusionError> {
-        if options.insert_op != InsertOp::Append {
-            return not_impl_err!(
-                "{} is not implemented for DataFrame::write_parquet.",
-                options.insert_op
-            );
-        }
-
-        let format = if let Some(parquet_opts) = writer_options {
-            Arc::new(ParquetFormatFactory::new_with_options(parquet_opts))
-        } else {
-            Arc::new(ParquetFormatFactory::new())
-        };
-
-        let file_type = format_as_file_type(format);
-
-        let plan = if options.sort_by.is_empty() {
-            self.plan
-        } else {
-            LogicalPlanBuilder::from(self.plan)
-                .sort(options.sort_by)?
-                .build()?
-        };
-
-        let plan = LogicalPlanBuilder::copy_to(
-            plan,
-            path.into(),
-            file_type,
-            Default::default(),
-            options.partition_by,
-        )?
-        .build()?;
-        DataFrame {
-            session_state: self.session_state,
-            plan,
-            projection_requires_validation: self.projection_requires_validation,
-        }
-        .collect()
-        .await
-    }
+pub struct TableGeoParquetOptions {
+    pub inner: TableParquetOptions,
+}

--- a/rust/sedona-geoparquet/src/writer.rs
+++ b/rust/sedona-geoparquet/src/writer.rs
@@ -92,7 +92,7 @@ pub fn create_geoparquet_writer_physical_plan(
             // Do nothing, lnglat is the meaning of an omitted CRS
         } else if let Some(crs) = crs {
             column_metadata.crs = Some(crs.to_json().parse().map_err(|e| {
-                exec_datafusion_err!("Failed to parse CRS for column '{}'{e}", f.name())
+                exec_datafusion_err!("Failed to parse CRS for column '{}' {e}", f.name())
             })?);
         } else {
             return exec_err!(

--- a/rust/sedona-geoparquet/src/writer.rs
+++ b/rust/sedona-geoparquet/src/writer.rs
@@ -1,6 +1,0 @@
-use datafusion::config::TableParquetOptions;
-
-#[derive(Debug, Default)]
-pub struct TableGeoParquetOptions {
-    pub inner: TableParquetOptions,
-}

--- a/rust/sedona-geoparquet/src/writer.rs
+++ b/rust/sedona-geoparquet/src/writer.rs
@@ -217,7 +217,7 @@ mod test {
         let example = test_geoparquet("example", "geometry").unwrap();
         let ctx = setup_context();
 
-        // Completely deselect all geometry columns
+        // Deselect all geometry columns
         let df = ctx
             .table(&example)
             .await

--- a/rust/sedona/Cargo.toml
+++ b/rust/sedona/Cargo.toml
@@ -40,6 +40,7 @@ spatial-join = ["dep:sedona-spatial-join"]
 s2geography = ["dep:sedona-s2geography"]
 
 [dev-dependencies]
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 rstest = { workspace = true }
 

--- a/rust/sedona/src/context.rs
+++ b/rust/sedona/src/context.rs
@@ -454,6 +454,7 @@ mod tests {
         datatypes::{Edges, SedonaType},
     };
     use sedona_testing::data::test_geoparquet;
+    use tempfile::tempdir;
 
     use super::*;
 
@@ -502,6 +503,23 @@ mod tests {
                 "+-----+"
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn write_geoparquet() {
+        let tmpdir = tempdir().unwrap();
+        let tmp_parquet = tmpdir.path().join("tmp.parquet");
+        let ctx = SedonaContext::new();
+        ctx.sql("SELECT 1 as one")
+            .await
+            .unwrap()
+            .write_parquet(
+                &tmp_parquet.to_string_lossy(),
+                DataFrameWriteOptions::default(),
+                None,
+            )
+            .await
+            .unwrap();
     }
 
     #[tokio::test]

--- a/rust/sedona/src/context.rs
+++ b/rust/sedona/src/context.rs
@@ -22,7 +22,10 @@ use crate::{
     random_geometry_provider::RandomGeometryFunction,
     show::{show_batches, DisplayTableOptions},
 };
+use arrow_array::RecordBatch;
 use async_trait::async_trait;
+use datafusion::dataframe::DataFrameWriteOptions;
+use datafusion::datasource::file_format::format_as_file_type;
 use datafusion::{
     common::{plan_datafusion_err, plan_err},
     error::{DataFusionError, Result},
@@ -30,11 +33,15 @@ use datafusion::{
     prelude::{DataFrame, SessionConfig, SessionContext},
     sql::parser::{DFParser, Statement},
 };
+use datafusion_common::not_impl_err;
+use datafusion_expr::dml::InsertOp;
 use datafusion_expr::sqlparser::dialect::{dialect_from_str, Dialect};
+use datafusion_expr::{LogicalPlanBuilder, SortExpr};
 use parking_lot::Mutex;
 use sedona_common::option::add_sedona_option_extension;
 use sedona_expr::aggregate_udf::SedonaAccumulatorRef;
 use sedona_expr::{function_set::FunctionSet, scalar_udf::ScalarKernelRef};
+use sedona_geoparquet::writer::TableGeoParquetOptions;
 use sedona_geoparquet::{
     format::GeoParquetFormatFactory,
     provider::{geoparquet_listing_table, GeoParquetReadOptions},
@@ -269,6 +276,14 @@ pub trait SedonaDataFrame {
         limit: Option<usize>,
         options: DisplayTableOptions<'a>,
     ) -> Result<String>;
+
+    async fn write_geoparquet(
+        self,
+        ctx: &SedonaContext,
+        path: &str,
+        options: SedonaWriteOptions,
+        writer_options: Option<TableGeoParquetOptions>,
+    ) -> Result<Vec<RecordBatch>>;
 }
 
 #[async_trait]
@@ -286,6 +301,118 @@ impl SedonaDataFrame for DataFrame {
         let mut out = Vec::new();
         show_batches(ctx, &mut out, schema, batches, options)?;
         String::from_utf8(out).map_err(|e| DataFusionError::External(Box::new(e)))
+    }
+
+    async fn write_geoparquet(
+        self,
+        ctx: &SedonaContext,
+        path: &str,
+        options: SedonaWriteOptions,
+        writer_options: Option<TableGeoParquetOptions>,
+    ) -> Result<Vec<RecordBatch>, DataFusionError> {
+        if options.insert_op != InsertOp::Append {
+            return not_impl_err!(
+                "{} is not implemented for DataFrame::write_geoparquet.",
+                options.insert_op
+            );
+        }
+
+        let format = if let Some(parquet_opts) = writer_options {
+            Arc::new(GeoParquetFormatFactory::new_with_options(
+                parquet_opts.inner,
+            ))
+        } else {
+            Arc::new(GeoParquetFormatFactory::new())
+        };
+
+        let file_type = format_as_file_type(format);
+
+        let plan = if options.sort_by.is_empty() {
+            self.into_unoptimized_plan()
+        } else {
+            LogicalPlanBuilder::from(self.into_unoptimized_plan())
+                .sort(options.sort_by)?
+                .build()?
+        };
+
+        let plan = LogicalPlanBuilder::copy_to(
+            plan,
+            path.into(),
+            file_type,
+            Default::default(),
+            options.partition_by,
+        )?
+        .build()?;
+
+        DataFrame::new(ctx.ctx.state(), plan).collect().await
+    }
+}
+
+/// A Sedona-specific copy of [DataFrameWriteOptions] with public fields
+pub struct SedonaWriteOptions {
+    /// Controls how new data should be written to the table, determining whether
+    /// to append, overwrite, or replace existing data.
+    pub insert_op: InsertOp,
+    /// Controls if all partitions should be coalesced into a single output file
+    /// Generally will have slower performance when set to true.
+    pub single_file_output: bool,
+    /// Sets which columns should be used for hive-style partitioned writes by name.
+    /// Can be set to empty vec![] for non-partitioned writes.
+    pub partition_by: Vec<String>,
+    /// Sets which columns should be used for sorting the output by name.
+    /// Can be set to empty vec![] for non-sorted writes.
+    pub sort_by: Vec<SortExpr>,
+}
+
+impl From<SedonaWriteOptions> for DataFrameWriteOptions {
+    fn from(value: SedonaWriteOptions) -> Self {
+        DataFrameWriteOptions::new()
+            .with_insert_operation(value.insert_op)
+            .with_single_file_output(value.single_file_output)
+            .with_partition_by(value.partition_by)
+            .with_sort_by(value.sort_by)
+    }
+}
+
+impl SedonaWriteOptions {
+    /// Create a new SedonaWriteOptions with default values
+    pub fn new() -> Self {
+        SedonaWriteOptions {
+            insert_op: InsertOp::Append,
+            single_file_output: false,
+            partition_by: vec![],
+            sort_by: vec![],
+        }
+    }
+
+    /// Set the insert operation
+    pub fn with_insert_operation(mut self, insert_op: InsertOp) -> Self {
+        self.insert_op = insert_op;
+        self
+    }
+
+    /// Set the single_file_output value to true or false
+    pub fn with_single_file_output(mut self, single_file_output: bool) -> Self {
+        self.single_file_output = single_file_output;
+        self
+    }
+
+    /// Sets the partition_by columns for output partitioning
+    pub fn with_partition_by(mut self, partition_by: Vec<String>) -> Self {
+        self.partition_by = partition_by;
+        self
+    }
+
+    /// Sets the sort_by columns for output sorting
+    pub fn with_sort_by(mut self, sort_by: Vec<SortExpr>) -> Self {
+        self.sort_by = sort_by;
+        self
+    }
+}
+
+impl Default for SedonaWriteOptions {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/rust/sedona/src/context.rs
+++ b/rust/sedona/src/context.rs
@@ -41,7 +41,7 @@ use parking_lot::Mutex;
 use sedona_common::option::add_sedona_option_extension;
 use sedona_expr::aggregate_udf::SedonaAccumulatorRef;
 use sedona_expr::{function_set::FunctionSet, scalar_udf::ScalarKernelRef};
-use sedona_geoparquet::writer::TableGeoParquetOptions;
+use sedona_geoparquet::options::TableGeoParquetOptions;
 use sedona_geoparquet::{
     format::GeoParquetFormatFactory,
     provider::{geoparquet_listing_table, GeoParquetReadOptions},
@@ -318,9 +318,7 @@ impl SedonaDataFrame for DataFrame {
         }
 
         let format = if let Some(parquet_opts) = writer_options {
-            Arc::new(GeoParquetFormatFactory::new_with_options(
-                parquet_opts.inner,
-            ))
+            Arc::new(GeoParquetFormatFactory::new_with_options(parquet_opts))
         } else {
             Arc::new(GeoParquetFormatFactory::new())
         };

--- a/rust/sedona/src/context.rs
+++ b/rust/sedona/src/context.rs
@@ -348,7 +348,11 @@ impl SedonaDataFrame for DataFrame {
     }
 }
 
-/// A Sedona-specific copy of [DataFrameWriteOptions] with public fields
+/// A Sedona-specific copy of [DataFrameWriteOptions]
+///
+/// This is needed because [DataFrameWriteOptions] has private fields, so we
+/// can't use it in our interfaces. This object can be converted to a
+/// [DataFrameWriteOptions] using `.into()`.
 pub struct SedonaWriteOptions {
     /// Controls how new data should be written to the table, determining whether
     /// to append, overwrite, or replace existing data.


### PR DESCRIPTION
This PR adds a writer for Parquet that writes GeoParquet metadata for output with spatial columns. Currently this doesn't write a bbox because that requires something a bit more sophisticated than just popping some metadata into the Parquet write options.

```python
import sedonadb

sd = sedonadb.connect()

sd.sql("SELECT ST_SetSRID(ST_GeomFromText('POINT (0 1)'), 4326) as geometry").to_parquet("foofy.parquet")
sd.read_parquet("foofy.parquet").show()
#> ┌────────────┐
#> │  geometry  │
#> │  geometry  │
#> ╞════════════╡
#> │ POINT(0 1) │
#> └────────────┘
```