### PR TITLE
chore: Add `.asf.yaml` to asf-site branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+github:
+  enabled_merge_buttons:
+    merge: false
+    rebase: false
+    squash: true
+  features:
+    issues: true
+
+notifications:
+  commits: commits@sedona.apache.org
+  issues_status: issues@sedona.apache.org
+  issues_comment: issues@sedona.apache.org
+  discussions: issues@sedona.apache.org
+  pullrequests_status: issues@sedona.apache.org
+  pullrequests_comment: issues@sedona.apache.org
+
+publish:
+  whoami: asf-site
+  subdir: sedonadb


### PR DESCRIPTION
(Note: PR into `asf-site` not `main`!)

This should start rendering it to https://sedona.apache.org/sedonadb .

We don't have anything in the root of that directory right now, but it will let us look at our dev documentation at https://sedona.apache.org/sedonadb/dev-snapshot-main so that it's easier to refine as we finalize it.