### PR TITLE
[#61] Accept SRIDs as args to ST_Transform 

### DIFF
--- a/c/sedona-proj/src/st_transform.rs
+++ b/c/sedona-proj/src/st_transform.rs
@@ -158,21 +158,19 @@ impl SedonaScalarKernel for STTransform {
         scalar_args: &[Option<&ScalarValue>],
     ) -> Result<Option<SedonaType>> {
         let matcher = ArgMatcher::new(
-           vec![
+            vec![
                 ArgMatcher::is_geometry_or_geography(),
-                ArgMatcher::or(vec![
-                    ArgMatcher::is_numeric(),
-                    ArgMatcher::is_string()
-                ]),
+                ArgMatcher::or(vec![ArgMatcher::is_numeric(), ArgMatcher::is_string()]),
                 ArgMatcher::optional(ArgMatcher::or(vec![
                     ArgMatcher::is_numeric(),
-                    ArgMatcher::is_string()
+                    ArgMatcher::is_string(),
                 ])),
                 ArgMatcher::optional(ArgMatcher::is_boolean()),
-            ], SedonaType::Wkb(Edges::Planar, None)
+            ],
+            SedonaType::Wkb(Edges::Planar, None),
         );
 
-        if !matcher.match_args(arg_types) {
+        if !matcher.matches(arg_types) {
             return Ok(None);
         }
 
@@ -216,7 +214,7 @@ impl SedonaScalarKernel for STTransform {
         let mut indexes = TransformArgIndexes::new();
         define_arg_indexes(arg_types, &mut indexes);
 
-        let first_crs = get_crs_str(args, indexes.first_crs).ok_or_else(|| {;
+        let first_crs = get_crs_str(args, indexes.first_crs).ok_or_else(|| {
             DataFusionError::Execution(
                 "First CRS argument must be a string or numeric scalar".to_string(),
             )


### PR DESCRIPTION
Currently, `ST_Transform` is only accepting utf8 args. 
This change allows for SRIDs to be passed in as ints.  It also adds some better argument checks.

Issue: #61

I tried going through a `CRS` and passing the `to_json()` output as the CRS args to the transform, but proj was failing to parse the json.  I'll need to figure that out separately, but accepting the SRID seemed like a P0 issue, so fixing that first.


## Testing

Unit tests and manual tests.

## Examples

```
> SELECT ST_Transform(ST_SetSrid(ST_GeomFromText('POINT (1 1)'), 4326), 3857) as geom;
┌─────────────────────────────────────────────┐
│                     geom                    │
│                   geometry                  │
╞═════════════════════════════════════════════╡
│ POINT(111319.49079327357 111325.1428663851) │
└─────────────────────────────────────────────┘

> SELECT ST_Transform(ST_SetSrid(ST_GeomFromText('POINT (1 1)'), 4326), 'EPSG:3857') as geom;
┌─────────────────────────────────────────────┐
│                     geom                    │
│                   geometry                  │
╞═════════════════════════════════════════════╡
│ POINT(111319.49079327357 111325.1428663851) │
└─────────────────────────────────────────────┘

```