### PR TITLE
Fix pytest hanging when test fails by closing PostgreSQL connection using `with` statement

### DIFF
--- a/python/sedonadb/python/sedonadb/testing.py
+++ b/python/sedonadb/python/sedonadb/testing.py
@@ -63,6 +63,17 @@ class DBEngine:
     of that name.
     """
 
+    def close(self):
+        """Close the connection - base implementation does nothing"""
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
+
     @classmethod
     def name(cls) -> str:
         """This engine's name
@@ -398,6 +409,11 @@ class PostGIS(DBEngine):
         if uri is None:
             uri = "postgresql://localhost:5432/postgres?user=postgres&password=password"
         self.con = adbc_driver_postgresql.dbapi.connect(uri)
+
+    def close(self):
+        """Close the connection"""
+        if self.con:
+            self.con.close()
 
     @classmethod
     def name(cls):

--- a/python/sedonadb/tests/test_knnjoin.py
+++ b/python/sedonadb/tests/test_knnjoin.py
@@ -23,322 +23,295 @@ from sedonadb.testing import PostGIS, SedonaDB
 @pytest.mark.parametrize("k", [1, 3, 5])
 def test_knn_join_basic(k):
     """Test basic KNN join functionality with synthetic data"""
-    eng_sedonadb = SedonaDB.create_or_skip()
-    eng_postgis = PostGIS.create_or_skip()
-
-    # Create query points (probe side)
-    point_options = json.dumps(
-        {
-            "geom_type": "Point",
-            "target_rows": 20,
-            "seed": 42,
-        }
-    )
-    df_points = eng_sedonadb.execute_and_collect(
-        f"SELECT * FROM sd_random_geometry('{point_options}') LIMIT 20"
-    )
-
-    # Create target points (build side)
-    target_options = json.dumps(
-        {
-            "geom_type": "Point",
-            "target_rows": 50,
-            "seed": 43,
-        }
-    )
-    df_targets = eng_sedonadb.execute_and_collect(
-        f"SELECT * FROM sd_random_geometry('{target_options}') LIMIT 50"
-    )
-
-    # Set up tables in both engines
-    eng_sedonadb.create_table_arrow("knn_query_points", df_points)
-    eng_sedonadb.create_table_arrow("knn_target_points", df_targets)
-    eng_postgis.create_table_arrow("knn_query_points", df_points)
-    eng_postgis.create_table_arrow("knn_target_points", df_targets)
-
-    # SedonaDB syntax using ST_KNN
-    sedonadb_sql = f"""
-        SELECT
-            q.id as query_id,
-            t.id as target_id,
-            ST_Distance(q.geometry, t.geometry) as distance
-        FROM knn_query_points q
-        JOIN knn_target_points t ON ST_KNN(q.geometry, t.geometry, {k}, FALSE)
-        ORDER BY query_id, distance
-    """
-
-    sedonadb_results = eng_sedonadb.execute_and_collect(sedonadb_sql).to_pandas()
-
-    # Verify basic correctness
-    assert len(sedonadb_results) > 0
-    assert (
-        len(sedonadb_results) == len(df_points) * k
-    )  # Each query point should have k neighbors
-
-    # Verify results are ordered by distance within each query point
-    for query_id in sedonadb_results["query_id"].unique():
-        query_results = sedonadb_results[sedonadb_results["query_id"] == query_id]
-        distances = query_results["distance"].tolist()
-        assert distances == sorted(distances), (
-            f"Distances not sorted for query_id {query_id}: {distances}"
+    with (
+        SedonaDB.create_or_skip() as eng_sedonadb,
+        PostGIS.create_or_skip() as eng_postgis,
+    ):
+        # Create query points (probe side)
+        point_options = json.dumps(
+            {
+                "geom_type": "Point",
+                "target_rows": 20,
+                "seed": 42,
+            }
+        )
+        df_points = eng_sedonadb.execute_and_collect(
+            f"SELECT * FROM sd_random_geometry('{point_options}') LIMIT 20"
         )
 
-    # PostGIS syntax using distance operator and window functions for KNN
-    postgis_sql = f"""
-        WITH ranked_neighbors AS (
+        # Create target points (build side)
+        target_options = json.dumps(
+            {
+                "geom_type": "Point",
+                "target_rows": 50,
+                "seed": 43,
+            }
+        )
+        df_targets = eng_sedonadb.execute_and_collect(
+            f"SELECT * FROM sd_random_geometry('{target_options}') LIMIT 50"
+        )
+
+        # Set up tables in both engines
+        eng_sedonadb.create_table_arrow("knn_query_points", df_points)
+        eng_sedonadb.create_table_arrow("knn_target_points", df_targets)
+        eng_postgis.create_table_arrow("knn_query_points", df_points)
+        eng_postgis.create_table_arrow("knn_target_points", df_targets)
+
+        # SedonaDB syntax using ST_KNN
+        sedonadb_sql = f"""
             SELECT
                 q.id as query_id,
                 t.id as target_id,
-                ST_Distance(q.geometry, t.geometry) as distance,
-                ROW_NUMBER() OVER (PARTITION BY q.id ORDER BY q.geometry <-> t.geometry) as rn
+                ST_Distance(q.geometry, t.geometry) as distance
             FROM knn_query_points q
-            CROSS JOIN knn_target_points t
-        )
-        SELECT query_id, target_id, distance
-        FROM ranked_neighbors
-        WHERE rn <= {k}
-        ORDER BY query_id, distance
-    """
+            JOIN knn_target_points t ON ST_KNN(q.geometry, t.geometry, {k}, FALSE)
+            ORDER BY query_id, distance
+        """
 
-    # Compare with PostGIS (if available)
-    eng_postgis.assert_query_result(postgis_sql, sedonadb_results)
+        sedonadb_results = eng_sedonadb.execute_and_collect(sedonadb_sql).to_pandas()
+
+        # Verify basic correctness
+        assert len(sedonadb_results) > 0
+        assert (
+            len(sedonadb_results) == len(df_points) * k
+        )  # Each query point should have k neighbors
+
+        # Verify results are ordered by distance within each query point
+        for query_id in sedonadb_results["query_id"].unique():
+            query_results = sedonadb_results[sedonadb_results["query_id"] == query_id]
+            distances = query_results["distance"].tolist()
+            assert distances == sorted(distances), (
+                f"Distances not sorted for query_id {query_id}: {distances}"
+            )
+
+        # PostGIS syntax using distance operator and window functions for KNN
+        postgis_sql = f"""
+            WITH ranked_neighbors AS (
+                SELECT
+                    q.id as query_id,
+                    t.id as target_id,
+                    ST_Distance(q.geometry, t.geometry) as distance,
+                    ROW_NUMBER() OVER (PARTITION BY q.id ORDER BY q.geometry <-> t.geometry) as rn
+                FROM knn_query_points q
+                CROSS JOIN knn_target_points t
+            )
+            SELECT query_id, target_id, distance
+            FROM ranked_neighbors
+            WHERE rn <= {k}
+            ORDER BY query_id, distance
+        """
+
+        # Compare with PostGIS (if available)
+        eng_postgis.assert_query_result(postgis_sql, sedonadb_results)
 
 
 def test_knn_join_with_polygons():
     """Test KNN join between points and polygons"""
-    eng_sedonadb = SedonaDB.create_or_skip()
-    eng_postgis = PostGIS.create_or_skip()
-
-    # Create query points
-    point_options = json.dumps(
-        {
-            "geom_type": "Point",
-            "target_rows": 15,
-            "seed": 100,
-        }
-    )
-    df_points = eng_sedonadb.execute_and_collect(
-        f"SELECT * FROM sd_random_geometry('{point_options}') LIMIT 15"
-    )
-
-    # Create target polygons
-    polygon_options = json.dumps(
-        {
-            "geom_type": "Polygon",
-            "target_rows": 30,
-            "vertices_per_linestring_range": [4, 8],
-            "size_range": [0.001, 0.01],
-            "seed": 101,
-        }
-    )
-    df_polygons = eng_sedonadb.execute_and_collect(
-        f"SELECT * FROM sd_random_geometry('{polygon_options}') LIMIT 30"
-    )
-
-    # Set up tables
-    eng_sedonadb.create_table_arrow("knn_points", df_points)
-    eng_sedonadb.create_table_arrow("knn_polygons", df_polygons)
-    eng_postgis.create_table_arrow("knn_points", df_points)
-    eng_postgis.create_table_arrow("knn_polygons", df_polygons)
-
-    k = 3
-    # SedonaDB syntax
-    sedonadb_sql = f"""
-        SELECT
-            p.id as point_id,
-            pol.id as polygon_id,
-            ST_Distance(p.geometry, pol.geometry) as distance
-        FROM knn_points p
-        JOIN knn_polygons pol ON ST_KNN(p.geometry, pol.geometry, {k}, FALSE)
-        ORDER BY point_id, distance
-    """
-
-    sedonadb_results = eng_sedonadb.execute_and_collect(sedonadb_sql).to_pandas()
-
-    # Verify correctness
-    assert len(sedonadb_results) > 0
-    assert len(sedonadb_results) == len(df_points) * k
-
-    # Verify ordering within each point
-    for point_id in sedonadb_results["point_id"].unique():
-        point_results = sedonadb_results[sedonadb_results["point_id"] == point_id]
-        distances = point_results["distance"].tolist()
-        assert distances == sorted(distances), (
-            f"Distances not sorted for point_id {point_id}"
+    with (
+        SedonaDB.create_or_skip() as eng_sedonadb,
+        PostGIS.create_or_skip() as eng_postgis,
+    ):
+        # Create query points
+        point_options = json.dumps(
+            {
+                "geom_type": "Point",
+                "target_rows": 15,
+                "seed": 100,
+            }
+        )
+        df_points = eng_sedonadb.execute_and_collect(
+            f"SELECT * FROM sd_random_geometry('{point_options}') LIMIT 15"
         )
 
-    # PostGIS syntax
-    postgis_sql = f"""
-        WITH ranked_neighbors AS (
+        # Create target polygons
+        polygon_options = json.dumps(
+            {
+                "geom_type": "Polygon",
+                "target_rows": 30,
+                "vertices_per_linestring_range": [4, 8],
+                "size_range": [0.001, 0.01],
+                "seed": 101,
+            }
+        )
+        df_polygons = eng_sedonadb.execute_and_collect(
+            f"SELECT * FROM sd_random_geometry('{polygon_options}') LIMIT 30"
+        )
+
+        # Set up tables
+        eng_sedonadb.create_table_arrow("knn_points", df_points)
+        eng_sedonadb.create_table_arrow("knn_polygons", df_polygons)
+        eng_postgis.create_table_arrow("knn_points", df_points)
+        eng_postgis.create_table_arrow("knn_polygons", df_polygons)
+
+        k = 3
+        # SedonaDB syntax
+        sedonadb_sql = f"""
             SELECT
                 p.id as point_id,
                 pol.id as polygon_id,
-                ST_Distance(p.geometry, pol.geometry) as distance,
-                ROW_NUMBER() OVER (PARTITION BY p.id ORDER BY p.geometry <-> pol.geometry) as rn
+                ST_Distance(p.geometry, pol.geometry) as distance
             FROM knn_points p
-            CROSS JOIN knn_polygons pol
-        )
-        SELECT point_id, polygon_id, distance
-        FROM ranked_neighbors
-        WHERE rn <= {k}
-        ORDER BY point_id, distance
-    """
+            JOIN knn_polygons pol ON ST_KNN(p.geometry, pol.geometry, {k}, FALSE)
+            ORDER BY point_id, distance
+        """
 
-    eng_postgis.assert_query_result(postgis_sql, sedonadb_results)
+        sedonadb_results = eng_sedonadb.execute_and_collect(sedonadb_sql).to_pandas()
+
+        # Verify correctness
+        assert len(sedonadb_results) > 0
+        assert len(sedonadb_results) == len(df_points) * k
+
+        # Verify ordering within each point
+        for point_id in sedonadb_results["point_id"].unique():
+            point_results = sedonadb_results[sedonadb_results["point_id"] == point_id]
+            distances = point_results["distance"].tolist()
+            assert distances == sorted(distances), (
+                f"Distances not sorted for point_id {point_id}"
+            )
+
+        # PostGIS syntax
+        postgis_sql = f"""
+            WITH ranked_neighbors AS (
+                SELECT
+                    p.id as point_id,
+                    pol.id as polygon_id,
+                    ST_Distance(p.geometry, pol.geometry) as distance,
+                    ROW_NUMBER() OVER (PARTITION BY p.id ORDER BY p.geometry <-> pol.geometry) as rn
+                FROM knn_points p
+                CROSS JOIN knn_polygons pol
+            )
+            SELECT point_id, polygon_id, distance
+            FROM ranked_neighbors
+            WHERE rn <= {k}
+            ORDER BY point_id, distance
+        """
+
+        eng_postgis.assert_query_result(postgis_sql, sedonadb_results)
 
 
 def test_knn_join_edge_cases():
     """Test KNN join edge cases"""
-    eng_sedonadb = SedonaDB.create_or_skip()
-    eng_postgis = PostGIS.create_or_skip()
+    with (
+        SedonaDB.create_or_skip() as eng_sedonadb,
+        PostGIS.create_or_skip() as eng_postgis,
+    ):
+        # Create small datasets for edge case testing
+        point_options = json.dumps(
+            {
+                "geom_type": "Point",
+                "target_rows": 5,
+                "seed": 200,
+            }
+        )
+        df_points = eng_sedonadb.execute_and_collect(
+            f"SELECT * FROM sd_random_geometry('{point_options}') LIMIT 5"
+        )
 
-    # Create small datasets for edge case testing
-    point_options = json.dumps(
-        {
-            "geom_type": "Point",
-            "target_rows": 5,
-            "seed": 200,
-        }
-    )
-    df_points = eng_sedonadb.execute_and_collect(
-        f"SELECT * FROM sd_random_geometry('{point_options}') LIMIT 5"
-    )
+        target_options = json.dumps(
+            {
+                "geom_type": "Point",
+                "target_rows": 3,  # Fewer targets than k in some tests
+                "seed": 201,
+            }
+        )
+        df_targets = eng_sedonadb.execute_and_collect(
+            f"SELECT * FROM sd_random_geometry('{target_options}') LIMIT 3"
+        )
 
-    target_options = json.dumps(
-        {
-            "geom_type": "Point",
-            "target_rows": 3,  # Fewer targets than k in some tests
-            "seed": 201,
-        }
-    )
-    df_targets = eng_sedonadb.execute_and_collect(
-        f"SELECT * FROM sd_random_geometry('{target_options}') LIMIT 3"
-    )
+        eng_sedonadb.create_table_arrow("knn_query_small", df_points)
+        eng_sedonadb.create_table_arrow("knn_target_small", df_targets)
+        eng_postgis.create_table_arrow("knn_query_small", df_points)
+        eng_postgis.create_table_arrow("knn_target_small", df_targets)
 
-    eng_sedonadb.create_table_arrow("knn_query_small", df_points)
-    eng_sedonadb.create_table_arrow("knn_target_small", df_targets)
-    eng_postgis.create_table_arrow("knn_query_small", df_points)
-    eng_postgis.create_table_arrow("knn_target_small", df_targets)
-
-    # Test k > number of available targets
-    k = 5  # More than 3 available targets
-    sql = f"""
-        SELECT
-            q.id as query_id,
-            t.id as target_id,
-            ST_Distance(q.geometry, t.geometry) as distance
-        FROM knn_query_small q
-        JOIN knn_target_small t ON ST_KNN(q.geometry, t.geometry, {k}, FALSE)
-        ORDER BY query_id, distance
-    """
-
-    sedonadb_results = eng_sedonadb.execute_and_collect(sql).to_pandas()
-
-    # Should return all available targets (3) for each query point
-    expected_results_per_query = min(k, len(df_targets))  # min(5, 3) = 3
-    assert len(sedonadb_results) == len(df_points) * expected_results_per_query
-
-    # PostGIS syntax
-    postgis_sql = f"""
-        WITH ranked_neighbors AS (
+        # Test k > number of available targets
+        k = 5  # More than 3 available targets
+        sql = f"""
             SELECT
                 q.id as query_id,
                 t.id as target_id,
-                ST_Distance(q.geometry, t.geometry) as distance,
-                ROW_NUMBER() OVER (PARTITION BY q.id ORDER BY q.geometry <-> t.geometry) as rn
+                ST_Distance(q.geometry, t.geometry) as distance
             FROM knn_query_small q
-            CROSS JOIN knn_target_small t
-        )
-        SELECT query_id, target_id, distance
-        FROM ranked_neighbors
-        WHERE rn <= {k}
-        ORDER BY query_id, distance
-    """
+            JOIN knn_target_small t ON ST_KNN(q.geometry, t.geometry, {k}, FALSE)
+            ORDER BY query_id, distance
+        """
 
-    eng_postgis.assert_query_result(postgis_sql, sedonadb_results)
+        sedonadb_results = eng_sedonadb.execute_and_collect(sql).to_pandas()
+
+        # Should return all available targets (3) for each query point
+        expected_results_per_query = min(k, len(df_targets))  # min(5, 3) = 3
+        assert len(sedonadb_results) == len(df_points) * expected_results_per_query
+
+        # PostGIS syntax
+        postgis_sql = f"""
+            WITH ranked_neighbors AS (
+                SELECT
+                    q.id as query_id,
+                    t.id as target_id,
+                    ST_Distance(q.geometry, t.geometry) as distance,
+                    ROW_NUMBER() OVER (PARTITION BY q.id ORDER BY q.geometry <-> t.geometry) as rn
+                FROM knn_query_small q
+                CROSS JOIN knn_target_small t
+            )
+            SELECT query_id, target_id, distance
+            FROM ranked_neighbors
+            WHERE rn <= {k}
+            ORDER BY query_id, distance
+        """
+
+        eng_postgis.assert_query_result(postgis_sql, sedonadb_results)
 
 
 def test_knn_join_with_attributes():
     """Test KNN join preserves and uses additional attributes"""
-    eng_sedonadb = SedonaDB.create_or_skip()
-    eng_postgis = PostGIS.create_or_skip()
+    with (
+        SedonaDB.create_or_skip() as eng_sedonadb,
+        PostGIS.create_or_skip() as eng_postgis,
+    ):
+        # Create points with additional attributes
+        point_options = json.dumps(
+            {
+                "geom_type": "Point",
+                "target_rows": 10,
+                "seed": 300,
+            }
+        )
 
-    # Create points with additional attributes
-    point_options = json.dumps(
-        {
-            "geom_type": "Point",
-            "target_rows": 10,
-            "seed": 300,
-        }
-    )
+        # Add custom attributes to the query
+        points_query = f"""
+            SELECT
+                *,
+                'QueryPoint_' || CAST(id AS VARCHAR) as point_name,
+                random() * 100 as point_value
+            FROM sd_random_geometry('{point_options}')
+            LIMIT 10
+        """
+        df_points = eng_sedonadb.execute_and_collect(points_query)
 
-    # Add custom attributes to the query
-    points_query = f"""
-        SELECT
-            *,
-            'QueryPoint_' || CAST(id AS VARCHAR) as point_name,
-            random() * 100 as point_value
-        FROM sd_random_geometry('{point_options}')
-        LIMIT 10
-    """
-    df_points = eng_sedonadb.execute_and_collect(points_query)
+        target_options = json.dumps(
+            {
+                "geom_type": "Point",
+                "target_rows": 20,
+                "seed": 301,
+            }
+        )
 
-    target_options = json.dumps(
-        {
-            "geom_type": "Point",
-            "target_rows": 20,
-            "seed": 301,
-        }
-    )
+        targets_query = f"""
+            SELECT
+                *,
+                'TargetPoint_' || CAST(id AS VARCHAR) as target_name,
+                random() * 1000 as target_value
+            FROM sd_random_geometry('{target_options}')
+            LIMIT 20
+        """
+        df_targets = eng_sedonadb.execute_and_collect(targets_query)
 
-    targets_query = f"""
-        SELECT
-            *,
-            'TargetPoint_' || CAST(id AS VARCHAR) as target_name,
-            random() * 1000 as target_value
-        FROM sd_random_geometry('{target_options}')
-        LIMIT 20
-    """
-    df_targets = eng_sedonadb.execute_and_collect(targets_query)
+        eng_sedonadb.create_table_arrow("knn_points_attr", df_points)
+        eng_sedonadb.create_table_arrow("knn_targets_attr", df_targets)
+        eng_postgis.create_table_arrow("knn_points_attr", df_points)
+        eng_postgis.create_table_arrow("knn_targets_attr", df_targets)
 
-    eng_sedonadb.create_table_arrow("knn_points_attr", df_points)
-    eng_sedonadb.create_table_arrow("knn_targets_attr", df_targets)
-    eng_postgis.create_table_arrow("knn_points_attr", df_points)
-    eng_postgis.create_table_arrow("knn_targets_attr", df_targets)
-
-    k = 2
-    sedonadb_sql = f"""
-        SELECT
-            q.id as query_id,
-            q.point_name,
-            q.point_value,
-            t.id as target_id,
-            t.target_name,
-            t.target_value,
-            ST_Distance(q.geometry, t.geometry) as distance
-        FROM knn_points_attr q
-        JOIN knn_targets_attr t ON ST_KNN(q.geometry, t.geometry, {k}, FALSE)
-        ORDER BY query_id, distance
-    """
-
-    sedonadb_results = eng_sedonadb.execute_and_collect(sedonadb_sql).to_pandas()
-
-    # Verify all attributes are preserved
-    assert len(sedonadb_results) == len(df_points) * k
-    assert "point_name" in sedonadb_results.columns
-    assert "point_value" in sedonadb_results.columns
-    assert "target_name" in sedonadb_results.columns
-    assert "target_value" in sedonadb_results.columns
-    assert "distance" in sedonadb_results.columns
-
-    # Verify no null values in critical columns
-    assert sedonadb_results["query_id"].notna().all()
-    assert sedonadb_results["target_id"].notna().all()
-    assert sedonadb_results["distance"].notna().all()
-
-    # PostGIS syntax
-    postgis_sql = f"""
-        WITH ranked_neighbors AS (
+        k = 2
+        sedonadb_sql = f"""
             SELECT
                 q.id as query_id,
                 q.point_name,
@@ -346,94 +319,126 @@ def test_knn_join_with_attributes():
                 t.id as target_id,
                 t.target_name,
                 t.target_value,
-                ST_Distance(q.geometry, t.geometry) as distance,
-                ROW_NUMBER() OVER (PARTITION BY q.id ORDER BY q.geometry <-> t.geometry) as rn
+                ST_Distance(q.geometry, t.geometry) as distance
             FROM knn_points_attr q
-            CROSS JOIN knn_targets_attr t
-        )
-        SELECT query_id, point_name, point_value, target_id, target_name, target_value, distance
-        FROM ranked_neighbors
-        WHERE rn <= {k}
-        ORDER BY query_id, distance
-    """
+            JOIN knn_targets_attr t ON ST_KNN(q.geometry, t.geometry, {k}, FALSE)
+            ORDER BY query_id, distance
+        """
 
-    eng_postgis.assert_query_result(postgis_sql, sedonadb_results)
+        sedonadb_results = eng_sedonadb.execute_and_collect(sedonadb_sql).to_pandas()
+
+        # Verify all attributes are preserved
+        assert len(sedonadb_results) == len(df_points) * k
+        assert "point_name" in sedonadb_results.columns
+        assert "point_value" in sedonadb_results.columns
+        assert "target_name" in sedonadb_results.columns
+        assert "target_value" in sedonadb_results.columns
+        assert "distance" in sedonadb_results.columns
+
+        # Verify no null values in critical columns
+        assert sedonadb_results["query_id"].notna().all()
+        assert sedonadb_results["target_id"].notna().all()
+        assert sedonadb_results["distance"].notna().all()
+
+        # PostGIS syntax
+        postgis_sql = f"""
+            WITH ranked_neighbors AS (
+                SELECT
+                    q.id as query_id,
+                    q.point_name,
+                    q.point_value,
+                    t.id as target_id,
+                    t.target_name,
+                    t.target_value,
+                    ST_Distance(q.geometry, t.geometry) as distance,
+                    ROW_NUMBER() OVER (PARTITION BY q.id ORDER BY q.geometry <-> t.geometry) as rn
+                FROM knn_points_attr q
+                CROSS JOIN knn_targets_attr t
+            )
+            SELECT query_id, point_name, point_value, target_id, target_name, target_value, distance
+            FROM ranked_neighbors
+            WHERE rn <= {k}
+            ORDER BY query_id, distance
+        """
+
+        eng_postgis.assert_query_result(postgis_sql, sedonadb_results)
 
 
 def test_knn_join_correctness_known_points():
     """Test KNN join correctness with deterministic synthetic data"""
-    eng_sedonadb = SedonaDB.create_or_skip()
-    eng_postgis = PostGIS.create_or_skip()
+    with (
+        SedonaDB.create_or_skip() as eng_sedonadb,
+        PostGIS.create_or_skip() as eng_postgis,
+    ):
+        # Create deterministic synthetic data for reproducible results
+        query_options = json.dumps(
+            {
+                "geom_type": "Point",
+                "target_rows": 3,
+                "seed": 1000,
+            }
+        )
+        df_known = eng_sedonadb.execute_and_collect(
+            f"SELECT * FROM sd_random_geometry('{query_options}') LIMIT 3"
+        )
 
-    # Create deterministic synthetic data for reproducible results
-    query_options = json.dumps(
-        {
-            "geom_type": "Point",
-            "target_rows": 3,
-            "seed": 1000,
-        }
-    )
-    df_known = eng_sedonadb.execute_and_collect(
-        f"SELECT * FROM sd_random_geometry('{query_options}') LIMIT 3"
-    )
+        target_options = json.dumps(
+            {
+                "geom_type": "Point",
+                "target_rows": 8,
+                "seed": 1001,
+            }
+        )
+        df_targets = eng_sedonadb.execute_and_collect(
+            f"SELECT * FROM sd_random_geometry('{target_options}') LIMIT 8"
+        )
 
-    target_options = json.dumps(
-        {
-            "geom_type": "Point",
-            "target_rows": 8,
-            "seed": 1001,
-        }
-    )
-    df_targets = eng_sedonadb.execute_and_collect(
-        f"SELECT * FROM sd_random_geometry('{target_options}') LIMIT 8"
-    )
+        eng_sedonadb.create_table_arrow("knn_known", df_known)
+        eng_sedonadb.create_table_arrow("knn_target_known", df_targets)
+        eng_postgis.create_table_arrow("knn_known", df_known)
+        eng_postgis.create_table_arrow("knn_target_known", df_targets)
 
-    eng_sedonadb.create_table_arrow("knn_known", df_known)
-    eng_sedonadb.create_table_arrow("knn_target_known", df_targets)
-    eng_postgis.create_table_arrow("knn_known", df_known)
-    eng_postgis.create_table_arrow("knn_target_known", df_targets)
-
-    # Test k=3 KNN join from first query point
-    k = 3
-    sedonadb_sql = f"""
-        SELECT
-            q.id as query_id,
-            t.id as target_id,
-            ST_Distance(q.geometry, t.geometry) as distance
-        FROM knn_known q
-        JOIN knn_target_known t ON ST_KNN(q.geometry, t.geometry, {k}, FALSE)
-        WHERE q.id = 0  -- Query from first point (synthetic data uses 0-based IDs)
-        ORDER BY distance
-    """
-
-    sedonadb_results = eng_sedonadb.execute_and_collect(sedonadb_sql).to_pandas()
-
-    # Verify correct result count
-    assert len(sedonadb_results) == k
-
-    # Verify distances are sorted (ascending order)
-    distances = sedonadb_results["distance"].tolist()
-    assert distances == sorted(distances), f"Distances not sorted: {distances}"
-
-    # Verify all distances are non-negative
-    assert all(d >= 0 for d in distances), f"Found negative distances: {distances}"
-
-    # PostGIS syntax
-    postgis_sql = f"""
-        WITH ranked_neighbors AS (
+        # Test k=3 KNN join from first query point
+        k = 3
+        sedonadb_sql = f"""
             SELECT
                 q.id as query_id,
                 t.id as target_id,
-                ST_Distance(q.geometry, t.geometry) as distance,
-                ROW_NUMBER() OVER (PARTITION BY q.id ORDER BY q.geometry <-> t.geometry) as rn
+                ST_Distance(q.geometry, t.geometry) as distance
             FROM knn_known q
-            CROSS JOIN knn_target_known t
-            WHERE q.id = 0
-        )
-        SELECT query_id, target_id, distance
-        FROM ranked_neighbors
-        WHERE rn <= {k}
-        ORDER BY distance
-    """
+            JOIN knn_target_known t ON ST_KNN(q.geometry, t.geometry, {k}, FALSE)
+            WHERE q.id = 0  -- Query from first point (synthetic data uses 0-based IDs)
+            ORDER BY distance
+        """
 
-    eng_postgis.assert_query_result(postgis_sql, sedonadb_results)
+        sedonadb_results = eng_sedonadb.execute_and_collect(sedonadb_sql).to_pandas()
+
+        # Verify correct result count
+        assert len(sedonadb_results) == k
+
+        # Verify distances are sorted (ascending order)
+        distances = sedonadb_results["distance"].tolist()
+        assert distances == sorted(distances), f"Distances not sorted: {distances}"
+
+        # Verify all distances are non-negative
+        assert all(d >= 0 for d in distances), f"Found negative distances: {distances}"
+
+        # PostGIS syntax
+        postgis_sql = f"""
+            WITH ranked_neighbors AS (
+                SELECT
+                    q.id as query_id,
+                    t.id as target_id,
+                    ST_Distance(q.geometry, t.geometry) as distance,
+                    ROW_NUMBER() OVER (PARTITION BY q.id ORDER BY q.geometry <-> t.geometry) as rn
+                FROM knn_known q
+                CROSS JOIN knn_target_known t
+                WHERE q.id = 0
+            )
+            SELECT query_id, target_id, distance
+            FROM ranked_neighbors
+            WHERE rn <= {k}
+            ORDER BY distance
+        """
+
+        eng_postgis.assert_query_result(postgis_sql, sedonadb_results)

--- a/python/sedonadb/tests/test_sjoin.py
+++ b/python/sedonadb/tests/test_sjoin.py
@@ -34,48 +34,49 @@ from sedonadb.testing import PostGIS, SedonaDB
     ],
 )
 def test_spatial_join(join_type, on):
-    eng_sedonadb = SedonaDB.create_or_skip()
-    eng_postgis = PostGIS.create_or_skip()
+    with (
+        SedonaDB.create_or_skip() as eng_sedonadb,
+        PostGIS.create_or_skip() as eng_postgis,
+    ):
+        options = json.dumps(
+            {
+                "geom_type": "Point",
+                "polygon_hole_rate": 0.5,
+                "num_parts_range": [2, 10],
+                "vertices_per_linestring_range": [2, 10],
+                "seed": 42,
+            }
+        )
+        df_point = eng_sedonadb.execute_and_collect(
+            f"SELECT * FROM sd_random_geometry('{options}') LIMIT 100"
+        )
+        options = json.dumps(
+            {
+                "geom_type": "Polygon",
+                "polygon_hole_rate": 0.5,
+                "num_parts_range": [2, 10],
+                "vertices_per_linestring_range": [2, 10],
+                "seed": 43,
+            }
+        )
+        df_polygon = eng_sedonadb.execute_and_collect(
+            f"SELECT * FROM sd_random_geometry('{options}') LIMIT 100"
+        )
+        eng_sedonadb.create_table_arrow("sjoin_point", df_point)
+        eng_sedonadb.create_table_arrow("sjoin_polygon", df_polygon)
+        eng_postgis.create_table_arrow("sjoin_point", df_point)
+        eng_postgis.create_table_arrow("sjoin_polygon", df_polygon)
 
-    options = json.dumps(
-        {
-            "geom_type": "Point",
-            "polygon_hole_rate": 0.5,
-            "num_parts_range": [2, 10],
-            "vertices_per_linestring_range": [2, 10],
-            "seed": 42,
-        }
-    )
-    df_point = eng_sedonadb.execute_and_collect(
-        f"SELECT * FROM sd_random_geometry('{options}') LIMIT 100"
-    )
-    options = json.dumps(
-        {
-            "geom_type": "Polygon",
-            "polygon_hole_rate": 0.5,
-            "num_parts_range": [2, 10],
-            "vertices_per_linestring_range": [2, 10],
-            "seed": 43,
-        }
-    )
-    df_polygon = eng_sedonadb.execute_and_collect(
-        f"SELECT * FROM sd_random_geometry('{options}') LIMIT 100"
-    )
-    eng_sedonadb.create_table_arrow("sjoin_point", df_point)
-    eng_sedonadb.create_table_arrow("sjoin_polygon", df_polygon)
-    eng_postgis.create_table_arrow("sjoin_point", df_point)
-    eng_postgis.create_table_arrow("sjoin_polygon", df_polygon)
+        sql = f"""
+               SELECT sjoin_point.id id0, sjoin_polygon.id id1
+               FROM sjoin_point {join_type} sjoin_polygon
+               ON {on}
+               ORDER BY id0, id1
+               """
 
-    sql = f"""
-           SELECT sjoin_point.id id0, sjoin_polygon.id id1
-           FROM sjoin_point {join_type} sjoin_polygon
-           ON {on}
-           ORDER BY id0, id1
-           """
-
-    sedonadb_results = eng_sedonadb.execute_and_collect(sql).to_pandas()
-    assert len(sedonadb_results) > 0
-    eng_postgis.assert_query_result(sql, sedonadb_results)
+        sedonadb_results = eng_sedonadb.execute_and_collect(sql).to_pandas()
+        assert len(sedonadb_results) > 0
+        eng_postgis.assert_query_result(sql, sedonadb_results)
 
 
 @pytest.mark.parametrize(
@@ -89,52 +90,53 @@ def test_spatial_join(join_type, on):
     ],
 )
 def test_spatial_join_geography(join_type, on):
-    eng_sedonadb = SedonaDB.create_or_skip()
-    eng_postgis = PostGIS.create_or_skip()
+    with (
+        SedonaDB.create_or_skip() as eng_sedonadb,
+        PostGIS.create_or_skip() as eng_postgis,
+    ):
+        # Select two sets of bounding boxes that cross the antimeridian,
+        # which would be disjoint on a Euclidean plane. A geography join will produce non-empty results,
+        # whereas a geometry join would not.
+        west_most_bound = [-190, -10, -170, 10]
+        east_most_bound = [170, -10, 190, 10]
+        options = json.dumps(
+            {
+                "geom_type": "Point",
+                "num_parts_range": [2, 10],
+                "vertices_per_linestring_range": [2, 10],
+                "bounds": west_most_bound,
+                "size_range": [0.1, 5],
+                "seed": 43,
+            }
+        )
+        df_point = eng_sedonadb.execute_and_collect(
+            f"SELECT id, ST_SetSRID(ST_GeogFromWKB(ST_AsBinary(geometry)), 4326) geog, dist FROM sd_random_geometry('{options}') LIMIT 100"
+        )
+        options = json.dumps(
+            {
+                "geom_type": "Polygon",
+                "polygon_hole_rate": 0.5,
+                "num_parts_range": [2, 10],
+                "vertices_per_linestring_range": [2, 10],
+                "bounds": east_most_bound,
+                "size_range": [0.1, 5],
+                "seed": 44,
+            }
+        )
+        df_polygon = eng_sedonadb.execute_and_collect(
+            f"SELECT id, ST_SetSRID(ST_GeogFromWKB(ST_AsBinary(geometry)), 4326) geog, dist FROM sd_random_geometry('{options}') LIMIT 100"
+        )
+        eng_sedonadb.create_table_arrow("sjoin_geog1", df_point)
+        eng_sedonadb.create_table_arrow("sjoin_geog2", df_polygon)
+        eng_postgis.create_table_arrow("sjoin_geog1", df_point)
+        eng_postgis.create_table_arrow("sjoin_geog2", df_polygon)
 
-    # Select two sets of bounding boxes that cross the antimeridian,
-    # which would be disjoint on a Euclidean plane. A geography join will produce non-empty results,
-    # whereas a geometry join would not.
-    west_most_bound = [-190, -10, -170, 10]
-    east_most_bound = [170, -10, 190, 10]
-    options = json.dumps(
-        {
-            "geom_type": "Point",
-            "num_parts_range": [2, 10],
-            "vertices_per_linestring_range": [2, 10],
-            "bounds": west_most_bound,
-            "size_range": [0.1, 5],
-            "seed": 43,
-        }
-    )
-    df_point = eng_sedonadb.execute_and_collect(
-        f"SELECT id, ST_SetSRID(ST_GeogFromWKB(ST_AsBinary(geometry)), 4326) geog, dist FROM sd_random_geometry('{options}') LIMIT 100"
-    )
-    options = json.dumps(
-        {
-            "geom_type": "Polygon",
-            "polygon_hole_rate": 0.5,
-            "num_parts_range": [2, 10],
-            "vertices_per_linestring_range": [2, 10],
-            "bounds": east_most_bound,
-            "size_range": [0.1, 5],
-            "seed": 44,
-        }
-    )
-    df_polygon = eng_sedonadb.execute_and_collect(
-        f"SELECT id, ST_SetSRID(ST_GeogFromWKB(ST_AsBinary(geometry)), 4326) geog, dist FROM sd_random_geometry('{options}') LIMIT 100"
-    )
-    eng_sedonadb.create_table_arrow("sjoin_geog1", df_point)
-    eng_sedonadb.create_table_arrow("sjoin_geog2", df_polygon)
-    eng_postgis.create_table_arrow("sjoin_geog1", df_point)
-    eng_postgis.create_table_arrow("sjoin_geog2", df_polygon)
+        sql = f"""
+               SELECT sjoin_geog1.id id0, sjoin_geog2.id id1
+               FROM sjoin_geog1 {join_type} sjoin_geog2
+               ON {on}
+               ORDER BY id0, id1
+               """
 
-    sql = f"""
-           SELECT sjoin_geog1.id id0, sjoin_geog2.id id1
-           FROM sjoin_geog1 {join_type} sjoin_geog2
-           ON {on}
-           ORDER BY id0, id1
-           """
-
-    sedonadb_results = eng_sedonadb.execute_and_collect(sql).to_pandas()
-    eng_postgis.assert_query_result(sql, sedonadb_results)
+        sedonadb_results = eng_sedonadb.execute_and_collect(sql).to_pandas()
+        eng_postgis.assert_query_result(sql, sedonadb_results)

--- a/python/sedonadb/tests/test_testing.py
+++ b/python/sedonadb/tests/test_testing.py
@@ -29,236 +29,242 @@ from sedonadb.testing import DuckDB, PostGIS, SedonaDB
 @pytest.mark.parametrize("eng", [SedonaDB, PostGIS, DuckDB])
 def test_assert_result_nonspatial(eng):
     q = "SELECT 'foofy' as f"
-    eng = eng.create_or_skip()
+    with eng.create_or_skip() as eng:
+        eng.assert_query_result(q, "foofy")
+        eng.assert_query_result(q, ("foofy",))
+        eng.assert_query_result(q, [("foofy",)])
+        eng.assert_query_result(q, pd.DataFrame({"f": ["foofy"]}))
 
-    eng.assert_query_result(q, "foofy")
-    eng.assert_query_result(q, ("foofy",))
-    eng.assert_query_result(q, [("foofy",)])
-    eng.assert_query_result(q, pd.DataFrame({"f": ["foofy"]}))
+        # DataFusion aggressively generates non-nullable outputs
+        if eng.name() == "sedonadb":
+            eng.assert_query_result(
+                q,
+                pa.table(
+                    [["foofy"]], schema=pa.schema([pa.field("f", pa.string(), False)])
+                ),
+            )
+        else:
+            eng.assert_query_result(q, pa.table({"f": ["foofy"]}))
 
-    # DataFusion aggressively generates non-nullable outputs
-    if eng.name() == "sedonadb":
-        eng.assert_query_result(
-            q,
-            pa.table(
-                [["foofy"]], schema=pa.schema([pa.field("f", pa.string(), False)])
-            ),
-        )
-    else:
-        eng.assert_query_result(q, pa.table({"f": ["foofy"]}))
+        with pytest.raises(AssertionError):
+            eng.assert_query_result(q, "not foofy")
 
-    with pytest.raises(AssertionError):
-        eng.assert_query_result(q, "not foofy")
+        # Asserting against a string for a result with count != 1 should fail
+        with pytest.raises(AssertionError):
+            eng.assert_query_result("SELECT 'foofy' as f WHERE false", "not foofy")
 
-    # Asserting against a string for a result with count != 1 should fail
-    with pytest.raises(AssertionError):
-        eng.assert_query_result("SELECT 'foofy' as f WHERE false", "not foofy")
+        with pytest.raises(AssertionError):
+            eng.assert_query_result(q, ("not foofy",))
 
-    with pytest.raises(AssertionError):
-        eng.assert_query_result(q, ("not foofy",))
+        # Asserting against a tuple for a result with count != 1 should fail
+        with pytest.raises(AssertionError):
+            eng.assert_query_result("SELECT 'foofy' as f WHERE false", ("not foofy",))
 
-    # Asserting against a tuple for a result with count != 1 should fail
-    with pytest.raises(AssertionError):
-        eng.assert_query_result("SELECT 'foofy' as f WHERE false", ("not foofy",))
+        with pytest.raises(AssertionError):
+            eng.assert_query_result(q, [("not foofy",)])
 
-    with pytest.raises(AssertionError):
-        eng.assert_query_result(q, [("not foofy",)])
+        with pytest.raises(AssertionError):
+            eng.assert_query_result(q, pd.DataFrame({"f": ["not foofy"]}))
 
-    with pytest.raises(AssertionError):
-        eng.assert_query_result(q, pd.DataFrame({"f": ["not foofy"]}))
+        with pytest.raises(AssertionError):
+            eng.assert_query_result(q, pa.table({"f": ["not foofy"]}))
 
-    with pytest.raises(AssertionError):
-        eng.assert_query_result(q, pa.table({"f": ["not foofy"]}))
+        # Because the result is not a GeoDataFrame
+        with pytest.raises(AssertionError):
+            eng.assert_query_result(q, geopandas.GeoDataFrame({"f": ["foofy"]}))
 
-    # Because the result is not a GeoDataFrame
-    with pytest.raises(AssertionError):
-        eng.assert_query_result(q, geopandas.GeoDataFrame({"f": ["foofy"]}))
-
-    with pytest.raises(TypeError, match="Can't assert result equality against dict"):
-        eng.assert_query_result(q, {})
+        with pytest.raises(
+            TypeError, match="Can't assert result equality against dict"
+        ):
+            eng.assert_query_result(q, {})
 
 
 @pytest.mark.parametrize("eng", [SedonaDB, PostGIS, DuckDB])
 def test_assert_result_spatial(eng):
     q = "SELECT ST_GeomFromText('POINT (0 1)') as geom"
-    eng = eng.create_or_skip()
-
-    # Check tuples/single-element target (with optional WKT precision)
-    eng.assert_query_result(q, "POINT (0 1)")
-    eng.assert_query_result(
-        "SELECT ST_GeomFromText('POINT (0 1.111111)') as geom",
-        "POINT (0 1.1)",
-        wkt_precision=1,
-    )
-    eng.assert_query_result(
-        q,
-        geopandas.GeoDataFrame(
-            {"geom": geopandas.GeoSeries.from_wkt(["POINT (0 1)"])}
-        ).set_geometry("geom"),
-    )
-
-    # SedonaDB aggressively returns non-nullable literals
-    eng.assert_query_result(
-        q,
-        pa.table(
-            [ga.as_wkb(["POINT (0 1)"])],
-            schema=pa.schema(
-                [pa.field("geom", ga.wkb(), nullable=not isinstance(eng, SedonaDB))]
-            ),
-        ),
-    )
-
-    with pytest.raises(AssertionError):
-        eng.assert_query_result(q, "POINT (0 2)")
-
-    with pytest.raises(AssertionError):
+    with eng.create_or_skip() as eng:
+        # Check tuples/single-element target (with optional WKT precision)
+        eng.assert_query_result(q, "POINT (0 1)")
+        eng.assert_query_result(
+            "SELECT ST_GeomFromText('POINT (0 1.111111)') as geom",
+            "POINT (0 1.1)",
+            wkt_precision=1,
+        )
         eng.assert_query_result(
             q,
             geopandas.GeoDataFrame(
-                {"geom": geopandas.GeoSeries.from_wkt(["POINT (0 2)"])}
+                {"geom": geopandas.GeoSeries.from_wkt(["POINT (0 1)"])}
             ).set_geometry("geom"),
         )
 
-    with pytest.raises(AssertionError):
-        eng.assert_query_result(q, pa.table({"geom": ga.as_wkb(["POINT (0 2)"])}))
-
-    with pytest.raises(AssertionError):
+        # SedonaDB aggressively returns non-nullable literals
         eng.assert_query_result(
             q,
-            pa.table({"not_geom": [1]}),
+            pa.table(
+                [ga.as_wkb(["POINT (0 1)"])],
+                schema=pa.schema(
+                    [pa.field("geom", ga.wkb(), nullable=not isinstance(eng, SedonaDB))]
+                ),
+            ),
         )
+
+        with pytest.raises(AssertionError):
+            eng.assert_query_result(q, "POINT (0 2)")
+
+        with pytest.raises(AssertionError):
+            eng.assert_query_result(
+                q,
+                geopandas.GeoDataFrame(
+                    {"geom": geopandas.GeoSeries.from_wkt(["POINT (0 2)"])}
+                ).set_geometry("geom"),
+            )
+
+        with pytest.raises(AssertionError):
+            eng.assert_query_result(q, pa.table({"geom": ga.as_wkb(["POINT (0 2)"])}))
+
+        with pytest.raises(AssertionError):
+            eng.assert_query_result(
+                q,
+                pa.table({"not_geom": [1]}),
+            )
 
 
 @pytest.mark.parametrize("eng", [SedonaDB, PostGIS, DuckDB])
 def test_table_arrow_no_crs(eng):
-    eng = eng.create_or_skip()
-
-    tab_no_crs = pa.table(
-        {"idx": [1, 2], "geom": ga.as_wkb(["POINT (0 1)", "POINT (2 3)"])}
-    )
-    assert eng.create_table_arrow("tab_no_crs", tab_no_crs) is eng
-
-    eng.assert_query_result("SELECT * FROM tab_no_crs ORDER BY idx", tab_no_crs)
-
-    with pytest.raises(AssertionError):
-        eng.assert_query_result(
-            "SELECT * FROM tab_no_crs ORDER BY idx DESC", tab_no_crs
+    with eng.create_or_skip() as eng:
+        tab_no_crs = pa.table(
+            {"idx": [1, 2], "geom": ga.as_wkb(["POINT (0 1)", "POINT (2 3)"])}
         )
+        assert eng.create_table_arrow("tab_no_crs", tab_no_crs) is eng
+
+        eng.assert_query_result("SELECT * FROM tab_no_crs ORDER BY idx", tab_no_crs)
+
+        with pytest.raises(AssertionError):
+            eng.assert_query_result(
+                "SELECT * FROM tab_no_crs ORDER BY idx DESC", tab_no_crs
+            )
 
 
 @pytest.mark.parametrize("eng", [SedonaDB, PostGIS])
 def test_table_arrow_crs(eng):
-    eng = eng.create_or_skip()
+    with eng.create_or_skip() as eng:
+        tab_no_crs = pa.table(
+            {"idx": [1, 2], "geom": ga.as_wkb(["POINT (0 1)", "POINT (2 3)"])}
+        )
+        tab_with_crs = tab_no_crs.set_column(
+            1, "geom", ga.with_crs(tab_no_crs["geom"], ga.OGC_CRS84)
+        )
+        tab_with_other_crs = tab_no_crs.set_column(
+            1, "geom", ga.with_crs(tab_no_crs["geom"], pyproj.CRS("EPSG:3857"))
+        )
+        df_no_crs = geopandas.GeoDataFrame.from_arrow(tab_no_crs)
+        df_with_crs = geopandas.GeoDataFrame.from_arrow(tab_with_crs)
+        df_with_other_crs = geopandas.GeoDataFrame.from_arrow(tab_with_other_crs)
 
-    tab_no_crs = pa.table(
-        {"idx": [1, 2], "geom": ga.as_wkb(["POINT (0 1)", "POINT (2 3)"])}
-    )
-    tab_with_crs = tab_no_crs.set_column(
-        1, "geom", ga.with_crs(tab_no_crs["geom"], ga.OGC_CRS84)
-    )
-    tab_with_other_crs = tab_no_crs.set_column(
-        1, "geom", ga.with_crs(tab_no_crs["geom"], pyproj.CRS("EPSG:3857"))
-    )
-    df_no_crs = geopandas.GeoDataFrame.from_arrow(tab_no_crs)
-    df_with_crs = geopandas.GeoDataFrame.from_arrow(tab_with_crs)
-    df_with_other_crs = geopandas.GeoDataFrame.from_arrow(tab_with_other_crs)
+        eng.create_table_arrow("tab_with_crs", tab_with_crs)
+        eng.create_table_arrow("tab_no_crs", tab_no_crs)
+        eng.create_table_arrow("tab_with_other_crs", tab_with_other_crs)
 
-    eng.create_table_arrow("tab_with_crs", tab_with_crs)
-    eng.create_table_arrow("tab_no_crs", tab_no_crs)
-    eng.create_table_arrow("tab_with_other_crs", tab_with_other_crs)
-
-    # Check against Table
-    eng.assert_query_result("SELECT * FROM tab_with_crs ORDER BY idx", tab_with_crs)
-    eng.assert_query_result(
-        "SELECT * FROM tab_with_other_crs ORDER BY idx", tab_with_other_crs
-    )
-
-    # Check against GeoDataFrame
-    eng.assert_query_result("SELECT * FROM tab_with_crs ORDER BY idx", df_with_crs)
-    eng.assert_query_result(
-        "SELECT * FROM tab_with_other_crs ORDER BY idx", df_with_other_crs
-    )
-
-    # Check that Table comparison fails on CRS mismatch
-    with pytest.raises(AssertionError):
-        eng.assert_query_result("SELECT * FROM tab_with_crs ORDER BY idx", tab_no_crs)
-    with pytest.raises(AssertionError):
-        eng.assert_query_result("SELECT * FROM tab_no_crs ORDER BY idx", tab_with_crs)
-    with pytest.raises(AssertionError):
+        # Check against Table
+        eng.assert_query_result("SELECT * FROM tab_with_crs ORDER BY idx", tab_with_crs)
         eng.assert_query_result(
-            "SELECT * FROM tab_with_crs ORDER BY idx", tab_with_other_crs
+            "SELECT * FROM tab_with_other_crs ORDER BY idx", tab_with_other_crs
         )
 
-    # Check that GeoDataFrame comparison fails on CRS mismatch
-    with pytest.raises(AssertionError):
-        eng.assert_query_result("SELECT * FROM tab_with_crs ORDER BY idx", df_no_crs)
-    with pytest.raises(AssertionError):
-        eng.assert_query_result("SELECT * FROM tab_no_crs ORDER BY idx", df_with_crs)
-    with pytest.raises(AssertionError):
+        # Check against GeoDataFrame
+        eng.assert_query_result("SELECT * FROM tab_with_crs ORDER BY idx", df_with_crs)
         eng.assert_query_result(
-            "SELECT * FROM tab_with_crs ORDER BY idx", df_with_other_crs
+            "SELECT * FROM tab_with_other_crs ORDER BY idx", df_with_other_crs
         )
 
-    # ...but we can pass an argument to disable the CRS check
-    eng.assert_query_result(
-        "SELECT * FROM tab_with_crs ORDER BY idx", df_with_other_crs, check_crs=False
-    )
+        # Check that Table comparison fails on CRS mismatch
+        with pytest.raises(AssertionError):
+            eng.assert_query_result(
+                "SELECT * FROM tab_with_crs ORDER BY idx", tab_no_crs
+            )
+        with pytest.raises(AssertionError):
+            eng.assert_query_result(
+                "SELECT * FROM tab_no_crs ORDER BY idx", tab_with_crs
+            )
+        with pytest.raises(AssertionError):
+            eng.assert_query_result(
+                "SELECT * FROM tab_with_crs ORDER BY idx", tab_with_other_crs
+            )
+
+        # Check that GeoDataFrame comparison fails on CRS mismatch
+        with pytest.raises(AssertionError):
+            eng.assert_query_result(
+                "SELECT * FROM tab_with_crs ORDER BY idx", df_no_crs
+            )
+        with pytest.raises(AssertionError):
+            eng.assert_query_result(
+                "SELECT * FROM tab_no_crs ORDER BY idx", df_with_crs
+            )
+        with pytest.raises(AssertionError):
+            eng.assert_query_result(
+                "SELECT * FROM tab_with_crs ORDER BY idx", df_with_other_crs
+            )
+
+        # ...but we can pass an argument to disable the CRS check
+        eng.assert_query_result(
+            "SELECT * FROM tab_with_crs ORDER BY idx",
+            df_with_other_crs,
+            check_crs=False,
+        )
 
 
 @pytest.mark.parametrize("eng", [SedonaDB, PostGIS])
 def test_table_arrow_geog(eng):
-    eng = eng.create_or_skip()
+    with eng.create_or_skip() as eng:
+        tab_geometry = pa.table(
+            {"idx": [1, 2], "geom": ga.as_wkb(["POINT (0 1)", "POINT (2 3)"])}
+        )
+        tab_geog = tab_geometry.set_column(
+            1, "geom", ga.with_edge_type(tab_geometry["geom"], ga.EdgeType.SPHERICAL)
+        )
 
-    tab_geometry = pa.table(
-        {"idx": [1, 2], "geom": ga.as_wkb(["POINT (0 1)", "POINT (2 3)"])}
-    )
-    tab_geog = tab_geometry.set_column(
-        1, "geom", ga.with_edge_type(tab_geometry["geom"], ga.EdgeType.SPHERICAL)
-    )
+        eng.create_table_arrow("tab_geometry", tab_geometry)
+        eng.create_table_arrow("tab_geog", tab_geog)
 
-    eng.create_table_arrow("tab_geometry", tab_geometry)
-    eng.create_table_arrow("tab_geog", tab_geog)
+        eng.assert_query_result("SELECT * FROM tab_geometry ORDER BY idx", tab_geometry)
+        eng.assert_query_result("SELECT * FROM tab_geog ORDER BY idx", tab_geog)
 
-    eng.assert_query_result("SELECT * FROM tab_geometry ORDER BY idx", tab_geometry)
-    eng.assert_query_result("SELECT * FROM tab_geog ORDER BY idx", tab_geog)
-
-    with pytest.raises(AssertionError):
-        eng.assert_query_result("SELECT * FROM tab_geometry ORDER BY idx", tab_geog)
-    with pytest.raises(AssertionError):
-        eng.assert_query_result("SELECT * FROM tab_geog ORDER BY idx", tab_geometry)
+        with pytest.raises(AssertionError):
+            eng.assert_query_result("SELECT * FROM tab_geometry ORDER BY idx", tab_geog)
+        with pytest.raises(AssertionError):
+            eng.assert_query_result("SELECT * FROM tab_geog ORDER BY idx", tab_geometry)
 
 
 @pytest.mark.parametrize("eng", [SedonaDB, PostGIS, DuckDB])
 def test_table_parquet(eng):
-    eng = eng.create_or_skip()
+    with eng.create_or_skip() as eng:
+        df = geopandas.GeoDataFrame(
+            {
+                "idx": [1, 2, 3],
+                "geometry": geopandas.GeoSeries.from_wkt(
+                    ["POINT (0 1)", "POINT (2 3)", "POINT (4 5)"], crs="EPSG:3857"
+                ),
+            }
+        ).set_geometry("geometry")
 
-    df = geopandas.GeoDataFrame(
-        {
-            "idx": [1, 2, 3],
-            "geometry": geopandas.GeoSeries.from_wkt(
-                ["POINT (0 1)", "POINT (2 3)", "POINT (4 5)"], crs="EPSG:3857"
-            ),
-        }
-    ).set_geometry("geometry")
+        # DuckDB doesn't support CRSes
+        if eng.name() == "duckdb":
+            check_crs = False
+        else:
+            check_crs = True
 
-    # DuckDB doesn't support CRSes
-    if eng.name() == "duckdb":
-        check_crs = False
-    else:
-        check_crs = True
+        with tempfile.TemporaryDirectory() as td:
+            parquet_file = Path(td) / "df.parquet"
+            df.to_parquet(parquet_file)
 
-    with tempfile.TemporaryDirectory() as td:
-        parquet_file = Path(td) / "df.parquet"
-        df.to_parquet(parquet_file)
+            # PostGIS doesn't support views
+            if eng.name() != "postgis":
+                eng.create_view_parquet("test_df", str(parquet_file))
+                eng.assert_query_result(
+                    "SELECT * FROM test_df ORDER BY idx", df, check_crs=check_crs
+                )
 
-        # PostGIS doesn't support views
-        if eng.name() != "postgis":
-            eng.create_view_parquet("test_df", str(parquet_file))
+            eng.create_table_parquet("test_df", str(parquet_file))
             eng.assert_query_result(
                 "SELECT * FROM test_df ORDER BY idx", df, check_crs=check_crs
             )
-
-        eng.create_table_parquet("test_df", str(parquet_file))
-        eng.assert_query_result(
-            "SELECT * FROM test_df ORDER BY idx", df, check_crs=check_crs
-        )


### PR DESCRIPTION
This patch depends on https://github.com/apache/sedona-db/pull/70.

The pytest may hang when some of the test fails. This is a workflow run that exhibited this problem: https://github.com/apache/sedona-db/actions/runs/17668086933/job/50213528921

Pytest does not free up resources held by local variables by calling `__del__` in time when a test fails. When pytest captured the AssertionError, it effectively adds a reference to the local c object, preventing it from being __del__-ed when the function ends. This leaves the transaction started by the failed test active when the next test starts running.

We generate test data by dropping a temporary table, inserting data into the temporary table, and finally renaming the temporary table. Dropping the temporary table will be blocked by a lock held by the still-active transaction started by the previously failed test:

```
postgres=# select pid, query, state, wait_event, wait_event_type, backend_type from pg_stat_activity;
  pid  |                                           query                                            |        state        |     wait_event      | wait_event_type |         backend_type         
-------+--------------------------------------------------------------------------------------------+---------------------+---------------------+-----------------+------------------------------
 99895 |                                                                                            |                     | AutoVacuumMain      | Activity        | autovacuum launcher
 99896 |                                                                                            |                     | LogicalLauncherMain | Activity        | logical replication launcher
 83813 | select pid, query, state, wait_event, wait_event_type, backend_type from pg_stat_activity; | active              |                     |                 | client backend
 47073 | DROP TABLE IF EXISTS "public" . "sjoin_polygon_xtemp"                                      | idle in transaction | ClientRead          | Client          | client backend
 51565 | DROP TABLE IF EXISTS "public" . "sjoin_point_xtemp"                                        | active              | relation            | Lock            | client backend
 66330 | DROP TABLE IF EXISTS "public" . "sjoin_point_xtemp"                                        | active              | relation            | Lock            | client backend
 71494 | DROP TABLE IF EXISTS "public" . "sjoin_point_xtemp"                                        | active              | relation            | Lock            | client backend
 99892 |                                                                                            |                     | BgWriterHibernate   | Activity        | background writer
 99891 |                                                                                            |                     | CheckpointerMain    | Activity        | checkpointer
 99894 |                                                                                            |                     | WalWriterMain       | Activity        | walwriter

```

This patch fixes this problem by managing connections using `with` statement. The transaction will be committed or rolled back when the connection is closed. This prevents us from leaking transactions and blocking ourselves on table locks.