### PR TITLE
Default proj log level to none

### DIFF
--- a/c/sedona-proj/src/proj.rs
+++ b/c/sedona-proj/src/proj.rs
@@ -132,16 +132,12 @@ impl ProjContext {
 
     /// Set the logging level for PROJ operations
     ///
-    /// # Arguments
-    ///
-    /// * `level` - Integer value representing the log level:
-    ///   - 0: PJ_LOG_NONE - No logging (default)
-    ///   - 1: PJ_LOG_ERROR - Log only errors
-    ///   - 2: PJ_LOG_DEBUG - Log detailed debug information
-    ///   - 3: PJ_LOG_TRACE - Log extremely detailed information
-    ///   - 4: PJ_LOG_TELL - Detailed settings info
-    ///
-    /// Returns an error if the PROJ API call fails.
+    /// `level` - Unsigned Integer value representing the log level:
+    /// - PJ_LOG_LEVEL_PJ_LOG_NONE (0): No logging
+    /// - PJ_LOG_LEVEL_PJ_LOG_ERROR (1): Error messages
+    /// - PJ_LOG_LEVEL_PJ_LOG_DEBUG (2): Debug messages
+    /// - PJ_LOG_LEVEL_PJ_LOG_TRACE (3): Trace
+    /// - PJ_LOG_LEVEL_PJ_LOG_TELL (4): Tell
     pub(crate) fn set_log_level(&self, level: u32) -> Result<(), SedonaProjError> {
         unsafe {
             call_proj_api!(self.api, proj_log_level, self.inner, level);

--- a/c/sedona-proj/src/proj.rs
+++ b/c/sedona-proj/src/proj.rs
@@ -130,6 +130,25 @@ impl ProjContext {
         }
     }
 
+    /// Set the logging level for PROJ operations
+    ///
+    /// # Arguments
+    ///
+    /// * `level` - Integer value representing the log level:
+    ///   - 0: PJ_LOG_NONE - No logging (default)
+    ///   - 1: PJ_LOG_ERROR - Log only errors
+    ///   - 2: PJ_LOG_DEBUG - Log detailed debug information
+    ///   - 3: PJ_LOG_TRACE - Log extremely detailed information
+    ///   - 4: PJ_LOG_TELL - Detailed settings info
+    ///
+    /// Returns an error if the PROJ API call fails.
+    pub(crate) fn set_log_level(&self, level: u32) -> Result<(), SedonaProjError> {
+        unsafe {
+            call_proj_api!(self.api, proj_log_level, self.inner, level);
+        }
+        Ok(())
+    }
+
     /// Set the path in which to look for PROJ data files
     ///
     /// Most PROJ distributions come with a few small data files installed to a /share directory

--- a/c/sedona-proj/src/transform.rs
+++ b/c/sedona-proj/src/transform.rs
@@ -14,6 +14,9 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+use crate::error::SedonaProjError;
+use crate::proj::{Proj, ProjContext};
+use proj_sys::PJ_LOG_LEVEL_PJ_LOG_NONE;
 use sedona_geometry::bounding_box::BoundingBox;
 use sedona_geometry::error::SedonaGeometryError;
 use sedona_geometry::interval::IntervalTrait;
@@ -21,9 +24,6 @@ use sedona_geometry::transform::{CrsEngine, CrsTransform};
 use std::cell::RefCell;
 use std::path::PathBuf;
 use std::rc::Rc;
-
-use crate::error::SedonaProjError;
-use crate::proj::{Proj, ProjContext};
 
 /// Builder for a [ProjCrsEngine]
 ///
@@ -34,6 +34,7 @@ pub struct ProjCrsEngineBuilder {
     shared_library: Option<PathBuf>,
     database_path: Option<PathBuf>,
     search_paths: Option<Vec<PathBuf>>,
+    log_level: Option<u32>,
 }
 
 impl ProjCrsEngineBuilder {
@@ -82,6 +83,25 @@ impl ProjCrsEngineBuilder {
         }
     }
 
+    /// Set the PROJ log level
+    ///
+    /// Set the verbosity of PROJ logging. The default is no logging,
+    /// however errors will still be propagated through the error
+    /// handling.
+    ///
+    /// Log level constants are defined in proj_sys:
+    /// - PJ_LOG_LEVEL_PJ_LOG_NONE (0): No logging
+    /// - PJ_LOG_LEVEL_PJ_LOG_ERROR (1): Error messages
+    /// - PJ_LOG_LEVEL_PJ_LOG_DEBUG (2): Debug messages
+    /// - PJ_LOG_LEVEL_PJ_LOG_TRACE (3): Trace
+    /// - PJ_LOG_LEVEL_PJ_LOG_TELL (4): Tell
+    pub fn with_log_level(self, log_level: u32) -> Self {
+        Self {
+            log_level: Some(log_level),
+            ..self
+        }
+    }
+
     /// Build a [ProjCrsEngine] with the specified options
     pub fn build(&self) -> Result<ProjCrsEngine, SedonaProjError> {
         let mut ctx = if let Some(shared_library) = self.shared_library.clone() {
@@ -100,6 +120,13 @@ impl ProjCrsEngineBuilder {
                 .map(|path| path.to_string_lossy().to_string())
                 .collect::<Vec<_>>();
             ctx.set_search_paths(&string_vec)?;
+        }
+
+        if let Some(log_level) = &self.log_level {
+            ctx.set_log_level(*log_level)?;
+        } else {
+            // Default log level to none
+            ctx.set_log_level(PJ_LOG_LEVEL_PJ_LOG_NONE)?;
         }
 
         Ok(ProjCrsEngine { ctx: Rc::new(ctx) })


### PR DESCRIPTION
Currently, invalid inputs to proj via `ST_Transform` are resulting in large log dumps to std out.

For example, for a single row:
```
> SELECT ST_Transform(ST_GeomFromText('POINT (1000 1000)'), 'EPSG:4326', 'EPSG:3857') as geom;
webmerc: Invalid latitude
webmerc: Invalid latitude
webmerc: Invalid latitude
webmerc: Invalid latitude
webmerc: Invalid latitude
webmerc: Invalid latitude
webmerc: Invalid latitude
webmerc: Invalid latitude
webmerc: Invalid latitude
webmerc: Invalid latitude
webmerc: Invalid latitude
webmerc: Invalid latitude
webmerc: Invalid latitude
Execution error: Transform error: PROJ coordinate transformation failed with error: Invalid coordinate
```

Since we are already capturing and sharing the error message, this change lowers the log level to none/0, but allows users to override it.



After this change, the excess error messages no longer appear and the user can jump straight to the useful error message. For example:
```
> SELECT ST_Transform(ST_GeomFromText('POINT (1000 1000)'), 'EPSG:4326', 'EPSG:3857') as geom;
Execution error: Transform error: PROJ coordinate transformation failed with error: Invalid coordinate
```

Tracking issue: #30 