### PR TITLE
Fix missing SRID on EPSG:4326

### DIFF
--- a/rust/sedona-schema/src/crs.rs
+++ b/rust/sedona-schema/src/crs.rs
@@ -213,7 +213,7 @@ impl CoordinateReferenceSystem for AuthorityCode {
     fn srid(&self) -> Result<Option<u32>> {
         if self.authority.eq_ignore_ascii_case("EPSG") {
             Ok(self.code.parse::<u32>().ok())
-        } else if LngLat::is_authority_code_lnglat(&format!("{}:{}", self.authority, self.code)) {
+        } else if LngLat::is_lnglat(self) {
             Ok(Some(4326))
         } else {
             Ok(None)

--- a/rust/sedona-schema/src/crs.rs
+++ b/rust/sedona-schema/src/crs.rs
@@ -213,6 +213,8 @@ impl CoordinateReferenceSystem for AuthorityCode {
     fn srid(&self) -> Result<Option<u32>> {
         if self.authority.eq_ignore_ascii_case("EPSG") {
             Ok(self.code.parse::<u32>().ok())
+        } else if LngLat::is_authority_code_lnglat(&format!("{}:{}", self.authority, self.code)) {
+            Ok(Some(4326))
         } else {
             Ok(None)
         }
@@ -391,5 +393,9 @@ mod test {
             Some("EPSG:4269".to_string())
         );
         assert_eq!(new_crs.unwrap().srid().unwrap(), Some(4269));
+
+        let value: Value = serde_json::from_str("\"EPSG:4326\"").unwrap();
+        let new_crs = deserialize_crs(&value).unwrap();
+        assert_eq!(new_crs.clone().unwrap().srid().unwrap(), Some(4326));
     }
 }


### PR DESCRIPTION
`EPSG:4326` has  a unique CRS implementation that accepts an EPSG and OGC code.  This was not working with the auth code's `srid()` function. 

Current:
```
> SELECT ST_SRID(ST_SetSrid(ST_GeomFromText('POINT (100 100)'), 4326));
Execution error: CRS has no SRID
```

After fix:
```
> SELECT ST_SRID(ST_SetSrid(ST_GeomFromText('POINT (100 100)'), 4326));
┌──────────────────────────────────────────────────────────────────────────┐
│ st_srid(st_setsrid(st_geomfromwkt(Utf8("POINT (100 100)")),Int64(4326))) │
│                                  uint32                                  │
╞══════════════════════════════════════════════════════════════════════════╡
│                                                                     4326 │
└──────────────────────────────────────────────────────────────────────────┘
```

# Testing
unit test + query validation