### PR TITLE
docs: crs tracking example

### DIFF
--- a/docs/crs-examples.ipynb
+++ b/docs/crs-examples.ipynb
@@ -1,0 +1,206 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "91910e50-a5ae-4d5a-a431-62ac5fbc11ca",
+   "metadata": {},
+   "source": [
+    "# CRS Examples\n",
+    "\n",
+    "This example demonstrates how one table with a EPSG 4326 CRS cannot be joined with another table that uses EPSG 3857."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c0626834-2960-4d24-b241-b57a91962998",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sedonadb\n",
+    "\n",
+    "sd = sedonadb.connect()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54b48173-6be0-4827-ac42-1439eb31e9f7",
+   "metadata": {},
+   "source": [
+    "Create a table with a geometry column that uses EPSG 4326."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "143f00d5-6878-4dab-a82c-c9fb4dbfaf00",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "countries = sd.read_parquet(\n",
+    "    \"https://raw.githubusercontent.com/geoarrow/geoarrow-data/v0.2.0/natural-earth/files/natural-earth_countries_geo.parquet\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8ef94b7b-b65d-4da5-9443-3253e84e2e7f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "SedonaSchema with 3 fields:\n",
+       "  name: Utf8View\n",
+       "  continent: Utf8View\n",
+       "  geometry: wkb_view <epsg:4326>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "countries.schema"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "12d94c4f-5e7f-47c6-b5cc-3a3363bbc290",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cities = sd.sql(\"\"\"\n",
+    "SELECT * FROM (VALUES\n",
+    "    ('New York', ST_SetSRID(ST_GeomFromText('POINT(-8238310.24 4969803.34)'), 3857)),\n",
+    "    ('Los Angeles', ST_SetSRID(ST_GeomFromText('POINT(-13153204.78 4037636.04)'), 3857)),\n",
+    "    ('Chicago', ST_SetSRID(ST_GeomFromText('POINT(-9757148.04 5138517.44)'), 3857)))\n",
+    "AS t(city, geometry)\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "36e53438-c2d2-444e-9f34-d391f0f3f588",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "SedonaSchema with 2 fields:\n",
+       "  city: Utf8\n",
+       "  geometry: Binary"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cities.schema"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "62c87571-50aa-4f57-a7dd-4afa3210320a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sd.sql(\"drop view if exists cities\")\n",
+    "cities.to_view(\"cities\")\n",
+    "sd.sql(\"drop view if exists countries\")\n",
+    "countries.to_view(\"countries\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "906bad37-4f3f-4028-82b4-487fabe5957f",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "SedonaError",
+     "evalue": "type_coercion\ncaused by\nThis feature is not implemented: st_intersects([Arrow(Binary), WkbView(Planar, Some(ProjJSON { value: Object {\"$schema\": String(\"https://proj.org/schemas/v0.7/projjson.schema.json\"), \"area\": String(\"World.\"), \"bbox\": Object {\"east_longitude\": Number(180), \"north_latitude\": Number(90), \"south_latitude\": Number(-90), \"west_longitude\": Number(-180)}, \"coordinate_system\": Object {\"axis\": Array [Object {\"abbreviation\": String(\"Lat\"), \"direction\": String(\"north\"), \"name\": String(\"Geodetic latitude\"), \"unit\": String(\"degree\")}, Object {\"abbreviation\": String(\"Lon\"), \"direction\": String(\"east\"), \"name\": String(\"Geodetic longitude\"), \"unit\": String(\"degree\")}], \"subtype\": String(\"ellipsoidal\")}, \"datum_ensemble\": Object {\"accuracy\": String(\"2.0\"), \"ellipsoid\": Object {\"inverse_flattening\": Number(298.257223563), \"name\": String(\"WGS 84\"), \"semi_major_axis\": Number(6378137)}, \"id\": Object {\"authority\": String(\"EPSG\"), \"code\": Number(6326)}, \"members\": Array [Object {\"name\": String(\"World Geodetic System 1984 (Transit)\")}, Object {\"name\": String(\"World Geodetic System 1984 (G730)\")}, Object {\"name\": String(\"World Geodetic System 1984 (G873)\")}, Object {\"name\": String(\"World Geodetic System 1984 (G1150)\")}, Object {\"name\": String(\"World Geodetic System 1984 (G1674)\")}, Object {\"name\": String(\"World Geodetic System 1984 (G1762)\")}, Object {\"name\": String(\"World Geodetic System 1984 (G2139)\")}, Object {\"name\": String(\"World Geodetic System 1984 (G2296)\")}], \"name\": String(\"World Geodetic System 1984 ensemble\")}, \"id\": Object {\"authority\": String(\"EPSG\"), \"code\": Number(4326)}, \"name\": String(\"WGS 84\"), \"scope\": String(\"Horizontal component of 3D system.\"), \"type\": String(\"GeographicCRS\")} }))]): No kernel matching arguments",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mSedonaError\u001b[0m                               Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[23], line 6\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# join doesn't work when CRSs don't match\u001b[39;00m\n\u001b[1;32m      2\u001b[0m \u001b[43msd\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43msql\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\"\"\u001b[39;49m\n\u001b[1;32m      3\u001b[0m \u001b[38;5;124;43mselect * from cities\u001b[39;49m\n\u001b[1;32m      4\u001b[0m \u001b[38;5;124;43mjoin countries\u001b[39;49m\n\u001b[1;32m      5\u001b[0m \u001b[38;5;124;43mwhere ST_Intersects(cities.geometry, countries.geometry)\u001b[39;49m\n\u001b[0;32m----> 6\u001b[0m \u001b[38;5;124;43m\"\"\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mshow\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/opt/miniconda3/lib/python3.12/site-packages/sedonadb/dataframe.py:297\u001b[0m, in \u001b[0;36mDataFrame.show\u001b[0;34m(self, limit, width, ascii)\u001b[0m\n\u001b[1;32m    272\u001b[0m \u001b[38;5;250m\u001b[39m\u001b[38;5;124;03m\"\"\"Print the first limit rows to the console\u001b[39;00m\n\u001b[1;32m    273\u001b[0m \n\u001b[1;32m    274\u001b[0m \u001b[38;5;124;03mArgs:\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    294\u001b[0m \n\u001b[1;32m    295\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    296\u001b[0m width \u001b[38;5;241m=\u001b[39m _out_width(width)\n\u001b[0;32m--> 297\u001b[0m \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_impl\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mshow\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_ctx\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mlimit\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mwidth\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mascii\u001b[49m\u001b[43m)\u001b[49m, end\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
+      "\u001b[0;31mSedonaError\u001b[0m: type_coercion\ncaused by\nThis feature is not implemented: st_intersects([Arrow(Binary), WkbView(Planar, Some(ProjJSON { value: Object {\"$schema\": String(\"https://proj.org/schemas/v0.7/projjson.schema.json\"), \"area\": String(\"World.\"), \"bbox\": Object {\"east_longitude\": Number(180), \"north_latitude\": Number(90), \"south_latitude\": Number(-90), \"west_longitude\": Number(-180)}, \"coordinate_system\": Object {\"axis\": Array [Object {\"abbreviation\": String(\"Lat\"), \"direction\": String(\"north\"), \"name\": String(\"Geodetic latitude\"), \"unit\": String(\"degree\")}, Object {\"abbreviation\": String(\"Lon\"), \"direction\": String(\"east\"), \"name\": String(\"Geodetic longitude\"), \"unit\": String(\"degree\")}], \"subtype\": String(\"ellipsoidal\")}, \"datum_ensemble\": Object {\"accuracy\": String(\"2.0\"), \"ellipsoid\": Object {\"inverse_flattening\": Number(298.257223563), \"name\": String(\"WGS 84\"), \"semi_major_axis\": Number(6378137)}, \"id\": Object {\"authority\": String(\"EPSG\"), \"code\": Number(6326)}, \"members\": Array [Object {\"name\": String(\"World Geodetic System 1984 (Transit)\")}, Object {\"name\": String(\"World Geodetic System 1984 (G730)\")}, Object {\"name\": String(\"World Geodetic System 1984 (G873)\")}, Object {\"name\": String(\"World Geodetic System 1984 (G1150)\")}, Object {\"name\": String(\"World Geodetic System 1984 (G1674)\")}, Object {\"name\": String(\"World Geodetic System 1984 (G1762)\")}, Object {\"name\": String(\"World Geodetic System 1984 (G2139)\")}, Object {\"name\": String(\"World Geodetic System 1984 (G2296)\")}], \"name\": String(\"World Geodetic System 1984 ensemble\")}, \"id\": Object {\"authority\": String(\"EPSG\"), \"code\": Number(4326)}, \"name\": String(\"WGS 84\"), \"scope\": String(\"Horizontal component of 3D system.\"), \"type\": String(\"GeographicCRS\")} }))]): No kernel matching arguments"
+     ]
+    }
+   ],
+   "source": [
+    "# join doesn't work when CRSs don't match\n",
+    "sd.sql(\"\"\"\n",
+    "select * from cities\n",
+    "join countries\n",
+    "where ST_Intersects(cities.geometry, countries.geometry)\n",
+    "\"\"\").show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "819c8d04-fa03-4ef8-aecb-e79d48f0b820",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "SedonaError",
+     "evalue": "type_coercion\ncaused by\nError during planning: Mismatched CRS arguments: None vs epsg:4326\nUse ST_Transform() or ST_SetSRID() to ensure arguments are compatible.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mSedonaError\u001b[0m                               Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[25], line 6\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# join works when CRSs match\u001b[39;00m\n\u001b[1;32m      2\u001b[0m \u001b[43msd\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43msql\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\"\"\u001b[39;49m\n\u001b[1;32m      3\u001b[0m \u001b[38;5;124;43mselect * from cities\u001b[39;49m\n\u001b[1;32m      4\u001b[0m \u001b[38;5;124;43mjoin countries\u001b[39;49m\n\u001b[1;32m      5\u001b[0m \u001b[38;5;124;43mwhere ST_Intersects(ST_Transform(cities.geometry, 4326), countries.geometry)\u001b[39;49m\n\u001b[0;32m----> 6\u001b[0m \u001b[38;5;124;43m\"\"\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mshow\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/opt/miniconda3/lib/python3.12/site-packages/sedonadb/dataframe.py:297\u001b[0m, in \u001b[0;36mDataFrame.show\u001b[0;34m(self, limit, width, ascii)\u001b[0m\n\u001b[1;32m    272\u001b[0m \u001b[38;5;250m\u001b[39m\u001b[38;5;124;03m\"\"\"Print the first limit rows to the console\u001b[39;00m\n\u001b[1;32m    273\u001b[0m \n\u001b[1;32m    274\u001b[0m \u001b[38;5;124;03mArgs:\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    294\u001b[0m \n\u001b[1;32m    295\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    296\u001b[0m width \u001b[38;5;241m=\u001b[39m _out_width(width)\n\u001b[0;32m--> 297\u001b[0m \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_impl\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mshow\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_ctx\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mlimit\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mwidth\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mascii\u001b[49m\u001b[43m)\u001b[49m, end\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
+      "\u001b[0;31mSedonaError\u001b[0m: type_coercion\ncaused by\nError during planning: Mismatched CRS arguments: None vs epsg:4326\nUse ST_Transform() or ST_SetSRID() to ensure arguments are compatible."
+     ]
+    }
+   ],
+   "source": [
+    "# join works when CRSs match\n",
+    "sd.sql(\"\"\"\n",
+    "select * from cities\n",
+    "join countries\n",
+    "where ST_Intersects(ST_Transform(cities.geometry, 4326), countries.geometry)\n",
+    "\"\"\").show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "99cd946c-53e7-4db6-b052-ed6daa9291ad",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
I'm trying to demonstrate how SedonaDB tracks CRSs and doesn't allow for operations with mismatched CRSs.

Doesn't look like this code is properly setting the CRS:

```python
cities = sd.sql("""
SELECT * FROM (VALUES
    ('New York', ST_SetSRID(ST_GeomFromText('POINT(-8238310.24 4969803.34)'), 3857)),
    ('Los Angeles', ST_SetSRID(ST_GeomFromText('POINT(-13153204.78 4037636.04)'), 3857)),
    ('Chicago', ST_SetSRID(ST_GeomFromText('POINT(-9757148.04 5138517.44)'), 3857)))
AS t(city, geometry)""")
```

```
cities.schema
SedonaSchema with 2 fields:
  city: Utf8
  geometry: Binary
```

Let me know if you have any suggestions on how to fix the code!