### PR TITLE
Add st_srid and st_crs benchmarks

### DIFF
--- a/rust/sedona-functions/benches/native-functions.rs
+++ b/rust/sedona-functions/benches/native-functions.rs
@@ -123,6 +123,9 @@ fn criterion_benchmark(c: &mut Criterion) {
         ),
     );
 
+    benchmark::scalar(c, &f, "native", "st_srid", Point);
+    benchmark::scalar(c, &f, "native", "st_crs", Point);
+
     benchmark::scalar(c, &f, "native", "st_x", Point);
     benchmark::scalar(c, &f, "native", "st_y", Point);
     benchmark::scalar(c, &f, "native", "st_z", Point);

--- a/rust/sedona-testing/src/datagen.rs
+++ b/rust/sedona-testing/src/datagen.rs
@@ -37,7 +37,8 @@ use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use sedona_common::sedona_internal_err;
 use sedona_geometry::types::GeometryTypeId;
-use sedona_schema::datatypes::{SedonaType, WKB_GEOMETRY};
+use sedona_schema::crs::lnglat;
+use sedona_schema::datatypes::{Edges, SedonaType};
 use std::f64::consts::PI;
 use std::sync::Arc;
 
@@ -106,7 +107,7 @@ impl Default for RandomPartitionedDataBuilder {
             num_partitions: 1,
             batches_per_partition: 1,
             rows_per_batch: 10,
-            sedona_type: WKB_GEOMETRY,
+            sedona_type: SedonaType::Wkb(Edges::Planar, lnglat()),
             null_rate: 0.0,
             options,
         }


### PR DESCRIPTION
Add benchmarks for `ST_SRID` and `ST_CRS`.

```

native-st_srid-Array(Point)
                        time:   [306.04 µs 306.57 µs 307.17 µs]
Found 14 outliers among 100 measurements (14.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  9 (9.00%) high severe

native-st_crs-Array(Point)
                        time:   [461.19 µs 493.95 µs 529.93 µs]
Found 18 outliers among 100 measurements (18.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  15 (15.00%) high severe
```

Issue: #28 