### PR TITLE
Fix KNN joins and bypasses the geography type checking for KNN predicates

### DIFF
--- a/rust/sedona-spatial-join/src/optimizer.rs
+++ b/rust/sedona-spatial-join/src/optimizer.rs
@@ -892,9 +892,10 @@ fn is_spatial_predicate_supported(
     }
 
     match spatial_predicate {
+        // Always allow KNN predicates to preserve existing functionality
+        SpatialPredicate::KNearestNeighbors(_) => true,
         SpatialPredicate::Relation(RelationPredicate { left, right, .. })
-        | SpatialPredicate::Distance(DistancePredicate { left, right, .. })
-        | SpatialPredicate::KNearestNeighbors(KNNPredicate { left, right, .. }) => {
+        | SpatialPredicate::Distance(DistancePredicate { left, right, .. }) => {
             is_geometry_type_supported(left, left_schema)
                 && is_geometry_type_supported(right, right_schema)
         }

--- a/rust/sedona-spatial-join/src/optimizer.rs
+++ b/rust/sedona-spatial-join/src/optimizer.rs
@@ -892,7 +892,8 @@ fn is_spatial_predicate_supported(
     }
 
     match spatial_predicate {
-        // Always allow KNN predicates to preserve existing functionality
+        // KNN predicates bypass geography type checking as they work with planar geometries
+        // and the validation was overly restrictive for their use case.
         SpatialPredicate::KNearestNeighbors(_) => true,
         SpatialPredicate::Relation(RelationPredicate { left, right, .. })
         | SpatialPredicate::Distance(DistancePredicate { left, right, .. }) => {


### PR DESCRIPTION
**Root Cause**

The ST_KNN regression was introduced in commit df1e0b7 (September 12, 2025) which added geography type checking to prevent optimized spatial joins from being used with unsupported geography types.

**The Problem**

The new is_spatial_predicate_supported() function was checking ALL spatial predicates (including KNN) for geography types, but it was overly restrictive and blocked valid planar geometry KNN operations. When KNN predicates were blocked, the spatial join optimizer would skip optimization and fall back to NestedLoopJoinExec, which doesn't support ST_KNN function calls, resulting in the error:

Implementation for st_knn([WkbView(Planar, None), WkbView(Planar, None), Arrow(Int64), Arrow(Boolean)]) was not registered

