### PR TITLE
Update the github action to leverage mike for versioned doc

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -150,10 +150,10 @@ jobs:
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
-          
+
           # Extract docs
           tar -xf docs.tgz
-          
+
           # Deploy based on trigger type
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             # Deploy tagged version and set as latest and default

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -129,21 +129,18 @@ jobs:
           path: |
             docs.tgz
 
-      - name: Deploy documentation with mike
-        if: github.event_name == 'push'
+      - name: Deploy the doc to the website branch
+        if: ${{ github.event_name != 'pull_request' && github.repository == 'apache/sedona-db' }}
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
+          git fetch origin asf-site --depth=1
 
-          # Deploy based on branch
-          if [ "${{ github.ref_name }}" = "main" ]; then
-            # Deploy development snapshot for main branch
+          if [[ "${GITHUB_REF##*/}" == "main" ]]; then
             mike deploy latest-snapshot -b asf-site -p
-          elif [[ "${{ github.ref_name }}" =~ ^branch-(.+)$ ]]; then
-            # Extract version from branch name (e.g., branch-0.1.0 -> 0.1.0)
-            VERSION=${BASH_REMATCH[1]}
-            # Deploy version and set as latest and default
-            mike deploy --update-aliases $VERSION latest -b asf-site -p
+          elif [[ "${GITHUB_REF##*/}" =~ ^branch-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            version="${GITHUB_REF##*/branch-}"
+            mike deploy --update-aliases "$version" latest -b asf-site -p
             mike set-default latest -b asf-site -p
           fi
 

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -21,17 +21,12 @@ on:
   push:
     branches:
       - main
+      - 'branch-*'
     tags:
         - 'apache-sedona-db-*-rc*'
   pull_request:
     branches:
       - main
-  workflow_dispatch:
-    inputs:
-      tag_name:
-        description: 'Git tag name to deploy documentation for a specific release version (e.g., 0.1.0)'
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -78,10 +73,12 @@ jobs:
           path: |
             apache-sedona-db-${{ env.VERSION }}.tar.gz
 
-  docs:
+  docs-and-deploy:
     runs-on: ubuntu-latest
     env:
       CARGO_INCREMENTAL: 0
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
@@ -132,42 +129,28 @@ jobs:
           path: |
             docs.tgz
 
-  update-asf-site:
-    runs-on: ubuntu-latest
-    needs:
-      - docs
-    permissions:
-      contents: write
-
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: docs
-
       - name: Deploy documentation with mike
-        env:
-          TAG_NAME: ${{ github.event.inputs.tag_name }}
+        if: github.event_name == 'push'
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
 
-          # Extract docs
-          tar -xf docs.tgz
-
-          # Deploy based on trigger type
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            # Deploy tagged version and set as latest and default
-            mike deploy --update-aliases $TAG_NAME latest -b asf-site -p
-            mike set-default latest -b asf-site -p
-          else
-            # Deploy development snapshot
+          # Deploy based on branch
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            # Deploy development snapshot for main branch
             mike deploy latest-snapshot -b asf-site -p
+          elif [[ "${{ github.ref_name }}" =~ ^branch-(.+)$ ]]; then
+            # Extract version from branch name (e.g., branch-0.1.0 -> 0.1.0)
+            VERSION=${BASH_REMATCH[1]}
+            # Deploy version and set as latest and default
+            mike deploy --update-aliases $VERSION latest -b asf-site -p
+            mike set-default latest -b asf-site -p
           fi
 
   create-release:
     runs-on: ubuntu-latest
     needs:
-      - docs
+      - docs-and-deploy
       - source
     permissions:
       contents: write

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -26,6 +26,12 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Git tag name to deploy documentation for a specific release version (e.g., 0.1.0)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -138,36 +144,25 @@ jobs:
         with:
           name: docs
 
-      - name: Clone asf-site branch
-        uses: actions/checkout@v4
-        with:
-          ref: asf-site
-          path: pages-clone
-
-      - name: Update development documentation
+      - name: Deploy documentation with mike
         env:
-          DOC_TAG: "dev-snapshot-main"
-
+          TAG_NAME: ${{ github.event.inputs.tag_name }}
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
-
-          cd pages-clone
-          if [ -d "$DOC_TAG" ]; then
-            git rm -rf "$DOC_TAG"
+          
+          # Extract docs
+          tar -xf docs.tgz
+          
+          # Deploy based on trigger type
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # Deploy tagged version and set as latest and default
+            mike deploy --update-aliases $TAG_NAME latest -b asf-site -p
+            mike set-default latest -b asf-site -p
+          else
+            # Deploy development snapshot
+            mike deploy latest-snapshot -b asf-site -p
           fi
-
-          tar -xf ../docs.tgz
-          mv sedona-db-docs "$DOC_TAG"
-
-          git add *
-          git commit --allow-empty -m"update documentation for tag $DOC_TAG"
-
-      - name: Push development documentation to asf-site
-        if: success() && github.repository == 'apache/sedona-db' && github.ref == 'refs/heads/main'
-        run: |
-          cd pages-clone
-          git push
 
   create-release:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ __pycache__
 
 # R-related files
 .Rproj.user
+*


### PR DESCRIPTION
## Summary
Migrated documentation deployment from manual git operations to mike mkdocs with automated versioning based on branch patterns.

## Key Changes
- **Replaced manual git operations** with mike deploy commands
- **New branching strategy**: 
  - `main` → deploys as `latest-snapshot`
  - `branch-x.y.z` → deploys as version `x.y.z` and sets as latest/default
  - PRs → build artifacts only, no deployment
- **Consolidated jobs**: Merged `docs` and `update-asf-site` into single `docs-and-deploy` job
- **Removed workflow dispatch**: Fully automated based on branch patterns

## Benefits
- Automated version management
- Cleaner, more efficient workflow
- Better maintainability with mike's built-in features