### PR TITLE
perf: Faster `st_geometrytype()` function

### DIFF
--- a/rust/sedona-functions/src/executor.rs
+++ b/rust/sedona-functions/src/executor.rs
@@ -129,12 +129,15 @@ impl<'a, 'b, Factory0: GeometryFactory, Factory1: GeometryFactory>
         &self,
         mut func: F,
     ) -> Result<()> {
-        // Ensure the first argument of the executor is either Wkb or WkbView
+        // Ensure the first argument of the executor is either Wkb, WkbView, or
+        // a Null type (to support columns of all-null values)
         match &self.arg_types[0] {
-            SedonaType::Wkb(_, _) | SedonaType::WkbView(_, _) => {}
+            SedonaType::Wkb(_, _)
+            | SedonaType::WkbView(_, _)
+            | SedonaType::Arrow(DataType::Null) => {}
             other => {
                 return sedona_internal_err!(
-                    "Expected SedonaType::Wkb or SedonaType::WkbView for the first arg, got {}",
+                    "Expected SedonaType::Wkb or SedonaType::WkbView or SedonaType::Arrow(DataType::Null) for the first arg, got {}",
                     other
                 )
             }

--- a/rust/sedona-functions/src/st_geometrytype.rs
+++ b/rust/sedona-functions/src/st_geometrytype.rs
@@ -89,6 +89,8 @@ impl SedonaScalarKernel for STGeometryType {
 /// An error will be thrown for invalid WKB bytes input
 ///
 /// Spec: https://libgeos.org/specifications/wkb/
+///
+/// TODO: Move it to `Wkb` crate
 #[inline]
 fn infer_geometry_type_name(buf: &[u8]) -> Result<&'static str> {
     if buf.len() < 5 {

--- a/rust/sedona-functions/src/st_geometrytype.rs
+++ b/rust/sedona-functions/src/st_geometrytype.rs
@@ -69,18 +69,6 @@ impl SedonaScalarKernel for STGeometryType {
         let min_output_size = "POINT".len() * executor.num_iterations();
         let mut builder = StringBuilder::with_capacity(executor.num_iterations(), min_output_size);
 
-        // // We can do quite a lot better than this with some vectorized WKB processing,
-        // // but for now we just do a slow iteration
-        // executor.execute_wkb_void(|maybe_item| {
-        //     match maybe_item {
-        //         Some(item) => {
-        //             builder.append_option(invoke_scalar(&item)?);
-        //         }
-        //         None => builder.append_null(),
-        //     }
-        //     Ok(())
-        // })?;
-
         // Iterate over raw WKB bytes for faster type inference
         executor.execute_wkb_bytes_void(|maybe_bytes| {
             match maybe_bytes {

--- a/rust/sedona-functions/src/st_geometrytype.rs
+++ b/rust/sedona-functions/src/st_geometrytype.rs
@@ -69,6 +69,18 @@ impl SedonaScalarKernel for STGeometryType {
         let min_output_size = "POINT".len() * executor.num_iterations();
         let mut builder = StringBuilder::with_capacity(executor.num_iterations(), min_output_size);
 
+        // // We can do quite a lot better than this with some vectorized WKB processing,
+        // // but for now we just do a slow iteration
+        // executor.execute_wkb_void(|maybe_item| {
+        //     match maybe_item {
+        //         Some(item) => {
+        //             builder.append_option(invoke_scalar(&item)?);
+        //         }
+        //         None => builder.append_null(),
+        //     }
+        //     Ok(())
+        // })?;
+
         // Iterate over raw WKB bytes for faster type inference
         executor.execute_wkb_bytes_void(|maybe_bytes| {
             match maybe_bytes {

--- a/rust/sedona-functions/src/st_geometrytype.rs
+++ b/rust/sedona-functions/src/st_geometrytype.rs
@@ -16,7 +16,7 @@
 // under the License.
 use std::sync::Arc;
 
-use crate::executor::WkbExecutor;
+use crate::executor::WkbBytesExecutor;
 use arrow_array::builder::StringBuilder;
 use arrow_schema::DataType;
 use datafusion_common::error::Result;
@@ -65,8 +65,8 @@ impl SedonaScalarKernel for STGeometryType {
         arg_types: &[SedonaType],
         args: &[ColumnarValue],
     ) -> Result<ColumnarValue> {
-        let executor = WkbExecutor::new(arg_types, args);
-        let min_output_size = "POINT".len() * executor.num_iterations();
+        let executor = WkbBytesExecutor::new(arg_types, args);
+        let min_output_size = "ST_POINT".len() * executor.num_iterations();
         let mut builder = StringBuilder::with_capacity(executor.num_iterations(), min_output_size);
 
         // Iterate over raw WKB bytes for faster type inference

--- a/rust/sedona-functions/src/st_geometrytype.rs
+++ b/rust/sedona-functions/src/st_geometrytype.rs
@@ -70,7 +70,7 @@ impl SedonaScalarKernel for STGeometryType {
         let mut builder = StringBuilder::with_capacity(executor.num_iterations(), min_output_size);
 
         // Iterate over raw WKB bytes for faster type inference
-        executor.execute_wkb_bytes_void(|maybe_bytes| {
+        executor.execute_wkb_void(|maybe_bytes| {
             match maybe_bytes {
                 Some(bytes) => {
                     let name = infer_geometry_type_name(bytes)?;
@@ -89,8 +89,6 @@ impl SedonaScalarKernel for STGeometryType {
 /// An error will be thrown for invalid WKB bytes input
 ///
 /// Spec: https://libgeos.org/specifications/wkb/
-///
-/// TODO: Move it to `Wkb` crate
 #[inline]
 fn infer_geometry_type_name(buf: &[u8]) -> Result<&'static str> {
     if buf.len() < 5 {

--- a/rust/sedona-functions/src/st_geometrytype.rs
+++ b/rust/sedona-functions/src/st_geometrytype.rs
@@ -23,11 +23,9 @@ use datafusion_common::error::Result;
 use datafusion_expr::{
     scalar_doc_sections::DOC_SECTION_OTHER, ColumnarValue, Documentation, Volatility,
 };
-use geo_traits::GeometryTrait;
 use sedona_common::sedona_internal_err;
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
-use wkb::reader::Wkb;
 
 pub fn st_geometry_type_udf() -> SedonaScalarUDF {
     SedonaScalarUDF::new(
@@ -71,12 +69,12 @@ impl SedonaScalarKernel for STGeometryType {
         let min_output_size = "POINT".len() * executor.num_iterations();
         let mut builder = StringBuilder::with_capacity(executor.num_iterations(), min_output_size);
 
-        // We can do quite a lot better than this with some vectorized WKB processing,
-        // but for now we just do a slow iteration
-        executor.execute_wkb_void(|maybe_item| {
-            match maybe_item {
-                Some(item) => {
-                    builder.append_option(invoke_scalar(&item)?);
+        // Iterate over raw WKB bytes for faster type inference
+        executor.execute_wkb_bytes_void(|maybe_bytes| {
+            match maybe_bytes {
+                Some(bytes) => {
+                    let name = infer_geometry_type_name(bytes)?;
+                    builder.append_value(name);
                 }
                 None => builder.append_null(),
             }
@@ -87,20 +85,33 @@ impl SedonaScalarKernel for STGeometryType {
     }
 }
 
-fn invoke_scalar(item: &Wkb) -> Result<Option<String>> {
-    match item.as_type() {
-        geo_traits::GeometryType::Point(_) => Ok(Some("ST_Point".to_string())),
-        geo_traits::GeometryType::LineString(_) => Ok(Some("ST_LineString".to_string())),
-        geo_traits::GeometryType::Polygon(_) => Ok(Some("ST_Polygon".to_string())),
-        geo_traits::GeometryType::MultiPoint(_) => Ok(Some("ST_MultiPoint".to_string())),
-        geo_traits::GeometryType::MultiLineString(_) => Ok(Some("ST_MultiLineString".to_string())),
-        geo_traits::GeometryType::MultiPolygon(_) => Ok(Some("ST_MultiPolygon".to_string())),
-        geo_traits::GeometryType::GeometryCollection(_) => {
-            Ok(Some("ST_GeometryCollection".to_string()))
-        }
+/// Fast-path inference of geometry type name from raw WKB bytes
+/// An error will be thrown for invalid WKB bytes input
+///
+/// Spec: https://libgeos.org/specifications/wkb/
+#[inline]
+fn infer_geometry_type_name(buf: &[u8]) -> Result<&'static str> {
+    if buf.len() < 5 {
+        return sedona_internal_err!("Invalid WKB: buffer too small ({} bytes)", buf.len());
+    }
 
-        // Other geometry types in geo that we should not get here: Rect, Triangle, Line
-        _ => sedona_internal_err!("unexpected geometry type"),
+    let byte_order = buf[0];
+    let code = match byte_order {
+        0 => u32::from_be_bytes([buf[1], buf[2], buf[3], buf[4]]),
+        1 => u32::from_le_bytes([buf[1], buf[2], buf[3], buf[4]]),
+        other => return sedona_internal_err!("Unexpected byte order: {other}"),
+    };
+
+    // Only low 3 bits is for the base type, high bits include additional info
+    match code & 0x7 {
+        1 => Ok("ST_Point"),
+        2 => Ok("ST_LineString"),
+        3 => Ok("ST_Polygon"),
+        4 => Ok("ST_MultiPoint"),
+        5 => Ok("ST_MultiLineString"),
+        6 => Ok("ST_MultiPolygon"),
+        7 => Ok("ST_GeometryCollection"),
+        _ => sedona_internal_err!("WKB type code out of range. Got: {}", code),
     }
 }
 


### PR DESCRIPTION
Hi 👋🏼 , I’m new to the project and still learning my way around. `sedona-db` looks great, and I’d really appreciate any feedbacks.

## Rationale
Before, the execution logic for `st_geometrytype()` function is, for each row, first parse the `WKB` binary into a `WKB` object, then extract the base type from the object. This approach includes parsing unused fields in the `WKB` binary, since only the geometry type is needed.

This PR let it iterate through the raw `WKB` bytes, and directly parse the bytes to get the geometry type.

## Implementation
1. Extend `GenericExecutor` with a new API `execute_wkb_bytes_void()` to iterate on raw `WKB` bytes.
2. Implement a util to parse the type from `WKB` binary according to the spec.
3. Update `st_geometrytype()` with 1 and 2

I think it's better to move `2` to `wkb` crate, it doesn't have such a public interface yet 🤔 

## Benchmark
### Command
```
pytest --benchmark-group-by=param:table --benchmark-columns=median,mean,stddev test_functions.py::TestBenchFunctions::test_st_geometrytype
```
### Result:
5x faster for complex collections, 30% faster for simple collections:
```sh
-------------------------------- benchmark 'table=collections_complex': 3 tests -------------------------------
Name (time in ms)                                        Median                Mean            StdDev
---------------------------------------------------------------------------------------------------------------
test_st_geometrytype[collections_complex-SedonaDB]       2.3656 (1.0)        2.4929 (1.0)      0.3857 (1.0)
test_st_geometrytype[collections_complex-DuckDB]        34.2037 (14.46)     34.3980 (13.80)    0.8402 (2.18)
test_st_geometrytype[collections_complex-PostGIS]      304.6275 (128.77)   306.7333 (123.04)   5.8908 (15.27)
---------------------------------------------------------------------------------------------------------------

------------------------------ benchmark 'table=collections_simple': 3 tests -------------------------------
Name (time in ms)                                      Median               Mean            StdDev
------------------------------------------------------------------------------------------------------------
test_st_geometrytype[collections_simple-SedonaDB]      1.3585 (1.0)       1.7419 (1.0)      1.2142 (9.41)
test_st_geometrytype[collections_simple-DuckDB]        5.1103 (3.76)      5.1443 (2.95)     0.1291 (1.0)
test_st_geometrytype[collections_simple-PostGIS]      46.8870 (34.51)    46.9021 (26.93)    0.3712 (2.88)
------------------------------------------------------------------------------------------------------------
```

```sh
-------------------------------------- benchmark 'table=collections_complex': 3 tests -------------------------------------
Name (time in us)                                            Median                    Mean                StdDev
---------------------------------------------------------------------------------------------------------------------------
test_st_geometrytype[collections_complex-SedonaDB]         419.2500 (1.0)          450.9272 (1.0)        124.1193 (1.0)
test_st_geometrytype[collections_complex-DuckDB]        32,422.7921 (77.34)     32,917.7395 (73.00)    2,088.4215 (16.83)
test_st_geometrytype[collections_complex-PostGIS]      295,752.0001 (705.43)   294,866.8750 (653.91)   3,872.8562 (31.20)
---------------------------------------------------------------------------------------------------------------------------

------------------------------------ benchmark 'table=collections_simple': 3 tests -------------------------------------
Name (time in us)                                          Median                   Mean                StdDev
------------------------------------------------------------------------------------------------------------------------
test_st_geometrytype[collections_simple-SedonaDB]        613.2090 (1.0)       1,144.3652 (1.0)      1,073.4389 (3.42)
test_st_geometrytype[collections_simple-DuckDB]        5,502.5411 (8.97)      5,556.3829 (4.86)       314.2311 (1.0)
test_st_geometrytype[collections_simple-PostGIS]      36,191.1250 (59.02)    36,322.7638 (31.74)      730.0613 (2.32)
------------------------------------------------------------------------------------------------------------------------
```