### PR TITLE
fix(ci): Don't set development version for wheel on a release branch and fix Windows wheel builds

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -26,7 +26,7 @@ on:
   push:
     branches:
       - main
-      - 'maint-**'
+      - 'branch-**'
   workflow_dispatch:
 
 permissions:
@@ -70,8 +70,15 @@ jobs:
           path: vcpkg
 
       - name: Set SedonaDB dev version
+        shell: bash
         run: |
-          python ci/scripts/set_dev_version.py
+          # Set the unique development version anywhere except a release branch
+          if [[ "${GITHUB_REF##*/}" =~ ^branch-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            version="${GITHUB_REF##*/branch-}"
+            echo "${version}"
+          else
+            python ci/scripts/set_dev_version.py
+          fi
 
       - name: Build and test wheels (sedonadb)
         run: |

--- a/c/sedona-proj/src/proj.rs
+++ b/c/sedona-proj/src/proj.rs
@@ -140,7 +140,7 @@ impl ProjContext {
     /// - PJ_LOG_LEVEL_PJ_LOG_TELL (4): Tell
     pub(crate) fn set_log_level(&self, level: u32) -> Result<(), SedonaProjError> {
         unsafe {
-            call_proj_api!(self.api, proj_log_level, self.inner, level);
+            call_proj_api!(self.api, proj_log_level, self.inner, level as _);
         }
         Ok(())
     }


### PR DESCRIPTION
When pushing to main, we need the Python development version to be set to a unique value, or the nightly gemfury repository will reject the upload. However, when releasing, we need the wheels to have the right version!

This PR also fixes the branch specification for the release branch (i.e., `branch-*` and not `maint-*`).

Windows wheel builds were failing because on Windows `PJ_LOG_LEVEL` is an `enum` with `i32` storage (whereas it's unsigned storage on Posix).