### PR TITLE
chore(python/sedonadb): Improve error message when pyproj is not installed

### DIFF
--- a/python/sedonadb/python/sedonadb/context.py
+++ b/python/sedonadb/python/sedonadb/context.py
@@ -245,7 +245,10 @@ def configure_proj(
             import warnings
 
             all_errors = "\n".join(errors)
-            warnings.warn(f"Failed to configure PROJ (tried {tried}):\n{all_errors}")
+            warnings.warn(
+                "Failed to configure PROJ. Is pyproj or a system install of PROJ available?"
+                f"\nDetails: tried {tried}\n{all_errors}"
+            )
             return
         else:
             raise ValueError(f"Unknown preset: {preset}")


### PR DESCRIPTION
This PR improves the error a user sees if pyproj is unavailable or for some reason the configuration fails. This shouldn't happen when users `pip install "apache-sedona[db]"` because it is installed for them; however, it can happen if somebody runs `pip install sedonadb` by accident. It now reads:

```python
UserWarning: Failed to configure PROJ. Is pyproj or a system install of PROJ available?
Details: tried ['pyproj', 'conda', 'homebrew', 'system']
pyproj: No module named 'pyproj'
...more details
```