### PR TITLE
fix(python/sedonadb): Ensure schema displays "geometry" and "geography" for spatial types

### DIFF
--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -49,11 +49,11 @@ class DataFrame:
             >>> df = con.sql("SELECT 1 as one")
             >>> df.schema
             SedonaSchema with 1 field:
-              one: non-nullable Int64
+              one: non-nullable int64<Int64>
             >>> df.schema.field(0)
-            SedonaField one: non-nullable Int64
+            SedonaField one: non-nullable int64<Int64>
             >>> df.schema.field(0).name, df.schema.field(0).type
-            ('one', SedonaType Int64)
+            ('one', SedonaType int64<Int64>)
         """
         return self._impl.schema()
 

--- a/python/sedonadb/src/schema.rs
+++ b/python/sedonadb/src/schema.rs
@@ -181,7 +181,7 @@ impl PySedonaType {
     }
 
     pub fn repr(&self) -> String {
-        format!("{}", self.inner)
+        format!("{}<{}>", self.inner.logical_type_name(), self.inner)
     }
 }
 

--- a/python/sedonadb/tests/test_dataframe.py
+++ b/python/sedonadb/tests/test_dataframe.py
@@ -131,14 +131,14 @@ def test_schema(con):
     # Non-geometry field accessor
     assert df.schema.field(0).name == "one"
     assert df.schema.field("one").name == "one"
-    assert repr(df.schema.field(0).type) == "SedonaType Int64"
+    assert repr(df.schema.field(0).type) == "SedonaType int64<Int64>"
     assert df.schema.field(0).type.edge_type is None
     assert df.schema.field(0).type.crs is None
 
     # Geometry field accessor
     assert df.schema.field(1).name == "geom"
     assert df.schema.field("geom").name == "geom"
-    assert repr(df.schema.field(1).type) == "SedonaType wkb"
+    assert repr(df.schema.field(1).type) == "SedonaType geometry<Wkb>"
     assert df.schema.field(1).type.edge_type == gat.EdgeType.PLANAR
     assert df.schema.field(1).type.crs is None
 

--- a/rust/sedona-schema/src/crs.rs
+++ b/rust/sedona-schema/src/crs.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 use datafusion_common::{DataFusionError, Result};
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -67,6 +67,18 @@ pub fn lnglat() -> Crs {
 /// to export it to Parquet/Iceberg) and something with which we can check
 /// equality (for binary operators).
 pub type Crs = Option<Arc<dyn CoordinateReferenceSystem + Send + Sync>>;
+
+impl Display for dyn CoordinateReferenceSystem + Send + Sync {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Ok(Some(auth_code)) = self.to_authority_code() {
+            write!(f, "{}", auth_code.to_lowercase())
+        } else {
+            // We can probably try harder to get compact output out of more
+            // types of CRSes
+            write!(f, "{{...}}")
+        }
+    }
+}
 
 impl PartialEq<dyn CoordinateReferenceSystem + Send + Sync>
     for dyn CoordinateReferenceSystem + Send + Sync

--- a/rust/sedona-schema/src/datatypes.rs
+++ b/rust/sedona-schema/src/datatypes.rs
@@ -403,6 +403,74 @@ mod tests {
     }
 
     #[test]
+    fn sedona_logical_type_name() {
+        assert_eq!(WKB_GEOMETRY.logical_type_name(), "geometry");
+        assert_eq!(WKB_GEOGRAPHY.logical_type_name(), "geography");
+
+        assert_eq!(
+            SedonaType::Arrow(DataType::Int32).logical_type_name(),
+            "int32"
+        );
+
+        assert_eq!(
+            SedonaType::Arrow(DataType::Utf8).logical_type_name(),
+            "utf8"
+        );
+        assert_eq!(
+            SedonaType::Arrow(DataType::Utf8View).logical_type_name(),
+            "utf8"
+        );
+
+        assert_eq!(
+            SedonaType::Arrow(DataType::Binary).logical_type_name(),
+            "binary"
+        );
+        assert_eq!(
+            SedonaType::Arrow(DataType::BinaryView).logical_type_name(),
+            "binary"
+        );
+
+        assert_eq!(
+            SedonaType::Arrow(DataType::Duration(arrow_schema::TimeUnit::Microsecond))
+                .logical_type_name(),
+            "duration"
+        );
+
+        assert_eq!(
+            SedonaType::Arrow(DataType::List(
+                Field::new("item", DataType::Int32, true).into()
+            ))
+            .logical_type_name(),
+            "list"
+        );
+        assert_eq!(
+            SedonaType::Arrow(DataType::ListView(
+                Field::new("item", DataType::Int32, true).into()
+            ))
+            .logical_type_name(),
+            "list"
+        );
+
+        assert_eq!(
+            SedonaType::Arrow(DataType::Dictionary(
+                Box::new(DataType::Int32),
+                Box::new(DataType::Binary)
+            ))
+            .logical_type_name(),
+            "binary"
+        );
+
+        assert_eq!(
+            SedonaType::Arrow(DataType::RunEndEncoded(
+                Field::new("ends", DataType::Int32, true).into(),
+                Field::new("values", DataType::Binary, true).into()
+            ))
+            .logical_type_name(),
+            "binary"
+        );
+    }
+
+    #[test]
     fn geoarrow_serialize() {
         assert_eq!(serialize_edges_and_crs(&Edges::Planar, &Crs::None), "{}");
         assert_eq!(

--- a/rust/sedona-schema/src/datatypes.rs
+++ b/rust/sedona-schema/src/datatypes.rs
@@ -136,6 +136,12 @@ impl SedonaType {
         }
     }
 
+    /// The logical type name for this type
+    ///
+    /// The logical type name is used in tabular display and schema printing. Notably,
+    /// it renders Wkb and WkbView as "geometry" or "geography" depending on the edge
+    /// type. For Arrow types, this similarly strips the storage details (e.g.,
+    /// both Utf8 and Utf8View types render as "utf8").
     pub fn logical_type_name(&self) -> String {
         match self {
             SedonaType::Wkb(Edges::Planar, _) | SedonaType::WkbView(Edges::Planar, _) => {

--- a/rust/sedona/src/show.rs
+++ b/rust/sedona/src/show.rs
@@ -24,10 +24,7 @@ use datafusion_common::format::DEFAULT_FORMAT_OPTIONS;
 use datafusion_common::{DataFusionError, ScalarValue};
 use datafusion_expr::{ColumnarValue, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDF};
 use sedona_expr::scalar_udf::SedonaScalarUDF;
-use sedona_schema::{
-    datatypes::{Edges, SedonaType},
-    matchers::ArgMatcher,
-};
+use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
 use std::iter::zip;
 use std::sync::Arc;
 
@@ -395,15 +392,7 @@ impl DisplayColumn {
     pub fn header(&self, options: &DisplayTableOptions) -> Cell {
         // Don't print the type ever if it's a continuation column
         let is_continuation = self.name == "…" || self.name == "...";
-        let display_type = match &self.sedona_type {
-            SedonaType::Wkb(Edges::Planar, _) | SedonaType::WkbView(Edges::Planar, _) => {
-                "geometry".to_string()
-            }
-            SedonaType::Wkb(Edges::Spherical, _) | SedonaType::WkbView(Edges::Spherical, _) => {
-                "geography".to_string()
-            }
-            _ => self.sedona_type.to_string().to_lowercase(),
-        };
+        let display_type = self.sedona_type.logical_type_name();
         if options.arrow_options.types_info() && !is_continuation {
             Cell::new(format!("{}\n{}", self.name, display_type)).set_delimiter('\0')
         } else {


### PR DESCRIPTION
This PR ensures we print the "logical type name" (term invented in this PR), which is what we show in the display table header, and a more verbose description of the type when printing a schema and we have the whole width of the console at our disposal. The output looks like this:

```python
import sedonadb

sd = sedonadb.connect()
sd.sql("SELECT ST_Point(0, 1) as geom, 1 as one").schema
#> SedonaSchema with 2 fields:
#>   geom: geometry<Wkb>
#>   one: non-nullable int64<Int64>
```

This PR implements the logical type name for arrow types too, so columns with those types have potentially shorter type names in tabular display (e.g., `struct(all the struct fields)` is now just `struct` in the tabular display.

Happy to workshop any of that...coming up with these names is hard!
