### PR TITLE
feat(python/sedonadb): Add DataFrame.execute() for non-result queries

### DIFF
--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -112,6 +112,32 @@ class DataFrame:
         """
         return DataFrame(self._ctx, self._impl.limit(n, offset))
 
+    def execute(self) -> None:
+        """Execute the plan represented by this DataFrame
+
+        This will execute the query without collecting results into memory,
+        which is useful for executing SQL statements like SET, CREATE VIEW,
+        and CREATE EXTERNAL TABLE.
+
+        Note that this is functionally similar to `.count()` except it does
+        not apply any optimizations (e.g., does not use statistics to avoid
+        reading data to calculate a count).
+
+        Examples:
+
+            >>> sd = sedona.db.connect()
+            >>> sd.sql("CREATE OR REPLACE VIEW temp_view AS SELECT 1 as one").execute()
+            0
+            >>> sd.view("temp_view").show()
+            ┌───────┐
+            │  one  │
+            │ int64 │
+            ╞═══════╡
+            │     1 │
+            └───────┘
+        """
+        return self._impl.execute()
+
     def count(self) -> int:
         """Compute the number of rows in this DataFrame
 

--- a/python/sedonadb/src/dataframe.rs
+++ b/python/sedonadb/src/dataframe.rs
@@ -89,6 +89,17 @@ impl InternalDataFrame {
         Ok(InternalDataFrame::new(inner, self.runtime.clone()))
     }
 
+    fn execute<'py>(&self, py: Python<'py>) -> Result<usize, PySedonaError> {
+        let mut c = 0;
+        let stream = wait_for_future(py, &self.runtime, self.inner.clone().execute_stream())??;
+        let reader = PySedonaStreamReader::new(self.runtime.clone(), stream);
+        for batch in reader {
+            c += batch?.num_rows();
+        }
+
+        Ok(c)
+    }
+
     fn count<'py>(&self, py: Python<'py>) -> Result<usize, PySedonaError> {
         Ok(wait_for_future(
             py,

--- a/python/sedonadb/tests/test_dataframe.py
+++ b/python/sedonadb/tests/test_dataframe.py
@@ -213,6 +213,16 @@ def test_head_limit(con):
     )
 
 
+def test_execute(con):
+    df = con.sql("SELECT * FROM (VALUES ('one'), ('two'), ('three')) AS t(val)")
+    assert df.execute() == 3
+
+    df = con.sql("CREATE OR REPLACE VIEW temp_view AS SELECT 1 as one")
+    assert df.execute() == 0
+    assert con.view("temp_view").count() == 1
+    con.drop_view("temp_view")
+
+
 def test_count(con):
     df = con.sql("SELECT * FROM (VALUES ('one'), ('two'), ('three')) AS t(val)")
     assert df.count() == 3


### PR DESCRIPTION
This PR adds `.execute()` to make it more intuitive what to do for a CREATE/SET query. Functionally it is very similar to .count() but doesn't actually use DataFusion's counter under the hood to avoid any issue with optimizations from that.

```python
import sedonadb

sd = sedonadb.connect()
sd.sql("CREATE OR REPLACE VIEW temp_view AS SELECT 1 as one").execute()
sd.view("temp_view").show()
#> ┌───────┐
#> │  one  │
#> │ int64 │
#> ╞═══════╡
#> │     1 │
#> └───────┘
```