### PR TITLE
chore(sedonadb/python): Reenable skipped check for null return in ST_FlipCoordinates

### DIFF
--- a/python/sedonadb/tests/functions/test_functions.py
+++ b/python/sedonadb/tests/functions/test_functions.py
@@ -294,7 +294,7 @@ def test_st_envelope(eng, geom, expected):
 @pytest.mark.parametrize(
     ("geom", "expected"),
     [
-        # Failing on None for SedonaDB: with datafusion optimizer exception
+        (None, None),
         ("POINT EMPTY", "POINT (nan nan)"),
         ("POLYGON EMPTY", "POLYGON EMPTY"),
         ("LINESTRING EMPTY", "LINESTRING EMPTY"),


### PR DESCRIPTION
Closes #74.