### PR TITLE
refactor(python/sedonadb): Scope options to the SedonaContext

### DIFF
--- a/python/sedonadb/python/sedonadb/__init__.py
+++ b/python/sedonadb/python/sedonadb/__init__.py
@@ -16,10 +16,6 @@
 # under the License.
 from sedonadb import _lib
 from sedonadb.context import connect, configure_proj
-from sedonadb import _options
-
-options = _options.global_options()
-"""Global options for SedonaDB"""
 
 __version__ = _lib.sedona_python_version()
 

--- a/python/sedonadb/python/sedonadb/_options.py
+++ b/python/sedonadb/python/sedonadb/_options.py
@@ -52,17 +52,3 @@ class Options:
     @width.setter
     def width(self, value: Optional[int]):
         self._width = value
-
-
-def global_options() -> Options:
-    """Access the global options
-
-    Most users should use `sedonadb.options` to access this singleton; however,
-    internal SedonaDB Python code must use this function to avoid a circular
-    dependency.
-    """
-    global _global_options
-    return _global_options
-
-
-_global_options = Options()

--- a/python/sedonadb/python/sedonadb/context.py
+++ b/python/sedonadb/python/sedonadb/context.py
@@ -22,6 +22,7 @@ from typing import Any, Dict, Iterable, Literal, Optional, Union
 from sedonadb._lib import InternalContext, configure_proj_shared
 from sedonadb.dataframe import DataFrame, _create_data_frame
 from sedonadb.utility import sedona  # noqa: F401
+from sedonadb._options import Options
 
 
 class SedonaContext:
@@ -34,6 +35,7 @@ class SedonaContext:
 
     def __init__(self):
         self._impl = InternalContext()
+        self.options = Options()
 
     def create_data_frame(self, obj: Any, schema: Any = None) -> DataFrame:
         """Create a DataFrame from an in-memory or protocol-enabled object.
@@ -64,7 +66,7 @@ class SedonaContext:
             │     1 │
             └───────┘
         """
-        return _create_data_frame(self._impl, obj, schema)
+        return _create_data_frame(self._impl, obj, schema, self.options)
 
     def view(self, name: str) -> DataFrame:
         """Create a [DataFrame][sedonadb.dataframe.DataFrame] from a named view
@@ -88,7 +90,7 @@ class SedonaContext:
             >>> sd.drop_view("foofy")
 
         """
-        return DataFrame(self._impl, self._impl.view(name))
+        return DataFrame(self._impl, self._impl.view(name), self.options)
 
     def drop_view(self, name: str) -> None:
         """Remove a named view
@@ -135,6 +137,7 @@ class SedonaContext:
         return DataFrame(
             self._impl,
             self._impl.read_parquet([str(path) for path in table_paths], options),
+            self.options,
         )
 
     def sql(self, sql: str) -> DataFrame:
@@ -153,7 +156,7 @@ class SedonaContext:
             <sedonadb.dataframe.DataFrame object at ...>
 
         """
-        return DataFrame(self._impl, self._impl.sql(sql))
+        return DataFrame(self._impl, self._impl.sql(sql), self.options)
 
 
 def connect() -> SedonaContext:

--- a/python/sedonadb/python/sedonadb/context.py
+++ b/python/sedonadb/python/sedonadb/context.py
@@ -31,6 +31,18 @@ class SedonaContext:
     This object keeps track of state such as registered functions,
     registered tables, and available memory. This is similar to a
     Spark SessionContext or a database connection.
+
+    Examples:
+
+        >>> sd = sedona.db.connect()
+        >>> sd.options.interactive = True
+        >>> sd.sql("SELECT 1 as one")
+        ┌───────┐
+        │  one  │
+        │ int64 │
+        ╞═══════╡
+        │     1 │
+        └───────┘
     """
 
     def __init__(self):

--- a/python/sedonadb/tests/test_context.py
+++ b/python/sedonadb/tests/test_context.py
@@ -20,6 +20,14 @@ import pytest
 import sedonadb
 
 
+def test_options():
+    sd = sedonadb.connect()
+    assert "DataFrame object at" in repr(sd.sql("SELECT 1 as one"))
+
+    sd.options.interactive = True
+    assert "DataFrame object at" not in repr(sd.sql("SELECT 1 as one"))
+
+
 def test_read_parquet(con, geoarrow_data):
     # Check one file
     tab = con.read_parquet(

--- a/python/sedonadb/tests/test_dataframe.py
+++ b/python/sedonadb/tests/test_dataframe.py
@@ -446,7 +446,7 @@ def test_repr(con):
     )
 
     try:
-        sedonadb.options.interactive = True
+        con.options.interactive = True
         repr_interactive = repr(con.sql("SELECT 1 as one"))
         expected = """
 ┌───────┐
@@ -458,4 +458,4 @@ def test_repr(con):
     """.strip()
         assert repr_interactive == expected
     finally:
-        sedonadb.options.interactive = False
+        con.options.interactive = False


### PR DESCRIPTION
Previously we had global options, however, the way we had structured the `sedona.db` import resulted in the options being completely inaccessible (i.e., `sedona.db.options.interactive = True` didn't work!).

This PR scopes the options to the context, which is probably better anyway because the `sd` object is the one most people are interacting with anyway.

```python
import sedona.db

sd = sedona.db.connect()
sd.options.interactive = True
sd.sql("SELECT 1")
#> ┌──────────┐
#> │ Int64(1) │
#> │   int64  │
#> ╞══════════╡
#> │        1 │
#> └──────────┘
```