### PR TITLE
Turn on the s2geography feature explicitly in verify release script to pass pytests

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -116,6 +116,7 @@ jobs:
 
       - name: Install
         run: |
+          # Keep this export in sync with the export in dev/release/verify-release-candidate.sh
           export MATURIN_PEP517_ARGS="--features s2geography"
           pip install -e "python/sedonadb/[test]" -vv
 

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -261,6 +261,9 @@ test_python() {
 
   show_info "Installing Python package"
   rm -rf "${SEDONADB_TMPDIR}/python"
+
+  # Keep this export in sync with the export in .github/workflows/python.yml
+  export MATURIN_PEP517_ARGS="--features s2geography"
   pip install "sedonadb/[test]" -v
 
   show_info "Testing Python package"


### PR DESCRIPTION
When running the raw `dev/release/verify-release-candidate.sh` script, I constantly ran into pytest errors for `test_spatial_join_geography` inside test_sjoin.py. The error message wasn't straightforward to debug, but I eventually found that I needed to turn on the `s2geography` feature explicitly to get the tests to pass. This PR sets it inside the verify release script explicitly to smoothen out the process. 