### PR TITLE
fix(r/sedonadb): Add missing settings to configure.win and Makevars.win.in

### DIFF
--- a/r/sedonadb/configure.win
+++ b/r/sedonadb/configure.win
@@ -15,6 +15,24 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# We need to link GEOS libs. The cargo build will use pkg-config
+# and then geos-config, in that order, and requires pkg-config to be
+# available (even if it isn't used). Here we just try pkg-config (LIB_DIR
+# can be used to specify the location of -lgeos_c)
+
+pkg-config geos  2>/dev/null
+if [ $? -eq 0 ]; then
+  PKGCONFIG_LIBS=`pkg-config --libs geos`
+fi
+
+if [ "$LIB_DIR" ]; then
+  echo "Found LIB_DIR!"
+  PKG_LIBS="-L$LIB_DIR -lgeos_c $PKG_LIBS"
+elif [ "$PKGCONFIG_CFLAGS" ] || [ "$PKGCONFIG_LIBS" ]; then
+  echo "Found GEOS pkg-config libs!"
+  PKG_LIBS=${PKGCONFIG_LIBS}
+fi
+
 CARGO_VERSION="$(cargo --version)"
 
 if [ $? -ne 0 ]; then
@@ -57,4 +75,5 @@ sed \
   -e "s/@TARGET@/x86_64-pc-windows-gnu/" \
   -e "s/@PROFILE@/${PROFILE}/" \
   -e "s/@FEATURE_FLAGS@/${FEATURE_FLAGS}/" \
+  -e "s|@PKG_LIBS@|${PKG_LIBS}|" \
   src/Makevars.win.in > src/Makevars.win

--- a/r/sedonadb/src/Makevars.win.in
+++ b/r/sedonadb/src/Makevars.win.in
@@ -25,8 +25,8 @@ RUSTFLAGS =
 
 TARGET_DIR = $(CURDIR)/rust/target
 LIBDIR = $(TARGET_DIR)/$(TARGET)/$(subst dev,debug,$(PROFILE))
-STATLIB = $(LIBDIR)/libsedonadb.a
-PKG_LIBS = -L$(LIBDIR) -lsedonadb -lws2_32 -ladvapi32 -luserenv -lbcrypt -lntdll
+STATLIB = $(LIBDIR)/libsedonadbr.a
+PKG_LIBS = -L$(LIBDIR) -lsedonadbr -lws2_32 -ladvapi32 -luserenv -lbcrypt -lntdll  @PKG_LIBS@
 
 # Rtools doesn't have the linker in the location that cargo expects, so we need
 # to overwrite it via configuration.


### PR DESCRIPTION
I succeeded to compile R sedonadb package on my local with https://github.com/apache/sedona-db/pull/114 and https://github.com/apache/datafusion/issues/17687. But, besides it, I found `configure.win` and `Makevars.win.in` needs a few tweaks to match with `configure` and `Makevars.in`.