### PR TITLE
chore(r/sedonadb): Add necessary tweaks for Windows CI on the R package

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -86,14 +86,6 @@ jobs:
           # Update this key to force a new cache
           prefix-key: "r-v1"
 
-      - name: Install build dependencies
-        run: |
-            R -e 'install.packages(c("nanoarrow", "geoarrow"))'
-
-      - name: Install R Package
-        run: |
-          R CMD INSTALL r/sedonadb --preclean
-
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           needs: check

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -67,7 +67,7 @@ jobs:
           rustup toolchain install stable --no-self-update
           rustup default stable
 
-      # GHA runnder installs GNU target by default, but --no-self-update might
+      # GHA runner installs GNU target by default, but --no-self-update might
       # remove it, so run `target add` to ensure the GNU target installed.
       - name: Setup Rust (Windows)
         if: matrix.config.os == 'windows-latest'

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -36,6 +36,9 @@ jobs:
   test:
     runs-on: ${{ matrix.config.os }}
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+    defaults:
+      run:
+        shell: bash
 
     strategy:
       fail-fast: false
@@ -43,6 +46,7 @@ jobs:
         config:
           - {os: ubuntu-latest, r: 'release'}
           - {os: macos-latest, r: 'release'}
+          # - {os: windows-latest, r: 'release'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -62,6 +66,12 @@ jobs:
         run: |
           rustup toolchain install stable --no-self-update
           rustup default stable
+
+      # GHA runnder installs GNU target by default, but --no-self-update might
+      # remove it, so run `target add` to ensure the GNU target installed.
+      - name: Setup Rust (Windows)
+        if: matrix.config.os == 'windows-latest'
+        run: rustup target add x86_64-pc-windows-gnu
 
       - name: Install dependencies (Linux)
         if: matrix.config.os == 'ubuntu-latest'
@@ -89,6 +99,10 @@ jobs:
           needs: check
           working-directory: r/sedonadb
 
+      - name: Install R Package
+        run: |
+          R CMD INSTALL r/sedonadb --preclean
+
       - name: Test R Package
         run: |
-            R -e 'library(testthat); test_local("r/sedonadb", MultiReporter$new(list(CheckReporter$new(), LocationReporter$new())))'
+          R -e 'library(testthat); test_local("r/sedonadb", MultiReporter$new(list(CheckReporter$new(), LocationReporter$new())))'

--- a/c/sedona-proj/README.md
+++ b/c/sedona-proj/README.md
@@ -35,7 +35,7 @@ to add it manually (hopefully, this will be automated).
 ### Windows
 
 On Windows, you might need to set `PATH` and `PKG_CONFIG_SYSROOT_DIR` for
-`pkg-config`. For example, when using Rtools45, you progbably need these
+`pkg-config`. For example, when using Rtools45, you probably need these
 envvars:
 
 ```ps1

--- a/c/sedona-tg/README.md
+++ b/c/sedona-tg/README.md
@@ -35,7 +35,7 @@ to add it manually (hopefully, this will be automated).
 ### Windows
 
 On Windows, you might need to set `PATH` and `PKG_CONFIG_SYSROOT_DIR` for
-`pkg-config`. For example, when using Rtools45, you progbably need these
+`pkg-config`. For example, when using Rtools45, you probably need these
 envvars:
 
 ```ps1


### PR DESCRIPTION
I confirmed my pull request to datafusion (https://github.com/apache/datafusion/pull/17688) will enable the Windows CI for R package. Note that the latest version of datafusion is already v50 while sedona-db uses v49. So, I think this won't happen very soon.

my experiment: https://github.com/yutannihilation/sedona-db/pull/1
diff: https://github.com/apache/datafusion/compare/49.0.2...yutannihilation:datafusion:49.0.2-pr-17688

Until the day, this pull request adds some necessary tweaks for Windows. Also, this includes a typo fix found in https://github.com/apache/sedona-db/pull/114#discussion_r2365915732