### PR TITLE
docs: Fix a documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ SedonaDB has several advantages:
 
 - 💬 **Discord:** Join our [Discord community](https://discord.com/invite/9A3k5dEBsY) for real-time chat and support
 - 💭 **GitHub Discussions:** Start a [GitHub Discussion](https://github.com/apache/sedona/discussions) with questions or ideas
-- 📚 **Documentation:** Check out our [comprehensive docs](https://sedona.apache.org/sedonadb/latest/)
+- 📚 **Documentation:** Check out our [comprehensive docs](https://sedona.apache.org/sedonadb)
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ SedonaDB has several advantages:
 
 - 💬 **Discord:** Join our [Discord community](https://discord.com/invite/9A3k5dEBsY) for real-time chat and support
 - 💭 **GitHub Discussions:** Start a [GitHub Discussion](https://github.com/apache/sedona/discussions) with questions or ideas
-- 📚 **Documentation:** Check out our [comprehensive docs](https://sedonadb.org/)
+- 📚 **Documentation:** Check out our [comprehensive docs](https://sedona.apache.org/sedonadb/latest/)
 
 ### Contributing
 


### PR DESCRIPTION
Currently, the URL of "Check out our comprehensive docs" points to a non-existent website. I'm not sure if there's a plan to actually use this URL at some point, but probably it's good to use <https://sedona.apache.org/sedonadb> for now.