### PR TITLE
fix(r/sedonadb): Increase CMAKE path length allowed on Windows and fix CMD check WARNINGs

### DIFF
--- a/.github/workflows/r-extended.yml
+++ b/.github/workflows/r-extended.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: r
+name: r-extended
 
 on:
   push:
@@ -25,11 +25,6 @@ on:
     branches:
       - main
     paths:
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - '.github/workflows/r.yml'
-      - 'rust/**'
-      - 'c/**'
       - 'r/**'
 jobs:
 
@@ -45,8 +40,6 @@ jobs:
       matrix:
         config:
           - {os: ubuntu-latest, r: 'release'}
-          - {os: macos-latest, r: 'release'}
-          # - {os: windows-latest, r: 'release'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -54,6 +47,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: r-lib/actions/setup-pandoc@v2
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
@@ -66,34 +60,15 @@ jobs:
           rustup toolchain install stable --no-self-update
           rustup default stable
 
-      # GHA runner installs GNU target by default, but --no-self-update might
-      # remove it, so run `target add` to ensure the GNU target installed.
-      - name: Setup Rust (Windows)
-        if: matrix.config.os == 'windows-latest'
-        run: rustup target add x86_64-pc-windows-gnu
-
-      - name: Install dependencies (Linux)
+      - name: Install dependencies
         if: matrix.config.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install -y libgeos-dev
-
-      - name: Install dependencies (MacOS)
-        if: matrix.config.os == 'macos-latest'
-        run: brew install geos
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          # Update this key to force a new cache
-          prefix-key: "r-v1"
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           needs: check
           working-directory: r/sedonadb
 
-      - name: Install R Package
-        run: |
-          R CMD INSTALL r/sedonadb --preclean
-
-      - name: Test R Package
-        run: |
-          R -e 'library(testthat); test_local("r/sedonadb", MultiReporter$new(list(CheckReporter$new(), LocationReporter$new())))'
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          working-directory: r/sedonadb

--- a/.github/workflows/r-extended.yml
+++ b/.github/workflows/r-extended.yml
@@ -66,6 +66,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          extra-packages: any::rcmdcheck
           needs: check
           working-directory: r/sedonadb
 

--- a/.github/workflows/r-extended.yml
+++ b/.github/workflows/r-extended.yml
@@ -73,3 +73,4 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         with:
           working-directory: r/sedonadb
+          error-on: '"error"'

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -46,7 +46,7 @@ jobs:
         config:
           - {os: ubuntu-latest, r: 'release'}
           - {os: macos-latest, r: 'release'}
-          # - {os: windows-latest, r: 'release'}
+          - {os: windows-latest, r: 'release'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,8 +1556,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69dfeda1633bf8ec75b068d9f6c27cdc392ffcf5ff83128d5dbab65b73c1fd02"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -1612,8 +1611,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2848fd1e85e2953116dab9cc2eb109214b0888d7bbd2230e30c07f1794f642c0"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1638,8 +1636,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051a1634628c2d1296d4e326823e7536640d87a118966cdaff069b68821ad53b"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1661,8 +1658,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765e4ad4ef7a4500e389a3f1e738791b71ff4c29fd00912c2f541d62b25da096"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "ahash",
  "apache-avro",
@@ -1688,8 +1684,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a2ae8393051ce25d232a6065c4558ab5a535c9637d5373bacfd464ac88ea12"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "futures",
  "log",
@@ -1699,8 +1694,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90cd841a77f378bc1a5c4a1c37345e1885a9203b008203f9f4b3a769729bf330"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "arrow",
  "async-compression",
@@ -1735,8 +1729,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-avro"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cba1696aa919da9517d29164d45f5902d6cc281f718e8d3bfe98bd52cd1142c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "apache-avro",
  "arrow",
@@ -1760,8 +1753,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f4a2c64939c6f0dd15b246723a699fa30d59d0133eb36a86e8ff8c6e2a8dc6"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1785,8 +1777,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11387aaf931b2993ad9273c63ddca33f05aef7d02df9b70fb757429b4b71cdae"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1810,8 +1801,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028f430c5185120bf806347848b8d8acd9823f4038875b3820eeefa35f2bb4a2"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1843,14 +1833,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff336d1d755399753a9e4fbab001180e346fc8bfa063a97f1214b82274c00f8"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 
 [[package]]
 name = "datafusion-execution"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "042ea192757d1b2d7dcf71643e7ff33f6542c7704f00228d8b85b40003fd8e0f"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "arrow",
  "dashmap",
@@ -1868,8 +1856,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025222545d6d7fab71e2ae2b356526a1df67a2872222cbae7535e557a42abd2e"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1890,8 +1877,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5c267104849d5fa6d81cf5ba88f35ecd58727729c5eb84066c25227b644ae2"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1903,8 +1889,7 @@ dependencies = [
 [[package]]
 name = "datafusion-ffi"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec21805d9df2d834e4c6ddfbf8a1bed2bd460b89b01686fe0dcd1cee06d0b60f"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "abi_stable",
  "arrow",
@@ -1925,8 +1910,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c620d105aa208fcee45c588765483314eb415f5571cfd6c1bae3a59c5b4d15bb"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1954,8 +1938,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35f61d5198a35ed368bf3aacac74f0d0fa33de7a7cb0c57e9f68ab1346d2f952"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "ahash",
  "arrow",
@@ -1975,8 +1958,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13efdb17362be39b5024f6da0d977ffe49c0212929ec36eec550e07e2bc7812f"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "ahash",
  "arrow",
@@ -1988,8 +1970,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9187678af567d7c9e004b72a0b6dc5b0a00ebf4901cb3511ed2db4effe092e66"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -2010,8 +1991,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecf156589cc21ef59fe39c7a9a841b4a97394549643bbfa88cc44e8588cf8fe5"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2026,8 +2006,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edcb25e3e369f1366ec9a261456e45b5aad6ea1c0c8b4ce546587207c501ed9e"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2044,8 +2023,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8996a8e11174d0bd7c62dc2f316485affc6ae5ffd5b8a68b508137ace2310294"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -2054,10 +2032,9 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ee8d1be549eb7316f437035f2cec7ec42aba8374096d807c4de006a3b5d78a"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
- "datafusion-expr",
+ "datafusion-doc",
  "quote",
  "syn 2.0.106",
 ]
@@ -2065,8 +2042,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9fa98671458254928af854e5f6c915e66b860a8bde505baea0ff2892deab74d"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "arrow",
  "chrono",
@@ -2085,8 +2061,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3515d51531cca5f7b5a6f3ea22742b71bb36fc378b465df124ff9a2fa349b002"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "ahash",
  "arrow",
@@ -2107,8 +2082,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24485475d9c618a1d33b2a3dad003d946dc7a7bbf0354d125301abc0a5a79e3e"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "ahash",
  "arrow",
@@ -2121,8 +2095,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9da411a0a64702f941a12af2b979434d14ec5d36c6f49296966b2c7639cbb3a"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2141,8 +2114,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d168282bb7b54880bb3159f89b51c047db4287f5014d60c3ef4c6e1468212b"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "ahash",
  "arrow",
@@ -2171,8 +2143,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b36a0c84f4500efd90487a004b533bd81de1f2bb3f143f71b7526f33b85d2e2"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "arrow",
  "chrono",
@@ -2187,8 +2158,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ec788be522806740ad6372c0a2f7e45fb37cb37f786d9b77933add49cdd058f"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2197,9 +2167,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-pruning"
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391a457b9d23744c53eeb89edd1027424cba100581488d89800ed841182df905"
+version = "49.0.2"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2216,8 +2185,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053201c2bb729c7938f85879034df2b5a52cfaba16f1b3b66ab8505c81b2aad3"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2240,8 +2208,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "49.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9082779be8ce4882189b229c0cff4393bd0808282a7194130c9f32159f185e25"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
 dependencies = [
  "arrow",
  "bigdecimal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,7 +1149,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -1556,7 +1556,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -1611,7 +1611,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1636,7 +1636,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1658,7 +1658,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "ahash",
  "apache-avro",
@@ -1684,7 +1684,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "futures",
  "log",
@@ -1694,7 +1694,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "arrow",
  "async-compression",
@@ -1729,7 +1729,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-avro"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "apache-avro",
  "arrow",
@@ -1753,7 +1753,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1777,7 +1777,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1801,7 +1801,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1833,12 +1833,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 
 [[package]]
 name = "datafusion-execution"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "arrow",
  "dashmap",
@@ -1856,7 +1856,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1877,7 +1877,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1889,7 +1889,7 @@ dependencies = [
 [[package]]
 name = "datafusion-ffi"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "abi_stable",
  "arrow",
@@ -1910,7 +1910,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1938,7 +1938,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "ahash",
  "arrow",
@@ -1958,7 +1958,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "ahash",
  "arrow",
@@ -1970,7 +1970,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -1991,7 +1991,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2006,7 +2006,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2023,7 +2023,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -2032,7 +2032,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -2042,7 +2042,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "arrow",
  "chrono",
@@ -2061,7 +2061,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "ahash",
  "arrow",
@@ -2082,7 +2082,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "ahash",
  "arrow",
@@ -2095,7 +2095,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2114,7 +2114,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "ahash",
  "arrow",
@@ -2143,7 +2143,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "arrow",
  "chrono",
@@ -2158,7 +2158,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2168,7 +2168,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2185,7 +2185,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2208,7 +2208,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "49.0.2"
-source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#fa1ede9220876c704c135a7a0dea5eaf7ba2b66c"
+source = "git+https://github.com/paleolimbot/datafusion.git?branch=local-49-with-patch#697caabb6da842f6a561b0bebdd7847eef311153"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -2259,7 +2259,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -2346,7 +2346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -3417,7 +3417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.3",
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
@@ -3556,9 +3556,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memoffset"
@@ -4369,9 +4369,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4381,9 +4381,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4557,7 +4557,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -4708,7 +4708,7 @@ version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -5493,7 +5493,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -6106,7 +6106,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -6117,22 +6117,22 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.62.0"
+version = "0.62.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+checksum = "6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.0",
+ "windows-link",
  "windows-result",
  "windows-strings",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "edb307e42a74fb6de9bf3a02d9712678b22399c87e6fa869d6dfcd8c1b7754e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6141,20 +6141,14 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "c0abd1ddbc6964ac14db11c7213d6532ef34bd9aa042c2e5935f59d7908b46a5"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
 ]
-
-[[package]]
-name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
@@ -6168,7 +6162,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -6177,7 +6171,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -6204,16 +6198,16 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.61.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -6234,11 +6228,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,17 @@ tokio = { version = "1.44" }
 url = "2.5.4"
 
 [patch.crates-io]
+# For R package build on Windows (can be removed when we upgrade to DataFusion main/51.0.0)
+datafusion = { git = "https://github.com/paleolimbot/datafusion.git", branch = "local-49-with-patch", package = "datafusion" }
+datafusion-catalog = { git = "https://github.com/paleolimbot/datafusion.git", branch = "local-49-with-patch", package = "datafusion-catalog" }
+datafusion-common = { git = "https://github.com/paleolimbot/datafusion.git", branch = "local-49-with-patch", package = "datafusion-common" }
+datafusion-common-runtime = { git = "https://github.com/paleolimbot/datafusion.git", branch = "local-49-with-patch", package = "datafusion-common-runtime" }
+datafusion-execution = { git = "https://github.com/paleolimbot/datafusion.git", branch = "local-49-with-patch", package = "datafusion-execution" }
+datafusion-expr = { git = "https://github.com/paleolimbot/datafusion.git", branch = "local-49-with-patch", package = "datafusion-expr" }
+datafusion-ffi = { git = "https://github.com/paleolimbot/datafusion.git", branch = "local-49-with-patch", package = "datafusion-ffi" }
+datafusion-physical-expr = { git = "https://github.com/paleolimbot/datafusion.git", branch = "local-49-with-patch", package = "datafusion-physical-expr" }
+datafusion-physical-plan = { git = "https://github.com/paleolimbot/datafusion.git", branch = "local-49-with-patch", package = "datafusion-physical-plan" }
+
 geo-types = { git = "https://github.com/wherobots/geo.git", branch = "generic-alg", package = "geo-types" }
 geo-traits = { git = "https://github.com/wherobots/geo.git", branch = "generic-alg", package = "geo-traits" }
 geo-traits-ext = { git = "https://github.com/wherobots/geo.git", branch = "generic-alg", package = "geo-traits-ext" }

--- a/r/sedonadb/DESCRIPTION
+++ b/r/sedonadb/DESCRIPTION
@@ -14,6 +14,7 @@ Depends: R (>= 4.1.0)
 Suggests:
     adbcdrivermanager,
     rlang,
+    sf,
     testthat (>= 3.0.0),
     withr,
     wk

--- a/r/sedonadb/bootstrap.R
+++ b/r/sedonadb/bootstrap.R
@@ -29,7 +29,6 @@ writeLines(
   cargo_toml
 )
 
-dir.create("src/dep_crates/")
 file.copy(
   c(
     "../../rust",

--- a/r/sedonadb/src/.gitignore
+++ b/r/sedonadb/src/.gitignore
@@ -22,3 +22,9 @@ target
 
 Makevars
 Makevars.win
+
+# Vendored sources
+rust/sedona*
+Cargo.lock
+Cargo.toml
+c/

--- a/r/sedonadb/src/Makevars.win.in
+++ b/r/sedonadb/src/Makevars.win.in
@@ -56,6 +56,7 @@ $(STATLIB):
 	  export PKG_CONFIG_SYSROOT_DIR="$(PKG_CONFIG_SYSROOT_DIR)" && \
 	  export CC="$(CC)" && \
 	  export CFLAGS="$(CFLAGS_TWEAKED)" && \
+	  export CMAKE_OBJECT_PATH_MAX=1024 && \
 	  export AWS_LC_SYS_CMAKE_BUILDER=1 && \
 	  export RUSTFLAGS="$(RUSTFLAGS)" && \
 	  cargo build --target $(TARGET) --lib --profile $(PROFILE) $(FEATURE_FLAGS) --manifest-path ./rust/Cargo.toml --target-dir $(TARGET_DIR)


### PR DESCRIPTION
We're building in R Universe now! https://paleolimbot.r-universe.dev/sedonadb

We have some WARNINGs from missing declared dependencies (my fault) and a build failure for Windows (path length related to the CMake builder for the AWS dependency) and WebR (which I don't attempt to solve here).