### PR TITLE
chore(r/sedonadb): Try to fix Windows build

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -83,7 +83,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           # Update this key to force a new cache
-          prefix-key: "r-v1"
+          prefix-key: "r-v2"
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/r/sedonadb/src/Makevars.win.in
+++ b/r/sedonadb/src/Makevars.win.in
@@ -56,8 +56,12 @@ $(STATLIB):
 	  export PKG_CONFIG_SYSROOT_DIR="$(PKG_CONFIG_SYSROOT_DIR)" && \
 	  export CC="$(CC)" && \
 	  export CFLAGS="$(CFLAGS_TWEAKED)" && \
-	  export CMAKE_OBJECT_PATH_MAX=1024 && \
-	  export AWS_LC_SYS_CMAKE_BUILDER=1 && \
+	  # Not ideal: It would be better to use the CMake builder but this
+	  # incurs path length errors on at least one Windows builder.
+	  # The AWS_LC_SYS_CMAKE_BUILDER environment variable
+	  # can still be set at a higher level on Windows environments that
+	  # support it.
+	  export AWS_LC_SYS_CFLAGS="$(CFLAGS_TWEAKED) -O0" && \
 	  export RUSTFLAGS="$(RUSTFLAGS)" && \
 	  cargo build --target $(TARGET) --lib --profile $(PROFILE) $(FEATURE_FLAGS) --manifest-path ./rust/Cargo.toml --target-dir $(TARGET_DIR)
 

--- a/r/sedonadb/src/Makevars.win.in
+++ b/r/sedonadb/src/Makevars.win.in
@@ -51,16 +51,16 @@ $(STATLIB):
 	# in actual, but we need this tweak to please the compiler.
 	mkdir -p $(LIBDIR)/libgcc_mock && touch $(LIBDIR)/libgcc_mock/libgcc_eh.a
 
+	# AWS_LC_SYS_CFLAGS are not ideal: It would be better to use the
+	# CMake builder but this incurs path length errors on at least one Windows builder.
+	# The AWS_LC_SYS_CMAKE_BUILDER environment variable can still be set at a
+	# higher level on Windows environments that support it.
+
 	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
 	  export LIBRARY_PATH="$${LIBRARY_PATH};$(LIBDIR)/libgcc_mock" && \
 	  export PKG_CONFIG_SYSROOT_DIR="$(PKG_CONFIG_SYSROOT_DIR)" && \
 	  export CC="$(CC)" && \
 	  export CFLAGS="$(CFLAGS_TWEAKED)" && \
-	  # Not ideal: It would be better to use the CMake builder but this
-	  # incurs path length errors on at least one Windows builder.
-	  # The AWS_LC_SYS_CMAKE_BUILDER environment variable
-	  # can still be set at a higher level on Windows environments that
-	  # support it.
 	  export AWS_LC_SYS_CFLAGS="$(CFLAGS_TWEAKED) -O0" && \
 	  export RUSTFLAGS="$(RUSTFLAGS)" && \
 	  cargo build --target $(TARGET) --lib --profile $(PROFILE) $(FEATURE_FLAGS) --manifest-path ./rust/Cargo.toml --target-dir $(TARGET_DIR)


### PR DESCRIPTION
It looks like the R Universe runner hasn't enabled long path support (or the GitHub runner we're using builds everything in a shorter starting directory). This uses the cc builder for the AWS dependency and sets the optimization flag. This is not ideal but is better than a no Windows build or a Windows build without AWS.