### PR TITLE
chore(r/sedonadb): Attempt to disable the CMake builder on Windows for aws-lc-sys

### DIFF
--- a/r/sedonadb/src/Makevars.win.in
+++ b/r/sedonadb/src/Makevars.win.in
@@ -61,6 +61,7 @@ $(STATLIB):
 	  export PKG_CONFIG_SYSROOT_DIR="$(PKG_CONFIG_SYSROOT_DIR)" && \
 	  export CC="$(CC)" && \
 	  export CFLAGS="$(CFLAGS_TWEAKED)" && \
+	  export AWS_LC_SYS_CMAKE_BUILDER=0 && \
 	  export AWS_LC_SYS_CFLAGS="$(CFLAGS_TWEAKED) -O0" && \
 	  export RUSTFLAGS="$(RUSTFLAGS)" && \
 	  cargo build --target $(TARGET) --lib --profile $(PROFILE) $(FEATURE_FLAGS) --manifest-path ./rust/Cargo.toml --target-dir $(TARGET_DIR)


### PR DESCRIPTION
Apparently the R-universe build is still trying to use a CMake build (which is failing due to path length constraints). This is an attempt to force that crate to use the cc builder with perhaps success.