### PR TITLE
chore(r/sedonadb): Set the CMAKE_TOOLCHAIN_FILE for aws-lc-sys

### DIFF
--- a/r/sedonadb/src/Makevars.win.in
+++ b/r/sedonadb/src/Makevars.win.in
@@ -61,7 +61,7 @@ $(STATLIB):
 	  export PKG_CONFIG_SYSROOT_DIR="$(PKG_CONFIG_SYSROOT_DIR)" && \
 	  export CC="$(CC)" && \
 	  export CFLAGS="$(CFLAGS_TWEAKED)" && \
-	  export AWS_LC_SYS_CFLAGS="$(CFLAGS_TWEAKED) -O0" && \
+	  export CMAKE_TOOLCHAIN_FILE="$(CURDIR)/rust/aws-lc-sys-win-toolchain.cmake" && \
 	  export RUSTFLAGS="$(RUSTFLAGS)" && \
 	  cargo build --target $(TARGET) --lib --profile $(PROFILE) $(FEATURE_FLAGS) --manifest-path ./rust/Cargo.toml --target-dir $(TARGET_DIR)
 

--- a/r/sedonadb/src/rust/aws-lc-sys-win-toolchain.cmake
+++ b/r/sedonadb/src/rust/aws-lc-sys-win-toolchain.cmake
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Include the default toolchain if needed
+if(CMAKE_TOOLCHAIN_FILE)
+    include("${CMAKE_TOOLCHAIN_FILE}")
+endif()
+
+# Set the maximum object path length
+set(CMAKE_OBJECT_PATH_MAX 1024)

--- a/r/sedonadb/src/rust/aws-lc-sys-win-toolchain.cmake
+++ b/r/sedonadb/src/rust/aws-lc-sys-win-toolchain.cmake
@@ -15,10 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Include the default toolchain if needed
-if(CMAKE_TOOLCHAIN_FILE)
-  include("${CMAKE_TOOLCHAIN_FILE}")
-endif()
-
 # Set the maximum object path length
 set(CMAKE_OBJECT_PATH_MAX 1024)

--- a/r/sedonadb/src/rust/aws-lc-sys-win-toolchain.cmake
+++ b/r/sedonadb/src/rust/aws-lc-sys-win-toolchain.cmake
@@ -17,7 +17,7 @@
 
 # Include the default toolchain if needed
 if(CMAKE_TOOLCHAIN_FILE)
-    include("${CMAKE_TOOLCHAIN_FILE}")
+  include("${CMAKE_TOOLCHAIN_FILE}")
 endif()
 
 # Set the maximum object path length


### PR DESCRIPTION
Another attempt to workaround the path length on Windows. I'm not sure if this will fix anything but it's worth a shot!