### PR TITLE
docs: Improve the format of the SQL references

### DIFF
--- a/docs/reference/sql.md
+++ b/docs/reference/sql.md
@@ -32,19 +32,19 @@ To query a file, place its path or URL in single quotes within the `FROM` clause
 
 ## ST_Analyze_Aggr
 
-### Description
+#### Description
 
 Return the statistics of geometries for the input geometry.
 
-### Format
+#### Format
 
 `ST_Analyze_Aggr (A: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geom**: Input geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_Analyze_Aggr(ST_GeomFromText('MULTIPOINT(1.1 101.1,2.1 102.1,3.1 103.1,4.1 104.1,5.1 105.1,6.1 106.1,7.1 107.1,8.1 108.1,9.1 109.1,10.1 110.1)'))
@@ -52,19 +52,19 @@ SELECT ST_Analyze_Aggr(ST_GeomFromText('MULTIPOINT(1.1 101.1,2.1 102.1,3.1 103.1
 
 ## ST_Area
 
-### Description
+#### Description
 
 Return the area of a geometry.
 
-### Format
+#### Format
 
 `ST_Area (A: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geom**: Input geometry.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_Area(ST_GeomFromWKT('POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))'));
@@ -72,19 +72,19 @@ SELECT ST_Area(ST_GeomFromWKT('POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))'));
 
 ## ST_AsBinary
 
-### Description
+#### Description
 
 Return the Well-Known Binary representation of a geometry or geography. This function also has the alias **ST_AsWKB**.
 
-### Format
+#### Format
 
 `ST_AsBinary (A: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geom**: Input geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_AsBinary(ST_Point(1.0, 2.0));
@@ -92,19 +92,19 @@ SELECT ST_AsBinary(ST_Point(1.0, 2.0));
 
 ## ST_AsText
 
-### Description
+#### Description
 
 Return the Well-Known Text string representation of a geometry or geography.
 
-### Format
+#### Format
 
 `ST_AsText (A: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geom**: Input geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_AsText(ST_Point(1.0, 2.0))
@@ -112,20 +112,20 @@ SELECT ST_AsText(ST_Point(1.0, 2.0))
 
 ## ST_Buffer
 
-### Description
+#### Description
 
 Returns a geometry that represents all points whose distance from the input geometry is less than or equal to a specified distance.
 
-### Format
+#### Format
 
 `ST_Buffer (A: Geometry, distance: Double)`
 
-### Arguments
+#### Arguments
 
   * **geom**: Input geometry.
   * **distance**: Radius of the buffer.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_Buffer(ST_GeomFromText('POLYGON ((10 10, 11 10, 10 11, 10 10))'), 1.0);
@@ -133,19 +133,19 @@ SELECT ST_Buffer(ST_GeomFromText('POLYGON ((10 10, 11 10, 10 11, 10 10))'), 1.0)
 
 ## ST_Centroid
 
-### Description
+#### Description
 
 Returns the centroid of geom.
 
-### Format
+#### Format
 
 `ST_Centroid (A: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geom**: Input geometry.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_AsText(ST_Centroid(ST_GeomFromWKT('POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))')));
@@ -153,19 +153,19 @@ SELECT ST_AsText(ST_Centroid(ST_GeomFromWKT('POLYGON ((0 0, 10 0, 10 10, 0 10, 0
 
 ## ST_Collect
 
-### Description
+#### Description
 
 Aggregates a set of geometries into a single `GeometryCollection`, `MultiPoint`, `MultiLineString`, or `MultiPolygon`. If all input geometries are of the same type (e.g., all points), it creates a multi-geometry of that type. If the geometries are of mixed types, it returns a `GeometryCollection`.
 
-### Format
+#### Format
 
 `ST_Collect (geom: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geom**: The input geometry or geography to be collected.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_Collect(ST_GeomFromWKT('MULTIPOINT (0 1, 10 11)'))
@@ -173,20 +173,20 @@ SELECT ST_Collect(ST_GeomFromWKT('MULTIPOINT (0 1, 10 11)'))
 
 ## ST_Contains
 
-### Description
+#### Description
 
 Return true if geomA contains geomB.
 
-### Format
+#### Format
 
 `ST_Contains (A: Geometry, B: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geomA**: Input geometry or geography.
   * **geomB**: Input geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_Contains(ST_Point(0.25 0.25), ST_GeomFromText('POLYGON ((0 0, 1 0, 0 1, 0 0))')) AS val
@@ -194,20 +194,20 @@ SELECT ST_Contains(ST_Point(0.25 0.25), ST_GeomFromText('POLYGON ((0 0, 1 0, 0 1
 
 ## ST_CoveredBy
 
-### Description
+#### Description
 
 Return true if geomA is covered by geomB.
 
-### Format
+#### Format
 
 `ST_CoveredBy (A: Geometry, B: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geomA**: Input geometry or geography.
   * **geomB**: Input geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_CoveredBy(ST_Point(0.25 0.25), ST_GeomFromText('POLYGON ((0 0, 1 0, 0 1, 0 0))')) AS val
@@ -215,20 +215,20 @@ SELECT ST_CoveredBy(ST_Point(0.25 0.25), ST_GeomFromText('POLYGON ((0 0, 1 0, 0 
 
 ## ST_Covers
 
-### Description
+#### Description
 
 Return true if geomA covers geomB.
 
-### Format
+#### Format
 
 `ST_Covers (A: Geometry, B: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geomA**: Input geometry or geography.
   * **geomB**: Input geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_Covers(ST_Point(0.25 0.25), ST_GeomFromText('POLYGON ((0 0, 1 0, 0 1, 0 0))')) AS val
@@ -236,20 +236,20 @@ SELECT ST_Covers(ST_Point(0.25 0.25), ST_GeomFromText('POLYGON ((0 0, 1 0, 0 1, 
 
 ## ST_Difference
 
-### Description
+#### Description
 
 Computes the difference between geomA and geomB.
 
-### Format
+#### Format
 
 `ST_Difference (A: Geometry, B: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geomA**: Input geometry or geography.
   * **geomB**: Input geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_Difference(ST_GeomFromText('POLYGON ((1 1, 11 1, 1 11, 0 0))'), ST_GeomFromText('POLYGON ((0 0, 10 0, 0 10, 0 0))')) AS val
@@ -257,19 +257,19 @@ SELECT ST_Difference(ST_GeomFromText('POLYGON ((1 1, 11 1, 1 11, 0 0))'), ST_Geo
 
 ## ST_Dimension
 
-### Description
+#### Description
 
 Return the dimension of the geometry.
 
-### Format
+#### Format
 
 `ST_Dimension (A: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geom**: Input geometry.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_Dimension(ST_GeomFromWKT('POLYGON ((0 0, 1 0, 0 1, 0 0))'));
@@ -277,20 +277,20 @@ SELECT ST_Dimension(ST_GeomFromWKT('POLYGON ((0 0, 1 0, 0 1, 0 0))'));
 
 ## ST_Disjoint
 
-### Description
+#### Description
 
 Return true if geomA is disjoint from geomB.
 
-### Format
+#### Format
 
 `ST_Disjoint (A: Geometry, B: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geomA**: Input geometry or geography.
   * **geomB**: Input geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_Disjoint(ST_Point(0.25 0.25), ST_GeomFromText('POLYGON ((0 0, 1 0, 0 1, 0 0))')) AS val
@@ -298,20 +298,20 @@ SELECT ST_Disjoint(ST_Point(0.25 0.25), ST_GeomFromText('POLYGON ((0 0, 1 0, 0 1
 
 ## ST_Distance
 
-### Description
+#### Description
 
 Calculates the distance between geomA and geomB.
 
-### Format
+#### Format
 
 `ST_Distance (A: Geometry, B: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geomA**: Input geometry or geography.
   * **geomB**: Input geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_Distance(ST_GeomFromText('POLYGON ((10 10, 11 10, 10 11, 10 10))'), ST_GeomFromText('POLYGON ((0 0, 1 0, 0 1, 0 0))')) AS val
@@ -319,20 +319,20 @@ SELECT ST_Distance(ST_GeomFromText('POLYGON ((10 10, 11 10, 10 11, 10 10))'), ST
 
 ## ST_DistanceSphere
 
-### Description
+#### Description
 
 Calculates the spherical distance between geomA and geomB.
 
-### Format
+#### Format
 
 `ST_DistanceSphere (A: Geometry, B: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geomA**: Input geometry or geography.
   * **geomB**: Input geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_DistanceSphere(ST_GeomFromText('POLYGON ((10 10, 11 10, 10 11, 10 10))'), ST_GeomFromText('POLYGON ((0 0, 1 0, 0 1, 0 0))')) AS val
@@ -340,20 +340,20 @@ SELECT ST_DistanceSphere(ST_GeomFromText('POLYGON ((10 10, 11 10, 10 11, 10 10))
 
 ## ST_DistanceSpheroid
 
-### Description
+#### Description
 
 Calculates the spheroidal (ellipsoidal) distance between geomA and geomB.
 
-### Format
+#### Format
 
 `ST_DistanceSpheroid (A: Geometry, B: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geomA**: Input geometry or geography.
   * **geomB**: Input geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_DistanceSpheroid(ST_GeomFromText('POLYGON ((10 10, 11 10, 10 11, 10 10))'), ST_GeomFromText('POLYGON ((0 0, 1 0, 0 1, 0 0))')) AS val
@@ -361,21 +361,21 @@ SELECT ST_DistanceSpheroid(ST_GeomFromText('POLYGON ((10 10, 11 10, 10 11, 10 10
 
 ## ST_DWithin
 
-### Description
+#### Description
 
 Returns true if two geometries are within a specified distance of each other.
 
-### Format
+#### Format
 
 `ST_DWithin (A: Geometry, B: Geometry, distance: Double)`
 
-### Arguments
+#### Arguments
 
   * **geomA**: Input geometry or geography.
   * **geomB**: Input geometry or geography.
   * **distance**: Distance in units of the geometry's coordinate system.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_DWithin(ST_Point(0.25, 0.25), ST_GeomFromText('POLYGON ((0 0, 1 0, 0 1, 0 0))'), 0.5);
@@ -383,19 +383,19 @@ SELECT ST_DWithin(ST_Point(0.25, 0.25), ST_GeomFromText('POLYGON ((0 0, 1 0, 0 1
 
 ## ST_Envelope
 
-### Description
+#### Description
 
 Returns the bounding box (envelope) of a geometry as a new geometry. The resulting geometry represents the minimum bounding rectangle that encloses the input geometry. Depending on the input, the output can be a `Point`, `LineString`, or `Polygon`.
 
-### Format
+#### Format
 
 `ST_Envelope (A: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geom**: The input geometry.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_Envelope(ST_Point(1.0, 2.0))
@@ -403,19 +403,19 @@ SELECT ST_Envelope(ST_Point(1.0, 2.0))
 
 ## ST_Envelope_Aggr
 
-### Description
+#### Description
 
 An aggregate function that returns the collective bounding box (envelope) of a set of geometries.
 
-### Format
+#### Format
 
 `ST_Envelope_Aggr (geom: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geom**: A column of geometries to be aggregated.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 -- Create a table with geometries and calculate the aggregate envelope
@@ -429,20 +429,20 @@ SELECT ST_AsText(ST_Envelope_Aggr(geom)) FROM shapes;
 
 ## ST_Equals
 
-### Description
+#### Description
 
 Return true if geomA equals geomB.
 
-### Format
+#### Format
 
 `ST_Equals (A: Geometry, B: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geomA**: Input geometry or geography.
   * **geomB**: Input geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_Equals(ST_Point(0.25 0.25), ST_GeomFromText('POLYGON ((0 0, 1 0, 0 1, 0 0))')) AS val
@@ -450,19 +450,19 @@ SELECT ST_Equals(ST_Point(0.25 0.25), ST_GeomFromText('POLYGON ((0 0, 1 0, 0 1, 
 
 ## ST_FlipCoordinates
 
-### Description
+#### Description
 
 Returns a new geometry with the X and Y coordinates of each vertex swapped. This is useful for correcting geometries that have been created with longitude and latitude in the wrong order.
 
-### Format
+#### Format
 
 `ST_FlipCoordinates (A: geometry)`
 
-### Arguments
+#### Arguments
 
   * **geom**: The input geometry whose coordinates will be flipped.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_FlipCoordinates(df.geometry)
@@ -470,20 +470,20 @@ SELECT ST_FlipCoordinates(df.geometry)
 
 ## ST_FrechetDistance
 
-### Description
+#### Description
 
 Calculates the Frechet distance between geomA and geomB.
 
-### Format
+#### Format
 
 `ST_FrechetDistance (A: Geometry, B: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geomA**: Input geometry or geography.
   * **geomB**: Input geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_FrechetDistance(ST_GeomFromText('POLYGON ((10 10, 11 10, 10 11, 10 10))'), ST_GeomFromText('POLYGON ((0 0, 1 0, 0 1, 0 0))')) AS val
@@ -491,19 +491,19 @@ SELECT ST_FrechetDistance(ST_GeomFromText('POLYGON ((10 10, 11 10, 10 11, 10 10)
 
 ## ST_GeomFromWKB
 
-### Description
+#### Description
 
 Construct a Geometry from WKB.
 
-### Format
+#### Format
 
 `ST_GeomFromWKB (Wkb: Binary)`
 
-### Arguments
+#### Arguments
 
   * **WKB**: binary: Well-known binary representation of the geometry.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 -- Creates a POINT(1 2) geometry from its WKB representation
@@ -512,19 +512,19 @@ SELECT ST_AsText(ST_GeomFromWKB(FROM_HEX('0101000000000000000000F03F000000000000
 
 ## ST_GeomFromWKT
 
-### Description
+#### Description
 
 Construct a Geometry from WKT. This function also has the alias **ST_GeomFromText**.
 
-### Format
+#### Format
 
 `ST_GeomFromWKT (Wkt: String)`
 
-### Arguments
+#### Arguments
 
   * **WKT**: string: Well-known text representation of the geometry.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_AsText(ST_GeomFromWKT('POINT (30 10)'));
@@ -532,19 +532,19 @@ SELECT ST_AsText(ST_GeomFromWKT('POINT (30 10)'));
 
 ## ST_GeometryType
 
-### Description
+#### Description
 
 Return the type of a geometry.
 
-### Format
+#### Format
 
 `ST_GeometryType (A: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geom**: Input geometry.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_GeometryType(ST_GeomFromWKT('POLYGON ((0 0, 1 0, 0 1, 0 0))'))
@@ -552,19 +552,19 @@ SELECT ST_GeometryType(ST_GeomFromWKT('POLYGON ((0 0, 1 0, 0 1, 0 0))'))
 
 ## ST_HasM
 
-### Description
+#### Description
 
 Return true if the geometry has a M dimension.
 
-### Format
+#### Format
 
 `ST_HasM (A: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geom**: Input geometry.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_HasM(ST_GeomFromWKT('POLYGON ((0 0, 1 0, 0 1, 0 0))'))
@@ -572,19 +572,19 @@ SELECT ST_HasM(ST_GeomFromWKT('POLYGON ((0 0, 1 0, 0 1, 0 0))'))
 
 ## ST_HasZ
 
-### Description
+#### Description
 
 Return true if the geometry has a Z dimension.
 
-### Format
+#### Format
 
 `ST_HasZ (A: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geom**: Input geometry.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_HasZ(ST_GeomFromWKT('POLYGON ((0 0, 1 0, 0 1, 0 0))'))
@@ -592,20 +592,20 @@ SELECT ST_HasZ(ST_GeomFromWKT('POLYGON ((0 0, 1 0, 0 1, 0 0))'))
 
 ## ST_HausdorffDistance
 
-### Description
+#### Description
 
 Calculates the Hausdorff distance between geomA and geomB.
 
-### Format
+#### Format
 
 `ST_HausdorffDistance (A: Geometry, B: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geomA**: Input geometry or geography.
   * **geomB**: Input geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_HausdorffDistance(ST_GeomFromText('POLYGON ((10 10, 11 10, 10 11, 10 10))'), ST_GeomFromText('POLYGON ((0 0, 1 0, 0 1, 0 0))')) AS val
@@ -613,20 +613,20 @@ SELECT ST_HausdorffDistance(ST_GeomFromText('POLYGON ((10 10, 11 10, 10 11, 10 1
 
 ## ST_Intersection
 
-### Description
+#### Description
 
 Computes the intersection between geomA and geomB.
 
-### Format
+#### Format
 
 `ST_Intersection (A: Geometry, B: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geomA**: Input geometry or geography.
   * **geomB**: Input geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_Intersection(ST_GeomFromText('POLYGON ((1 1, 11 1, 1 11, 0 0))'), ST_GeomFromText('POLYGON ((0 0, 10 0, 0 10, 0 0))')) AS val
@@ -634,19 +634,19 @@ SELECT ST_Intersection(ST_GeomFromText('POLYGON ((1 1, 11 1, 1 11, 0 0))'), ST_G
 
 ## ST_Intersection_Aggr
 
-### Description
+#### Description
 
 An aggregate function that returns the geometric intersection of all geometries in a set.
 
-### Format
+#### Format
 
 `ST_Intersection_Aggr (geom: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geom**: A column of geometries to be aggregated.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 -- Create a table with overlapping polygons and find their common intersection
@@ -660,20 +660,20 @@ SELECT ST_AsText(ST_Intersection_Aggr(geom)) FROM shapes;
 
 ## ST_Intersects
 
-### Description
+#### Description
 
 Return true if geomA intersects geomB.
 
-### Format
+#### Format
 
 `ST_Intersects (A: Geometry, B: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geomA**: Input geometry or geography.
   * **geomB**: Input geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_Intersects(ST_Point(0.25 0.25), ST_GeomFromText('POLYGON ((0 0, 1 0, 0 1, 0 0))')) AS val
@@ -681,19 +681,19 @@ SELECT ST_Intersects(ST_Point(0.25 0.25), ST_GeomFromText('POLYGON ((0 0, 1 0, 0
 
 ## ST_IsEmpty
 
-### Description
+#### Description
 
 Return true if the geometry is empty.
 
-### Format
+#### Format
 
 `ST_IsEmpty (A: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geom**: Input geometry.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_IsEmpty(ST_GeomFromWKT('POLYGON EMPTY'));
@@ -701,22 +701,22 @@ SELECT ST_IsEmpty(ST_GeomFromWKT('POLYGON EMPTY'));
 
 ## ST_KNN
 
-### Description
+#### Description
 
 Return true if geomA finds k nearest neighbors from geomB.
 
-### Format
+#### Format
 
 `ST_KNN (A: Geometry, B: Geometry, k: Integer, use_spheroid: Boolean)`
 
-### Arguments
+#### Arguments
 
   * **geomA**: Query geometry or geography.
   * **geomB**: Object geometry or geography.
   * **k**: Number of nearest neighbors to find.
   * **use_spheroid**: Use spheroid distance calculation.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT * FROM table1 a JOIN table2 b ON ST_KNN(a.geom, b.geom, 5, false)
@@ -724,19 +724,19 @@ SELECT * FROM table1 a JOIN table2 b ON ST_KNN(a.geom, b.geom, 5, false)
 
 ## ST_Length
 
-### Description
+#### Description
 
 Returns the length of geom. This function only supports LineString, MultiLineString, and GeometryCollections containing linear geometries. Use ST_Perimeter for polygons.
 
-### Format
+#### Format
 
 `ST_Length (A: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geom**: geometry: Input geometry.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_Length(ST_GeomFromWKT('LINESTRING(0 0, 10 0)'));
@@ -744,19 +744,19 @@ SELECT ST_Length(ST_GeomFromWKT('LINESTRING(0 0, 10 0)'));
 
 ## ST_M
 
-### Description
+#### Description
 
 Returns the M (measure) coordinate of a `Point` geometry. If the geometry does not have an M value, it returns `NULL`.
 
-### Format
+#### Format
 
 `ST_M (A: Point)`
 
-### Arguments
+#### Arguments
 
   * **geom**: The input point geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_M(ST_Point(1.0, 2.0))
@@ -764,20 +764,20 @@ SELECT ST_M(ST_Point(1.0, 2.0))
 
 ## ST_MakeLine
 
-### Description
+#### Description
 
 Creates a `LineString` from two or more input `Point`, `MultiPoint`, or `LineString` geometries. The function connects the input geometries in the order they are provided to form a single continuous line.
 
-### Format
+#### Format
 
 `ST_MakeLine (g1: Geometry or Geography, g2: Geometry or Geography)`
 
-### Arguments
+#### Arguments
 
   * **g1**: The first `Point`, `MultiPoint`, or `LineString` geometry or geography.
   * **g2**: The second `Point`, `MultiPoint`, or `LineString` geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_MakeLine(ST_Point(0, 1), ST_Point(2, 3)) as geom
@@ -785,20 +785,20 @@ SELECT ST_MakeLine(ST_Point(0, 1), ST_Point(2, 3)) as geom
 
 ## ST_MaxDistance
 
-### Description
+#### Description
 
 Calculates the maximum distance between geomA and geomB.
 
-### Format
+#### Format
 
 `ST_MaxDistance (A: Geometry, B: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geomA**: Input geometry or geography.
   * **geomB**: Input geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_MaxDistance(ST_GeomFromText('POLYGON ((10 10, 11 10, 10 11, 10 10))'), ST_GeomFromText('POLYGON ((0 0, 1 0, 0 1, 0 0))')) AS val
@@ -806,19 +806,19 @@ SELECT ST_MaxDistance(ST_GeomFromText('POLYGON ((10 10, 11 10, 10 11, 10 10))'),
 
 ## ST_MMax
 
-### Description
+#### Description
 
 Returns the maximum M (measure) value from a geometry's bounding box.
 
-### Format
+#### Format
 
 `ST_MMax (A: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geom**: The input geometry.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_MMax(ST_GeomFromWKT('POLYGON ((0 0, 1 0, 0 1, 0 0))'))
@@ -826,19 +826,19 @@ SELECT ST_MMax(ST_GeomFromWKT('POLYGON ((0 0, 1 0, 0 1, 0 0))'))
 
 ## ST_MMin
 
-### Description
+#### Description
 
 Returns the minimum **M-coordinate** (measure) of a geometry's bounding box.
 
-### Format
+#### Format
 
 `ST_MMin (A: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geom**: Input geometry.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_MMin(ST_GeomFromWKT('LINESTRING ZM (1 2 3 4, 5 6 7 8)'));
@@ -847,25 +847,25 @@ SELECT ST_MMin(ST_GeomFromWKT('LINESTRING ZM (1 2 3 4, 5 6 7 8)'));
 
 ## ST_Perimeter
 
-### Description
+#### Description
 
 This function calculates the 2D perimeter of a given geometry. It supports Polygon, MultiPolygon, and GeometryCollection geometries (as long as the GeometryCollection contains polygonal geometries). For other types, it returns 0. To measure lines, use ST_Length.
 
 To get the perimeter in meters, set **use_spheroid** to true. This calculates the geodesic perimeter using the WGS84 spheroid. When using use_spheroid, the **lenient** parameter defaults to true, assuming the geometry uses EPSG:4326. To throw an exception instead, set lenient to false.
 
-### Format
+#### Format
 
 `ST_Perimeter(geom: Geometry)`
 `ST_Perimeter(geom: Geometry, use_spheroid: Boolean)`
 `ST_Perimeter(geom: Geometry, use_spheroid: Boolean, lenient: Boolean = True)`
 
-### Arguments
+#### Arguments
 
   * **geom**: Input geometry.
   * **use_spheroid**: If true, calculates the geodesic perimeter using the WGS84 spheroid. Defaults to false.
   * **lenient**: If true, assumes the geometry uses EPSG:4326 when use_spheroid is true. Defaults to true.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_Perimeter(ST_GeomFromWKT('POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))'));
@@ -873,20 +873,20 @@ SELECT ST_Perimeter(ST_GeomFromWKT('POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))'));
 
 ## ST_Point
 
-### Description
+#### Description
 
 Construct a Point Geometry from X and Y.
 
-### Format
+#### Format
 
 `ST_Point (x: Double, y: Double)`
 
-### Arguments
+#### Arguments
 
   * **x**: X value.
   * **y**: Y value.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_AsText(ST_Point(-74.0060, 40.7128));
@@ -894,21 +894,21 @@ SELECT ST_AsText(ST_Point(-74.0060, 40.7128));
 
 ## ST_PointM
 
-### Description
+#### Description
 
 Constructs a `Point` with an M (measure) coordinate from X, Y, and M values.
 
-### Format
+#### Format
 
 `ST_PointM (x: Double, y: Double, m: Double)`
 
-### Arguments
+#### Arguments
 
   * **x**: The X-coordinate value.
   * **y**: The Y-coordinate value.
   * **m**: The M-coordinate (measure) value.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_PointM(-64.36, 45.09, 50.0)
@@ -916,21 +916,21 @@ SELECT ST_PointM(-64.36, 45.09, 50.0)
 
 ## ST_PointZ
 
-### Description
+#### Description
 
 Constructs a `Point` with a Z (elevation) coordinate from X, Y, and Z values.
 
-### Format
+#### Format
 
 `ST_PointZ (x: Double, y: Double, z: Double)`
 
-### Arguments
+#### Arguments
 
   * **x**: The X-coordinate value.
   * **y**: The Y-coordinate value.
   * **z**: The Z-coordinate (elevation) value.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_PointZ(-64.36, 45.09, 100.0)
@@ -938,22 +938,22 @@ SELECT ST_PointZ(-64.36, 45.09, 100.0)
 
 ## ST_PointZM
 
-### Description
+#### Description
 
 Constructs a `Point` with both Z (elevation) and M (measure) coordinates from X, Y, Z, and M values.
 
-### Format
+#### Format
 
 `ST_PointZM (x: Double, y: Double, z: Double, m: Double)`
 
-### Arguments
+#### Arguments
 
   * **x**: The X-coordinate value.
   * **y**: The Y-coordinate value.
   * **z**: The Z-coordinate (elevation) value.
   * **m**: The M-coordinate (measure) value.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_PointZM(-64.36, 45.09, 100.0, 50.0)
@@ -961,20 +961,20 @@ SELECT ST_PointZM(-64.36, 45.09, 100.0, 50.0)
 
 ## ST_SetSRID
 
-### Description
+#### Description
 
 Sets the spatial reference system identifier (SRID) of a geometry. This only changes the metadata; it does not transform the coordinates.
 
-### Format
+#### Format
 
 `ST_SetSRID (geom: Geometry, srid: Integer)`
 
-### Arguments
+#### Arguments
 
   * **geom**: Input geometry or geography.
   * **srid**: EPSG code to set (e.g., 4326).
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_SetSRID(ST_GeomFromWKT('POINT (-64.363049 45.091501)'), 4326);
@@ -982,19 +982,19 @@ SELECT ST_SetSRID(ST_GeomFromWKT('POINT (-64.363049 45.091501)'), 4326);
 
 ## ST_SRID
 
-### Description
+#### Description
 
 Returns the Spatial Reference System Identifier (SRID) of a geometry. If the geometry does not have an SRID, it returns 0.
 
-### Format
+#### Format
 
 `ST_SRID (geom: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geom**: The input geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_SRID(polygon)
@@ -1002,20 +1002,20 @@ SELECT ST_SRID(polygon)
 
 ## ST_SymDifference
 
-### Description
+#### Description
 
 Computes the symmetric difference between geomA and geomB.
 
-### Format
+#### Format
 
 `ST_SymDifference (A: Geometry, B: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geomA**: Input geometry or geography.
   * **geomB**: Input geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_SymDifference(ST_GeomFromText('POLYGON ((1 1, 11 1, 1 11, 0 0))'), ST_GeomFromText('POLYGON ((0 0, 10 0, 0 10, 0 0))')) AS val
@@ -1023,20 +1023,20 @@ SELECT ST_SymDifference(ST_GeomFromText('POLYGON ((1 1, 11 1, 1 11, 0 0))'), ST_
 
 ## ST_Touches
 
-### Description
+#### Description
 
 Return true if geomA touches geomB.
 
-### Format
+#### Format
 
 `ST_Touches (A: Geometry, B: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geomA**: Input geometry or geography.
   * **geomB**: Input geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_Touches(ST_Point(0.25 0.25), ST_GeomFromText('POLYGON ((0 0, 1 0, 0 1, 0 0))')) AS val
@@ -1044,25 +1044,25 @@ SELECT ST_Touches(ST_Point(0.25 0.25), ST_GeomFromText('POLYGON ((0 0, 1 0, 0 1,
 
 ## ST_Transform
 
-### Description
+#### Description
 
 Transforms the coordinates of a geometry from a source Coordinate Reference System (CRS) to a target CRS.
 
 If the source CRS is not specified, it will be read from the geometry's metadata. Sedona ensures that coordinates are handled in longitude/latitude order for geographic CRS transformations.
 
-### Format
+#### Format
 
 `ST_Transform (A: Geometry, TargetCRS: String)`
 `ST_Transform (A: Geometry, SourceCRS: String, TargetCRS: String)`
 
-### Arguments
+#### Arguments
 
   * **geom**: Input geometry or geography.
   * **source_crs**: The source CRS code (e.g., 'EPSG:4326').
   * **target_crs**: The target CRS code to transform into.
   * **lenient**: A boolean that, if true, assumes the source is EPSG:4326 if not specified. Defaults to true.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 -- Transform a WGS84 polygon to UTM zone 49N
@@ -1071,20 +1071,20 @@ SELECT ST_Transform(ST_SetSRID(ST_GeomFromWkt('POLYGON((170 50,170 72,-130 72,-1
 
 ## ST_Union
 
-### Description
+#### Description
 
 Computes the union between geomA and geomB.
 
-### Format
+#### Format
 
 `ST_Union (A: Geometry, B: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geomA**: Input geometry or geography.
   * **geomB**: Input geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_Union(ST_GeomFromText('POLYGON ((1 1, 11 1, 1 11, 0 0))'), ST_GeomFromText('POLYGON ((0 0, 10 0, 0 10, 0 0))')) AS val
@@ -1092,19 +1092,19 @@ SELECT ST_Union(ST_GeomFromText('POLYGON ((1 1, 11 1, 1 11, 0 0))'), ST_GeomFrom
 
 ## ST_Union_Aggr
 
-### Description
+#### Description
 
 An aggregate function that returns the geometric union of all geometries in a set.
 
-### Format
+#### Format
 
 `ST_Union_Aggr (geom: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geom**: A column of geometries to be aggregated.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 -- Create a table with two separate polygons and unite them into a single multipolygon
@@ -1118,20 +1118,20 @@ SELECT ST_AsText(ST_Union_Aggr(geom)) FROM shapes;
 
 ## ST_Within
 
-### Description
+#### Description
 
 Return true if geomA is fully contained by geomB.
 
-### Format
+#### Format
 
 `ST_Within (A: Geometry, B: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geomA**: Input geometry or geography.
   * **geomB**: Input geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_Within(ST_Point(0.25 0.25), ST_GeomFromText('POLYGON ((0 0, 1 0, 0 1, 0 0))')) AS val
@@ -1139,19 +1139,19 @@ SELECT ST_Within(ST_Point(0.25 0.25), ST_GeomFromText('POLYGON ((0 0, 1 0, 0 1, 
 
 ## ST_X
 
-### Description
+#### Description
 
 Return the X component of a point geometry or geography.
 
-### Format
+#### Format
 
 `ST_X(A: Point)`
 
-### Arguments
+#### Arguments
 
   * **geom**: Input geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_X(ST_Point(1.0, 2.0))
@@ -1159,19 +1159,19 @@ SELECT ST_X(ST_Point(1.0, 2.0))
 
 ## ST_XMax
 
-### Description
+#### Description
 
 Returns the maximum **X-coordinate** of a geometry's bounding box.
 
-### Format
+#### Format
 
 `ST_XMax (A: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geom**: Input geometry.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_XMax(ST_GeomFromWKT('LINESTRING(1 5, 10 15)'));
@@ -1180,19 +1180,19 @@ SELECT ST_XMax(ST_GeomFromWKT('LINESTRING(1 5, 10 15)'));
 
 ## ST_XMin
 
-### Description
+#### Description
 
 Returns the minimum **X-coordinate** of a geometry's bounding box.
 
-### Format
+#### Format
 
 `ST_XMin (A: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geom**: Input geometry.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_XMin(ST_GeomFromWKT('LINESTRING(1 5, 10 15)'));
@@ -1201,19 +1201,19 @@ SELECT ST_XMin(ST_GeomFromWKT('LINESTRING(1 5, 10 15)'));
 
 ## ST_Y
 
-### Description
+#### Description
 
 Return the Y component of a point geometry or geography.
 
-### Format
+#### Format
 
 `ST_Y(A: Point)`
 
-### Arguments
+#### Arguments
 
   * **geom**: Input geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_Y(ST_Point(1.0, 2.0))
@@ -1221,19 +1221,19 @@ SELECT ST_Y(ST_Point(1.0, 2.0))
 
 ## ST_YMax
 
-### Description
+#### Description
 
 Returns the maximum **Y-coordinate** of a geometry's bounding box.
 
-### Format
+#### Format
 
 `ST_YMax (A: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geom**: Input geometry.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_YMax(ST_GeomFromWKT('LINESTRING(1 5, 10 15)'));
@@ -1242,19 +1242,19 @@ SELECT ST_YMax(ST_GeomFromWKT('LINESTRING(1 5, 10 15)'));
 
 ## ST_YMin
 
-### Description
+#### Description
 
 Returns the minimum **Y-coordinate** of a geometry's bounding box.
 
-### Format
+#### Format
 
 `ST_YMin (A: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geom**: Input geometry.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_YMin(ST_GeomFromWKT('LINESTRING(1 5, 10 15)'));
@@ -1263,19 +1263,19 @@ SELECT ST_YMin(ST_GeomFromWKT('LINESTRING(1 5, 10 15)'));
 
 ## ST_Z
 
-### Description
+#### Description
 
 Return the Z component of a point geometry or geography.
 
-### Format
+#### Format
 
 `ST_Z(A: Point)`
 
-### Arguments
+#### Arguments
 
   * **geom**: Input geometry or geography.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_Z(ST_Point(1.0, 2.0))
@@ -1283,19 +1283,19 @@ SELECT ST_Z(ST_Point(1.0, 2.0))
 
 ## ST_ZMax
 
-### Description
+#### Description
 
 Returns the maximum **Z-coordinate** of a geometry's bounding box.
 
-### Format
+#### Format
 
 `ST_ZMax (A: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geom**: Input geometry.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_ZMax(ST_GeomFromWKT('LINESTRING ZM (1 2 3 4, 5 6 7 8)'));
@@ -1304,19 +1304,19 @@ SELECT ST_ZMax(ST_GeomFromWKT('LINESTRING ZM (1 2 3 4, 5 6 7 8)'));
 
 ## ST_ZMin
 
-### Description
+#### Description
 
 Returns the minimum **Z-coordinate** of a geometry's bounding box.
 
-### Format
+#### Format
 
 `ST_ZMin (A: Geometry)`
 
-### Arguments
+#### Arguments
 
   * **geom**: Input geometry.
 
-### SQL Example
+#### SQL Example
 
 ```sql
 SELECT ST_ZMin(ST_GeomFromWKT('LINESTRING ZM (1 2 3 4, 5 6 7 8)'));


### PR DESCRIPTION
Move all `###` to `####` in SQL references (https://sedona.apache.org/sedonadb/latest/reference/sql/)


## Before 

<img width="330" height="1076" alt="image" src="https://github.com/user-attachments/assets/2169f08c-069f-4ae5-9731-7beaed3e0c90" />


## After


<img width="267" height="1044" alt="image" src="https://github.com/user-attachments/assets/adc60020-d9fb-42b9-a38b-9b314008475a" />
