### PR TITLE
chore: Refactor `with_aliases` to a more builder-like pattern

### DIFF
--- a/rust/sedona-expr/src/scalar_udf.rs
+++ b/rust/sedona-expr/src/scalar_udf.rs
@@ -139,20 +139,15 @@ impl SedonaScalarUDF {
         }
     }
 
-    pub fn new_with_aliases(
-        name: &str,
-        kernels: Vec<ScalarKernelRef>,
-        volatility: Volatility,
-        documentation: Option<Documentation>,
-        aliases: Vec<String>,
-    ) -> SedonaScalarUDF {
-        let signature = Signature::user_defined(volatility);
+    /// Add aliases to an existing SedonaScalarUDF
+    pub fn with_aliases(self, aliases: Vec<String>) -> SedonaScalarUDF {
         Self {
-            name: name.to_string(),
-            signature,
-            kernels,
-            documentation,
+            name: self.name,
+            signature: self.signature,
+            kernels: self.kernels,
+            documentation: self.documentation,
             aliases,
+            ..self
         }
     }
 

--- a/rust/sedona-functions/src/st_asbinary.rs
+++ b/rust/sedona-functions/src/st_asbinary.rs
@@ -28,13 +28,13 @@ use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
 ///
 /// An implementation of WKB writing using GeoRust's wkt crate.
 pub fn st_asbinary_udf() -> SedonaScalarUDF {
-    SedonaScalarUDF::new_with_aliases(
+    let udf = SedonaScalarUDF::new(
         "st_asbinary",
         vec![Arc::new(STAsBinary {})],
         Volatility::Immutable,
         Some(st_asbinary_doc()),
-        vec!["st_aswkb".to_string()],
-    )
+    );
+    udf.with_aliases(vec!["st_aswkb".to_string()])
 }
 
 fn st_asbinary_doc() -> Documentation {

--- a/rust/sedona-functions/src/st_astext.rs
+++ b/rust/sedona-functions/src/st_astext.rs
@@ -30,13 +30,13 @@ use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
 ///
 /// An implementation of WKT writing using GeoRust's wkt crate.
 pub fn st_astext_udf() -> SedonaScalarUDF {
-    SedonaScalarUDF::new_with_aliases(
+    let udf = SedonaScalarUDF::new(
         "st_astext",
         vec![Arc::new(STAsText {})],
         Volatility::Immutable,
         Some(st_astext_doc()),
-        vec!["st_aswkt".to_string()],
-    )
+    );
+    udf.with_aliases(vec!["st_aswkt".to_string()])
 }
 
 fn st_astext_doc() -> Documentation {

--- a/rust/sedona-functions/src/st_geomfromwkt.rs
+++ b/rust/sedona-functions/src/st_geomfromwkt.rs
@@ -39,15 +39,15 @@ use crate::executor::WkbExecutor;
 /// An implementation of WKT reading using GeoRust's wkt crate.
 /// See [`st_geogfromwkt_udf`] for the corresponding geography function.
 pub fn st_geomfromwkt_udf() -> SedonaScalarUDF {
-    SedonaScalarUDF::new_with_aliases(
+    let udf = SedonaScalarUDF::new(
         "st_geomfromwkt",
         vec![Arc::new(STGeoFromWKT {
             out_type: WKB_GEOMETRY,
         })],
         Volatility::Immutable,
         Some(doc("ST_GeomFromWKT", "Geometry")),
-        vec!["st_geomfromtext".to_string()],
-    )
+    );
+    udf.with_aliases(vec!["st_geomfromtext".to_string()])
 }
 
 /// ST_GeogFromWKT() UDF implementation
@@ -55,15 +55,15 @@ pub fn st_geomfromwkt_udf() -> SedonaScalarUDF {
 /// An implementation of WKT reading using GeoRust's wkt crate.
 /// See [`st_geomfromwkt_udf`] for the corresponding geometry function.
 pub fn st_geogfromwkt_udf() -> SedonaScalarUDF {
-    SedonaScalarUDF::new_with_aliases(
+    let udf = SedonaScalarUDF::new(
         "st_geogfromwkt",
         vec![Arc::new(STGeoFromWKT {
             out_type: WKB_GEOGRAPHY,
         })],
         Volatility::Immutable,
         Some(doc("ST_GeogFromWKT", "Geography")),
-        vec!["st_geogfromtext".to_string()],
-    )
+    );
+    udf.with_aliases(vec!["st_geogfromtext".to_string()])
 }
 
 fn doc(name: &str, out_type_name: &str) -> Documentation {


### PR DESCRIPTION
I wanted to create some trivial issues for creating aliases for functions, but I figured we should fix this before we add some more. The current `new_with_aliases` function was a workaround to not having optional parameters in Rust. It wouldn't work well if wanted to add more optional parameters to the constructor. This PR refactors it to be more builder style so we can easily customize in case we want to add more optional parameters later.