### PR TITLE
fix(r/sedonadb): Add -Wno-pedantic to avoid compile error

### DIFF
--- a/r/sedonadb/src/Makevars.in
+++ b/r/sedonadb/src/Makevars.in
@@ -30,6 +30,11 @@ PKG_LIBS = -L$(LIBDIR) -lsedonadbr @PKG_LIBS@
 
 CARGO_BUILD_ARGS = --lib --profile $(PROFILE) $(FEATURE_FLAGS) --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
+# "-Wno-pedantic" is to override the "-pedantic" flag passed by pkgbuild, which
+# makes the compilation of aws-lc-sys fail. Hopefully, such C code will be fixed
+# on upstream so that we can remove this.
+CFLAGS_TWEAKED = $(CFLAGS) -Wno-pedantic
+
 all: $(SHLIB) clean_intermediate
 
 $(SHLIB): $(STATLIB)
@@ -40,7 +45,7 @@ $(STATLIB):
 	# therefore is only used if cargo is absent from the user's PATH.
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
 	  export CC="$(CC)" && \
-	  export CFLAGS="$(CFLAGS)" && \
+	  export CFLAGS="$(CFLAGS_TWEAKED)" && \
 	  export AWS_LC_SYS_CMAKE_BUILDER=1 && \
 	  export RUSTFLAGS="$(RUSTFLAGS)" && \
 	  if [ "$(TARGET)" != "wasm32-unknown-emscripten" ]; then \

--- a/r/sedonadb/src/Makevars.win.in
+++ b/r/sedonadb/src/Makevars.win.in
@@ -37,9 +37,10 @@ CARGO_LINKER = x86_64-w64-mingw32.static.posix-gcc.exe
 # cf. https://stackoverflow.com/a/68979087
 PKG_CONFIG_SYSROOT_DIR = /x86_64-w64-mingw32.static.posix/
 
-# TODO: should $(CFLAGS) be included here?
-# Do not pass -pedantic
-CFLAGS_TWEAKED = $(subst -pedantic,,$(ALL_CPPFLAGS))
+# "-Wno-pedantic" is to override the "-pedantic" flag passed by pkgbuild, which
+# makes the compilation of aws-lc-sys fail. Hopefully, such C code will be fixed
+# on upstream so that we can remove this.
+CFLAGS_TWEAKED = $(CFLAGS) -Wno-pedantic
 
 all: $(SHLIB) clean_intermediate
 

--- a/r/sedonadb/src/Makevars.win.in
+++ b/r/sedonadb/src/Makevars.win.in
@@ -52,11 +52,6 @@ $(STATLIB):
 	# in actual, but we need this tweak to please the compiler.
 	mkdir -p $(LIBDIR)/libgcc_mock && touch $(LIBDIR)/libgcc_mock/libgcc_eh.a
 
-	# AWS_LC_SYS_CFLAGS are not ideal: It would be better to use the
-	# CMake builder but this incurs path length errors on at least one Windows builder.
-	# The AWS_LC_SYS_CMAKE_BUILDER environment variable can still be set at a
-	# higher level on Windows environments that support it.
-
 	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
 	  export LIBRARY_PATH="$${LIBRARY_PATH};$(LIBDIR)/libgcc_mock" && \
 	  export PKG_CONFIG_SYSROOT_DIR="$(PKG_CONFIG_SYSROOT_DIR)" && \


### PR DESCRIPTION
Fix #164

## Background

When `-pedantic` flag is passed via `CFLAGS`, the aws-lc-sys crate cannot be compiled. `R CMD INSTALL` is not the case, so the CI is fine without this. However, when using devtools or pak, this flag is passed via pkgbuild. 

Why? Pkgbuild's comment says this flag is to "enforce good coding practice" to the R package developers. Also, it says this flag is used on CRAN check. But, considering this package doesn't strongly aim for CRAN (at least at the moment), probably it's fine to ignore the warnings.

https://github.com/r-lib/pkgbuild/blob/d88519a177c18c6a2701e1eaf9fb22d37f9580b9/R/compiler-flags.R#L3-L5

## Details

This pull request simply tries to override `-pedantic` by `-Wno-pedantic`. In the current `Makevars.win.in`, I used `substr` to remove `-pedantic` flag. However, it seems appending this flag is simpler if this works.

Some more tweaks on `Makevars.win.in`:

- Replaced `ALL_CPPFLAGS` with `CFLAGS`. `CPPFLAGS` is C Pre-Processor flags, so I think `CFLAGS` is appropriate here.
- Remove outdated comment `AWS_LC_SYS_CFLAGS`
