### PR TITLE
feat(sql): Implement `ST_Azimuth()`

### DIFF
--- a/rust/sedona-functions/src/lib.rs
+++ b/rust/sedona-functions/src/lib.rs
@@ -26,6 +26,7 @@ pub mod st_analyze_aggr;
 mod st_area;
 mod st_asbinary;
 mod st_astext;
+mod st_azimuth;
 mod st_buffer;
 mod st_centroid;
 mod st_collect;

--- a/rust/sedona-functions/src/register.rs
+++ b/rust/sedona-functions/src/register.rs
@@ -64,6 +64,7 @@ pub fn default_function_set() -> FunctionSet {
         crate::st_area::st_area_udf,
         crate::st_asbinary::st_asbinary_udf,
         crate::st_astext::st_astext_udf,
+        crate::st_azimuth::st_azimuth_udf,
         crate::st_buffer::st_buffer_udf,
         crate::st_centroid::st_centroid_udf,
         crate::st_dimension::st_dimension_udf,
@@ -127,6 +128,7 @@ pub mod stubs {
     pub use crate::predicates::*;
     pub use crate::referencing::*;
     pub use crate::st_area::st_area_udf;
+    pub use crate::st_azimuth::st_azimuth_udf;
     pub use crate::st_centroid::st_centroid_udf;
     pub use crate::st_length::st_length_udf;
     pub use crate::st_perimeter::st_perimeter_udf;

--- a/rust/sedona-functions/src/st_azimuth.rs
+++ b/rust/sedona-functions/src/st_azimuth.rs
@@ -40,13 +40,13 @@ pub fn st_azimuth_udf() -> SedonaScalarUDF {
 fn st_azimuth_doc() -> Documentation {
     Documentation::builder(
         DOC_SECTION_OTHER,
-        "Returns the azimuth in radians from geomA to geomB",
+        "Returns the azimuth (a clockwise angle measured from north) in radians from geomA to geomB",
         "ST_Azimuth (A: Geometry, B: Geometry)",
     )
     .with_argument("geomA", "geometry: Start point geometry")
     .with_argument("geomB", "geometry: End point geometry")
     .with_sql_example(
-        "SELECT ST_Azimuth(\n            ST_GeomFromText('POINT (0 0)'),\n            ST_GeomFromText('POINT (1 1)')\n        )",
+        "SELECT ST_Azimuth(\n            ST_Point(0, 0),\n            ST_Point(1, 1)\n        )",
     )
     .build()
 }

--- a/rust/sedona-functions/src/st_azimuth.rs
+++ b/rust/sedona-functions/src/st_azimuth.rs
@@ -1,0 +1,66 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+use arrow_schema::DataType;
+use datafusion_expr::{scalar_doc_sections::DOC_SECTION_OTHER, Documentation, Volatility};
+use sedona_expr::scalar_udf::SedonaScalarUDF;
+use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
+
+/// ST_Azimuth() scalar UDF stub
+///
+/// Stub function for azimuth calculation between two points.
+pub fn st_azimuth_udf() -> SedonaScalarUDF {
+    SedonaScalarUDF::new_stub(
+        "st_azimuth",
+        ArgMatcher::new(
+            vec![
+                ArgMatcher::is_geometry_or_geography(),
+                ArgMatcher::is_geometry_or_geography(),
+            ],
+            SedonaType::Arrow(DataType::Float64),
+        ),
+        Volatility::Immutable,
+        Some(st_azimuth_doc()),
+    )
+}
+
+fn st_azimuth_doc() -> Documentation {
+    Documentation::builder(
+        DOC_SECTION_OTHER,
+        "Returns the azimuth in radians from geomA to geomB",
+        "ST_Azimuth (A: Geometry, B: Geometry)",
+    )
+    .with_argument("geomA", "geometry: Start point geometry")
+    .with_argument("geomB", "geometry: End point geometry")
+    .with_sql_example(
+        "SELECT ST_Azimuth(\n            ST_GeomFromText('POINT (0 0)'),\n            ST_GeomFromText('POINT (1 1)')\n        )",
+    )
+    .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion_expr::ScalarUDF;
+
+    use super::*;
+
+    #[test]
+    fn udf_metadata() {
+        let udf: ScalarUDF = st_azimuth_udf().into();
+        assert_eq!(udf.name(), "st_azimuth");
+        assert!(udf.documentation().is_some());
+    }
+}

--- a/rust/sedona-geo/src/lib.rs
+++ b/rust/sedona-geo/src/lib.rs
@@ -17,6 +17,7 @@
 pub mod centroid;
 pub mod register;
 mod st_area;
+mod st_azimuth;
 mod st_centroid;
 mod st_distance;
 mod st_dwithin;

--- a/rust/sedona-geo/src/register.rs
+++ b/rust/sedona-geo/src/register.rs
@@ -21,15 +21,16 @@ use crate::st_intersection_aggr::st_intersection_aggr_impl;
 use crate::st_line_interpolate_point::st_line_interpolate_point_impl;
 use crate::st_union_aggr::st_union_aggr_impl;
 use crate::{
-    st_area::st_area_impl, st_centroid::st_centroid_impl, st_distance::st_distance_impl,
-    st_dwithin::st_dwithin_impl, st_intersects::st_intersects_impl, st_length::st_length_impl,
-    st_perimeter::st_perimeter_impl,
+    st_area::st_area_impl, st_azimuth::st_azimuth_impl, st_centroid::st_centroid_impl,
+    st_distance::st_distance_impl, st_dwithin::st_dwithin_impl, st_intersects::st_intersects_impl,
+    st_length::st_length_impl, st_perimeter::st_perimeter_impl,
 };
 
 pub fn scalar_kernels() -> Vec<(&'static str, ScalarKernelRef)> {
     vec![
         ("st_intersects", st_intersects_impl()),
         ("st_area", st_area_impl()),
+        ("st_azimuth", st_azimuth_impl()),
         ("st_centroid", st_centroid_impl()),
         ("st_distance", st_distance_impl()),
         ("st_dwithin", st_dwithin_impl()),

--- a/rust/sedona-geo/src/st_azimuth.rs
+++ b/rust/sedona-geo/src/st_azimuth.rs
@@ -1,0 +1,182 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use arrow_array::builder::Float64Builder;
+use arrow_schema::DataType;
+use datafusion_common::{error::Result, exec_datafusion_err};
+use datafusion_expr::ColumnarValue;
+use geo_traits::{CoordTrait, GeometryTrait, GeometryType, PointTrait};
+use sedona_expr::scalar_udf::{ScalarKernelRef, SedonaScalarKernel};
+use sedona_functions::executor::WkbExecutor;
+use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
+use wkb::reader::Wkb;
+
+/// ST_Azimuth() implementation following PostGIS semantics
+pub fn st_azimuth_impl() -> ScalarKernelRef {
+    Arc::new(STAzimuth {})
+}
+
+#[derive(Debug)]
+struct STAzimuth {}
+
+impl SedonaScalarKernel for STAzimuth {
+    fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
+        let matcher = ArgMatcher::new(
+            vec![ArgMatcher::is_geometry(), ArgMatcher::is_geometry()],
+            SedonaType::Arrow(DataType::Float64),
+        );
+
+        matcher.match_args(args)
+    }
+
+    fn invoke_batch(
+        &self,
+        arg_types: &[SedonaType],
+        args: &[ColumnarValue],
+    ) -> Result<ColumnarValue> {
+        let executor = WkbExecutor::new(arg_types, args);
+        let mut builder = Float64Builder::with_capacity(executor.num_iterations());
+        executor.execute_wkb_wkb_void(|maybe_start, maybe_end| {
+            match (maybe_start, maybe_end) {
+                (Some(start), Some(end)) => match invoke_scalar(start, end)? {
+                    Some(angle) => builder.append_value(angle),
+                    None => builder.append_null(),
+                },
+                _ => builder.append_null(),
+            }
+
+            Ok(())
+        })?;
+
+        executor.finish(Arc::new(builder.finish()))
+    }
+}
+
+fn invoke_scalar(start: &Wkb, end: &Wkb) -> Result<Option<f64>> {
+    let Some((start_x, start_y)) = point_xy(start)? else {
+        return Ok(None);
+    };
+    let Some((end_x, end_y)) = point_xy(end)? else {
+        return Ok(None);
+    };
+
+    let dx = end_x - start_x;
+    let dy = end_y - start_y;
+
+    if dx == 0.0 && dy == 0.0 {
+        return Ok(None);
+    }
+
+    let mut angle = dx.atan2(dy);
+    if angle < 0.0 {
+        angle += 2.0 * std::f64::consts::PI;
+    }
+
+    Ok(Some(angle))
+}
+
+fn point_xy(geom: &Wkb) -> Result<Option<(f64, f64)>> {
+    match geom.as_type() {
+        GeometryType::Point(point) => {
+            if let Some(coord) = point.coord() {
+                Ok(Some((coord.x(), coord.y())))
+            } else {
+                Ok(None)
+            }
+        }
+        _ => Err(exec_datafusion_err!(
+            "ST_Azimuth expects both arguments to be POINT geometries"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion_common::scalar::ScalarValue;
+    use rstest::rstest;
+    use sedona_functions::register::stubs::st_azimuth_udf;
+    use sedona_schema::datatypes::{WKB_GEOMETRY, WKB_VIEW_GEOMETRY};
+    use sedona_testing::create::create_scalar;
+    use sedona_testing::testers::ScalarUdfTester;
+
+    use super::*;
+
+    #[rstest]
+    fn udf(
+        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] start_type: SedonaType,
+        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] end_type: SedonaType,
+    ) {
+        let mut udf = st_azimuth_udf();
+        udf.add_kernel(st_azimuth_impl());
+        let tester = ScalarUdfTester::new(udf.into(), vec![start_type.clone(), end_type.clone()]);
+
+        assert_eq!(
+            tester.return_type().unwrap(),
+            SedonaType::Arrow(DataType::Float64)
+        );
+
+        let start = create_scalar(Some("POINT (0 0)"), &start_type);
+        let north = create_scalar(Some("POINT (0 1)"), &end_type);
+        let east = create_scalar(Some("POINT (1 0)"), &end_type);
+        let south = create_scalar(Some("POINT (0 -1)"), &end_type);
+        let west = create_scalar(Some("POINT (-1 0)"), &end_type);
+
+        let result = tester
+            .invoke_scalar_scalar(start.clone(), north.clone())
+            .unwrap();
+        assert!(matches!(
+            result,
+            ScalarValue::Float64(Some(val)) if (val - 0.0).abs() < 1e-12
+        ));
+
+        let result = tester
+            .invoke_scalar_scalar(start.clone(), east.clone())
+            .unwrap();
+        assert!(matches!(
+            result,
+            ScalarValue::Float64(Some(val)) if (val - std::f64::consts::FRAC_PI_2).abs() < 1e-12
+        ));
+
+        let result = tester
+            .invoke_scalar_scalar(start.clone(), south.clone())
+            .unwrap();
+        assert!(matches!(
+            result,
+            ScalarValue::Float64(Some(val)) if (val - std::f64::consts::PI).abs() < 1e-12
+        ));
+
+        let result = tester
+            .invoke_scalar_scalar(start.clone(), west.clone())
+            .unwrap();
+        assert!(matches!(
+            result,
+            ScalarValue::Float64(Some(val)) if (val - (3.0 * std::f64::consts::FRAC_PI_2)).abs() < 1e-12
+        ));
+
+        let result = tester
+            .invoke_scalar_scalar(start.clone(), start.clone())
+            .unwrap();
+        assert!(result.is_null());
+
+        let result = tester
+            .invoke_scalar_scalar(ScalarValue::Null, north.clone())
+            .unwrap();
+        assert!(result.is_null());
+    }
+}


### PR DESCRIPTION
This pull request is my attempt to implement `ST_Azimuth()`.

```
> sd_sql("select ST_Azimuth( ST_Point(25, 45),  ST_Point(75, 100))")
┌──────────────────────────────────────────────────────────────────────────┐
│ st_azimuth(st_point(Int64(25),Int64(45)),st_point(Int64(75),Int64(100))) │
│                                  float64                                 │
╞══════════════════════════════════════════════════════════════════════════╡
│                                                       0.7378150601204649 │
└──────────────────────────────────────────────────────────────────────────┘
Preview of up to 6 row(s)
```

This pull request is mostly for figuring out how to implement a function so that I can contribute more. So, please feel free to close if there's another plan to implement this.

I picked `ST_Azimuth()` because it looks relatively simple. I follow the implementation of Sedona, although I might not understand the code correctly as I'm poor at Java...

https://github.com/apache/sedona/blob/f9069e7dc6682d53335f0e0c6fb4bd444024d3b5/common/src/main/java/org/apache/sedona/common/Functions.java#L202-L209

I think the implementation is straightforward. One thing to note is that, if I understand the Sedona's implementation correctly, it returns `0.0` when the two points are the same. However, PostGIS returns `NULL`. [The document](https://postgis.net/docs/en/ST_Azimuth.html) says:

> NULL if the two points are coincident