### PR TITLE
feat: Add ST_Azimuth benchmark and update benchmarking docs

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -42,6 +42,8 @@ To run a benchmark, simply run the corresponding test function. For example, to 
 pytest test_functions.py::TestBenchFunctions::test_st_buffer
 ```
 
+Note: It is recommended to run a single (pytest) benchmark function at a time instead of the whole suite because these benchmarks take a long time. This is because they run multiple iterations by default. For example, it often takes 2-3 minutes to run a single benchmark for a basic function.
+
 Most of the time, you'll also want to group by `param:table` or `func` (function) by using the `--benchmark-group-by=param:table` flag. pytest-benchmark will highlight the "best" value in green (e.g fastest for median, lowest for stddev) and "worse" value in red for each column per each group.
 
 ```bash

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -36,6 +36,8 @@ The below commands assume your working directory is in `benchmarks`.
 cd benchmarks/
 ```
 
+Please also make sure you have PostGIS running. Instructions for starting PostGIS using the provided docker image can be found in the [contributors-guide](../docs/contributors-guide.md)
+
 To run a benchmark, simply run the corresponding test function. For example, to run the benchmarks for st_buffer, you can run
 
 ```bash

--- a/benchmarks/test_bench_base.py
+++ b/benchmarks/test_bench_base.py
@@ -29,6 +29,13 @@ class TestBenchBase:
         # Setup tables
         for name, base_options in [
             (
+                "points_simple",
+                {
+                    "geom_type": "Point",
+                    "target_rows": num_geoms,
+                },
+            ),
+            (
                 "segments_large",
                 {
                     "geom_type": "LineString",

--- a/benchmarks/test_functions.py
+++ b/benchmarks/test_functions.py
@@ -40,6 +40,21 @@ class TestBenchFunctions(TestBenchBase):
     @pytest.mark.parametrize(
         "table",
         [
+            "points_simple",
+        ],
+    )
+    def test_st_azimuth(self, benchmark, eng, table):
+        eng = self._get_eng(eng)
+
+        def queries():
+            eng.execute_and_collect(f"SELECT ST_Azimuth(geom1, geom2) from {table}")
+
+        benchmark(queries)
+
+    @pytest.mark.parametrize("eng", [SedonaDB, PostGIS, DuckDB])
+    @pytest.mark.parametrize(
+        "table",
+        [
             "collections_simple",
             "collections_complex",
         ],


### PR DESCRIPTION
Follow up to https://github.com/apache/sedona-db/pull/183, this PR adds the pytest-benchmarks for ST_Azimuth, which uses a new `points_simple` table. Additionally, it updates the docs to recommend only running one benchmark at a time.

Result of ST_Azimuth benchmark
<img width="697" height="95" alt="image" src="https://github.com/user-attachments/assets/694c098d-e4da-4c68-a19b-70baa7ab1fa1" />
