### PR TITLE
chore: Upgrade ADBC to 0.20.0 release (adbc_core + adbc_ffi) and adapt API changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,8 @@ rust-version = "1.82"
 [workspace.dependencies]
 approx = "0.5"
 abi_stable = "0.11.3"
-adbc_core = { git = "https://github.com/apache/arrow-adbc", rev = "1ba248290cd299c4969b679463bcd54c217cf2e4" }
+adbc_core = "0.20.0"
+adbc_ffi = "0.20.0"
 lru = "0.12"
 arrow = { version = "55.1.0", features = ["prettyprint", "ffi", "chrono-tz"] }
 arrow-array = { version = "55.1.0" }

--- a/rust/sedona-adbc/Cargo.toml
+++ b/rust/sedona-adbc/Cargo.toml
@@ -29,6 +29,7 @@ result_large_err = "allow"
 
 [dependencies]
 adbc_core = { workspace = true }
+adbc_ffi = { workspace = true }
 arrow-array = { workspace = true }
 arrow-schema = { workspace = true }
 datafusion = { workspace = true }

--- a/rust/sedona-adbc/src/database.rs
+++ b/rust/sedona-adbc/src/database.rs
@@ -51,12 +51,12 @@ impl Optionable for SedonaDatabase {
 impl Database for SedonaDatabase {
     type ConnectionType = SedonaConnection;
 
-    fn new_connection(&mut self) -> Result<SedonaConnection> {
+    fn new_connection(&self) -> Result<SedonaConnection> {
         self.new_connection_with_opts([])
     }
 
     fn new_connection_with_opts(
-        &mut self,
+        &self,
         opts: impl IntoIterator<Item = (OptionConnection, OptionValue)>,
     ) -> Result<SedonaConnection> {
         SedonaConnection::try_new(opts)

--- a/rust/sedona-adbc/src/lib.rs
+++ b/rust/sedona-adbc/src/lib.rs
@@ -21,7 +21,6 @@ pub mod database;
 pub mod driver;
 pub mod statement;
 
-use adbc_core::error::{Error, Status};
 use driver::SedonaDriver;
 
-adbc_core::export_driver!(AdbcSedonadbDriverInit, SedonaDriver);
+adbc_ffi::export_driver!(AdbcSedonadbDriverInit, SedonaDriver);


### PR DESCRIPTION
This is part of the forked/non-crates.io dependency elimination plan: https://github.com/apache/sedona-db/pull/165. We switch the adbc_core version from a git rev to latest release version and fixed API breaking changes.