### PR TITLE
Add assert_scalar_equal_wkb_geometry_topologically to compare WKBs topologically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,21 @@ dependencies = [
 
 [[package]]
 name = "adbc_core"
-version = "0.18.0"
-source = "git+https://github.com/apache/arrow-adbc?rev=1ba248290cd299c4969b679463bcd54c217cf2e4#1ba248290cd299c4969b679463bcd54c217cf2e4"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b891479797b5588e320f7fd3caf15faba311cf8f8a76911195b6a3d55304eb"
 dependencies = [
+ "arrow-array",
+ "arrow-schema",
+]
+
+[[package]]
+name = "adbc_ffi"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c30e0f28a8363a76a8ec802934223ea5811ea658308c7403c8beb9aa86fa808f"
+dependencies = [
+ "adbc_core",
  "arrow-array",
  "arrow-schema",
 ]
@@ -4787,6 +4799,7 @@ name = "sedona-adbc"
 version = "0.2.0"
 dependencies = [
  "adbc_core",
+ "adbc_ffi",
  "arrow-array",
  "arrow-schema",
  "datafusion",
@@ -5090,6 +5103,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "datafusion-physical-expr",
+ "geo",
  "geo-traits 0.2.0",
  "geo-types",
  "parquet",

--- a/rust/sedona-testing/Cargo.toml
+++ b/rust/sedona-testing/Cargo.toml
@@ -32,6 +32,7 @@ rstest = { workspace = true }
 
 [features]
 default = []
+geo = ["dep:geo"]
 criterion = ["dep:criterion"]
 
 [dependencies]
@@ -42,7 +43,7 @@ criterion = { workspace = true, optional = true }
 datafusion-common = { workspace = true }
 datafusion-expr = { workspace = true }
 datafusion-physical-expr = { workspace = true }
-geo-traits = { workspace = true }
+geo-traits = { workspace = true, features = ["geo-types"] }
 geo-types = { workspace = true }
 parquet = { workspace = true, features = ["arrow", "snap", "zstd"] }
 rand = { workspace = true }
@@ -52,3 +53,4 @@ sedona-expr = { path = "../sedona-expr" }
 sedona-schema = { path = "../sedona-schema" }
 wkb = { workspace = true }
 wkt = { workspace = true }
+geo = { workspace = true, optional = true }


### PR DESCRIPTION
This is part of the forked dependency elimination plan https://github.com/apache/sedona-db/pull/165. We've hit some overlay operation result assertion errors after upgrading geo to the latest 0.31.0 release. The failures were caused by geo producing different, but topologically equivalent results, and we are asserting on the byte-level equality of resulting WKBs.

This patch adds `assert_scalar_equal_wkb_geometry_topologically` to sedona-testing behind a feature flag "geo". We'll switch to use `assert_scalar_equal_wkb_geometry_topologically` for testing overlay ST functions (ST_Union_Aggr and ST_Intersection_Aggr) after upgrading geo. This function is also useful in many other scenarios, so we add this function in its dedicated PR.