### PR TITLE
docs: update navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,11 +27,6 @@ extra:
       link: 'https://twitter.com/ApacheSedona'
     - icon: fontawesome/brands/discord
       link: 'https://discord.gg/9A3k5dEBsY'
-  # community_links: &community_links
-  #   - Get Involved:
-  #       - Sedona OSS Blog: "https://sedona.apache.org/latest/blog/"
-  #       - Community: "https://sedona.apache.org/latest/community/contact/"
-  #       - Apache Software Foundation: "https://sedona.apache.org/latest/asf/asf/"
 
 site_name: SedonaDB
 site_description: "Documentation for SedonaDB"


### PR DESCRIPTION
This is to make the SedonaDB website visually consistent with the main Apache Sedona site, so users don’t feel like they’re jumping between two different worlds.