### PR TITLE
feat: Add ST_GeometryFromText alias for ST_GeomFromWKT

### DIFF
--- a/rust/sedona-functions/src/st_geomfromwkt.rs
+++ b/rust/sedona-functions/src/st_geomfromwkt.rs
@@ -51,7 +51,7 @@ pub fn st_geomfromwkt_udf() -> SedonaScalarUDF {
     udf.with_aliases(vec![
         "st_geomfromtext".to_string(),
         "st_geometryfromtext".to_string(),
-        ])
+    ])
 }
 
 /// ST_GeogFromWKT() UDF implementation


### PR DESCRIPTION
Fixes #211 as a part of #200 

Adds `ST_GeometryFromText` as an additional alias for `ST_GeomFromWKT` to support all function names from the original Apache Sedona documentation.
