### PR TITLE
fix(c/sedona-c2geography): Remove outdated feature `cxx17` from abseil in vcpkg.json

### DIFF
--- a/c/sedona-s2geography/vcpkg.json
+++ b/c/sedona-s2geography/vcpkg.json
@@ -1,11 +1,3 @@
 {
-  "dependencies": [
-    "openssl",
-    {
-      "name": "abseil",
-      "features": [
-        "test-helpers"
-      ]
-    }
-  ]
+  "dependencies": ["openssl", "abseil"]
 }


### PR DESCRIPTION
Currently, `cargo build` on my Windows fails with this vcpkg error.

```
  error: abseil@20250512.1 does not have required feature cxx17 needed by
```

It seems this is because feature `cxx17` is removed by this commit because CXX17 is now its baseline.

https://github.com/microsoft/vcpkg/pull/46867/files

However, during preparing this pull request, I found vcpkg is pinned to this commit on CI, so probably this pull request doesn't pass the CI check. 

https://github.com/apache/sedona-db/blob/c17260b202363811d43e63d7634c379bd96ed86b/.github/workflows/python-wheels.yml#L41

On the other hand, I think [the contributors' guide](https://github.com/apache/sedona-db/blob/main/docs/contributors-guide.md#linux-and-windows) assumes the contributor runs with the latest vcpkg... So, I'm not sure if this change is necessary or not. Please feel free to close if this is too early.