### PR TITLE
chore(ci): Turn off fail-fast in rust.yml

### DIFF
--- a/c/sedona-geos/src/st_buffer.rs
+++ b/c/sedona-geos/src/st_buffer.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use arrow_array::builder::BinaryBuilder;
 use arrow_schema::DataType;
 use datafusion_common::error::Result;
-use datafusion_common::{internal_err, DataFusionError};
+use datafusion_common::DataFusionError;
 use datafusion_expr::ColumnarValue;
 use geos::{BufferParams, Geom};
 use sedona_expr::scalar_udf::{ScalarKernelRef, SedonaScalarKernel};


### PR DESCRIPTION
See discussion here: https://github.com/apache/sedona-db/pull/239#issuecomment-3443914706

tldr; It can be easy to forget to run clippy since it's not included in pre-commit. Contributors already have to wait for someone to trigger CI for them. We should avoid failing fast, so we don't have to wait an extra CI cycle to see CI results.