### PR TITLE
chore: Update MSRV to match with DataFusion's MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ edition = "2021"
 
 # Same rust-version, arrow, and datafusion dependencies as datafusion-comet
 # https://github.com/apache/datafusion-comet/blob/main/native/Cargo.toml
-rust-version = "1.82"
+rust-version = "1.86"
 
 [workspace.dependencies]
 approx = "0.5"


### PR DESCRIPTION
Just happened to find the comment on `rust-version` says "Same rust-version, arrow, and datafusion dependencies as datafusion-comet". It seems it's currently `1.86`. So, probably this should be updated as well? 

https://crates.io/crates/datafusion/50.2.0

Two side comments:

- I don't think MSRV should be strictly maintained, but it might be a good idea to have a GitHub Actions CI to check if this project can actually be compiled with the version.
- Rust 1.86 means that SedonaDB can switch to Rust 2024 edition. It might be good idea to migrate sooner before SedonaDB's code grows more and more.