### PR TITLE
refactor(rust/sedona-functions): Use new .buf() method of the wkb crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6522,7 +6522,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 [[package]]
 name = "wkb"
 version = "0.9.1"
-source = "git+https://github.com/georust/wkb.git?rev=130eb0c2b343bc9299aeafba6d34c2a6e53f3b6a#130eb0c2b343bc9299aeafba6d34c2a6e53f3b6a"
+source = "git+https://github.com/georust/wkb.git?rev=3158e6295e4a39dc7fd75f3cfebee113c8b844d0#3158e6295e4a39dc7fd75f3cfebee113c8b844d0"
 dependencies = [
  "byteorder",
  "geo-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,4 +130,4 @@ adbc_ffi = { git = "https://github.com/apache/arrow-adbc.git", package = "adbc_f
 
 # TODO: remove them once changes we made to geo-index and wkb crates are merged to upstream and released
 geo-index = { git = "https://github.com/wherobots/geo-index.git", branch = "main" }
-wkb = { git = "https://github.com/georust/wkb.git", rev = "130eb0c2b343bc9299aeafba6d34c2a6e53f3b6a" }
+wkb = { git = "https://github.com/georust/wkb.git", rev = "3158e6295e4a39dc7fd75f3cfebee113c8b844d0" }


### PR DESCRIPTION
Thanks to @Kontinuation (cf. https://github.com/georust/wkb/pull/88), the wkb crate now has `.buf()` on all geometry types not only `Wkb`!

This pull request uses it to slightly improve `ST_Dump`. When I implemented `ST_Dump` in https://github.com/apache/sedona-db/pull/269, `.buf()` was not usable for this, so I used `wkb::writer::*`. But, it's probably more efficient to copy a raw WKB rather than newly constructing a WKB. 