### PR TITLE
docs: Update contributors guide about Windows DLL path

### DIFF
--- a/docs/contributors-guide.md
+++ b/docs/contributors-guide.md
@@ -119,10 +119,13 @@ Configure environment variables (PowerShell example — update paths as needed):
 $env:VCPKG_ROOT = 'C:\dev\vcpkg'
 $env:CMAKE_TOOLCHAIN_FILE = "${env:VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
 
-# pkg-config/ msys path (hash may vary)
-$env:PATH = "${env:VCPKG_ROOT}/downloads/tools/msys2/<msys-hash>/mingw64/bin/;$env:PATH"
+# Add pkg-config/ msys path (hash may vary) for using pkg-config command
+$env:PATH = "${env:VCPKG_ROOT}/downloads/tools/msys2/<msys-hash>/mingw64/bin/;${env:PATH}"
+# Add path to DLLs (without this, the build still succeeds, but loading fails)
+$env:PATH = "${env:VCPKG_ROOT}/installed/x64-windows/bin/;${env:PATH}"
+# Add other pkg-config related settings
 $env:PKG_CONFIG_SYSROOT_DIR = "${env:VCPKG_ROOT}/downloads/tools/msys2/<msys-hash>/mingw64/"
-$env:PKG_CONFIG_PATH = "${env:VCPKG_ROOT}/installed/x64-windows-dynamic-release/lib/pkgconfig/"
+$env:PKG_CONFIG_PATH = "${env:VCPKG_ROOT}/installed/x64-windows/lib/pkgconfig/"
 ```
 
 


### PR DESCRIPTION
This tweaks the contributors guide in two minor points about the Windows case.

First one is that, with the current `PATH`, I get this error when I run `cargo run -p sedona-cli`. I mean, it successfully compiles, but fails to run. It seems this is because I forgot to add a path to vcpkg's DLLs. So, I added one.

```
     Running `target\debug\sedona-cli.exe`
error: process didn't exit successfully: `target\debug\sedona-cli.exe` (exit code: 0xc0000135, STATUS_DLL_NOT_FOUND)
```

Second, `PKG_CONFIG_PATH` refers to `VCPKG_ROOT/installed/x64-windows-dynamic-release/lib/pkgconfig/`, but I guess the triple should be `x64-windows` instead of `x64-windows-dynamic-release` because the guide doesn't specify `$env:VCPKG_DEFAULT_TRIPLET = 'x64-windows-dynamic-release'` (Guessing from the CI setting, this should be used only when building Python?) It seems either works fine, though.

Note that, while this allows me to run the CLI, I'm still failing to load the sedonadb module on Python. I hope we can eventually find how to make it work...