### PR TITLE
perf: Optimize `RasterStructArray::get` to avoid repeatedly extracting arrays from struct array

### DIFF
--- a/rust/sedona-raster/src/array.rs
+++ b/rust/sedona-raster/src/array.rs
@@ -335,7 +335,11 @@ pub struct RasterRefImpl<'a> {
 }
 
 impl<'a> RasterRefImpl<'a> {
-    /// Create a new RasterRefImpl from a struct array and index using hard-coded indices
+    /// Creates a new RasterRefImpl that provides zero-copy access to the raster at the specified index.
+    ///
+    /// # Arguments
+    /// * `raster_struct_array` - The Arrow StructArray containing raster data
+    /// * `raster_index` - The zero-based index of the raster to access
     #[inline(always)]
     pub fn new(raster_struct_array: &RasterStructArray<'a>, raster_index: usize) -> Self {
         let metadata = MetadataRefImpl {


### PR DESCRIPTION
This optimization simply hoists per-column arrays in `RasterStructArray`, so that we don't need to extract individual arrays from the struct array each time we construct a `RasterRefImpl` value in `RasterStructArray::get`. We also marked short getters as inline so that the compiler could optimize away the construction of intermediate objects in simple metadata getter functions such as RS_Width.

I've benchmarked this using the `rs_width` bench in PR https://github.com/apache/sedona-db/pull/297, the performance improvement is quite significant.

Baseline:

```
native-rs_width-Array(Raster(64, 64))
                        time:   [7.3810 ms 7.3912 ms 7.4034 ms]
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe
```

This PR:

```
native-rs_width-Array(Raster(64, 64))
                        time:   [474.81 µs 475.81 µs 476.75 µs]
                        change: [-93.593% -93.576% -93.560%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
```