### PR TITLE
chore(deps): bump actions/checkout from v4 to v6

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -56,7 +56,7 @@ jobs:
       CARGO_INCREMENTAL: 0
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use stable Rust
         id: rust
         run: |


### PR DESCRIPTION
It seems `examples.yml` was not covered by https://github.com/apache/sedona-db/pull/335.