### PR TITLE
fix(python/sedonadb): Fix GDAL/OGR read on Windows

### DIFF
--- a/python/sedonadb/python/sedonadb/datasource.py
+++ b/python/sedonadb/python/sedonadb/datasource.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import sys
 from typing import Any, Mapping
 
 from sedonadb._lib import PyExternalFormat, PyProjectedRecordBatchReader
@@ -133,8 +134,10 @@ class PyogrioFormatSpec(ExternalFormatSpec):
 
         if url.startswith("http://") or url.startswith("https://"):
             ogr_src = f"/vsicurl/{url}"
-        elif url.startswith("file://"):
+        elif url.startswith("file://") and sys.platform != "win32":
             ogr_src = url.removeprefix("file://")
+        elif url.startswith("file:///"):
+            ogr_src = url.removeprefix("file:///")
         else:
             raise ValueError(f"Can't open {url} with OGR")
 


### PR DESCRIPTION
File URIs on Windows are rendered in the form `file://C:/...`, so to be intepreted by GDAL we need to remove an extra slash at the front of the rendered URI.