### PR TITLE
chore(ci): Add s2geography to default Windows Python wheel build

### DIFF
--- a/ci/scripts/wheels-build-windows.ps1
+++ b/ci/scripts/wheels-build-windows.ps1
@@ -73,6 +73,8 @@ $env:PATH += ";$scriptDirectory\windows"
 $env:GEOS_LIB_DIR = "$vcpkgLibDirectory"
 $env:GEOS_VERSION = "3.13.0"
 
+$env:MATURIN_PEP517_ARGS='--features s2geography,pyo3/extension-module'
+
 # Some CMake configurations needs this separately from the toolchain file
 $env:CMAKE_PREFIX_PATH="$vcpkgInstalledDirectory"
 $env:OPENSSL_ROOT_DIR="$vcpkgInstalledDirectory"


### PR DESCRIPTION
I'm not sure why we didn't do this before (perhaps CI is about to tell us), but building and installing the wheel seems to work for me locally.

```python
sd.sql("""
SELECT ST_Intersection(
  ST_GeogPoint(-64, 45),
  ST_GeogFromWKT('POLYGON ((0 0, 10 0, 0 10, 0 0))')
)
""").show()
```

Closes #356.