### PR TITLE
chore(rust,c): Run cargo clippy --fix

### DIFF
--- a/c/sedona-geos/src/st_polygonize_agg.rs
+++ b/c/sedona-geos/src/st_polygonize_agg.rs
@@ -111,7 +111,7 @@ impl PolygonizeAccumulator {
         let mut geos_geoms = Vec::with_capacity(num_geoms);
         for i in 0..num_geoms {
             let geom = collection.get_geometry_n(i).map_err(|e| {
-                DataFusionError::Execution(format!("Failed to get geometry {}: {e}", i))
+                DataFusionError::Execution(format!("Failed to get geometry {i}: {e}"))
             })?;
             geos_geoms.push(geom.clone());
         }

--- a/rust/sedona-geometry/src/types.rs
+++ b/rust/sedona-geometry/src/types.rs
@@ -332,8 +332,7 @@ impl GeometryTypeAndDimensionsSet {
     ) -> Result<(), SedonaGeometryError> {
         if let Dimensions::Unknown(n) = type_and_dim.dimensions() {
             return Err(SedonaGeometryError::Invalid(format!(
-                "Unknown dimensions {} in GeometryTypeAndDimensionsSet::insert",
-                n
+                "Unknown dimensions {n} in GeometryTypeAndDimensionsSet::insert"
             )));
         }
         self.insert_or_ignore(type_and_dim);
@@ -352,8 +351,7 @@ impl GeometryTypeAndDimensionsSet {
         // WKB ID must be < 8 to fit in the bitset layout (8 bits per dimension)
         if geom_shift >= 8 {
             panic!(
-                "Invalid geometry type wkb_id {} in GeometryTypeAndDimensionsSet::insert_or_ignore",
-                geom_shift
+                "Invalid geometry type wkb_id {geom_shift} in GeometryTypeAndDimensionsSet::insert_or_ignore"
             );
         }
         let dim_shift = match type_and_dim.dimensions() {
@@ -428,8 +426,7 @@ impl Iterator for GeometryTypeSetIter {
                     16 => Dimensions::Xym,
                     24 => Dimensions::Xyzm,
                     _ => panic!(
-                        "Invalid dimension bits at position {} in GeometryTypeAndDimensionsSet",
-                        bit
+                        "Invalid dimension bits at position {bit} in GeometryTypeAndDimensionsSet"
                     ),
                 };
 

--- a/rust/sedona-raster/src/array.rs
+++ b/rust/sedona-raster/src/array.rs
@@ -213,8 +213,7 @@ impl<'a> BandsRef for BandsRefImpl<'a> {
     fn band(&self, number: usize) -> Result<Box<dyn BandRef + '_>, ArrowError> {
         if number == 0 {
             return Err(ArrowError::InvalidArgumentError(format!(
-                "Invalid band number {}: band numbers must be 1-based",
-                number
+                "Invalid band number {number}: band numbers must be 1-based"
             )));
         }
         // By convention, band numbers are 1-based.
@@ -522,8 +521,7 @@ impl<'a> RasterStructArray<'a> {
     pub fn get(&self, index: usize) -> Result<RasterRefImpl<'a>, ArrowError> {
         if index >= self.raster_array.len() {
             return Err(ArrowError::InvalidArgumentError(format!(
-                "Invalid raster index: {}",
-                index
+                "Invalid raster index: {index}"
             )));
         }
 

--- a/rust/sedona-raster/src/builder.rs
+++ b/rust/sedona-raster/src/builder.rs
@@ -687,8 +687,7 @@ mod tests {
 
             assert_eq!(
                 actual_type, *expected_type,
-                "Band {} expected data type {:?}, got {:?}",
-                i, expected_type, actual_type
+                "Band {i} expected data type {expected_type:?}, got {actual_type:?}"
             );
         }
     }

--- a/rust/sedona-spatial-join/src/build_index.rs
+++ b/rust/sedona-spatial-join/src/build_index.rs
@@ -58,7 +58,7 @@ pub(crate) async fn build_index(
     let mut reservations = Vec::with_capacity(num_partitions);
     for k in 0..num_partitions {
         let consumer =
-            MemoryConsumer::new(format!("SpatialJoinCollectBuildSide[{}]", k)).with_can_spill(true);
+            MemoryConsumer::new(format!("SpatialJoinCollectBuildSide[{k}]")).with_can_spill(true);
         let reservation = consumer.register(memory_pool);
         reservations.push(reservation);
         collect_metrics_vec.push(CollectBuildSideMetrics::new(k, &metrics));


### PR DESCRIPTION
Nothing urgent, but this PR updates a few files that my local build keeps warning about. I think my local rust is more recent than the one that runs clippy in CI, which is why these aren't flagged otherwise.