### PR TITLE
docs(rust/sedona-functions): Fix minor typos in function description

### DIFF
--- a/rust/sedona-functions/src/st_analyze_agg.rs
+++ b/rust/sedona-functions/src/st_analyze_agg.rs
@@ -58,7 +58,7 @@ pub fn st_analyze_agg_udf() -> SedonaAggregateUDF {
 fn st_analyze_agg_doc() -> Documentation {
     Documentation::builder(
         DOC_SECTION_OTHER,
-        "Return Return the statistics of geometries for geom.",
+        "Return the statistics of geometries for geom.",
         "ST_Analyze_Agg (A: Geometry)",
     )
     .with_argument("geom", "geometry: Input geometry or geography")

--- a/rust/sedona-functions/src/st_length.rs
+++ b/rust/sedona-functions/src/st_length.rs
@@ -37,7 +37,7 @@ pub fn st_length_udf() -> SedonaScalarUDF {
 fn st_length_doc() -> Documentation {
     Documentation::builder(
         DOC_SECTION_OTHER,
-        "Returns the length of geom\
+        "Returns the length of geom. \
          This function only supports LineString, MultiLineString, and GeometryCollections \
          containing linear geometries. Use ST_Perimeter for polygons.\
         ",


### PR DESCRIPTION
(Just happened to find when I looked around the function descriptions)