### PR TITLE
chore(docs): Update mkdocs for latest mkdocstrings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -171,4 +171,3 @@ plugins:
                  signature_crossrefs: true
                  preload_modules:
                    - sedonadb
-                 search_paths: [python]


### PR DESCRIPTION
This PR updates mkdocs for mkdocstrings 1.0.0, which removed a feature that we had referenced in our mkdocs.yml. Removing it seems to not have any effect on the build.