### PR TITLE
fix(rust/sedona-expr): Resolve filter expression bounding box by name and not by index

### DIFF
--- a/python/sedonadb/python/sedonadb/datasource.py
+++ b/python/sedonadb/python/sedonadb/datasource.py
@@ -154,8 +154,11 @@ class PyogrioFormatSpec(ExternalFormatSpec):
 
         if args.filter and args.file_schema is not None:
             geometry_column_indices = args.file_schema.geometry_column_indices
+            file_columns = args.file_schema.names
             if len(geometry_column_indices) == 1:
-                bbox = args.filter.bounding_box(geometry_column_indices[0])
+                bbox = args.filter.bounding_box(
+                    file_columns[geometry_column_indices[0]]
+                )
             else:
                 bbox = None
         else:

--- a/python/sedonadb/src/datasource.rs
+++ b/python/sedonadb/src/datasource.rs
@@ -282,10 +282,10 @@ pub struct PyFilter {
 impl PyFilter {
     fn bounding_box(
         &self,
-        column_index: usize,
+        column_name: &str,
     ) -> Result<Option<(f64, f64, f64, f64)>, PySedonaError> {
         let filter = SpatialFilter::try_from_expr(&self.inner)?;
-        let filter_bbox = filter.filter_bbox(column_index);
+        let filter_bbox = filter.filter_bbox(column_name);
         if filter_bbox.x().is_full() || filter_bbox.y().is_full() {
             Ok(None)
         } else {

--- a/rust/sedona-expr/src/spatial_filter.rs
+++ b/rust/sedona-expr/src/spatial_filter.rs
@@ -73,24 +73,24 @@ impl SpatialFilter {
     /// Note that this always succeeds; however, for a non-spatial expression or
     /// a non-spatial expression that is unsupported, the full bounding box is
     /// returned.
-    pub fn filter_bbox(&self, column_index: usize) -> BoundingBox {
+    pub fn filter_bbox(&self, column_name: &str) -> BoundingBox {
         match self {
             SpatialFilter::Intersects(column, bounding_box)
             | SpatialFilter::Covers(column, bounding_box) => {
-                if column.index() == column_index {
+                if column.name() == column_name {
                     return bounding_box.clone();
                 }
             }
             SpatialFilter::And(lhs, rhs) => {
-                let lhs_box = lhs.filter_bbox(column_index);
-                let rhs_box = rhs.filter_bbox(column_index);
+                let lhs_box = lhs.filter_bbox(column_name);
+                let rhs_box = rhs.filter_bbox(column_name);
                 if let Ok(bounds) = lhs_box.intersection(&rhs_box) {
                     return bounds;
                 }
             }
             SpatialFilter::Or(lhs, rhs) => {
-                let mut bounds = lhs.filter_bbox(column_index);
-                bounds.update_box(&rhs.filter_bbox(column_index));
+                let mut bounds = lhs.filter_bbox(column_name);
+                bounds.update_box(&rhs.filter_bbox(column_name));
                 return bounds;
             }
             SpatialFilter::LiteralFalse => {
@@ -1153,25 +1153,25 @@ mod test {
         let bbox_13 = BoundingBox::xy((1, 3), (1, 3));
 
         assert_eq!(
-            SpatialFilter::Intersects(col_zero.clone(), bbox_02.clone()).filter_bbox(0),
+            SpatialFilter::Intersects(col_zero.clone(), bbox_02.clone()).filter_bbox("foofy"),
             bbox_02
         );
 
         assert_eq!(
-            SpatialFilter::Covers(col_zero.clone(), bbox_02.clone()).filter_bbox(0),
+            SpatialFilter::Covers(col_zero.clone(), bbox_02.clone()).filter_bbox("foofy"),
             bbox_02
         );
 
         assert_eq!(
-            SpatialFilter::LiteralFalse.filter_bbox(0),
+            SpatialFilter::LiteralFalse.filter_bbox("foofy"),
             BoundingBox::xy(Interval::empty(), Interval::empty())
         );
         assert_eq!(
-            SpatialFilter::HasZ(col_zero.clone()).filter_bbox(0),
+            SpatialFilter::HasZ(col_zero.clone()).filter_bbox("foofy"),
             BoundingBox::xy(Interval::full(), Interval::full())
         );
         assert_eq!(
-            SpatialFilter::Unknown.filter_bbox(0),
+            SpatialFilter::Unknown.filter_bbox("foofy"),
             BoundingBox::xy(Interval::full(), Interval::full())
         );
 
@@ -1182,7 +1182,7 @@ mod test {
                 Box::new(intersects_02.clone()),
                 Box::new(intersects_13.clone())
             )
-            .filter_bbox(0),
+            .filter_bbox("foofy"),
             BoundingBox::xy((1, 2), (1, 2))
         );
 
@@ -1191,7 +1191,7 @@ mod test {
                 Box::new(intersects_02.clone()),
                 Box::new(intersects_13.clone())
             )
-            .filter_bbox(0),
+            .filter_bbox("foofy"),
             BoundingBox::xy((0, 3), (0, 3))
         );
     }


### PR DESCRIPTION
Closes #380. The issue was that we were passed a column index of `0` in some circumstances when the geometry column index was `2` (see the debug output on the issue for details).

I think the fact that we are passed an incorrect `Column { ..., index: 0}` is a DataFusion bug (I am guessing there is an `unwrap_or(0)` in some `try_pushdown_filter()`); however, in the meantime using the column name seems to work.

```python
# pip install "apache-sedona[db]"
import sedona.db

sd = sedona.db.connect()

# 12 GB file
url = "https://flatgeobuf.septima.dk/population_areas.fgb"
sd.read_pyogrio(url).to_view("population_areas")

wkt = "POLYGON ((-73.978329 40.767412, -73.950005 40.767412, -73.950005 40.795098, -73.978329 40.795098, -73.978329 40.767412))"
sd.sql(f"""
SELECT sum(population::INTEGER) FROM population_areas
WHERE ST_Intersects(wkb_geometry, ST_SetSRID(ST_GeomFromWKT('{wkt}'), 4326))
""").show()
#> ┌──────────────────────────────────┐
#> │ sum(population_areas.population) │
#> │               int64              │
#> ╞══════════════════════════════════╡
#> │                           256251 │
#> └──────────────────────────────────┘
```