### PR TITLE
docs(r/sedonadb): Minor fix to remove an unintentional cross-ref

### DIFF
--- a/r/sedonadb/DESCRIPTION
+++ b/r/sedonadb/DESCRIPTION
@@ -8,7 +8,7 @@ Description: Provides bindings for Apache SedonaDB, a lightweight
 License: Apache License (>= 2)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 SystemRequirements: Cargo (Rust's package manager), rustc
 Depends: R (>= 4.1.0)
 Suggests:

--- a/r/sedonadb/R/dataframe.R
+++ b/r/sedonadb/R/dataframe.R
@@ -214,7 +214,7 @@ sd_preview <- function(.data, n = NULL, ascii = NULL, width = NULL) {
 #'   for every geometry column in the output: some readers can use these columns
 #'   to prune row groups when files contain an effective spatial ordering.
 #'   The extra columns will appear just before their geometry column and
-#'   will be named "[geom_col_name]_bbox" for all geometry columns except
+#'   will be named "\[geom_col_name\]_bbox" for all geometry columns except
 #'   "geometry", whose bounding box column name is just "bbox"
 #' @param overwrite_bbox_columns Use TRUE to overwrite any bounding box columns
 #'   that already exist in the input. This is useful in a read -> modify

--- a/r/sedonadb/man/sd_write_parquet.Rd
+++ b/r/sedonadb/man/sd_write_parquet.Rd
@@ -38,7 +38,7 @@ Use "1.1" to compute an additional bounding box column
 for every geometry column in the output: some readers can use these columns
 to prune row groups when files contain an effective spatial ordering.
 The extra columns will appear just before their geometry column and
-will be named "\link{geom_col_name}_bbox" for all geometry columns except
+will be named "[geom_col_name]_bbox" for all geometry columns except
 "geometry", whose bounding box column name is just "bbox"}
 
 \item{overwrite_bbox_columns}{Use TRUE to overwrite any bounding box columns


### PR DESCRIPTION
When I was looking at [the R-universe page](https://apache.r-universe.dev/builds), I found there's a WARNING in R CMD check. It seems a `[ ]` in a variable name was interpreted as a link to another doc. This pull request escapes it.

```
 * checking Rd cross-references ... WARNING
Missing link(s) in Rd file 'sd_write_parquet.Rd':
  ‘geom_col_name’
```