### PR TITLE
chore(dependabot): Add groups for datafusion, wasm-bindgen, and savvy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,7 +31,7 @@ updates:
       day: "sunday"
     open-pull-requests-limit: 50
     ignore:
-       # For all packages, ignore all patch updates
+      # For all packages, ignore all patch updates
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
     groups:
@@ -40,3 +40,16 @@ updates:
         patterns:
           - "arrow*"
           - "parquet"
+      datafusion:
+        applies-to: version-updates
+        patterns:
+          - "datafusion*"
+      wasm-bindgen:
+        applies-to: version-updates
+        patterns:
+          - "wasm-bindgen*"
+          - "web-sys"
+      savvy:
+        applies-to: version-updates
+        patterns:
+          - "savvy*"


### PR DESCRIPTION
Just like the `arrow-parquet` group, there are several more crates that are likely to be updated together. This pull request adds the following three groups in the dependabot configuration.

- datafusion (Maybe we can just let this ignored by dependabot...? I guess the update of DataFusion is well-tracked anyway)
- wasm-bindgen (I guess it would be really rare that wasm-bindgen bumps the minor or major version, though...)
- savvy