### PR TITLE
chore(docs): Add missing dependency to docs build and ensure build fails if quarto render fails

### DIFF
--- a/ci/scripts/build-docs.sh
+++ b/ci/scripts/build-docs.sh
@@ -40,7 +40,12 @@ pushd "${SEDONADB_DIR}/docs/reference/functions"
 find . -name "*.md" -delete
 
 # Render the Quarto project
-quarto render
+if quarto render ; then
+  echo "Function reference Quarto project rendered successfully"
+else
+  echo "Function reference Quarto project build failed"
+  exit 1
+fi
 
 popd
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -17,6 +17,7 @@
 
 griffe
 ipykernel
+matplotlib
 mike
 mkdocs
 mkdocs-git-revision-date-localized-plugin


### PR DESCRIPTION
In checking https://sedona.apache.org/sedonadb/latest-snapshot/reference/functions/ for the new docs, I noticed they hadn't been built. `quarto render` had silently failed due to a missing dependency.