### PR TITLE
chore(rust/sedona-functions): Fix ST_LineInterpolatePoint and ST_LineLocatePoint

### DIFF
--- a/rust/sedona-functions/src/referencing.rs
+++ b/rust/sedona-functions/src/referencing.rs
@@ -85,11 +85,11 @@ mod tests {
     #[test]
     fn udf_metadata() {
         let udf: ScalarUDF = st_line_interpolate_point_udf().into();
-        assert_eq!(udf.name(), "st_line_interpolate_point");
+        assert_eq!(udf.name(), "st_lineinterpolatepoint");
         assert!(udf.documentation().is_some());
 
         let udf: ScalarUDF = st_line_locate_point_udf().into();
-        assert_eq!(udf.name(), "st_line_locate_point");
+        assert_eq!(udf.name(), "st_linelocatepoint");
         assert!(udf.documentation().is_some());
     }
 }


### PR DESCRIPTION
I found mismatches of function names during addressing #428. Currently, if a user tries to use `ST_LineLocatePoint`, they gets a bit confusing error which suggests a wrong function name. `ST_LineLocatePoint` is anyway not implemented and this probably doesn't happen if it's implemented. So, this pull request doesn't matter much and is mainly for correctness.

```sql
> SELECT ST_LineLocatePoint(ST_GeomFromWKT('LINESTRING(38 16, 38 50, 65 50, 66 16, 38 16)'), ST_Point(38, 50));
Error during planning: Invalid function 'st_linelocatepoint'.
Did you mean 'st_line_locate_point'?
```