### PR TITLE
chore(c/sedona-libgpuspatial): Fix typo in relate.cuh comment (#463)

### DIFF
--- a/c/sedona-libgpuspatial/libgpuspatial/include/gpuspatial/relate/relate.cuh
+++ b/c/sedona-libgpuspatial/libgpuspatial/include/gpuspatial/relate/relate.cuh
@@ -397,7 +397,7 @@ DEV_HOST int32_t relate(const POINT_T& P1, bool p1_is_head, const POINT_T& P2,
             (p1_location == 'B' && p2_location == 'I') ||
             (p1_location == 'B' && p2_location == 'B' && pc_location == 'I')) {
           /*
-           * P1-P2 goes throught inside of the hole.
+           * P1-P2 goes through inside of the hole.
            */
           return (retval | IntersectionMatrix::INTER_EXTER_1D);
         }
@@ -1118,7 +1118,7 @@ DEV_HOST int32_t relate(bool p_has_boundary, POINT_T P1, bool p1_is_head, POINT_
         }
       }
 
-      /* P1-P2 and Q1-Q2 are colinear */
+      /* P1-P2 and Q1-Q2 are collinear */
       if (qp1 == 0 && qp2 == 0) {
         if (p1_in_qq != PointLocation::kOutside && p2_in_qq != PointLocation::kOutside) {
           /* P1-P2 is fully contained by Q1-Q2 */


### PR DESCRIPTION
While working on this, I noticed additional typos reported by `typos` in other parts of the repository.

I limited this change strictly to a comment typo in `relate.cuh`. 
Several other reported typos occur in identifiers, test names, generated code, 
or in directories/files where changes are not allowed or could affect APIs, ABI, 
or test expectations.

To avoid unintended behavior changes or breaking compatibility, I intentionally 
did not modify those files.
