### PR TITLE
chore(r/sedonadb): Bump savvy to v0.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4840,9 +4840,9 @@ dependencies = [
 
 [[package]]
 name = "savvy"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e69a44aaa46a28273b777ac51c340a9776ddab3bdbb9cecd9e65f23c5a52e81"
+checksum = "8ba18d2bd9f22d449c43519d7504c74590204423c3a27d8e5b77de9a981f5a13"
 dependencies = [
  "cc",
  "savvy-ffi",
@@ -4851,9 +4851,9 @@ dependencies = [
 
 [[package]]
 name = "savvy-bindgen"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9668be1fc20e5452ac46aa5d218c8f19283c5691e04e04e1cce5e0eb1c34f9cd"
+checksum = "0998bef42631c5f985ac0d14d6e3e33e95dc08822843abc582419181cbecb3a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4862,15 +4862,18 @@ dependencies = [
 
 [[package]]
 name = "savvy-ffi"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fba684ece740b1099f03f97689c8258fc5d781f7b26c5b929ba73e883edd5300"
+checksum = "9f81ed9226f1b3f7a3420b1f61d2a2ba72a572edecfa74880abfdd60c7c1b351"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "savvy-macro"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0ad2dc8ba6fd28234d70a5e4a60c6a04525d151a82ef5c85abfeee1f4435b3"
+checksum = "caa2b65e2a8abfd689639cd8655f3ecb7a90bb6cdbbe40025a2f04fd0360edf1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/r/sedonadb/src/init.c
+++ b/r/sedonadb/src/init.c
@@ -15,11 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// clang-format sorts includes unless SortIncludes: Never. However, the ordering
+// does matter here. So, we need to disable clang-format for safety.
+
+// clang-format off
 #include <stdint.h>
-
 #include <Rinternals.h>
-
 #include <R_ext/Parse.h>
+// clang-format on
 
 #include "rust/api.h"
 

--- a/r/sedonadb/tools/savvy-update.sh
+++ b/r/sedonadb/tools/savvy-update.sh
@@ -40,9 +40,7 @@ main() {
 
     # Add license header, put includes on their own lines, and fix a typo in init.c
     echo "${LICENSE_C}" > "${init_c}"
-    sed 's/#include/\n#include/g' "${init_c}.tmp" | \
-        sed '1s/^\n//' | \
-        sed 's/initialzation/initialization/g' >> "${init_c}"
+    cat "${init_c}.tmp" >> "${init_c}"
 
     # Add license header to 000-wrappers.R
     echo "${LICENSE_R}" > "${wrappers_r}"


### PR DESCRIPTION
Bump savvy to the version so that we need two less minor tweaks currently done in `r/sedonadb/tools/savvy-update.sh`:

- Prevent the ordering of `#include` from clang-format
- A silly typo of "initialization"

(To be clear, we only need to update the savvy-cli which is set up locally, but this pull request also bumps the version in Cargo.lock just for consistency)

cf. https://github.com/apache/sedona-db/pull/468#discussion_r2660118381