### PR TITLE
chore(ci): Add intel MacOS wheels to gemfury upload

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -252,7 +252,7 @@ jobs:
           path: python/sedonadb/dist/*.whl
 
   upload_nightly:
-    needs: ["wheels-linux", "macOS-arm64", "windows-x86_64"]
+    needs: ["wheels-linux", "macOS-arm64", "macOS-amd64", "windows-x86_64"]
     name: Upload nightly packages
     runs-on: "macos-latest"
     steps:


### PR DESCRIPTION
Missed this in #497...the wheels build but weren't uploaded.