### PR TITLE
fix(python/sedonadb): Tweaks to support pandas>=3.0

### DIFF
--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -518,7 +518,10 @@ def _qualified_type_name(obj):
 
 SPECIAL_CASED_SCANS = {
     "pyarrow.lib.Table": _scan_collected_default,
+    # pandas < 3.0
     "pandas.core.frame.DataFrame": _scan_collected_default,
+    # pandas >= 3.0
+    "pandas.DataFrame": _scan_collected_default,
     "geopandas.geodataframe.GeoDataFrame": _scan_geopandas,
     "polars.dataframe.frame.DataFrame": _scan_collected_default,
 }


### PR DESCRIPTION
There are two issues introduced by the recent pandas 3.0 release:

- The qualified name of the `DataFrame` changed. In the current release these dataframes will still work but can only be queried exactly once. This PR fixes that so that pandas>=3.0 and pandas<3.0 data frames work exaclty the same.
- There is a new default string type that defaults to `LargeUtf8` when getting translated to Arrow. There was at least one operation in our tests that failed because DataFusion didn't support LargeUtf8 in some internal. This PR just updates the test but I'll also file an issue in DataFusion.

Closes #536.