### PR TITLE
fix(rust/sedona): Fix panic when displaying very long content

### DIFF
--- a/rust/sedona/src/show.rs
+++ b/rust/sedona/src/show.rs
@@ -536,10 +536,7 @@ impl DisplayColumn {
         // Never return content longer than WIDTH_MAX because comfy table may
         // do arithmetic with it without checking for overflow.
         let content_str = content.to_string();
-        let content_safe: String = content_str
-            .chars()
-            .take(WIDTH_MAX as usize)
-            .collect();
+        let content_safe: String = content_str.chars().take(WIDTH_MAX as usize).collect();
 
         let cell = Cell::new(content_safe).set_delimiter('\0');
         let is_numeric = ArgMatcher::is_numeric();


### PR DESCRIPTION
Fixes a panic when the content of a table is unexpectedly large. The first issue I hit this was was explain plans.

In addition to at least one issue here, there is quite a lot of unchecked addition in the underlying renderer, which we work around by truncating any u16s or strings to 32,000.

Reprex from original issue now renders without panicing:

```python
import sedona.db

sd = sedona.db.connect()

buildings_url = (
    "s3://overturemaps-us-west-2/release/2026-01-21.0/theme=buildings/type=building/"
)

target_wkt = (
    "POLYGON ((-73.21 44.03, -73.21 43.98, -73.11 43.97, -73.12 44.03, -73.21 44.03))"
)

sd.read_parquet(
    buildings_url,
    options={"aws.skip_signature": True, "aws.region": "us-west-2"},
).to_view("buildings")

sd.sql(f"""
SELECT count(*) FROM buildings
WHERE ST_Intersects(geometry, ST_SetSRID(ST_GeomFromText('{target_wkt}'), 4326))
""").explain("extended").show()
#> ...very, very long output that does not crash
```

Closes #388.