### PR TITLE
feat(rust/sedona-geoparquet): prettier spatial pruning metrics display

### DIFF
--- a/rust/sedona/tests/metrics.rs
+++ b/rust/sedona/tests/metrics.rs
@@ -56,10 +56,8 @@ async fn geo_parquet_metrics() {
     "#;
 
     let prune_plan = run_and_format(&ctx, prune_query).await;
-    assert!(prune_plan.contains("files_ranges_spatial_pruned=1"));
-    assert!(prune_plan.contains("files_ranges_spatial_matched=0"));
-    assert!(prune_plan.contains("row_groups_spatial_pruned=0"));
-    assert!(prune_plan.contains("row_groups_spatial_matched=0"));
+    assert!(prune_plan.contains("files_ranges_spatial_pruned=1 total \u{2192} 0 matched"));
+    assert!(prune_plan.contains("row_groups_spatial_pruned=0 total \u{2192} 0 matched"));
 
     // Test 2: query with spatial filter that can't skip any file or row group
     // -----------------------------------------------------------------------
@@ -79,10 +77,8 @@ async fn geo_parquet_metrics() {
     "#;
 
     let match_plan = run_and_format(&ctx, match_query).await;
-    assert!(match_plan.contains("files_ranges_spatial_pruned=0"));
-    assert!(match_plan.contains("files_ranges_spatial_matched=1"));
-    assert!(match_plan.contains("row_groups_spatial_pruned=0"));
-    assert!(match_plan.contains("row_groups_spatial_matched=1"));
+    assert!(match_plan.contains("files_ranges_spatial_pruned=1 total \u{2192} 1 matched"));
+    assert!(match_plan.contains("row_groups_spatial_pruned=1 total \u{2192} 1 matched"));
 }
 
 async fn run_and_format(ctx: &SedonaContext, sql: &str) -> String {


### PR DESCRIPTION
This PR only includes metrics display change to improve eye comfort.

DataFusion 51 added a utility to display pruning metrics (https://github.com/apache/datafusion/pull/18297) like:
Before: `metrics=[...files_ranges_matched_statistics=3, files_ranges_pruned_statistics=7...]`
After: `metrics=[...files_ranges_pruned_statistics=10 total → 3 matched...]`

It applied this display style to spatial pruning metrics.

## Demo (sedona-cli)
See `*_spatial_*` entries in `EXPLAIN ANALYZE`
```
Sedona CLI v0.3.0
> CREATE EXTERNAL TABLE test
STORED AS PARQUET
LOCATION '/Users/yongting/Code/sedona-db/submodules/sedona-testing/data/parquet/geoparquet-1.1.0.parquet';
0 row(s)/0 column(s) fetched.
Elapsed 0.064 seconds.

> set datafusion.explain.analyze_level='summary';
0 row(s)/0 column(s) fetched.
Elapsed 0.003 seconds.

> EXPLAIN ANALYZE
        SELECT *
        FROM test
        WHERE ST_Intersects(
            geometry,
            ST_SetSRID(
                ST_GeomFromText('POLYGON((-10 84, -10 88, 10 88, 10 84, -10 84))'),
                4326
            )
        );
┌───────────────────┬───────────────────────────────────────────────────────────────────────────────┐
│     plan_type     ┆                                      plan                                     │
│        utf8       ┆                                      utf8                                     │
╞═══════════════════╪═══════════════════════════════════════════════════════════════════════════════╡
│ Plan with Metrics ┆ CoalesceBatchesExec: target_batch_size=8192, metrics=[output_rows=0, elapsed_ │
│                   ┆ compute=3.625µs, output_bytes=0.0 B]                                          │
│                   ┆   FilterExec: st_intersects(geometry@5, 01030000000100000005...), metrics=[ou │
│                   ┆ tput_rows=0, elapsed_compute=14ns, output_bytes=0.0 B, selectivity=N/A (0/0)] │
│                   ┆     RepartitionExec: partitioning=RoundRobinBatch(14), input_partitions=1, me │
│                   ┆ trics=[]                                                                      │
│                   ┆       DataSourceExec: file_groups={1 group: [[Users/yongting/Code/sedona-db/s │
│                   ┆ ubmodules/sedona-testing/data/parquet/geoparquet-1.1.0.parquet]]}, projection │
│                   ┆ =[pop_est, continent, name, iso_a3, gdp_md_est, geometry, bbox], file_type=pa │
│                   ┆ rquet, metrics=[output_rows=0, elapsed_compute=1ns, output_bytes=0.0 B, files │
│                   ┆ _ranges_pruned_statistics=1 total → 1 matched, row_groups_pruned_statistics=0 │
│                   ┆  total → 0 matched, row_groups_pruned_bloom_filter=0 total → 0 matched, page_ │
│                   ┆ index_rows_pruned=0 total → 0 matched, files_ranges_spatial_pruned=1 total →  │
│                   ┆ 0 matched, row_groups_spatial_pruned=0 total → 0 matched, bytes_scanned=0, me │
│                   ┆ tadata_load_time=486.084µs]                                                   │
│                   ┆                                                                               │
└───────────────────┴───────────────────────────────────────────────────────────────────────────────┘
1 row(s)/2 column(s) fetched.
Elapsed 0.017 seconds.
```
