### PR TITLE
chore(ci): Add cargo clippy check to git pre-commit hooks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -153,11 +153,7 @@ jobs:
       - name: Clippy
         if: matrix.name == 'clippy'
         run: |
-          cargo clippy --workspace --all-targets --all-features -- -Dwarnings
-          # Clean up clippy artifacts aggressively
-          rm -rf target/debug/deps
-          rm -rf target/debug/incremental
-          rm -rf target/debug/build
+          bash ci/scripts/cargo-clippy.sh --ci-cleanup
 
       - name: Test
         if: matrix.name == 'test'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,3 +66,12 @@ repos:
         types_or: [c, c++]
         # Don't run on vendored files
         exclude: "^c/(sedona-geoarrow-c/src/geoarrow|sedona-geoarrow-c/src/nanoarrow|sedona-tg/src/tg)/.*"
+
+  - repo: local
+    hooks:
+      - id: cargo-clippy-fix-workspace
+        name: cargo clippy fix workspace (best effort)
+        entry: bash -c 'bash ci/scripts/cargo-clippy.sh --fix || true'
+        language: system
+        pass_filenames: false
+        files: '(^|/)(Cargo\.toml|Cargo\.lock|.*\.rs)$'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,11 +67,13 @@ repos:
         # Don't run on vendored files
         exclude: "^c/(sedona-geoarrow-c/src/geoarrow|sedona-geoarrow-c/src/nanoarrow|sedona-tg/src/tg)/.*"
 
+  # Slow hooks, only run on `git push`
   - repo: local
     hooks:
       - id: cargo-clippy-fix-workspace
         name: cargo clippy fix workspace (best effort)
-        entry: bash -c 'bash ci/scripts/cargo-clippy.sh --fix || true'
+        entry: bash -c 'bash ci/scripts/cargo-clippy.sh --fix'
         language: system
+        stages: [pre-push]
         pass_filenames: false
         files: '(^|/)(Cargo\.toml|Cargo\.lock|.*\.rs)$'

--- a/ci/scripts/cargo-clippy.sh
+++ b/ci/scripts/cargo-clippy.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Used by both CI and local pre-commit hooks.
+
+set -uo pipefail
+
+mode="check"
+ci_cleanup="false"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --fix)
+            mode="fix"
+            shift
+            ;;
+        --ci-cleanup)
+            ci_cleanup="true"
+            shift
+            ;;
+        -h|--help)
+            cat <<'EOF'
+Usage: ci/scripts/cargo-clippy.sh [--fix] [--ci-cleanup]
+
+Options:
+  --fix         Run clippy with --fix (best-effort; may not fix all violations).
+  --ci-cleanup  Remove selected target/debug artifacts after clippy run.
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+status=0
+if [[ "$mode" == "fix" ]]; then
+    cargo clippy --fix --workspace --all-targets --all-features --allow-dirty --allow-staged -- -Dwarnings || status=$?
+else
+    cargo clippy --workspace --all-targets --all-features -- -Dwarnings || status=$?
+fi
+
+if [[ "$ci_cleanup" == "true" ]]; then
+    rm -rf target/debug/deps
+    rm -rf target/debug/incremental
+    rm -rf target/debug/build
+fi
+
+exit "$status"


### PR DESCRIPTION
## Rationale

Now `clippy` check is not available in local pre-commit hooks, this PR:
1. Extract ci's `cargo clippy` check to a local script for consistency
2. Reuse this script for local pre-commit check

I have tested it locally:
```sh
(.venv) yongting@Yongtings-MacBook-Pro-2 ~/C/sedona-db (pre-commit-clippy)> git diff
diff --git a/rust/sedona-geoparquet/src/file_opener.rs b/rust/sedona-geoparquet/src/file_opener.rs
index ae2a56d..a0ca352 100644
--- a/rust/sedona-geoparquet/src/file_opener.rs
+++ b/rust/sedona-geoparquet/src/file_opener.rs
@@ -205,7 +205,7 @@ fn filter_access_plan_using_geoparquet_covering(
     let row_group_indices_to_scan = access_plan.row_group_indexes();

     // What we're about to do is a bit of work, so skip it if we can.
-    if row_group_indices_to_scan.is_empty() {
+    if row_group_indices_to_scan.len() == 0 {
         return Ok(());
     }

(.venv) yongting@Yongtings-MacBook-Pro-2 ~/C/sedona-db (pre-commit-clippy *)> git add .
(.venv) yongting@Yongtings-MacBook-Pro-2 ~/C/sedona-db (pre-commit-clippy +)> git commit -m "test clippy violation"
check illegal windows names..........................(no files to check)Skipped
...
clang-format.........................................(no files to check)Skipped
cargo clippy fix workspace (best effort).................................Failed
- hook id: cargo-clippy-fix-workspace
- files were modified by this hook

    Checking sedona-geo-traits-ext v0.3.0 (/Users/yongting/Code/sedona-db/rust/sedona-geo-traits-ext)
    ...
    Checking sedonadb v0.3.0 (/Users/yongting/Code/sedona-db/python/sedonadb)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 26.46s

(.venv) yongting@Yongtings-MacBook-Pro-2 ~/C/sedona-db (pre-commit-clippy +*) [0|1]> git diff
diff --git a/rust/sedona-geoparquet/src/file_opener.rs b/rust/sedona-geoparquet/src/file_opener.rs
index a0ca352..ae2a56d 100644
--- a/rust/sedona-geoparquet/src/file_opener.rs
+++ b/rust/sedona-geoparquet/src/file_opener.rs
@@ -205,7 +205,7 @@ fn filter_access_plan_using_geoparquet_covering(
     let row_group_indices_to_scan = access_plan.row_group_indexes();

     // What we're about to do is a bit of work, so skip it if we can.
-    if row_group_indices_to_scan.len() == 0 {
+    if row_group_indices_to_scan.is_empty() {
         return Ok(());
     }
```