### PR TITLE
feat(c/sedona-libgpuspatial): Add Rust Wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,6 +1579,16 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
@@ -1603,6 +1613,20 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "darling_core"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
@@ -1623,6 +1647,17 @@ dependencies = [
  "darling_core 0.13.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4011,6 +4046,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "nvml-wrapper"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9bff0aa1d48904a1385ea2a8b97576fbdcbc9a3cfccd0d31fe978e1c4038c5"
+dependencies = [
+ "bitflags",
+ "libloading 0.8.9",
+ "nvml-wrapper-sys",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "wrapcenum-derive",
+]
+
+[[package]]
+name = "nvml-wrapper-sys"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "698d45156f28781a4e79652b6ebe2eaa0589057d588d3aec1333f6466f13fcb5"
+dependencies = [
+ "libloading 0.8.9",
+]
+
+[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5431,9 +5489,20 @@ dependencies = [
 name = "sedona-libgpuspatial"
 version = "0.3.0"
 dependencies = [
+ "arrow-array",
+ "arrow-schema",
  "bindgen",
  "cmake",
+ "geo",
+ "log",
+ "nvml-wrapper",
+ "sedona-expr",
+ "sedona-geos",
+ "sedona-schema",
+ "sedona-testing",
+ "thiserror 2.0.17",
  "which",
+ "wkt 0.14.0",
 ]
 
 [[package]]
@@ -5943,6 +6012,12 @@ dependencies = [
  "psm",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -7062,6 +7137,18 @@ dependencies = [
  "log",
  "num-traits",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "wrapcenum-derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76ff259533532054cfbaefb115c613203c73707017459206380f03b3b3f266e"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5436,7 +5436,7 @@ dependencies = [
  "bindgen",
  "cmake",
  "geo",
- "log",
+ "geo-types",
  "sedona-expr",
  "sedona-geos",
  "sedona-schema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,16 +1579,6 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
@@ -1613,20 +1603,6 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.11.1",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "darling_core"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
@@ -1647,17 +1623,6 @@ dependencies = [
  "darling_core 0.13.4",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -4046,29 +4011,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nvml-wrapper"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9bff0aa1d48904a1385ea2a8b97576fbdcbc9a3cfccd0d31fe978e1c4038c5"
-dependencies = [
- "bitflags",
- "libloading 0.8.9",
- "nvml-wrapper-sys",
- "static_assertions",
- "thiserror 1.0.69",
- "wrapcenum-derive",
-]
-
-[[package]]
-name = "nvml-wrapper-sys"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "698d45156f28781a4e79652b6ebe2eaa0589057d588d3aec1333f6466f13fcb5"
-dependencies = [
- "libloading 0.8.9",
-]
-
-[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5495,7 +5437,6 @@ dependencies = [
  "cmake",
  "geo",
  "log",
- "nvml-wrapper",
  "sedona-expr",
  "sedona-geos",
  "sedona-schema",
@@ -6012,12 +5953,6 @@ dependencies = [
  "psm",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -7137,18 +7072,6 @@ dependencies = [
  "log",
  "num-traits",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "wrapcenum-derive"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76ff259533532054cfbaefb115c613203c73707017459206380f03b3b3f266e"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]

--- a/c/sedona-libgpuspatial/Cargo.toml
+++ b/c/sedona-libgpuspatial/Cargo.toml
@@ -43,7 +43,6 @@ thiserror = { workspace = true }
 log = { workspace = true }
 geo = { workspace = true }
 sedona-schema = { workspace = true }
-nvml-wrapper = "0.10.0"
 
 [dev-dependencies]
 wkt = { workspace = true }

--- a/c/sedona-libgpuspatial/Cargo.toml
+++ b/c/sedona-libgpuspatial/Cargo.toml
@@ -40,12 +40,12 @@ which = "8.0"
 arrow-array = { workspace = true, features = ["ffi"] }
 arrow-schema = { workspace = true }
 thiserror = { workspace = true }
-log = { workspace = true }
-geo = { workspace = true }
+geo-types = { workspace = true }
 sedona-schema = { workspace = true }
 
 [dev-dependencies]
 wkt = { workspace = true }
+geo = { workspace = true }
 sedona-expr = { path = "../../rust/sedona-expr" }
 sedona-geos = { path = "../sedona-geos" }
 sedona-testing = { path = "../../rust/sedona-testing" }

--- a/c/sedona-libgpuspatial/Cargo.toml
+++ b/c/sedona-libgpuspatial/Cargo.toml
@@ -35,3 +35,18 @@ gpu = []
 bindgen = "0.72.1"
 cmake = "0.1"
 which = "8.0"
+
+[dependencies]
+arrow-array = { workspace = true, features = ["ffi"] }
+arrow-schema = { workspace = true }
+thiserror = { workspace = true }
+log = { workspace = true }
+geo = { workspace = true }
+sedona-schema = { workspace = true }
+nvml-wrapper = "0.10.0"
+
+[dev-dependencies]
+wkt = { workspace = true }
+sedona-expr = { path = "../../rust/sedona-expr" }
+sedona-geos = { path = "../sedona-geos" }
+sedona-testing = { path = "../../rust/sedona-testing" }

--- a/c/sedona-libgpuspatial/libgpuspatial/include/gpuspatial/gpuspatial_c.h
+++ b/c/sedona-libgpuspatial/libgpuspatial/include/gpuspatial/gpuspatial_c.h
@@ -54,7 +54,7 @@ void GpuSpatialRuntimeCreate(struct GpuSpatialRuntime* runtime);
 
 struct GpuSpatialIndexConfig {
   /** Pointer to an initialized GpuSpatialRuntime struct */
-  struct GpuSpatialRuntime* runtime;
+  const struct GpuSpatialRuntime* runtime;
   /** How many threads will concurrently call Probe method */
   uint32_t concurrency;
 };
@@ -124,7 +124,7 @@ int GpuSpatialIndexFloat2DCreate(struct SedonaFloatIndex2D* index,
 
 struct GpuSpatialRefinerConfig {
   /** Pointer to an initialized GpuSpatialRuntime struct */
-  struct GpuSpatialRuntime* runtime;
+  const struct GpuSpatialRuntime* runtime;
   /** How many threads will concurrently call Probe method */
   uint32_t concurrency;
   /** Whether to compress the BVH structures to save memory */

--- a/c/sedona-libgpuspatial/libgpuspatial/include/gpuspatial/gpuspatial_c.h
+++ b/c/sedona-libgpuspatial/libgpuspatial/include/gpuspatial/gpuspatial_c.h
@@ -84,30 +84,23 @@ struct SedonaFloatIndex2D {
    * @return 0 on success, non-zero on failure
    */
   int (*finish_building)(struct SedonaFloatIndex2D* self);
+
   /**
    * Probe the spatial index with the given rectangles, each rectangle is represented by 4
    * floats: [min_x, min_y, max_x, max_y] Points can also be probed by providing [x, y, x,
    * y] but points and rectangles cannot be mixed in one Probe call. The results of the
-   * probe will be stored in the context.
+   * probe will be stored in the context. The callback function will be called for each
+   * batch of results, with the build and probe indices of the candidate pairs in the
+   * batch. The user_data pointer will be passed to the callback
    *
    * @return 0 on success, non-zero on failure
    */
   int (*probe)(struct SedonaFloatIndex2D* self, struct SedonaSpatialIndexContext* context,
-               const float* buf, uint32_t n_rects);
-  /** Get the build indices buffer from the context
-   *
-   * @return A pointer to the buffer and its length
-   */
-  void (*get_build_indices_buffer)(struct SedonaSpatialIndexContext* context,
-                                   uint32_t** build_indices,
-                                   uint32_t* build_indices_length);
-  /** Get the probe indices buffer from the context
-   *
-   * @return A pointer to the buffer and its length
-   */
-  void (*get_probe_indices_buffer)(struct SedonaSpatialIndexContext* context,
-                                   uint32_t** probe_indices,
-                                   uint32_t* probe_indices_length);
+               const float* buf, uint32_t n_rects,
+               void (*callback)(const uint32_t* build_indices,
+                                const uint32_t* probe_indices, uint32_t length,
+                                void* user_data),
+               void* user_data);
   /** Get the last error message from either the index
    *
    * @return A pointer to the error message string

--- a/c/sedona-libgpuspatial/libgpuspatial/test/c_wrapper_test.cc
+++ b/c/sedona-libgpuspatial/libgpuspatial/test/c_wrapper_test.cc
@@ -278,6 +278,7 @@ TEST_F(CWrapperTest, InitializeJoiner) {
           ids->build_indices_ptr = (uint32_t*)build_indices;
           ids->probe_indices_ptr = (uint32_t*)probe_indices;
           ids->length = length;
+          return 0;
         },
         &intersection_ids);
 

--- a/c/sedona-libgpuspatial/src/error.rs
+++ b/c/sedona-libgpuspatial/src/error.rs
@@ -18,6 +18,7 @@ use arrow_schema::ArrowError;
 use std::fmt;
 use thiserror::Error;
 
+/// Errors that can occur during GPU spatial operations.
 #[derive(Error, Debug)]
 pub enum GpuSpatialError {
     Arrow(ArrowError),

--- a/c/sedona-libgpuspatial/src/error.rs
+++ b/c/sedona-libgpuspatial/src/error.rs
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+use arrow_schema::ArrowError;
+use std::fmt;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum GpuSpatialError {
+    Arrow(ArrowError),
+    Init(String),
+    PushBuild(String),
+    FinishBuild(String),
+    Probe(String),
+    Refine(String),
+}
+
+impl From<ArrowError> for GpuSpatialError {
+    fn from(value: ArrowError) -> Self {
+        GpuSpatialError::Arrow(value)
+    }
+}
+
+impl fmt::Display for GpuSpatialError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            GpuSpatialError::Arrow(error) => {
+                write!(f, "{error}")
+            }
+            GpuSpatialError::Init(errmsg) => {
+                write!(f, "Initialization failed: {}", errmsg)
+            }
+            GpuSpatialError::PushBuild(errmsg) => {
+                write!(f, "Push build failed: {}", errmsg)
+            }
+            GpuSpatialError::FinishBuild(errmsg) => {
+                write!(f, "Finish building failed: {}", errmsg)
+            }
+            GpuSpatialError::Probe(errmsg) => {
+                write!(f, "Probe failed: {}", errmsg)
+            }
+            GpuSpatialError::Refine(errmsg) => {
+                write!(f, "Refine failed: {}", errmsg)
+            }
+        }
+    }
+}

--- a/c/sedona-libgpuspatial/src/error.rs
+++ b/c/sedona-libgpuspatial/src/error.rs
@@ -56,6 +56,9 @@ impl fmt::Display for GpuSpatialError {
             GpuSpatialError::Refine(errmsg) => {
                 write!(f, "Refine failed: {}", errmsg)
             }
+            GpuSpatialError::GpuNotAvailable => {
+                write!(f, "GPU is not available")
+            }
         }
     }
 }

--- a/c/sedona-libgpuspatial/src/error.rs
+++ b/c/sedona-libgpuspatial/src/error.rs
@@ -26,6 +26,7 @@ pub enum GpuSpatialError {
     FinishBuild(String),
     Probe(String),
     Refine(String),
+    GpuNotAvailable,
 }
 
 impl From<ArrowError> for GpuSpatialError {

--- a/c/sedona-libgpuspatial/src/lib.rs
+++ b/c/sedona-libgpuspatial/src/lib.rs
@@ -23,17 +23,10 @@ pub mod error;
 mod libgpuspatial;
 #[cfg(gpu_available)]
 mod libgpuspatial_glue_bindgen;
-
-pub struct GpuSpatialOptions {
-    pub cuda_use_memory_pool: bool,
-    pub cuda_memory_pool_init_percent: i32,
-    pub concurrency: u32,
-    pub device_id: i32,
-    pub compress_bvh: bool,
-    pub pipeline_batches: u32,
-}
+pub mod options;
 
 use crate::libgpuspatial::GpuSpatialRelationPredicate;
+use crate::options::GpuSpatialOptions;
 /// Spatial predicates for GPU operations
 // Re-export Error type from the sys module abstraction
 

--- a/c/sedona-libgpuspatial/src/lib.rs
+++ b/c/sedona-libgpuspatial/src/lib.rs
@@ -48,10 +48,6 @@ mod sys {
         FloatIndex2DBuilder, GpuSpatialRefinerWrapper, GpuSpatialRelationPredicate,
         GpuSpatialRuntimeWrapper, SharedFloatIndex2D,
     };
-    use libgpuspatial_glue_bindgen::SedonaSpatialIndexContext;
-
-    // -- Thread Safety Setup --
-    unsafe impl Send for SedonaSpatialIndexContext {}
     unsafe impl Send for libgpuspatial_glue_bindgen::GpuSpatialRuntime {}
     unsafe impl Sync for libgpuspatial_glue_bindgen::GpuSpatialRuntime {}
 

--- a/c/sedona-libgpuspatial/src/lib.rs
+++ b/c/sedona-libgpuspatial/src/lib.rs
@@ -134,17 +134,9 @@ mod sys {
     impl GpuSpatialIndex {
         /// Probes the index with a batch of rectangles and returns matching build and probe indices.
         pub fn probe(&self, rects: &[Rect<f32>]) -> Result<(Vec<u32>, Vec<u32>)> {
-            // 1. Create a thread-local context
             let mut ctx = self.inner.create_context()?;
 
-            // 2. Perform the probe using the context
-            ctx.probe(rects.as_ptr() as *const f32, rects.len() as u32)?;
-
-            // 3. Extract results from the context
-            Ok((
-                ctx.get_build_indices_buffer().to_vec(),
-                ctx.get_probe_indices_buffer().to_vec(),
-            ))
+            ctx.probe(rects.as_ptr() as *const f32, rects.len() as u32)
         }
     }
 

--- a/c/sedona-libgpuspatial/src/lib.rs
+++ b/c/sedona-libgpuspatial/src/lib.rs
@@ -224,11 +224,12 @@ mod sys {
 #[cfg(not(gpu_available))]
 mod sys {
     use super::*;
+    pub type Result<T> = std::result::Result<T, crate::error::GpuSpatialError>;
 
     pub struct SpatialImpl;
 
     impl SpatialImpl {
-        pub fn new() -> std::result::Result<Self, GpuSpatialError> {
+        pub fn new() -> Result<Self> {
             Err(GpuSpatialError::GpuNotAvailable)
         }
 

--- a/c/sedona-libgpuspatial/src/lib.rs
+++ b/c/sedona-libgpuspatial/src/lib.rs
@@ -15,6 +15,628 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Module declarations
+use arrow_schema::DataType;
+use geo::Rect;
+
+#[cfg(gpu_available)]
+pub mod error;
+#[cfg(gpu_available)]
+mod libgpuspatial;
 #[cfg(gpu_available)]
 mod libgpuspatial_glue_bindgen;
+
+pub struct GpuSpatialOptions {
+    pub cuda_use_memory_pool: bool,
+    pub cuda_memory_pool_init_percent: i32,
+    pub concurrency: u32,
+    pub device_id: i32,
+    pub compress_bvh: bool,
+    pub pipeline_batches: u32,
+}
+
+/// Spatial predicates for GPU operations
+#[repr(u32)]
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum GpuSpatialRelationPredicate {
+    Equals = 0,
+    Disjoint = 1,
+    Touches = 2,
+    Contains = 3,
+    Covers = 4,
+    Intersects = 5,
+    Within = 6,
+    CoveredBy = 7,
+}
+
+impl std::fmt::Display for GpuSpatialRelationPredicate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GpuSpatialRelationPredicate::Equals => write!(f, "equals"),
+            GpuSpatialRelationPredicate::Disjoint => write!(f, "disjoint"),
+            GpuSpatialRelationPredicate::Touches => write!(f, "touches"),
+            GpuSpatialRelationPredicate::Contains => write!(f, "contains"),
+            GpuSpatialRelationPredicate::Covers => write!(f, "covers"),
+            GpuSpatialRelationPredicate::Intersects => write!(f, "intersects"),
+            GpuSpatialRelationPredicate::Within => write!(f, "within"),
+            GpuSpatialRelationPredicate::CoveredBy => write!(f, "coveredby"),
+        }
+    }
+}
+
+// Re-export Error type from the sys module abstraction
+pub use sys::GpuSpatialError;
+pub type Result<T> = std::result::Result<T, GpuSpatialError>;
+
+// 1. GPU Available Implementation
+#[cfg(gpu_available)]
+mod sys {
+    use super::libgpuspatial;
+    use super::libgpuspatial_glue_bindgen;
+    use super::*;
+
+    use nvml_wrapper::Nvml;
+    use std::sync::{Arc, Mutex};
+
+    // Re-export the error from the parent module so the public API works
+    pub use super::error::GpuSpatialError;
+
+    use libgpuspatial::{
+        GpuSpatialIndexFloat2DWrapper, GpuSpatialRefinerWrapper,
+        GpuSpatialRelationPredicateWrapper, GpuSpatialRuntimeWrapper,
+    };
+    use libgpuspatial_glue_bindgen::SedonaSpatialIndexContext;
+
+    // -- Thread Safety Setup --
+    unsafe impl Send for SedonaSpatialIndexContext {}
+    unsafe impl Send for libgpuspatial_glue_bindgen::GpuSpatialRuntime {}
+    unsafe impl Sync for libgpuspatial_glue_bindgen::GpuSpatialRuntime {}
+    unsafe impl Send for libgpuspatial_glue_bindgen::SedonaFloatIndex2D {}
+    unsafe impl Send for libgpuspatial_glue_bindgen::SedonaSpatialRefiner {}
+    unsafe impl Sync for libgpuspatial_glue_bindgen::SedonaFloatIndex2D {}
+    unsafe impl Sync for libgpuspatial_glue_bindgen::SedonaSpatialRefiner {}
+
+    // -- Global State --
+    static GLOBAL_GPUSPATIAL_RUNTIME: Mutex<Option<Arc<Mutex<GpuSpatialRuntimeWrapper>>>> =
+        Mutex::new(None);
+
+    // -- Conversion Trait --
+    impl From<GpuSpatialRelationPredicate> for GpuSpatialRelationPredicateWrapper {
+        fn from(pred: GpuSpatialRelationPredicate) -> Self {
+            match pred {
+                GpuSpatialRelationPredicate::Equals => GpuSpatialRelationPredicateWrapper::Equals,
+                GpuSpatialRelationPredicate::Disjoint => {
+                    GpuSpatialRelationPredicateWrapper::Disjoint
+                }
+                GpuSpatialRelationPredicate::Touches => GpuSpatialRelationPredicateWrapper::Touches,
+                GpuSpatialRelationPredicate::Contains => {
+                    GpuSpatialRelationPredicateWrapper::Contains
+                }
+                GpuSpatialRelationPredicate::Covers => GpuSpatialRelationPredicateWrapper::Covers,
+                GpuSpatialRelationPredicate::Intersects => {
+                    GpuSpatialRelationPredicateWrapper::Intersects
+                }
+                GpuSpatialRelationPredicate::Within => GpuSpatialRelationPredicateWrapper::Within,
+                GpuSpatialRelationPredicate::CoveredBy => {
+                    GpuSpatialRelationPredicateWrapper::CoveredBy
+                }
+            }
+        }
+    }
+
+    // -- The Actual Implementation Struct --
+    pub struct SpatialImpl {
+        runtime: Option<Arc<Mutex<GpuSpatialRuntimeWrapper>>>,
+        index: Option<GpuSpatialIndexFloat2DWrapper>,
+        refiner: Option<GpuSpatialRefinerWrapper>,
+    }
+
+    impl SpatialImpl {
+        pub fn new() -> Result<Self> {
+            Ok(Self {
+                runtime: None,
+                index: None,
+                refiner: None,
+            })
+        }
+
+        pub fn init(&mut self, options: GpuSpatialOptions) -> Result<()> {
+            let mut global_runtime_guard = GLOBAL_GPUSPATIAL_RUNTIME.lock().unwrap();
+
+            if global_runtime_guard.is_none() {
+                let out_path = std::path::PathBuf::from(env!("OUT_DIR"));
+                let ptx_root = out_path.join("share/gpuspatial/shaders");
+                let ptx_root_str = ptx_root
+                    .to_str()
+                    .ok_or_else(|| GpuSpatialError::Init("Invalid PTX path".to_string()))?;
+
+                let runtime = GpuSpatialRuntimeWrapper::try_new(
+                    options.device_id,
+                    ptx_root_str,
+                    options.cuda_use_memory_pool,
+                    options.cuda_memory_pool_init_percent,
+                )?;
+                *global_runtime_guard = Some(Arc::new(Mutex::new(runtime)));
+            }
+
+            let runtime_ref = global_runtime_guard.as_ref().unwrap().clone();
+            self.runtime = Some(runtime_ref);
+
+            // FIX: Clone the Arc here
+            let index = GpuSpatialIndexFloat2DWrapper::try_new(
+                self.runtime.as_ref().unwrap().clone(),
+                options.concurrency,
+            )?;
+            self.index = Some(index);
+
+            // FIX: Clone the Arc here as well
+            let refiner = GpuSpatialRefinerWrapper::try_new(
+                self.runtime.as_ref().unwrap().clone(),
+                options.concurrency,
+                options.compress_bvh,
+                options.pipeline_batches,
+            )?;
+            self.refiner = Some(refiner);
+
+            Ok(())
+        }
+
+        pub fn index_clear(&mut self) -> Result<()> {
+            let index = self
+                .index
+                .as_mut()
+                .ok_or_else(|| GpuSpatialError::Init("GPU index is not available".into()))?;
+            index.clear();
+            Ok(())
+        }
+
+        pub fn index_push_build(&mut self, rects: &[Rect<f32>]) -> Result<()> {
+            let index = self
+                .index
+                .as_mut()
+                .ok_or_else(|| GpuSpatialError::Init("GPU index not available".into()))?;
+            unsafe { index.push_build(rects.as_ptr() as *const f32, rects.len() as u32) }
+        }
+
+        pub fn index_finish_building(&mut self) -> Result<()> {
+            self.index
+                .as_mut()
+                .ok_or_else(|| GpuSpatialError::Init("GPU index not available".into()))?
+                .finish_building()
+        }
+
+        pub fn probe(&self, rects: &[Rect<f32>]) -> Result<(Vec<u32>, Vec<u32>)> {
+            let index = self
+                .index
+                .as_ref()
+                .ok_or_else(|| GpuSpatialError::Init("GPU index not available".into()))?;
+
+            let mut ctx = SedonaSpatialIndexContext {
+                private_data: std::ptr::null_mut(),
+            };
+            index.create_context(&mut ctx);
+
+            let result = (|| -> Result<(Vec<u32>, Vec<u32>)> {
+                unsafe {
+                    index.probe(&mut ctx, rects.as_ptr() as *const f32, rects.len() as u32)?;
+                }
+                let build_indices = index.get_build_indices_buffer(&mut ctx).to_vec();
+                let probe_indices = index.get_probe_indices_buffer(&mut ctx).to_vec();
+                Ok((build_indices, probe_indices))
+            })();
+
+            index.destroy_context(&mut ctx);
+            result
+        }
+
+        pub fn refiner_clear(&mut self) -> Result<()> {
+            let refiner = self
+                .refiner
+                .as_mut()
+                .ok_or_else(|| GpuSpatialError::Init("GPU refiner is not available".into()))?;
+            refiner.clear();
+            Ok(())
+        }
+
+        pub fn refiner_init_schema(
+            &mut self,
+            build_data_type: &DataType,
+            probe_data_type: &DataType,
+        ) -> Result<()> {
+            let refiner = self
+                .refiner
+                .as_mut()
+                .ok_or_else(|| GpuSpatialError::Init("GPU refiner not available".into()))?;
+            refiner.init_schema(build_data_type, probe_data_type)
+        }
+
+        pub fn refiner_push_build(&mut self, array: &arrow_array::ArrayRef) -> Result<()> {
+            let refiner = self
+                .refiner
+                .as_ref()
+                .ok_or_else(|| GpuSpatialError::Init("GPU refiner not available".into()))?;
+            refiner.push_build(array)
+        }
+
+        pub fn refiner_finish_building(&mut self) -> Result<()> {
+            let refiner = self
+                .refiner
+                .as_mut()
+                .ok_or_else(|| GpuSpatialError::Init("GPU refiner not available".into()))?;
+            refiner.finish_building()
+        }
+
+        pub fn refine(
+            &self,
+            probe_array: &arrow_array::ArrayRef,
+            predicate: GpuSpatialRelationPredicate,
+            build_indices: &mut Vec<u32>,
+            probe_indices: &mut Vec<u32>,
+        ) -> Result<()> {
+            let refiner = self
+                .refiner
+                .as_ref()
+                .ok_or_else(|| GpuSpatialError::Init("GPU refiner not available".into()))?;
+
+            refiner.refine(
+                probe_array,
+                GpuSpatialRelationPredicateWrapper::from(predicate),
+                build_indices,
+                probe_indices,
+            )
+        }
+    }
+
+    pub fn is_gpu_available() -> bool {
+        match Nvml::init() {
+            Ok(instance) => instance.device_count().map(|c| c > 0).unwrap_or(false),
+            Err(_) => false,
+        }
+    }
+}
+
+// 2. GPU Not Available Implementation
+#[cfg(not(gpu_available))]
+mod sys {
+    use super::*;
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum GpuSpatialError {
+        #[error("GPU not available - CUDA not found during build")]
+        GpuNotAvailable,
+    }
+
+    pub struct SpatialImpl;
+
+    impl SpatialImpl {
+        pub fn new() -> std::result::Result<Self, GpuSpatialError> {
+            Err(GpuSpatialError::GpuNotAvailable)
+        }
+
+        pub fn init(&mut self, _options: GpuSpatialOptions) -> Result<()> {
+            Err(GpuSpatialError::GpuNotAvailable)
+        }
+        pub fn index_clear(&mut self) -> Result<()> {
+            Err(GpuSpatialError::GpuNotAvailable)
+        }
+        pub fn index_push_build(&mut self, _rects: &[Rect<f32>]) -> Result<()> {
+            Err(GpuSpatialError::GpuNotAvailable)
+        }
+        pub fn index_finish_building(&mut self) -> Result<()> {
+            Err(GpuSpatialError::GpuNotAvailable)
+        }
+        pub fn probe(&self, _rects: &[Rect<f32>]) -> Result<(Vec<u32>, Vec<u32>)> {
+            Err(GpuSpatialError::GpuNotAvailable)
+        }
+        pub fn refiner_clear(&mut self) -> Result<()> {
+            Err(GpuSpatialError::GpuNotAvailable)
+        }
+        pub fn refiner_init_schema(&mut self, _build: &DataType, _probe: &DataType) -> Result<()> {
+            Err(GpuSpatialError::GpuNotAvailable)
+        }
+        pub fn refiner_push_build(&mut self, _array: &arrow_array::ArrayRef) -> Result<()> {
+            Err(GpuSpatialError::GpuNotAvailable)
+        }
+        pub fn refiner_finish_building(&mut self) -> Result<()> {
+            Err(GpuSpatialError::GpuNotAvailable)
+        }
+        pub fn refine(
+            &self,
+            _probe: &arrow_array::ArrayRef,
+            _pred: GpuSpatialRelationPredicate,
+            _bi: &mut Vec<u32>,
+            _pi: &mut Vec<u32>,
+        ) -> Result<()> {
+            Err(GpuSpatialError::GpuNotAvailable)
+        }
+    }
+
+    pub fn is_gpu_available() -> bool {
+        false
+    }
+}
+
+// ----------------------------------------------------------------------
+// Main GpuSpatial Wrapper
+// ----------------------------------------------------------------------
+
+/// High-level wrapper for GPU spatial operations
+pub struct GpuSpatial {
+    inner: sys::SpatialImpl,
+}
+
+impl GpuSpatial {
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            inner: sys::SpatialImpl::new()?,
+        })
+    }
+
+    pub fn is_gpu_available() -> bool {
+        sys::is_gpu_available()
+    }
+
+    pub fn init(&mut self, options: GpuSpatialOptions) -> Result<()> {
+        self.inner.init(options)
+    }
+
+    pub fn index_clear(&mut self) -> Result<()> {
+        self.inner.index_clear()
+    }
+
+    pub fn index_push_build(&mut self, rects: &[Rect<f32>]) -> Result<()> {
+        self.inner.index_push_build(rects)
+    }
+
+    pub fn index_finish_building(&mut self) -> Result<()> {
+        self.inner.index_finish_building()
+    }
+
+    pub fn probe(&self, rects: &[Rect<f32>]) -> Result<(Vec<u32>, Vec<u32>)> {
+        self.inner.probe(rects)
+    }
+
+    pub fn refiner_clear(&mut self) -> Result<()> {
+        self.inner.refiner_clear()
+    }
+
+    pub fn refiner_init_schema(
+        &mut self,
+        build_data_type: &DataType,
+        probe_data_type: &DataType,
+    ) -> Result<()> {
+        self.inner
+            .refiner_init_schema(build_data_type, probe_data_type)
+    }
+
+    pub fn refiner_push_build(&mut self, array: &arrow_array::ArrayRef) -> Result<()> {
+        self.inner.refiner_push_build(array)
+    }
+
+    pub fn refiner_finish_building(&mut self) -> Result<()> {
+        self.inner.refiner_finish_building()
+    }
+
+    pub fn refine(
+        &self,
+        probe_array: &arrow_array::ArrayRef,
+        predicate: GpuSpatialRelationPredicate,
+        build_indices: &mut Vec<u32>,
+        probe_indices: &mut Vec<u32>,
+    ) -> Result<()> {
+        self.inner
+            .refine(probe_array, predicate, build_indices, probe_indices)
+    }
+}
+
+// ----------------------------------------------------------------------
+// Tests
+// ----------------------------------------------------------------------
+#[cfg(gpu_available)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::Array;
+    use geo::{BoundingRect, Intersects, Point, Polygon};
+    use sedona_expr::scalar_udf::SedonaScalarUDF;
+    use sedona_geos::register::scalar_kernels;
+    use sedona_schema::crs::lnglat;
+    use sedona_schema::datatypes::{Edges, SedonaType, WKB_GEOMETRY};
+    use sedona_testing::create::create_array_storage;
+    use sedona_testing::testers::ScalarUdfTester;
+    use wkt::TryFromWkt;
+
+    pub fn compute_expected_intersections(
+        vec_a: &[Rect<f32>],
+        vec_b: &[Rect<f32>],
+    ) -> (Vec<u32>, Vec<u32>) {
+        let mut ids_a = Vec::new();
+        let mut ids_b = Vec::new();
+
+        for (i, rect_a) in vec_a.iter().enumerate() {
+            for (j, rect_b) in vec_b.iter().enumerate() {
+                if rect_a.intersects(rect_b) {
+                    ids_a.push(i as u32);
+                    ids_b.push(j as u32);
+                }
+            }
+        }
+        (ids_a, ids_b)
+    }
+
+    fn compute_expected_pip_results(
+        polygons: &[Option<&str>],
+        points: &[Option<&str>],
+    ) -> (Vec<u32>, Vec<u32>) {
+        let kernels = scalar_kernels();
+        let st_intersects = kernels
+            .into_iter()
+            .find(|(name, _)| *name == "st_intersects")
+            .map(|(_, kernel_ref)| kernel_ref)
+            .unwrap();
+
+        let sedona_type = SedonaType::Wkb(Edges::Planar, lnglat());
+        let udf = SedonaScalarUDF::from_impl("st_intersects", st_intersects);
+        let tester =
+            ScalarUdfTester::new(udf.into(), vec![sedona_type.clone(), sedona_type.clone()]);
+
+        let mut ans_build_indices: Vec<u32> = Vec::new();
+        let mut ans_probe_indices: Vec<u32> = Vec::new();
+
+        for (poly_index, poly) in polygons.iter().enumerate() {
+            for (point_index, point) in points.iter().enumerate() {
+                let result = tester
+                    .invoke_scalar_scalar(poly.unwrap(), point.unwrap())
+                    .unwrap();
+                if result == true.into() {
+                    ans_build_indices.push(poly_index as u32);
+                    ans_probe_indices.push(point_index as u32);
+                }
+            }
+        }
+        ans_build_indices.sort();
+        ans_probe_indices.sort();
+        (ans_build_indices, ans_probe_indices)
+    }
+
+    #[test]
+    fn test_spatial_index() {
+        let mut gs = GpuSpatial::new().unwrap();
+        let options = GpuSpatialOptions {
+            concurrency: 1,
+            device_id: 0,
+            compress_bvh: false,
+            pipeline_batches: 1,
+            cuda_use_memory_pool: true,
+            cuda_memory_pool_init_percent: 10,
+        };
+        gs.init(options).expect("Failed to initialize GpuSpatial");
+
+        let polygon_values = &[
+            Some("POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))"),
+            Some("POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10), (20 30, 35 35, 30 20, 20 30))"),
+            Some("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (2 2, 3 2, 3 3, 2 3, 2 2), (6 6, 8 6, 8 8, 6 8, 6 6))"),
+            Some("POLYGON ((30 0, 60 20, 50 50, 10 50, 0 20, 30 0), (20 30, 25 40, 15 40, 20 30), (30 30, 35 40, 25 40, 30 30), (40 30, 45 40, 35 40, 40 30))"),
+            Some("POLYGON ((40 0, 50 30, 80 20, 90 70, 60 90, 30 80, 20 40, 40 0), (50 20, 65 30, 60 50, 45 40, 50 20), (30 60, 50 70, 45 80, 30 60))"),
+        ];
+        let rects: Vec<Rect<f32>> = polygon_values
+            .iter()
+            .filter_map(|opt_wkt| {
+                let wkt_str = opt_wkt.as_ref()?;
+                let polygon: Polygon<f32> = Polygon::try_from_wkt_str(wkt_str).ok()?;
+                polygon.bounding_rect()
+            })
+            .collect();
+        gs.index_push_build(&rects)
+            .expect("Failed to push build data");
+        gs.index_finish_building()
+            .expect("Failed to finish building");
+        let point_values = &[
+            Some("POINT (30 20)"),
+            Some("POINT (20 20)"),
+            Some("POINT (1 1)"),
+            Some("POINT (70 70)"),
+            Some("POINT (55 35)"),
+        ];
+        let points: Vec<Rect<f32>> = point_values
+            .iter()
+            .map(|opt_wkt| -> Rect<f32> {
+                let wkt_str = opt_wkt.unwrap();
+                let point: Point<f32> = Point::try_from_wkt_str(wkt_str).ok().unwrap();
+                point.bounding_rect()
+            })
+            .collect();
+        let (mut build_indices, mut probe_indices) = gs.probe(&points).unwrap();
+        build_indices.sort();
+        probe_indices.sort();
+
+        let (mut ans_build_indices, mut ans_probe_indices) =
+            compute_expected_intersections(&rects, &points);
+
+        ans_build_indices.sort();
+        ans_probe_indices.sort();
+
+        assert_eq!(build_indices, ans_build_indices);
+        assert_eq!(probe_indices, ans_probe_indices);
+    }
+    #[test]
+    fn test_spatial_refiner() {
+        let mut gs = GpuSpatial::new().unwrap();
+        let options = GpuSpatialOptions {
+            concurrency: 1,
+            device_id: 0,
+            compress_bvh: false,
+            pipeline_batches: 1,
+            cuda_use_memory_pool: true,
+            cuda_memory_pool_init_percent: 10,
+        };
+        gs.init(options).expect("Failed to initialize GpuSpatial");
+
+        let polygon_values = &[
+            Some("POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))"),
+            Some("POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10), (20 30, 35 35, 30 20, 20 30))"),
+            Some("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (2 2, 3 2, 3 3, 2 3, 2 2), (6 6, 8 6, 8 8, 6 8, 6 6))"),
+            Some("POLYGON ((30 0, 60 20, 50 50, 10 50, 0 20, 30 0), (20 30, 25 40, 15 40, 20 30), (30 30, 35 40, 25 40, 30 30), (40 30, 45 40, 35 40, 40 30))"),
+            Some("POLYGON ((40 0, 50 30, 80 20, 90 70, 60 90, 30 80, 20 40, 40 0), (50 20, 65 30, 60 50, 45 40, 50 20), (30 60, 50 70, 45 80, 30 60))"),
+        ];
+
+        let polygons = create_array_storage(polygon_values, &WKB_GEOMETRY);
+
+        let rects: Vec<Rect<f32>> = polygon_values
+            .iter()
+            .map(|opt_wkt| -> Rect<f32> {
+                let wkt_str = opt_wkt.unwrap();
+                let polygon: Polygon<f32> = Polygon::try_from_wkt_str(wkt_str).ok().unwrap();
+                polygon.bounding_rect().unwrap()
+            })
+            .collect();
+        gs.index_push_build(&rects)
+            .expect("Failed to push build data");
+        gs.index_finish_building()
+            .expect("Failed to finish building");
+
+        let point_values = &[
+            Some("POINT (30 20)"),
+            Some("POINT (20 20)"),
+            Some("POINT (1 1)"),
+            Some("POINT (70 70)"),
+            Some("POINT (55 35)"),
+        ];
+        let points = create_array_storage(point_values, &WKB_GEOMETRY);
+        let point_rects: Vec<Rect<f32>> = point_values
+            .iter()
+            .map(|wkt| -> Rect<f32> {
+                let wkt_str = wkt.unwrap();
+                let point: Point<f32> = Point::try_from_wkt_str(wkt_str).unwrap();
+                point.bounding_rect()
+            })
+            .collect();
+
+        // 1. Get GPU Results
+        let (mut build_indices, mut probe_indices) = gs.probe(&point_rects).unwrap();
+
+        gs.refiner_init_schema(polygons.data_type(), points.data_type())
+            .expect("Failed to init schema");
+        gs.refiner_push_build(&polygons)
+            .expect("Failed to push build");
+        gs.refiner_finish_building()
+            .expect("Failed to finish building refiner");
+        gs.refine(
+            &points,
+            GpuSpatialRelationPredicate::Intersects,
+            &mut build_indices,
+            &mut probe_indices,
+        )
+        .expect("Failed to refine results");
+
+        build_indices.sort();
+        probe_indices.sort();
+
+        // 2. Get CPU Expected Results
+        let (ans_build_indices, ans_probe_indices) =
+            compute_expected_pip_results(polygon_values, point_values);
+
+        // 3. Compare
+        assert_eq!(build_indices, ans_build_indices);
+        assert_eq!(probe_indices, ans_probe_indices);
+    }
+}

--- a/c/sedona-libgpuspatial/src/lib.rs
+++ b/c/sedona-libgpuspatial/src/lib.rs
@@ -224,7 +224,6 @@ mod tests {
     use geo::{BoundingRect, Point, Polygon};
     use sedona_schema::datatypes::WKB_GEOMETRY;
     use sedona_testing::create::create_array_storage;
-    use std::sync::Arc;
     use wkt::TryFromWkt;
 
     #[test]

--- a/c/sedona-libgpuspatial/src/lib.rs
+++ b/c/sedona-libgpuspatial/src/lib.rs
@@ -39,10 +39,6 @@ mod sys {
 
     pub type Result<T> = std::result::Result<T, GpuSpatialError>;
 
-    // Global Runtime State
-    unsafe impl Send for GpuSpatialRuntimeWrapper {}
-    unsafe impl Sync for GpuSpatialRuntimeWrapper {}
-
     static GLOBAL_GPUSPATIAL_RUNTIME: Mutex<Option<Arc<GpuSpatialRuntimeWrapper>>> =
         Mutex::new(None);
     /// Handles initialization of the GPU runtime.

--- a/c/sedona-libgpuspatial/src/libgpuspatial.rs
+++ b/c/sedona-libgpuspatial/src/libgpuspatial.rs
@@ -1,0 +1,523 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::error::GpuSpatialError;
+use crate::libgpuspatial_glue_bindgen::*;
+use arrow_array::{Array, ArrayRef};
+use arrow_schema::ffi::FFI_ArrowSchema;
+use arrow_schema::DataType;
+use std::convert::TryFrom;
+use std::ffi::{CStr, CString};
+use std::os::raw::{c_char, c_uint};
+use std::sync::{Arc, Mutex};
+
+// ----------------------------------------------------------------------
+// Helper Functions
+// ----------------------------------------------------------------------
+/// Helper to handle the common pattern of calling a C function returning an int status,
+/// checking if it failed, and retrieving the error message if so.
+///
+/// T: The type of the object (Runtime, Index, Refiner) being operated on.
+unsafe fn check_ffi_call<T, F, ErrMap>(
+    call_fn: F,
+    get_error_fn: Option<unsafe extern "C" fn(*mut T) -> *const c_char>,
+    obj_ptr: *mut T,
+    err_mapper: ErrMap,
+) -> Result<(), GpuSpatialError>
+where
+    F: FnOnce() -> i32,
+    ErrMap: FnOnce(String) -> GpuSpatialError,
+{
+    if call_fn() != 0 {
+        let error_string = if let Some(get_err) = get_error_fn {
+            let err_ptr = get_err(obj_ptr);
+            if !err_ptr.is_null() {
+                CStr::from_ptr(err_ptr).to_string_lossy().into_owned()
+            } else {
+                "Unknown error (null error message)".to_string()
+            }
+        } else {
+            "Unknown error (get_last_error not available)".to_string()
+        };
+
+        log::error!("GpuSpatial FFI Error: {}", error_string);
+        return Err(err_mapper(error_string));
+    }
+    Ok(())
+}
+
+// ----------------------------------------------------------------------
+// Runtime Wrapper
+// ----------------------------------------------------------------------
+
+pub struct GpuSpatialRuntimeWrapper {
+    runtime: GpuSpatialRuntime,
+}
+
+impl GpuSpatialRuntimeWrapper {
+    /// Initializes the GpuSpatialRuntime.
+    /// This function should only be called once per engine instance.
+    pub fn try_new(
+        device_id: i32,
+        ptx_root: &str,
+        use_cuda_memory_pool: bool,
+        cuda_memory_pool_init_precent: i32,
+    ) -> Result<GpuSpatialRuntimeWrapper, GpuSpatialError> {
+        let mut runtime = GpuSpatialRuntime {
+            init: None,
+            release: None,
+            get_last_error: None,
+            private_data: std::ptr::null_mut(),
+        };
+
+        unsafe {
+            GpuSpatialRuntimeCreate(&mut runtime);
+        }
+
+        if let Some(init_fn) = runtime.init {
+            let c_ptx_root = CString::new(ptx_root).map_err(|_| {
+                GpuSpatialError::Init("Failed to convert ptx_root to CString".into())
+            })?;
+
+            let mut config = GpuSpatialRuntimeConfig {
+                device_id,
+                ptx_root: c_ptx_root.as_ptr(),
+                use_cuda_memory_pool,
+                cuda_memory_pool_init_precent,
+            };
+
+            unsafe {
+                check_ffi_call(
+                    || init_fn(&runtime as *const _ as *mut _, &mut config),
+                    runtime.get_last_error,
+                    &runtime as *const _ as *mut _,
+                    GpuSpatialError::Init,
+                )?;
+            }
+        }
+
+        Ok(GpuSpatialRuntimeWrapper { runtime })
+    }
+}
+
+impl Drop for GpuSpatialRuntimeWrapper {
+    fn drop(&mut self) {
+        if let Some(release_fn) = self.runtime.release {
+            unsafe {
+                release_fn(&mut self.runtime as *mut _);
+            }
+        }
+    }
+}
+
+// ----------------------------------------------------------------------
+// Spatial Index Wrapper
+// ----------------------------------------------------------------------
+
+pub struct GpuSpatialIndexFloat2DWrapper {
+    index: SedonaFloatIndex2D,
+    // Keep a reference to the RT engine to ensure it lives as long as the index
+    _runtime: Arc<Mutex<GpuSpatialRuntimeWrapper>>,
+}
+
+impl GpuSpatialIndexFloat2DWrapper {
+    pub fn try_new(
+        runtime: Arc<Mutex<GpuSpatialRuntimeWrapper>>,
+        concurrency: u32,
+    ) -> Result<Self, GpuSpatialError> {
+        let mut index = SedonaFloatIndex2D {
+            clear: None,
+            create_context: None,
+            destroy_context: None,
+            push_build: None,
+            finish_building: None,
+            probe: None,
+            get_build_indices_buffer: None,
+            get_probe_indices_buffer: None,
+            get_last_error: None,
+            context_get_last_error: None,
+            release: None,
+            private_data: std::ptr::null_mut(),
+        };
+
+        let mut engine_guard = runtime
+            .lock()
+            .map_err(|_| GpuSpatialError::Init("Failed to acquire mutex lock".to_string()))?;
+
+        let config = GpuSpatialIndexConfig {
+            runtime: &mut engine_guard.runtime,
+            concurrency,
+        };
+
+        unsafe {
+            if GpuSpatialIndexFloat2DCreate(&mut index, &config) != 0 {
+                // Can't use check_ffi_call helper here easily because 'index' isn't fully initialized/wrapped yet
+                let msg = if let Some(get_err) = index.get_last_error {
+                    CStr::from_ptr(get_err(&index as *const _ as *mut _))
+                        .to_string_lossy()
+                        .into_owned()
+                } else {
+                    "Unknown error during Index Create".into()
+                };
+                return Err(GpuSpatialError::Init(msg));
+            }
+        }
+
+        Ok(GpuSpatialIndexFloat2DWrapper {
+            index,
+            _runtime: runtime.clone(),
+        })
+    }
+
+    pub fn clear(&mut self) {
+        if let Some(clear_fn) = self.index.clear {
+            unsafe {
+                clear_fn(&mut self.index as *mut _);
+            }
+        }
+    }
+
+    pub unsafe fn push_build(
+        &mut self,
+        buf: *const f32,
+        n_rects: u32,
+    ) -> Result<(), GpuSpatialError> {
+        if let Some(push_build_fn) = self.index.push_build {
+            let get_last_error = self.index.get_last_error;
+            let index_ptr = &mut self.index as *mut _;
+
+            check_ffi_call(
+                move || push_build_fn(index_ptr, buf, n_rects),
+                get_last_error,
+                index_ptr,
+                GpuSpatialError::PushBuild,
+            )?;
+        }
+        Ok(())
+    }
+
+    pub fn finish_building(&mut self) -> Result<(), GpuSpatialError> {
+        if let Some(finish_building_fn) = self.index.finish_building {
+            let get_last_error = self.index.get_last_error;
+            let index_ptr = &mut self.index as *mut _;
+
+            unsafe {
+                check_ffi_call(
+                    move || finish_building_fn(index_ptr),
+                    get_last_error,
+                    index_ptr,
+                    GpuSpatialError::FinishBuild,
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn create_context(&self, ctx: &mut SedonaSpatialIndexContext) {
+        if let Some(create_context_fn) = self.index.create_context {
+            unsafe {
+                create_context_fn(ctx as *mut _);
+            }
+        }
+    }
+
+    pub fn destroy_context(&self, ctx: &mut SedonaSpatialIndexContext) {
+        if let Some(destroy_context_fn) = self.index.destroy_context {
+            unsafe {
+                destroy_context_fn(ctx as *mut _);
+            }
+        }
+    }
+
+    pub unsafe fn probe(
+        &self,
+        ctx: &mut SedonaSpatialIndexContext,
+        buf: *const f32,
+        n_rects: u32,
+    ) -> Result<(), GpuSpatialError> {
+        if let Some(probe_fn) = self.index.probe {
+            // Note: probe uses context_get_last_error, not the index one
+            if probe_fn(
+                &self.index as *const _ as *mut _,
+                ctx as *mut _,
+                buf,
+                n_rects,
+            ) != 0
+            {
+                let error_string = if let Some(get_ctx_err) = self.index.context_get_last_error {
+                    CStr::from_ptr(get_ctx_err(ctx))
+                        .to_string_lossy()
+                        .into_owned()
+                } else {
+                    "Unknown context error".to_string()
+                };
+                log::error!("DEBUG FFI: probe failed: {}", error_string);
+                return Err(GpuSpatialError::Probe(error_string));
+            }
+        }
+        Ok(())
+    }
+
+    fn get_indices_buffer_helper(
+        &self,
+        ctx: &mut SedonaSpatialIndexContext,
+        func: Option<unsafe extern "C" fn(*mut SedonaSpatialIndexContext, *mut *mut u32, *mut u32)>,
+    ) -> &[u32] {
+        if let Some(f) = func {
+            let mut ptr: *mut u32 = std::ptr::null_mut();
+            let mut len: u32 = 0;
+            unsafe {
+                f(ctx, &mut ptr, &mut len);
+                if len > 0 && !ptr.is_null() {
+                    return std::slice::from_raw_parts(ptr, len as usize);
+                }
+            }
+        }
+        &[]
+    }
+
+    pub fn get_build_indices_buffer(&self, ctx: &mut SedonaSpatialIndexContext) -> &[u32] {
+        self.get_indices_buffer_helper(ctx, self.index.get_build_indices_buffer)
+    }
+
+    pub fn get_probe_indices_buffer(&self, ctx: &mut SedonaSpatialIndexContext) -> &[u32] {
+        self.get_indices_buffer_helper(ctx, self.index.get_probe_indices_buffer)
+    }
+}
+
+impl Drop for GpuSpatialIndexFloat2DWrapper {
+    fn drop(&mut self) {
+        if let Some(release_fn) = self.index.release {
+            unsafe {
+                release_fn(&mut self.index as *mut _);
+            }
+        }
+    }
+}
+
+// ----------------------------------------------------------------------
+// Predicate Wrapper
+// ----------------------------------------------------------------------
+
+#[repr(u32)]
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum GpuSpatialRelationPredicateWrapper {
+    Equals = 0,
+    Disjoint = 1,
+    Touches = 2,
+    Contains = 3,
+    Covers = 4,
+    Intersects = 5,
+    Within = 6,
+    CoveredBy = 7,
+}
+
+impl TryFrom<c_uint> for GpuSpatialRelationPredicateWrapper {
+    type Error = &'static str;
+
+    fn try_from(v: c_uint) -> Result<Self, Self::Error> {
+        match v {
+            0 => Ok(Self::Equals),
+            1 => Ok(Self::Disjoint),
+            2 => Ok(Self::Touches),
+            3 => Ok(Self::Contains),
+            4 => Ok(Self::Covers),
+            5 => Ok(Self::Intersects),
+            6 => Ok(Self::Within),
+            7 => Ok(Self::CoveredBy),
+            _ => Err("Invalid GpuSpatialPredicate value"),
+        }
+    }
+}
+
+// ----------------------------------------------------------------------
+// Refiner Wrapper
+// ----------------------------------------------------------------------
+
+pub struct GpuSpatialRefinerWrapper {
+    refiner: SedonaSpatialRefiner,
+    _runtime: Arc<Mutex<GpuSpatialRuntimeWrapper>>,
+}
+
+impl GpuSpatialRefinerWrapper {
+    pub fn try_new(
+        runtime: Arc<Mutex<GpuSpatialRuntimeWrapper>>,
+        concurrency: u32,
+        compress_bvh: bool,
+        pipeline_batches: u32,
+    ) -> Result<Self, GpuSpatialError> {
+        let mut refiner = SedonaSpatialRefiner {
+            clear: None,
+            init_schema: None,
+            push_build: None,
+            finish_building: None,
+            refine: None,
+            get_last_error: None,
+            release: None,
+            private_data: std::ptr::null_mut(),
+        };
+
+        let mut engine_guard = runtime
+            .lock()
+            .map_err(|_| GpuSpatialError::Init("Failed to acquire mutex lock".to_string()))?;
+
+        let config = GpuSpatialRefinerConfig {
+            runtime: &mut engine_guard.runtime,
+            concurrency,
+            compress_bvh,
+            pipeline_batches,
+        };
+
+        unsafe {
+            if GpuSpatialRefinerCreate(&mut refiner, &config) != 0 {
+                let msg = if let Some(get_err) = refiner.get_last_error {
+                    CStr::from_ptr(get_err(&refiner as *const _ as *mut _))
+                        .to_string_lossy()
+                        .into_owned()
+                } else {
+                    "Unknown error during Refiner Create".into()
+                };
+                return Err(GpuSpatialError::Init(msg));
+            }
+        }
+
+        Ok(GpuSpatialRefinerWrapper {
+            refiner,
+            _runtime: runtime.clone(),
+        })
+    }
+
+    pub fn init_schema(
+        &self,
+        build_data_type: &DataType,
+        probe_data_type: &DataType,
+    ) -> Result<(), GpuSpatialError> {
+        let ffi_build_schema = FFI_ArrowSchema::try_from(build_data_type)?;
+        let ffi_probe_schema = FFI_ArrowSchema::try_from(probe_data_type)?;
+
+        if let Some(init_schema_fn) = self.refiner.init_schema {
+            // Use pointer casting instead of transmute for safer FFI
+            let ffi_build_ptr = &ffi_build_schema as *const _ as *const ArrowSchema;
+            let ffi_probe_ptr = &ffi_probe_schema as *const _ as *const ArrowSchema;
+
+            unsafe {
+                check_ffi_call(
+                    || {
+                        init_schema_fn(
+                            &self.refiner as *const _ as *mut _,
+                            ffi_build_ptr,
+                            ffi_probe_ptr,
+                        )
+                    },
+                    self.refiner.get_last_error,
+                    &self.refiner as *const _ as *mut _,
+                    GpuSpatialError::Init,
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn clear(&self) {
+        if let Some(clear_fn) = self.refiner.clear {
+            unsafe {
+                clear_fn(&self.refiner as *const _ as *mut _);
+            }
+        }
+    }
+
+    pub fn push_build(&self, array: &ArrayRef) -> Result<(), GpuSpatialError> {
+        // Keep ffi_array alive until the C function returns
+        let (ffi_array, _ffi_schema) = arrow_array::ffi::to_ffi(&array.to_data())?;
+
+        if let Some(push_build_fn) = self.refiner.push_build {
+            let ffi_array_ptr = &ffi_array as *const _ as *const ArrowArray;
+            unsafe {
+                check_ffi_call(
+                    || push_build_fn(&self.refiner as *const _ as *mut _, ffi_array_ptr as *mut _),
+                    self.refiner.get_last_error,
+                    &self.refiner as *const _ as *mut _,
+                    GpuSpatialError::PushBuild,
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn finish_building(&self) -> Result<(), GpuSpatialError> {
+        if let Some(finish_building_fn) = self.refiner.finish_building {
+            unsafe {
+                check_ffi_call(
+                    || finish_building_fn(&self.refiner as *const _ as *mut _),
+                    self.refiner.get_last_error,
+                    &self.refiner as *const _ as *mut _,
+                    GpuSpatialError::FinishBuild,
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn refine(
+        &self,
+        probe_array: &ArrayRef,
+        predicate: GpuSpatialRelationPredicateWrapper,
+        build_indices: &mut Vec<u32>,
+        probe_indices: &mut Vec<u32>,
+    ) -> Result<(), GpuSpatialError> {
+        let (ffi_array, _ffi_schema) = arrow_array::ffi::to_ffi(&probe_array.to_data())?;
+
+        if let Some(refine_fn) = self.refiner.refine {
+            let ffi_array_ptr = &ffi_array as *const _ as *const ArrowArray;
+            let mut new_len: u32 = 0;
+
+            unsafe {
+                check_ffi_call(
+                    || {
+                        refine_fn(
+                            &self.refiner as *const _ as *mut _,
+                            ffi_array_ptr as *mut _,
+                            predicate as c_uint,
+                            build_indices.as_mut_ptr(),
+                            probe_indices.as_mut_ptr(),
+                            build_indices.len() as u32,
+                            &mut new_len as *mut u32,
+                        )
+                    },
+                    self.refiner.get_last_error,
+                    &self.refiner as *const _ as *mut _,
+                    GpuSpatialError::Refine,
+                )?;
+            }
+
+            // Update the lengths of the output index vectors based on GPU result
+            build_indices.truncate(new_len as usize);
+            probe_indices.truncate(new_len as usize);
+        }
+        Ok(())
+    }
+}
+
+impl Drop for GpuSpatialRefinerWrapper {
+    fn drop(&mut self) {
+        if let Some(release_fn) = self.refiner.release {
+            unsafe {
+                release_fn(&mut self.refiner as *mut _);
+            }
+        }
+    }
+}

--- a/c/sedona-libgpuspatial/src/libgpuspatial.rs
+++ b/c/sedona-libgpuspatial/src/libgpuspatial.rs
@@ -313,35 +313,16 @@ impl Drop for GpuSpatialIndexFloat2DWrapper {
 // Predicate Wrapper
 // ----------------------------------------------------------------------
 
-#[repr(u32)]
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum GpuSpatialRelationPredicateWrapper {
-    Equals = 0,
-    Disjoint = 1,
-    Touches = 2,
-    Contains = 3,
-    Covers = 4,
-    Intersects = 5,
-    Within = 6,
-    CoveredBy = 7,
-}
-
-impl TryFrom<c_uint> for GpuSpatialRelationPredicateWrapper {
-    type Error = &'static str;
-
-    fn try_from(v: c_uint) -> Result<Self, Self::Error> {
-        match v {
-            0 => Ok(Self::Equals),
-            1 => Ok(Self::Disjoint),
-            2 => Ok(Self::Touches),
-            3 => Ok(Self::Contains),
-            4 => Ok(Self::Covers),
-            5 => Ok(Self::Intersects),
-            6 => Ok(Self::Within),
-            7 => Ok(Self::CoveredBy),
-            _ => Err("Invalid GpuSpatialPredicate value"),
-        }
-    }
+    Equals,
+    Disjoint,
+    Touches,
+    Contains,
+    Covers,
+    Intersects,
+    Within,
+    CoveredBy,
 }
 
 // ----------------------------------------------------------------------

--- a/c/sedona-libgpuspatial/src/libgpuspatial.rs
+++ b/c/sedona-libgpuspatial/src/libgpuspatial.rs
@@ -28,6 +28,7 @@ use std::ffi::{c_void, CStr, CString};
 use std::os::raw::c_char;
 use std::sync::Arc;
 
+/// Public wrapper around the C `GpuSpatialRuntime` struct that manages its lifecycle and provides safe Rust methods to interact with it.
 pub struct GpuSpatialRuntimeWrapper {
     runtime: UnsafeCell<GpuSpatialRuntime>,
     /// Store which device the runtime is created on
@@ -35,6 +36,12 @@ pub struct GpuSpatialRuntimeWrapper {
 }
 
 impl GpuSpatialRuntimeWrapper {
+    /// Creates a new `GpuSpatialRuntimeWrapper` instance by initializing the underlying C struct with the provided configuration. It returns a `GpuSpatialError` if initialization fails.
+    /// # Arguments
+    /// * `device_id` - The ID of the GPU device to use for the runtime
+    /// * `ptx_root` - The root directory where the PTX files are located
+    /// * `use_cuda_memory_pool` - Whether to use the CUDA memory pool for allocations
+    /// * `cuda_memory_pool_init_precent` - The initial percentage of the CUDA memory pool to use (0-100)
     pub fn try_new(
         device_id: i32,
         ptx_root: &str,
@@ -113,11 +120,19 @@ impl Drop for FloatIndex2DWrapper {
     }
 }
 
+/// Public struct representing the 2D float spatial index. It provides safe Rust methods to interact with the underlying C implementation.
 pub struct FloatIndex2D {
     inner: FloatIndex2DWrapper,
 }
 
+unsafe impl Send for FloatIndex2D {}
+unsafe impl Sync for FloatIndex2D {}
+
 impl FloatIndex2D {
+    /// Creates a new `FloatIndex2D` instance by initializing the underlying C struct with the provided configuration. It returns a `GpuSpatialError` if initialization fails.
+    /// # Arguments
+    /// * `runtime` - An `Arc` to the `GpuSpatialRuntimeWrapper` that the index will use for GPU operations
+    /// * `concurrency` - The maximum level of concurrency allowed to use for probing the index
     pub fn try_new(
         runtime: Arc<GpuSpatialRuntimeWrapper>,
         concurrency: u32,
@@ -154,6 +169,7 @@ impl FloatIndex2D {
         })
     }
 
+    /// Clears the internal state of the index.
     pub fn clear(&mut self) {
         if let Some(clear_fn) = self.inner.index.clear {
             unsafe {
@@ -162,6 +178,13 @@ impl FloatIndex2D {
         }
     }
 
+    /// Pushes a batch of rectangles to the index for building.
+    /// # Arguments
+    /// * `buf` - A pointer to a buffer containing the rectangle data in the format [x_min, y_min, x_max, y_max] for each rectangle
+    /// * `n_rects` - The number of rectangles in the buffer
+    /// # Returns
+    /// * `Ok(())` if the push operation is successful
+    /// * `Err(GpuSpatialError)` if an error occurs during the push operation, with the error message retrieved from the C struct
     pub fn push_build(&mut self, buf: *const f32, n_rects: u32) -> Result<(), GpuSpatialError> {
         let push_fn =
             self.inner.index.push_build.ok_or_else(|| {
@@ -180,6 +203,10 @@ impl FloatIndex2D {
         }
     }
 
+    /// Finalizes the building process of the index.
+    /// # Returns
+    /// * `Ok(())` if the finish building operation is successful
+    /// * `Err(GpuSpatialError)` if an error occurs during the finish building operation, with the error message retrieved from the C struct
     pub fn finish_building(&mut self) -> Result<(), GpuSpatialError> {
         let finish_fn = self
             .inner
@@ -199,6 +226,13 @@ impl FloatIndex2D {
         }
     }
 
+    /// Probes the index with a batch of rectangles and retrieves the candidate pairs.
+    /// # Arguments
+    /// * `buf` - A pointer to a buffer containing the rectangle data in the format [x_min, y_min, x_max, y_max] for each rectangle
+    /// * `n_rects` - The number of rectangles in the buffer
+    /// # Returns
+    /// * `Ok((Vec<u32>, Vec<u32>))` containing the build and probe indices of the candidate pairs if the probe operation is successful
+    /// * `Err(GpuSpatialError)` if an error occurs during the probe operation, with the error message retrieved from the C struct or from the callback wrapper
     pub fn probe(
         &self,
         buf: *const f32,
@@ -237,6 +271,16 @@ impl FloatIndex2D {
             );
 
             if status != 0 {
+                // IMPROVEMENT: Check Rust error first!
+                // If the callback returned -1, 'state.error' has the real reason (the panic).
+                if let Some(callback_error) = state.error {
+                    if let Some(destroy_ctx) = destroy_context_fn {
+                        destroy_ctx(&mut ctx);
+                    }
+                    return Err(callback_error);
+                }
+
+                // If no Rust error, it was a genuine C-side error
                 let error_string = if let Some(get_ctx_err) = context_err_fn {
                     CStr::from_ptr(get_ctx_err(&mut ctx))
                         .to_string_lossy()
@@ -251,13 +295,7 @@ impl FloatIndex2D {
                 return Err(GpuSpatialError::Probe(error_string));
             }
 
-            if let Some(callback_error) = state.error {
-                if let Some(destroy_ctx) = destroy_context_fn {
-                    destroy_ctx(&mut ctx);
-                }
-                return Err(callback_error);
-            }
-
+            // Cleanup on success
             if let Some(destroy_ctx) = destroy_context_fn {
                 destroy_ctx(&mut ctx);
             }
@@ -267,6 +305,7 @@ impl FloatIndex2D {
     }
 }
 
+/// Internal wrapper that manages the lifecycle of the C `SedonaSpatialRefiner` struct.
 struct RefinerWrapper {
     refiner: SedonaSpatialRefiner,
     _runtime: Arc<GpuSpatialRuntimeWrapper>,
@@ -280,11 +319,22 @@ impl Drop for RefinerWrapper {
         }
     }
 }
+
+/// Public struct representing the spatial refiner. It provides safe Rust methods to interact with the underlying C implementation.
 pub struct Refiner {
     inner: RefinerWrapper,
 }
 
+unsafe impl Send for Refiner {}
+unsafe impl Sync for Refiner {}
+
 impl Refiner {
+    /// Creates a new `Refiner` instance by initializing the underlying C struct with the provided configuration. It returns a `GpuSpatialError` if initialization fails.
+    /// # Arguments
+    /// * `runtime` - An `Arc` to the `GpuSpatialRuntimeWrapper` that the refiner will use for GPU operations
+    /// * `concurrency` - The maximum level of concurrency allowed to use for refining candidate pairs
+    /// * `compress_bvh` - Whether to compress the BVH used internally by the refiner to save memory at the cost of potentially slower refinement times
+    /// * `pipeline_batches` - The number of batches to use for pipelining the refinement process, which can improve performance by overlapping GPU computation with WKB parsing. A value of 1 means no pipelining.
     pub fn try_new(
         runtime: Arc<GpuSpatialRuntimeWrapper>,
         concurrency: u32,
@@ -321,6 +371,9 @@ impl Refiner {
         })
     }
 
+    /// Initializes the schema for the refiner using the provided build and probe data types.
+    /// It converts the Arrow `DataType` to the C-compatible `FFI_ArrowSchema` and calls the underlying C function.
+    /// If initialization fails, it retrieves the error message from the C struct and returns a `GpuSpatialError`.
     pub fn init_schema(
         &mut self,
         build_dt: &DataType,
@@ -348,6 +401,9 @@ impl Refiner {
         }
     }
 
+    /// Pushes a batch of data to the refiner for building.
+    /// It converts the provided Arrow array to its FFI representation and calls the underlying C function.
+    /// If the push operation fails, it retrieves the error message from the C struct and returns a `GpuSpatialError`.
     pub fn push_build(&mut self, array: &ArrayRef) -> Result<(), GpuSpatialError> {
         let (ffi_array, _) = arrow_array::ffi::to_ffi(&array.to_data())?;
         let push_fn = self.inner.refiner.push_build.unwrap();
@@ -364,6 +420,7 @@ impl Refiner {
         }
     }
 
+    /// Clears the internal state of the refiner.
     pub fn clear(&mut self) {
         if let Some(clear_fn) = self.inner.refiner.clear {
             unsafe {
@@ -372,6 +429,7 @@ impl Refiner {
         }
     }
 
+    /// Finalizes the building process of the refiner.
     pub fn finish_building(&mut self) -> Result<(), GpuSpatialError> {
         let finish_fn = self.inner.refiner.finish_building.unwrap();
         let get_last_error = self.inner.refiner.get_last_error;
@@ -387,6 +445,15 @@ impl Refiner {
         }
     }
 
+    /// Refines the candidate pairs based on the provided predicate.
+    /// # Arguments
+    /// * `array` - The probe array containing the geometries to be refined.
+    /// * `predicate` - The spatial relation predicate to apply for refinement.
+    /// * `build_indices` - A mutable vector of build indices corresponding to the candidate pairs
+    /// * `probe_indices` - A mutable vector of probe indices corresponding to the candidate pairs
+    /// # Returns
+    /// * `Ok(())` if the refinement is successful, with `build_indices` and `probe_indices` updated to contain only the pairs that satisfy the predicate.
+    /// * `Err(GpuSpatialError)` if an error occurs during refinement, with the error message retrieved from the C struct.
     pub fn refine(
         &self,
         array: &ArrayRef,
@@ -461,19 +528,21 @@ where
     Ok(())
 }
 
+/// Wrapper for the probe callback that C will call.
+/// It safely converts the raw pointers to Rust slices and updates the `ProbeState` with the results.
+/// It also catches any panics that occur within the callback and stores the error message in the `ProbeState`,
+/// returning an error code to C to indicate that the callback failed.
 unsafe extern "C" fn probe_callback_wrapper(
     build_indices: *const u32,
     probe_indices: *const u32,
     length: u32,
     user_data: *mut c_void,
-) {
-    // Cast user_data back to our state struct
+) -> i32 {
     let state = &mut *(user_data as *mut ProbeState);
 
-    // Short-circuit: If an error already occurred in a previous call,
-    // stop processing to save time and prevent overwriting the error.
+    // 1. Short-circuit: If previous error exists, tell C to stop immediately.
     if state.error.is_some() {
-        return;
+        return -1;
     }
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -486,17 +555,21 @@ unsafe extern "C" fn probe_callback_wrapper(
         }
     }));
 
-    // If a panic occurred, capture it as an error
-    if let Err(payload) = result {
-        // Try to extract the panic message
-        let msg = if let Some(s) = payload.downcast_ref::<&str>() {
-            format!("Panic in callback: {}", s)
-        } else if let Some(s) = payload.downcast_ref::<String>() {
-            format!("Panic in callback: {}", s)
-        } else {
-            "Unknown panic in callback".to_string()
-        };
+    match result {
+        Ok(_) => 0, // Success code
+        Err(payload) => {
+            // Extract panic message
+            let msg = if let Some(s) = payload.downcast_ref::<&str>() {
+                format!("Panic in callback: {}", s)
+            } else if let Some(s) = payload.downcast_ref::<String>() {
+                format!("Panic in callback: {}", s)
+            } else {
+                "Unknown panic in callback".to_string()
+            };
 
-        state.error = Some(GpuSpatialError::Probe(msg));
+            // Set state and return error code to C
+            state.error = Some(GpuSpatialError::Probe(msg));
+            -1
+        }
     }
 }

--- a/c/sedona-libgpuspatial/src/libgpuspatial.rs
+++ b/c/sedona-libgpuspatial/src/libgpuspatial.rs
@@ -35,6 +35,9 @@ pub struct GpuSpatialRuntimeWrapper {
     pub device_id: i32,
 }
 
+unsafe impl Send for GpuSpatialRuntimeWrapper {}
+unsafe impl Sync for GpuSpatialRuntimeWrapper {}
+
 impl GpuSpatialRuntimeWrapper {
     /// Creates a new `GpuSpatialRuntimeWrapper` instance by initializing the underlying C struct with the provided configuration. It returns a `GpuSpatialError` if initialization fails.
     /// # Arguments

--- a/c/sedona-libgpuspatial/src/libgpuspatial.rs
+++ b/c/sedona-libgpuspatial/src/libgpuspatial.rs
@@ -18,12 +18,13 @@
 use crate::error::GpuSpatialError;
 #[cfg(gpu_available)]
 use crate::libgpuspatial_glue_bindgen::*;
+use crate::predicate::GpuSpatialRelationPredicate;
 use arrow_array::{Array, ArrayRef};
 use arrow_schema::ffi::FFI_ArrowSchema;
 use arrow_schema::DataType;
 use std::convert::TryFrom;
 use std::ffi::{CStr, CString};
-use std::os::raw::{c_char, c_uint};
+use std::os::raw::c_char;
 use std::sync::{Arc, Mutex};
 
 // ----------------------------------------------------------------------
@@ -329,52 +330,6 @@ impl Drop for FloatIndex2DContext {
             unsafe {
                 destroy_context_fn(&mut self.context);
             }
-        }
-    }
-}
-
-// ----------------------------------------------------------------------
-// Predicate Wrapper
-// ----------------------------------------------------------------------
-
-#[derive(Debug, PartialEq, Copy, Clone)]
-pub enum GpuSpatialRelationPredicate {
-    Equals,
-    Disjoint,
-    Touches,
-    Contains,
-    Covers,
-    Intersects,
-    Within,
-    CoveredBy,
-}
-
-impl GpuSpatialRelationPredicate {
-    /// Internal helper to convert the Rust enum to the C-compatible integer.
-    fn as_c_uint(self) -> c_uint {
-        match self {
-            Self::Equals => 0,
-            Self::Disjoint => 1,
-            Self::Touches => 2,
-            Self::Contains => 3,
-            Self::Covers => 4,
-            Self::Intersects => 5,
-            Self::Within => 6,
-            Self::CoveredBy => 7,
-        }
-    }
-}
-impl std::fmt::Display for GpuSpatialRelationPredicate {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            GpuSpatialRelationPredicate::Equals => write!(f, "equals"),
-            GpuSpatialRelationPredicate::Disjoint => write!(f, "disjoint"),
-            GpuSpatialRelationPredicate::Touches => write!(f, "touches"),
-            GpuSpatialRelationPredicate::Contains => write!(f, "contains"),
-            GpuSpatialRelationPredicate::Covers => write!(f, "covers"),
-            GpuSpatialRelationPredicate::Intersects => write!(f, "intersects"),
-            GpuSpatialRelationPredicate::Within => write!(f, "within"),
-            GpuSpatialRelationPredicate::CoveredBy => write!(f, "coveredby"),
         }
     }
 }

--- a/c/sedona-libgpuspatial/src/libgpuspatial.rs
+++ b/c/sedona-libgpuspatial/src/libgpuspatial.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::error::GpuSpatialError;
+#[cfg(gpu_available)]
 use crate::libgpuspatial_glue_bindgen::*;
 use arrow_array::{Array, ArrayRef};
 use arrow_schema::ffi::FFI_ArrowSchema;

--- a/c/sedona-libgpuspatial/src/libgpuspatial_glue_bindgen.rs
+++ b/c/sedona-libgpuspatial/src/libgpuspatial_glue_bindgen.rs
@@ -19,5 +19,10 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(dead_code)]
+#![allow(clippy::type_complexity)]
 
-include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+mod sys {
+    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+}
+
+pub use sys::*;

--- a/c/sedona-libgpuspatial/src/libgpuspatial_glue_bindgen.rs
+++ b/c/sedona-libgpuspatial/src/libgpuspatial_glue_bindgen.rs
@@ -25,4 +25,5 @@ mod sys {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
 
+#[cfg(gpu_available)]
 pub use sys::*;

--- a/c/sedona-libgpuspatial/src/options.rs
+++ b/c/sedona-libgpuspatial/src/options.rs
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+pub struct GpuSpatialOptions {
+    pub cuda_use_memory_pool: bool,
+    pub cuda_memory_pool_init_percent: i32,
+    pub concurrency: u32,
+    pub device_id: i32,
+    pub compress_bvh: bool,
+    pub pipeline_batches: u32,
+}

--- a/c/sedona-libgpuspatial/src/options.rs
+++ b/c/sedona-libgpuspatial/src/options.rs
@@ -15,11 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Options for GPU-accelerated index and refiner.
 pub struct GpuSpatialOptions {
+    /// Whether to use CUDA memory pool for allocations
     pub cuda_use_memory_pool: bool,
+    /// Ratio of initial memory pool size to total GPU memory, between 0 and 100
     pub cuda_memory_pool_init_percent: i32,
+    /// How many threads will concurrently use the library
     pub concurrency: u32,
+    /// The device id to use
     pub device_id: i32,
+    /// Whether to build a compressed BVH, which can reduce memory usage, but may increase build time
     pub compress_bvh: bool,
+    /// The number of batches for pipelined refinement that overlaps the WKB loading and refinement. Setting 1 effectively disables pipelining.
     pub pipeline_batches: u32,
 }

--- a/c/sedona-libgpuspatial/src/predicate.rs
+++ b/c/sedona-libgpuspatial/src/predicate.rs
@@ -29,9 +29,9 @@ pub enum GpuSpatialRelationPredicate {
     CoveredBy,
 }
 
+#[allow(dead_code)] // not used if the GPU feature is disabled
 impl GpuSpatialRelationPredicate {
     /// Internal helper to convert the Rust enum to the C-compatible integer.
-    #[allow(dead_code)] // not used if the GPU feature is disabled
     pub(crate) fn as_c_uint(self) -> c_uint {
         match self {
             Self::Equals => 0,

--- a/c/sedona-libgpuspatial/src/predicate.rs
+++ b/c/sedona-libgpuspatial/src/predicate.rs
@@ -29,7 +29,7 @@ pub enum GpuSpatialRelationPredicate {
     CoveredBy,
 }
 
-#[allow(dead_code)] // not used if the GPU feature is disabled
+#[cfg(gpu_available)] // not used if the GPU feature is disabled
 impl GpuSpatialRelationPredicate {
     /// Internal helper to convert the Rust enum to the C-compatible integer.
     pub(crate) fn as_c_uint(self) -> c_uint {

--- a/c/sedona-libgpuspatial/src/predicate.rs
+++ b/c/sedona-libgpuspatial/src/predicate.rs
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
+#[cfg(gpu_available)]
 use std::os::raw::c_uint;
 
 #[derive(Debug, PartialEq, Copy, Clone)]

--- a/c/sedona-libgpuspatial/src/predicate.rs
+++ b/c/sedona-libgpuspatial/src/predicate.rs
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::os::raw::c_uint;
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum GpuSpatialRelationPredicate {
+    Equals,
+    Disjoint,
+    Touches,
+    Contains,
+    Covers,
+    Intersects,
+    Within,
+    CoveredBy,
+}
+
+impl GpuSpatialRelationPredicate {
+    /// Internal helper to convert the Rust enum to the C-compatible integer.
+    pub(crate) fn as_c_uint(self) -> c_uint {
+        match self {
+            Self::Equals => 0,
+            Self::Disjoint => 1,
+            Self::Touches => 2,
+            Self::Contains => 3,
+            Self::Covers => 4,
+            Self::Intersects => 5,
+            Self::Within => 6,
+            Self::CoveredBy => 7,
+        }
+    }
+}
+impl std::fmt::Display for GpuSpatialRelationPredicate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GpuSpatialRelationPredicate::Equals => write!(f, "equals"),
+            GpuSpatialRelationPredicate::Disjoint => write!(f, "disjoint"),
+            GpuSpatialRelationPredicate::Touches => write!(f, "touches"),
+            GpuSpatialRelationPredicate::Contains => write!(f, "contains"),
+            GpuSpatialRelationPredicate::Covers => write!(f, "covers"),
+            GpuSpatialRelationPredicate::Intersects => write!(f, "intersects"),
+            GpuSpatialRelationPredicate::Within => write!(f, "within"),
+            GpuSpatialRelationPredicate::CoveredBy => write!(f, "coveredby"),
+        }
+    }
+}

--- a/c/sedona-libgpuspatial/src/predicate.rs
+++ b/c/sedona-libgpuspatial/src/predicate.rs
@@ -31,6 +31,7 @@ pub enum GpuSpatialRelationPredicate {
 
 impl GpuSpatialRelationPredicate {
     /// Internal helper to convert the Rust enum to the C-compatible integer.
+    #[allow(dead_code)] // not used if the GPU feature is disabled
     pub(crate) fn as_c_uint(self) -> c_uint {
         match self {
             Self::Equals => 0,


### PR DESCRIPTION
This PR adds Rust wrappers and tests for c/sedona-libgpuspatial. `libgpuspatial.rs` contains the Rust wrappers for `GpuSpatialIndexFloat2D` and `GpuSpatialRefiner`; `lib.rs` contains a high-level struct `GpuSpatial` that supports all functions of libgpuspatial. 