### PR TITLE
feat(rust/sedona-schema): Add Int8, UInt64, Int64 band data types, don't panic in BandMetadataRef

### DIFF
--- a/rust/sedona-raster-functions/src/rs_example.rs
+++ b/rust/sedona-raster-functions/src/rs_example.rs
@@ -142,9 +142,9 @@ mod tests {
             let bands = raster.bands();
             let band = bands.band(1).unwrap();
             let band_metadata = band.metadata();
-            assert_eq!(band_metadata.data_type(), BandDataType::UInt8);
+            assert_eq!(band_metadata.data_type().unwrap(), BandDataType::UInt8);
             assert_eq!(band_metadata.nodata_value(), Some(&[127u8][..]));
-            assert_eq!(band_metadata.storage_type(), StorageType::InDb);
+            assert_eq!(band_metadata.storage_type().unwrap(), StorageType::InDb);
         } else {
             panic!("Expected scalar struct result");
         }

--- a/rust/sedona-raster/src/array.rs
+++ b/rust/sedona-raster/src/array.rs
@@ -133,19 +133,24 @@ impl<'a> BandMetadataRef for BandMetadataRefImpl<'a> {
         }
     }
 
-    fn storage_type(&self) -> StorageType {
-        match self.storage_type_array.value(self.band_index) {
+    fn storage_type(&self) -> Result<StorageType, ArrowError> {
+        let value = self.storage_type_array.value(self.band_index);
+        let storage_type = match value {
             0 => StorageType::InDb,
             1 => StorageType::OutDbRef,
-            _ => panic!(
-                "Unknown storage type: {}",
-                self.storage_type_array.value(self.band_index)
-            ),
-        }
+            _ => {
+                return Err(ArrowError::InvalidArgumentError(format!(
+                    "Unknown storage type: {}",
+                    value
+                )))
+            }
+        };
+        Ok(storage_type)
     }
 
-    fn data_type(&self) -> BandDataType {
-        match self.datatype_array.value(self.band_index) {
+    fn data_type(&self) -> Result<BandDataType, ArrowError> {
+        let value = self.datatype_array.value(self.band_index);
+        let band_data_type = match value {
             1 => BandDataType::UInt8,
             2 => BandDataType::UInt16,
             3 => BandDataType::Int16,
@@ -153,14 +158,17 @@ impl<'a> BandMetadataRef for BandMetadataRefImpl<'a> {
             5 => BandDataType::Int32,
             6 => BandDataType::Float32,
             7 => BandDataType::Float64,
-            12 => BandDataType::UInt64,
-            13 => BandDataType::Int64,
-            14 => BandDataType::Int8,
-            _ => panic!(
-                "Unknown band data type: {}",
-                self.datatype_array.value(self.band_index)
-            ),
-        }
+            8 => BandDataType::UInt64,
+            9 => BandDataType::Int64,
+            10 => BandDataType::Int8,
+            _ => {
+                return Err(ArrowError::InvalidArgumentError(format!(
+                    "Unknown band data type: {}",
+                    self.datatype_array.value(self.band_index)
+                )))
+            }
+        };
+        Ok(band_data_type)
     }
 
     fn outdb_url(&self) -> Option<&str> {
@@ -546,6 +554,7 @@ mod tests {
     use super::*;
     use crate::builder::RasterBuilder;
     use crate::traits::{BandMetadata, RasterMetadata};
+    use arrow_schema::DataType;
     use sedona_schema::raster::{BandDataType, StorageType};
     use sedona_testing::rasters::generate_test_rasters;
 
@@ -611,8 +620,8 @@ mod tests {
         assert_eq!(band.data()[0], 1u8);
 
         let band_meta = band.metadata();
-        assert_eq!(band_meta.storage_type(), StorageType::InDb);
-        assert_eq!(band_meta.data_type(), BandDataType::UInt8);
+        assert_eq!(band_meta.storage_type().unwrap(), StorageType::InDb);
+        assert_eq!(band_meta.data_type().unwrap(), BandDataType::UInt8);
 
         let crs = raster.crs().unwrap();
         assert_eq!(crs, epsg4326);
@@ -695,5 +704,124 @@ mod tests {
         assert_eq!(rasters.len(), 2);
         assert!(!rasters.is_null(0));
         assert!(rasters.is_null(1));
+    }
+
+    /// Test that `data_type()` and `storage_type()` return `Err` for invalid values
+    /// instead of panicking.
+    #[test]
+    fn test_invalid_band_metadata_returns_err() {
+        use arrow_buffer::{OffsetBuffer, ScalarBuffer};
+        use sedona_schema::raster::RasterSchema;
+        use std::sync::Arc;
+
+        // Build a valid single-band raster first
+        let mut builder = RasterBuilder::new(1);
+        let metadata = RasterMetadata {
+            width: 2,
+            height: 2,
+            upperleft_x: 0.0,
+            upperleft_y: 0.0,
+            scale_x: 1.0,
+            scale_y: -1.0,
+            skew_x: 0.0,
+            skew_y: 0.0,
+        };
+        builder.start_raster(&metadata, None).unwrap();
+        let band_meta = BandMetadata {
+            nodata_value: None,
+            storage_type: StorageType::InDb,
+            datatype: BandDataType::UInt8,
+            outdb_url: None,
+            outdb_band_id: None,
+        };
+        builder.start_band(band_meta).unwrap();
+        builder.band_data_writer().append_value([1u8; 4]);
+        builder.finish_band().unwrap();
+        builder.finish_raster().unwrap();
+        let valid_array = builder.finish().unwrap();
+
+        // Extract original columns from the valid raster
+        let metadata_col = valid_array.column(raster_indices::METADATA).clone();
+        let crs_col = valid_array.column(raster_indices::CRS).clone();
+        let bands_list = valid_array
+            .column(raster_indices::BANDS)
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .unwrap();
+        let bands_struct = bands_list
+            .values()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        let orig_band_meta_struct = bands_struct
+            .column(band_indices::METADATA)
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        let band_data_col = bands_struct.column(band_indices::DATA).clone();
+
+        // Build tampered band metadata with invalid storage_type=99 and datatype=99
+        let DataType::Struct(band_metadata_fields) = RasterSchema::band_metadata_type() else {
+            panic!("Expected struct type for band metadata");
+        };
+        let tampered_band_metadata = StructArray::new(
+            band_metadata_fields,
+            vec![
+                orig_band_meta_struct
+                    .column(band_metadata_indices::NODATAVALUE)
+                    .clone(),
+                Arc::new(UInt32Array::from(vec![99u32])), // invalid storage_type
+                Arc::new(UInt32Array::from(vec![99u32])), // invalid datatype
+                orig_band_meta_struct
+                    .column(band_metadata_indices::OUTDB_URL)
+                    .clone(),
+                orig_band_meta_struct
+                    .column(band_metadata_indices::OUTDB_BAND_ID)
+                    .clone(),
+            ],
+            None,
+        );
+
+        // Rebuild band struct
+        let DataType::Struct(band_fields) = RasterSchema::band_type() else {
+            panic!("Expected struct type for band");
+        };
+        let tampered_band_struct = StructArray::new(
+            band_fields,
+            vec![Arc::new(tampered_band_metadata), band_data_col],
+            None,
+        );
+
+        // Rebuild bands list
+        let DataType::List(band_field) = RasterSchema::bands_type() else {
+            panic!("Expected list type for bands");
+        };
+        let tampered_bands_list = ListArray::new(
+            band_field,
+            OffsetBuffer::new(ScalarBuffer::from(vec![0i32, 1])),
+            Arc::new(tampered_band_struct),
+            None,
+        );
+
+        // Rebuild the top-level raster struct
+        let tampered_raster = StructArray::new(
+            RasterSchema::fields(),
+            vec![metadata_col, crs_col, Arc::new(tampered_bands_list)],
+            None,
+        );
+
+        // Read back and verify that data_type() and storage_type() return Err
+        let rasters = RasterStructArray::new(&tampered_raster);
+        let raster = rasters.get(0).unwrap();
+        let band = raster.bands().band(1).unwrap();
+        let band_meta = band.metadata();
+
+        let storage_err = band_meta.storage_type().unwrap_err();
+        assert!(storage_err.to_string().contains("Unknown storage type: 99"));
+
+        let data_type_err = band_meta.data_type().unwrap_err();
+        assert!(data_type_err
+            .to_string()
+            .contains("Unknown band data type: 99"));
     }
 }

--- a/rust/sedona-raster/src/builder.rs
+++ b/rust/sedona-raster/src/builder.rs
@@ -414,8 +414,8 @@ mod tests {
         assert_eq!(band.data()[0], 1u8);
 
         let band_meta = band.metadata();
-        assert_eq!(band_meta.storage_type(), StorageType::InDb);
-        assert_eq!(band_meta.data_type(), BandDataType::UInt8);
+        assert_eq!(band_meta.storage_type().unwrap(), StorageType::InDb);
+        assert_eq!(band_meta.data_type().unwrap(), BandDataType::UInt8);
 
         let crs = raster.crs().unwrap();
         assert_eq!(crs, epsg4326);
@@ -573,7 +573,7 @@ mod tests {
         // But band data and metadata should be different
         let target_band = target_raster.bands().band(1).unwrap();
         let target_band_meta = target_band.metadata();
-        assert_eq!(target_band_meta.data_type(), BandDataType::UInt16);
+        assert_eq!(target_band_meta.data_type().unwrap(), BandDataType::UInt16);
         assert!(target_band_meta.nodata_value().is_none());
         assert_eq!(target_band.data().len(), 2016); // 1008 * 2 bytes per u16
 
@@ -702,7 +702,7 @@ mod tests {
             // Bands are 1-based band_number
             let band = bands.band(i + 1).unwrap();
             let band_metadata = band.metadata();
-            let actual_type = band_metadata.data_type();
+            let actual_type = band_metadata.data_type().unwrap();
 
             assert_eq!(
                 actual_type, *expected_type,
@@ -770,8 +770,8 @@ mod tests {
         // Test InDb band
         let indb_band = bands.band(1).unwrap();
         let indb_metadata = indb_band.metadata();
-        assert_eq!(indb_metadata.storage_type(), StorageType::InDb);
-        assert_eq!(indb_metadata.data_type(), BandDataType::UInt8);
+        assert_eq!(indb_metadata.storage_type().unwrap(), StorageType::InDb);
+        assert_eq!(indb_metadata.data_type().unwrap(), BandDataType::UInt8);
         assert!(indb_metadata.outdb_url().is_none());
         assert!(indb_metadata.outdb_band_id().is_none());
         assert_eq!(indb_band.data().len(), 100);
@@ -779,8 +779,11 @@ mod tests {
         // Test OutDbRef band
         let outdb_band = bands.band(2).unwrap();
         let outdb_metadata = outdb_band.metadata();
-        assert_eq!(outdb_metadata.storage_type(), StorageType::OutDbRef);
-        assert_eq!(outdb_metadata.data_type(), BandDataType::Float32);
+        assert_eq!(
+            outdb_metadata.storage_type().unwrap(),
+            StorageType::OutDbRef
+        );
+        assert_eq!(outdb_metadata.data_type().unwrap(), BandDataType::Float32);
         assert_eq!(
             outdb_metadata.outdb_url().unwrap(),
             "s3://mybucket/satellite_image.tif"

--- a/rust/sedona-raster/src/traits.rs
+++ b/rust/sedona-raster/src/traits.rs
@@ -101,9 +101,9 @@ pub trait BandMetadataRef {
     /// No-data value as raw bytes (None if null)
     fn nodata_value(&self) -> Option<&[u8]>;
     /// Storage type (InDb, OutDbRef, etc)
-    fn storage_type(&self) -> StorageType;
+    fn storage_type(&self) -> Result<StorageType, ArrowError>;
     /// Band data type (UInt8, Float32, etc.)
-    fn data_type(&self) -> BandDataType;
+    fn data_type(&self) -> Result<BandDataType, ArrowError>;
     /// OutDb URL (only used when storage_type == OutDbRef)
     fn outdb_url(&self) -> Option<&str>;
     /// OutDb band ID (only used when storage_type == OutDbRef)

--- a/rust/sedona-schema/src/raster.rs
+++ b/rust/sedona-schema/src/raster.rs
@@ -88,10 +88,9 @@ impl RasterSchema {
 
 /// Band data type enumeration for raster bands.
 ///
-/// Ordinals match GDALDataType for real-valued pixel types only.
-/// GDT_Unknown (0) and complex types (CInt16=8, CInt32=9, CFloat32=10, CFloat64=11)
-/// are intentionally omitted.
-#[repr(u16)]
+/// Only supports basic numeric types.
+/// In future versions, consider support for complex types used in
+/// radar and other wave-based data.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Copy)]
 pub enum BandDataType {
     UInt8 = 1,
@@ -101,9 +100,9 @@ pub enum BandDataType {
     Int32 = 5,
     Float32 = 6,
     Float64 = 7,
-    UInt64 = 12,
-    Int64 = 13,
-    Int8 = 14,
+    UInt64 = 8,
+    Int64 = 9,
+    Int8 = 10,
 }
 
 /// Storage strategy for raster band data within Apache Arrow arrays.

--- a/rust/sedona-testing/src/rasters.rs
+++ b/rust/sedona-testing/src/rasters.rs
@@ -340,8 +340,8 @@ pub fn assert_raster_equal(raster1: &impl RasterRef, raster2: &impl RasterRef) {
         let band_meta1 = band1.metadata();
         let band_meta2 = band2.metadata();
         assert_eq!(
-            band_meta1.data_type(),
-            band_meta2.data_type(),
+            band_meta1.data_type().unwrap(),
+            band_meta2.data_type().unwrap(),
             "Band data types do not match"
         );
         assert_eq!(
@@ -350,8 +350,8 @@ pub fn assert_raster_equal(raster1: &impl RasterRef, raster2: &impl RasterRef) {
             "Band nodata values do not match"
         );
         assert_eq!(
-            band_meta1.storage_type(),
-            band_meta2.storage_type(),
+            band_meta1.storage_type().unwrap(),
+            band_meta2.storage_type().unwrap(),
             "Band storage types do not match"
         );
         assert_eq!(
@@ -397,9 +397,9 @@ mod tests {
             let bands = raster.bands();
             let band = bands.band(1).unwrap();
             let band_metadata = band.metadata();
-            assert_eq!(band_metadata.data_type(), BandDataType::UInt16);
+            assert_eq!(band_metadata.data_type().unwrap(), BandDataType::UInt16);
             assert_eq!(band_metadata.nodata_value(), Some(&[0u8, 0u8][..]));
-            assert_eq!(band_metadata.storage_type(), StorageType::InDb);
+            assert_eq!(band_metadata.storage_type().unwrap(), StorageType::InDb);
             assert_eq!(band_metadata.outdb_url(), None);
             assert_eq!(band_metadata.outdb_band_id(), None);
 
@@ -438,8 +438,8 @@ mod tests {
             for band_index in 0..3 {
                 let band = bands.band(band_index + 1).unwrap();
                 let band_metadata = band.metadata();
-                assert_eq!(band_metadata.data_type(), BandDataType::UInt8);
-                assert_eq!(band_metadata.storage_type(), StorageType::InDb);
+                assert_eq!(band_metadata.data_type().unwrap(), BandDataType::UInt8);
+                assert_eq!(band_metadata.storage_type().unwrap(), StorageType::InDb);
                 let band_data = band.data();
                 assert_eq!(band_data.len(), 64 * 64); // 4096 pixels
             }


### PR DESCRIPTION
## Summary
- Add three new `BandDataType` variants: `Int8`, `UInt64`, `Int64`
- Derive `Hash` and `Copy` on both `BandDataType` and `StorageType` enums for ergonomic use
- Update match arms in `BandMetadataRefImpl::data_type()` to decode the new ordinals
- Update data_type() and storage_type() to return Result, don't panic when observing unknown values
- Extend test coverage and test data generators (`generate_random_band_data`, `get_nodata_value_for_type`) to handle all 10 band data types