### PR TITLE
refactor(rust/sedona-spatial-join): Unify execute and execute_knn, move end-to-end tests in exec.rs to tests directory

### DIFF
--- a/rust/sedona-spatial-join/tests/spatial_join_integration.rs
+++ b/rust/sedona-spatial-join/tests/spatial_join_integration.rs
@@ -271,7 +271,7 @@ async fn get_or_init_expected_join_results<'a>(
                     sql,
                 )
                 .await
-                .unwrap_or_else(|_| panic!("Failed to generate expected result {}", i + 1));
+                .unwrap_or_else(|e| panic!("Failed to generate expected result {}: {}", i + 1, e));
                 expected_results.push(result);
             }
 


### PR DESCRIPTION
## Summary
- relocate spatial join integration tests from `exec.rs` into `rust/sedona-spatial-join/tests/`
- keep test helpers and data builders intact while switching to public crate imports
- preserve existing behavior while enabling integration-style execution