### PR TITLE
fix(python/sedonadb): Add pandas < 3.0 Series entry to SPECIAL_CASED_LITERALS

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -23,7 +23,6 @@ on:
     paths:
       - 'ci/scripts/wheels-*'
       - '.github/workflows/python-wheels.yml'
-      - 'python/sedonadb/python/sedonadb/expr/literal.py'
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary

- Adds the missing `"pandas.core.series.Series"` entry to `SPECIAL_CASED_LITERALS` in `literal.py`, fixing `test_pandas_literal` and `test_geopandas_literal` failures on pandas < 3.0 (Python 3.9 CI).
- The dict already handled both pandas < 3.0 and >= 3.0 naming for `DataFrame` but was missing the < 3.0 variant for `Series`.