### PR TITLE
docs(sql): normalize reference descriptions to third-person singular verbs

### DIFF
--- a/docs/reference/sql/rs_convexhull.qmd
+++ b/docs/reference/sql/rs_convexhull.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: RS_ConvexHull
-description: Return the convex hull geometry of a raster.
+description: Returns the convex hull geometry of a raster.
 kernels:
   - returns: geometry
     args: [raster]

--- a/docs/reference/sql/rs_crs.qmd
+++ b/docs/reference/sql/rs_crs.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: RS_CRS
-description: Return the CRS string for a raster.
+description: Returns the CRS string for a raster.
 kernels:
   - returns: string
     args: [raster]

--- a/docs/reference/sql/rs_envelope.qmd
+++ b/docs/reference/sql/rs_envelope.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: RS_Envelope
-description: Return the envelope (bounding box) of a raster as a geometry.
+description: Returns the envelope (bounding box) of a raster as a geometry.
 kernels:
   - returns: geometry
     args: [raster]

--- a/docs/reference/sql/rs_example.qmd
+++ b/docs/reference/sql/rs_example.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: RS_Example
-description: Create a simple example raster for testing and demos.
+description: Creates a simple example raster for testing and demos.
 kernels:
   - returns: raster
     args: []

--- a/docs/reference/sql/rs_height.qmd
+++ b/docs/reference/sql/rs_height.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: RS_Height
-description: Return the height of a raster in pixels.
+description: Returns the height of a raster in pixels.
 kernels:
   - returns: bigint
     args: [raster]

--- a/docs/reference/sql/rs_rastertoworldcoord.qmd
+++ b/docs/reference/sql/rs_rastertoworldcoord.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: RS_RasterToWorldCoord
-description: Convert raster pixel coordinates to world coordinates as a point.
+description: Converts raster pixel coordinates to world coordinates as a point.
 kernels:
   - returns: geometry
     args:

--- a/docs/reference/sql/rs_rastertoworldcoordx.qmd
+++ b/docs/reference/sql/rs_rastertoworldcoordx.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: RS_RasterToWorldCoordX
-description: Convert raster pixel coordinates to world X coordinate.
+description: Converts raster pixel coordinates to world X coordinate.
 kernels:
   - returns: double
     args:

--- a/docs/reference/sql/rs_rastertoworldcoordy.qmd
+++ b/docs/reference/sql/rs_rastertoworldcoordy.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: RS_RasterToWorldCoordY
-description: Convert raster pixel coordinates to world Y coordinate.
+description: Converts raster pixel coordinates to world Y coordinate.
 kernels:
   - returns: double
     args:

--- a/docs/reference/sql/rs_rotation.qmd
+++ b/docs/reference/sql/rs_rotation.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: RS_Rotation
-description: Return the raster rotation in radians based on skew parameters.
+description: Returns the raster rotation in radians based on skew parameters.
 kernels:
   - returns: double
     args: [raster]

--- a/docs/reference/sql/rs_scalex.qmd
+++ b/docs/reference/sql/rs_scalex.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: RS_ScaleX
-description: Return the pixel width (scale X) of a raster.
+description: Returns the pixel width (scale X) of a raster.
 kernels:
   - returns: double
     args: [raster]

--- a/docs/reference/sql/rs_scaley.qmd
+++ b/docs/reference/sql/rs_scaley.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: RS_ScaleY
-description: Return the pixel height (scale Y) of a raster.
+description: Returns the pixel height (scale Y) of a raster.
 kernels:
   - returns: double
     args: [raster]

--- a/docs/reference/sql/rs_skewx.qmd
+++ b/docs/reference/sql/rs_skewx.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: RS_SkewX
-description: Return the X skew (rotation) parameter of a raster.
+description: Returns the X skew (rotation) parameter of a raster.
 kernels:
   - returns: double
     args: [raster]

--- a/docs/reference/sql/rs_skewy.qmd
+++ b/docs/reference/sql/rs_skewy.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: RS_SkewY
-description: Return the Y skew (rotation) parameter of a raster.
+description: Returns the Y skew (rotation) parameter of a raster.
 kernels:
   - returns: double
     args: [raster]

--- a/docs/reference/sql/rs_srid.qmd
+++ b/docs/reference/sql/rs_srid.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: RS_SRID
-description: Return the SRID of a raster.
+description: Returns the SRID of a raster.
 kernels:
   - returns: integer
     args: [raster]

--- a/docs/reference/sql/rs_upperleftx.qmd
+++ b/docs/reference/sql/rs_upperleftx.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: RS_UpperLeftX
-description: Return the upper-left X coordinate of a raster.
+description: Returns the upper-left X coordinate of a raster.
 kernels:
   - returns: double
     args: [raster]

--- a/docs/reference/sql/rs_upperlefty.qmd
+++ b/docs/reference/sql/rs_upperlefty.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: RS_UpperLeftY
-description: Return the upper-left Y coordinate of a raster.
+description: Returns the upper-left Y coordinate of a raster.
 kernels:
   - returns: double
     args: [raster]

--- a/docs/reference/sql/rs_width.qmd
+++ b/docs/reference/sql/rs_width.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: RS_Width
-description: Return the width of a raster in pixels.
+description: Returns the width of a raster in pixels.
 kernels:
   - returns: bigint
     args: [raster]

--- a/docs/reference/sql/rs_worldtorastercoord.qmd
+++ b/docs/reference/sql/rs_worldtorastercoord.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: RS_WorldToRasterCoord
-description: Convert world coordinates to raster coordinates as a point.
+description: Converts world coordinates to raster coordinates as a point.
 kernels:
   - returns: geometry
     args:

--- a/docs/reference/sql/rs_worldtorastercoordx.qmd
+++ b/docs/reference/sql/rs_worldtorastercoordx.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: RS_WorldToRasterCoordX
-description: Convert world coordinates to raster X coordinate.
+description: Converts world coordinates to raster X coordinate.
 kernels:
   - returns: integer
     args:

--- a/docs/reference/sql/rs_worldtorastercoordy.qmd
+++ b/docs/reference/sql/rs_worldtorastercoordy.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: RS_WorldToRasterCoordY
-description: Convert world coordinates to raster Y coordinate.
+description: Converts world coordinates to raster Y coordinate.
 kernels:
   - returns: integer
     args:

--- a/docs/reference/sql/sd_format.qmd
+++ b/docs/reference/sql/sd_format.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: SD_Format
-description: Format values for display with optional JSON options.
+description: Formats values for display with optional JSON options.
 kernels:
   - returns: any
     args:

--- a/docs/reference/sql/sd_order.qmd
+++ b/docs/reference/sql/sd_order.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: SD_Order
-description: Return a value suitable for ordering or sorting.
+description: Returns a value suitable for ordering or sorting.
 kernels:
   - returns: any
     args:

--- a/docs/reference/sql/st_affine.qmd
+++ b/docs/reference/sql/st_affine.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_Affine
-description: Apply an affine transformation to a geometry.
+description: Applies an affine transformation to a geometry.
 kernels:
   - returns: geometry
     args:

--- a/docs/reference/sql/st_analyze_agg.qmd
+++ b/docs/reference/sql/st_analyze_agg.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_Analyze_Agg
-description: Compute the statistics of geometries for the input geometry.
+description: Computes the statistics of geometries for the input geometry.
 kernels:
   - returns: struct
     args: [geometry]

--- a/docs/reference/sql/st_asewkb.qmd
+++ b/docs/reference/sql/st_asewkb.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_AsEWKB
-description: Return the EWKB representation of a geometry or geography.
+description: Returns the EWKB representation of a geometry or geography.
 kernels:
   - returns: binary
     args: [geometry]

--- a/docs/reference/sql/st_asgeojson.qmd
+++ b/docs/reference/sql/st_asgeojson.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_AsGeoJSON
-description: Return the GeoJSON representation of a geometry.
+description: Returns the GeoJSON representation of a geometry.
 kernels:
   - returns: string
     args: [geometry]

--- a/docs/reference/sql/st_concavehull.qmd
+++ b/docs/reference/sql/st_concavehull.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_ConcaveHull
-description: Return a concave hull enclosing the input geometry.
+description: Returns a concave hull enclosing the input geometry.
 kernels:
   - returns: geometry
     args:

--- a/docs/reference/sql/st_contains.qmd
+++ b/docs/reference/sql/st_contains.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_Contains
-description: Return true if geomA contains geomB.
+description: Returns true if geomA contains geomB.
 kernels:
   - returns: boolean
     args: [geometry, geometry]

--- a/docs/reference/sql/st_convexhull.qmd
+++ b/docs/reference/sql/st_convexhull.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_ConvexHull
-description: Return the Convex Hull of polygon A.
+description: Returns the Convex Hull of polygon A.
 kernels:
   - returns: geometry
     args: [geometry]

--- a/docs/reference/sql/st_coveredby.qmd
+++ b/docs/reference/sql/st_coveredby.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_CoveredBy
-description: Return true if geomA is covered by geomB.
+description: Returns true if geomA is covered by geomB.
 kernels:
   - returns: boolean
     args: [geometry, geometry]

--- a/docs/reference/sql/st_covers.qmd
+++ b/docs/reference/sql/st_covers.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_Covers
-description: Return true if geomA covers geomB.
+description: Returns true if geomA covers geomB.
 kernels:
   - returns: boolean
     args: [geometry, geometry]

--- a/docs/reference/sql/st_crosses.qmd
+++ b/docs/reference/sql/st_crosses.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_Crosses
-description: Return true if A crosses B.
+description: Returns true if A crosses B.
 kernels:
   - returns: boolean
     args: [geometry, geometry]

--- a/docs/reference/sql/st_dimension.qmd
+++ b/docs/reference/sql/st_dimension.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_Dimension
-description: Return the dimension of the geometry.
+description: Returns the dimension of the geometry.
 kernels:
   - returns: integer
     args: [geometry]

--- a/docs/reference/sql/st_disjoint.qmd
+++ b/docs/reference/sql/st_disjoint.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_Disjoint
-description: Return true if geomA is disjoint from geomB.
+description: Returns true if geomA is disjoint from geomB.
 kernels:
   - returns: boolean
     args: [geometry, geometry]

--- a/docs/reference/sql/st_distance.qmd
+++ b/docs/reference/sql/st_distance.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_Distance
-description: Return the distance between two geometries or geographies.
+description: Returns the distance between two geometries or geographies.
 kernels:
   - returns: double
     args: [geometry, geometry]

--- a/docs/reference/sql/st_equals.qmd
+++ b/docs/reference/sql/st_equals.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_Equals
-description: Return true if geomA equals geomB.
+description: Returns true if geomA equals geomB.
 kernels:
   - returns: boolean
     args: [geometry, geometry]

--- a/docs/reference/sql/st_force2d.qmd
+++ b/docs/reference/sql/st_force2d.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_Force2D
-description: Force a geometry into a XY coordinate model.
+description: Forces a geometry into a XY coordinate model.
 kernels:
   - returns: geometry
     args: [geometry]

--- a/docs/reference/sql/st_force3d.qmd
+++ b/docs/reference/sql/st_force3d.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_Force3D
-description: Force a geometry into a XYZ coordinate model with an optional Z value.
+description: Forces a geometry into a XYZ coordinate model with an optional Z value.
 kernels:
   - returns: geometry
     args: [geometry]

--- a/docs/reference/sql/st_force3dm.qmd
+++ b/docs/reference/sql/st_force3dm.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_Force3DM
-description: Force a geometry into a XYM coordinate model with an optional M value.
+description: Forces a geometry into a XYM coordinate model with an optional M value.
 kernels:
   - returns: geometry
     args: [geometry]

--- a/docs/reference/sql/st_force4d.qmd
+++ b/docs/reference/sql/st_force4d.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_Force4D
-description: Force a geometry into a XYZM coordinate model with optional Z and M values.
+description: Forces a geometry into a XYZM coordinate model with optional Z and M values.
 kernels:
   - returns: geometry
     args: [geometry]

--- a/docs/reference/sql/st_geogfromwkb.qmd
+++ b/docs/reference/sql/st_geogfromwkb.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_GeogFromWKB
-description: Construct a Geography from WKB Binary.
+description: Constructs a Geography from WKB Binary.
 kernels:
   - returns: geography
     args:

--- a/docs/reference/sql/st_geogfromwkt.qmd
+++ b/docs/reference/sql/st_geogfromwkt.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_GeogFromWKT
-description: Construct a Geography from WKT.
+description: Constructs a Geography from WKT.
 kernels:
   - returns: geography
     args:

--- a/docs/reference/sql/st_geometryn.qmd
+++ b/docs/reference/sql/st_geometryn.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_GeometryN
-description: Return the 0-based Nth geometry if the geometry is a GEOMETRYCOLLECTION, (MULTI)POINT, (MULTI)LINESTRING, MULTICURVE or (MULTI)POLYGON.
+description: Returns the 0-based Nth geometry if the geometry is a GEOMETRYCOLLECTION, (MULTI)POINT, (MULTI)LINESTRING, MULTICURVE or (MULTI)POLYGON.
 kernels:
   - returns: geometry
     args:

--- a/docs/reference/sql/st_geometrytype.qmd
+++ b/docs/reference/sql/st_geometrytype.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_GeometryType
-description: Return the type of a geometry.
+description: Returns the type of a geometry.
 kernels:
   - returns: string
     args: [geometry]

--- a/docs/reference/sql/st_geomfromewkb.qmd
+++ b/docs/reference/sql/st_geomfromewkb.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_GeomFromEWKB
-description: Construct a geometry from Extended Well-Known Binary (EWKB).
+description: Constructs a geometry from Extended Well-Known Binary (EWKB).
 kernels:
   - returns: geometry
     args:

--- a/docs/reference/sql/st_geomfromewkt.qmd
+++ b/docs/reference/sql/st_geomfromewkt.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_GeomFromEWKT
-description: Construct a geometry from Extended Well-Known Text (EWKT).
+description: Constructs a geometry from Extended Well-Known Text (EWKT).
 kernels:
   - returns: geometry
     args:

--- a/docs/reference/sql/st_geomfromwkb.qmd
+++ b/docs/reference/sql/st_geomfromwkb.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_GeomFromWKB
-description: Construct a Geometry from Well-Known Binary (WKB).
+description: Constructs a Geometry from Well-Known Binary (WKB).
 kernels:
   - returns: geometry
     args:

--- a/docs/reference/sql/st_geomfromwkt.qmd
+++ b/docs/reference/sql/st_geomfromwkt.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_GeomFromWKT
-description: Construct a Geometry from Well-Known Text (WKT).
+description: Constructs a Geometry from Well-Known Text (WKT).
 kernels:
   - returns: geometry
     args:

--- a/docs/reference/sql/st_hasm.qmd
+++ b/docs/reference/sql/st_hasm.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_HasM
-description: Return true if the geometry has a M dimension.
+description: Returns true if the geometry has a M dimension.
 kernels:
   - returns: boolean
     args: [geometry]

--- a/docs/reference/sql/st_hasz.qmd
+++ b/docs/reference/sql/st_hasz.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_HasZ
-description: Return true if the geometry has a Z dimension.
+description: Returns true if the geometry has a Z dimension.
 kernels:
   - returns: boolean
     args: [geometry]

--- a/docs/reference/sql/st_intersection.qmd
+++ b/docs/reference/sql/st_intersection.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_Intersection
-description: Compute the intersection of two geometries or geographies.
+description: Computes the intersection of two geometries or geographies.
 kernels:
   - returns: geometry
     args: [geometry, geometry]

--- a/docs/reference/sql/st_intersection_agg.qmd
+++ b/docs/reference/sql/st_intersection_agg.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_Intersection_Agg
-description: Return the cumulative intersection of all geometries in the input.
+description: Returns the cumulative intersection of all geometries in the input.
 kernels:
   - returns: geometry
     args: [geometry]

--- a/docs/reference/sql/st_intersects.qmd
+++ b/docs/reference/sql/st_intersects.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_Intersects
-description: Return true if geomA intersects geomB.
+description: Returns true if geomA intersects geomB.
 kernels:
   - returns: boolean
     args: [geometry, geometry]

--- a/docs/reference/sql/st_isempty.qmd
+++ b/docs/reference/sql/st_isempty.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_IsEmpty
-description: Return true if the geometry is empty.
+description: Returns true if the geometry is empty.
 kernels:
   - returns: boolean
     args: [geometry]

--- a/docs/reference/sql/st_isring.qmd
+++ b/docs/reference/sql/st_isring.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_IsRing
-description: Return true if a linestring is ST_IsClosed and ST_IsSimple.
+description: Returns true if a linestring is ST_IsClosed and ST_IsSimple.
 kernels:
   - returns: boolean
     args: [geometry]

--- a/docs/reference/sql/st_issimple.qmd
+++ b/docs/reference/sql/st_issimple.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_IsSimple
-description: Test if geometry's only self-intersections are at boundary points.
+description: Tests if geometry's only self-intersections are at boundary points.
 kernels:
   - returns: boolean
     args: [geometry]

--- a/docs/reference/sql/st_knn.qmd
+++ b/docs/reference/sql/st_knn.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_KNN
-description: Return true if geomA finds k nearest neighbors from geomB.
+description: Returns true if geomA finds k nearest neighbors from geomB.
 kernels:
   - returns: boolean
     args:

--- a/docs/reference/sql/st_makevalid.qmd
+++ b/docs/reference/sql/st_makevalid.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_MakeValid
-description: Given an invalid geometry, create a valid representation of the geometry.
+description: Creates a valid representation of an invalid geometry.
 kernels:
   - returns: geometry
     args: [geometry]

--- a/docs/reference/sql/st_npoints.qmd
+++ b/docs/reference/sql/st_npoints.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_NPoints
-description: Return the number of points of the geometry.
+description: Returns the number of points of the geometry.
 kernels:
   - returns: integer
     args: [geometry]

--- a/docs/reference/sql/st_overlaps.qmd
+++ b/docs/reference/sql/st_overlaps.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_Overlaps
-description: Return true if A overlaps B.
+description: Returns true if A overlaps B.
 kernels:
   - returns: boolean
     args: [geometry, geometry]

--- a/docs/reference/sql/st_point.qmd
+++ b/docs/reference/sql/st_point.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_Point
-description: Construct a Point Geometry from X and Y.
+description: Constructs a Point Geometry from X and Y.
 kernels:
   - returns: geometry
     args:

--- a/docs/reference/sql/st_pointn.qmd
+++ b/docs/reference/sql/st_pointn.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_PointN
-description: Return the Nth point in a linestring.
+description: Returns the Nth point in a linestring.
 kernels:
   - returns: geometry
     args:

--- a/docs/reference/sql/st_reverse.qmd
+++ b/docs/reference/sql/st_reverse.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_Reverse
-description: Return the geometry with vertex order reversed.
+description: Returns the geometry with vertex order reversed.
 kernels:
   - returns: geometry
     args: [geometry]

--- a/docs/reference/sql/st_rotate.qmd
+++ b/docs/reference/sql/st_rotate.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_Rotate
-description: Rotate a geometry counter-clockwise around the Z axis by an angle in radians.
+description: Rotates a geometry counter-clockwise around the Z axis by an angle in radians.
 kernels:
   - returns: geometry
     args:

--- a/docs/reference/sql/st_rotatex.qmd
+++ b/docs/reference/sql/st_rotatex.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_RotateX
-description: Rotate a geometry around the X axis by an angle in radians.
+description: Rotates a geometry around the X axis by an angle in radians.
 kernels:
   - returns: geometry
     args:

--- a/docs/reference/sql/st_rotatey.qmd
+++ b/docs/reference/sql/st_rotatey.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_RotateY
-description: Rotate a geometry around the Y axis by an angle in radians.
+description: Rotates a geometry around the Y axis by an angle in radians.
 kernels:
   - returns: geometry
     args:

--- a/docs/reference/sql/st_scale.qmd
+++ b/docs/reference/sql/st_scale.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_Scale
-description: Scale a geometry by multiplying ordinates with scale factors.
+description: Scales a geometry by multiplying ordinates with scale factors.
 kernels:
   - returns: geometry
     args:

--- a/docs/reference/sql/st_touches.qmd
+++ b/docs/reference/sql/st_touches.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_Touches
-description: Return true if A touches B.
+description: Returns true if A touches B.
 kernels:
   - returns: boolean
     args: [geometry, geometry]

--- a/docs/reference/sql/st_within.qmd
+++ b/docs/reference/sql/st_within.qmd
@@ -17,7 +17,7 @@
 # under the License.
 
 title: ST_Within
-description: Return true if A is completely inside B.
+description: Returns true if A is completely inside B.
 kernels:
   - returns: boolean
     args: [geometry, geometry]


### PR DESCRIPTION
Currently, some of the description start with a verb in third-person singular form, and some are not. This pull request normalize the form.