### PR TITLE
chore: Keep builds passing after yanked 11.0.0 geos release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2885,9 +2885,8 @@ dependencies = [
 
 [[package]]
 name = "geos"
-version = "11.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b236fab6ae800ae29f31e473433e0fd61a07dacdab29644b5e6fd69c835921b9"
+version = "11.0.1"
+source = "git+https://github.com/georust/geos?rev=23e9fd50275ba93688a74dd3767fa0a7bcd906aa#23e9fd50275ba93688a74dd3767fa0a7bcd906aa"
 dependencies = [
  "geo-types",
  "geos-sys",
@@ -2897,9 +2896,8 @@ dependencies = [
 
 [[package]]
 name = "geos-sys"
-version = "2.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "582778505a1ec6d017d0382e947eb592b5f623479b6f1b1f2adf506934e84f89"
+version = "2.0.9"
+source = "git+https://github.com/georust/geos?rev=23e9fd50275ba93688a74dd3767fa0a7bcd906aa#23e9fd50275ba93688a74dd3767fa0a7bcd906aa"
 dependencies = [
  "libc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ geo-index = { version = "0.3.3", features = ["use-geo_0_31"] }
 geo-traits = "0.3.0"
 geo-types = "0.7.17"
 geojson = "0.24.2"
-geos = { version = "11.0.0", features = ["geo", "v3_12_0"] }
+geos = { version = "11.0.1", features = ["geo", "v3_12_0"], git = "https://github.com/georust/geos", rev = "23e9fd50275ba93688a74dd3767fa0a7bcd906aa" }
 glam = "0.32.0"
 libmimalloc-sys = { version = "0.1", default-features = false }
 log = "^0.4"


### PR DESCRIPTION
The 11.0.0 release was yanked to fix a releas issue ( https://github.com/georust/geos/issues/216 ), so we need to go back to a git dependency.