### PR TITLE
chore: Update geo-index to 0.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,8 +2793,9 @@ dependencies = [
 
 [[package]]
 name = "geo-index"
-version = "0.3.3"
-source = "git+https://github.com/Kontinuation/geo-index?rev=9051730508609892c748bda8de99f4c73e204464#9051730508609892c748bda8de99f4c73e204464"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f310ad245e63f6b5fcf4a7c2663139708eae1374045396eef95ea3badd242d57"
 dependencies = [
  "bytemuck",
  "float_next_after 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ fastrand = "2.0"
 float_next_after = "2"
 futures = "0.3"
 geo = "0.31.0"
-geo-index = { git = "https://github.com/Kontinuation/geo-index", rev = "9051730508609892c748bda8de99f4c73e204464", features = ["use-geo_0_31"] }
+geo-index = { version = "0.3.4", features = ["use-geo_0_31"] }
 geo-traits = "0.3.0"
 geo-types = "0.7.17"
 geojson = "0.24.2"


### PR DESCRIPTION
This PR updates geo-index to the version that contains https://github.com/georust/geo-index/pull/157 , which fixes a crash + severely degraded performance for input to the spatial join that is previously sorted.

```python
import sedona.db

sd = sedona.db.connect()

sd.read_parquet(
    "https://github.com/geoarrow/geoarrow-data/releases/download/v0.2.0/ns-water_elevation.parquet"
).to_view("elevation")

sd.read_parquet(
    "https://github.com/geoarrow/geoarrow-data/releases/download/v0.2.0/ns-water_water-point.parquet"
).to_view("water_point")

sd.sql("""
  SELECT water_point."OBJECTID", water_point.geometry, elevation."ZVALUE"
  FROM water_point
  INNER JOIN elevation ON ST_KNN(
    ST_Transform(water_point.geometry, 26920),
    ST_Transform(elevation.geometry, 26920),
    1,
    false
  )
""").to_parquet("foofy.parquet")
```

...now completes in 6s (previously this example crashed).
