### PR TITLE
fix(rust/sedona-testing): serialize env-mutating tests with a mutex to prevent race conditions

### DIFF
--- a/rust/sedona-testing/src/data.rs
+++ b/rust/sedona-testing/src/data.rs
@@ -144,16 +144,16 @@ pub fn test_raster(name: &str) -> Result<String> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
+    use std::sync::Mutex;
 
-    fn env_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
+    // These tests mutate global states including environment variables so they must
+    // run serially. The SERIAL_TEST mutex ensures that only one test executes at a time,
+    // preventing race conditions when modifying and restoring environment variables.
+    static SERIAL_TEST: Mutex<()> = Mutex::new(());
 
     #[test]
     fn example_files() {
-        let _guard = env_lock().lock().unwrap();
+        let _guard = SERIAL_TEST.lock().unwrap();
 
         // By default this should resolve, since we are in a test!
         assert!(geoarrow_data_dir().is_ok());
@@ -181,7 +181,7 @@ mod test {
 
     #[test]
     fn sedona_testing_dir_resolves() {
-        let _guard = env_lock().lock().unwrap();
+        let _guard = SERIAL_TEST.lock().unwrap();
 
         assert!(sedona_testing_dir().is_ok());
 
@@ -201,7 +201,7 @@ mod test {
 
     #[test]
     fn test_raster_resolves() {
-        let _guard = env_lock().lock().unwrap();
+        let _guard = SERIAL_TEST.lock().unwrap();
 
         // Test that test_raster can find existing raster files
         let path = test_raster("test4.tiff");


### PR DESCRIPTION
## Problem

The test became flaky after merging https://github.com/apache/sedona-db/pull/587:

```
failures:

---- data::test::test_raster_resolves stdout ----

thread 'data::test::test_raster_resolves' (26305233) panicked at rust/sedona-testing/src/data.rs:196:9:
Failed to find test4.tiff: Some(External("SedonaDB internal error: Can't resolve sedona-testing directory because\nthe value of the SEDONA_TESTING_DIR (this_directory_does_not_exist) does not exist.\nThis issue was likely caused by a bug in SedonaDB's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/sedona-db/issues"))


failures:
    data::test::test_raster_resolves
```

This is because Rust tests may run in parallel, mutating env in tests introduces race condition.

## Fixes

- Add a shared `Mutex` (`env_lock`) to the `sedona-testing` test module to serialize tests that call `env::set_var` / `env::remove_var`, preventing race conditions when tests run in parallel.
- Applies the lock guard to `example_files`, `sedona_testing_dir_resolves`, and `test_raster_resolves` tests.

## Alternatives that were considered

[serial_test](https://docs.rs/serial_test/latest/serial_test/) crate is an elegant solution to this problem. However, I don't think we need to introduce another dev dependency for resolving this, as the solution using synchronization primitives is simple enough.