### PR TITLE
fix(python/sedonadb): support DuckDB 1.5 spatial tests

### DIFF
--- a/python/sedonadb/python/sedonadb/testing.py
+++ b/python/sedonadb/python/sedonadb/testing.py
@@ -383,7 +383,13 @@ class DuckDB(DBEngine):
         self.con = duckdb.connect()
         self.con.install_extension("spatial")
         self.con.load_extension("spatial")
-        self.con.sql("CALL register_geoarrow_extensions()")
+        needs_geoarrow_registration = self.con.sql(
+            "SELECT count(*) > 0 FROM duckdb_functions() "
+            "WHERE function_name = 'register_geoarrow_extensions'"
+        ).fetchone()[0]
+
+        if needs_geoarrow_registration:
+            self.con.sql("CALL register_geoarrow_extensions()")
 
     @classmethod
     def name(cls):
@@ -422,7 +428,7 @@ class DuckDB(DBEngine):
         return self
 
     def execute_and_collect(self, query) -> pa.Table:
-        return self.con.sql(query).fetch_arrow_table()
+        return self.con.execute(query).arrow().read_all()
 
 
 class DuckDBSingleThread(DuckDB):


### PR DESCRIPTION
## Summary
- guard the DuckDB test helper's GeoArrow registration call so it still works across DuckDB 1.4 and 1.5
- switch DuckDB test result collection to the DB-API Arrow path, which avoids the DuckDB 1.5 GeoParquet relation export failure
- validate the focused Python regression suite against both DuckDB 1.4.4 and 1.5.0