### PR TITLE
docs: Remove badges from docs homepage due to Apache CSP restrictions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,8 +22,6 @@ title: Introducing SedonaDB
   under the License.
 -->
 
-[![PyPI Version](https://img.shields.io/pypi/v/sedonadb)](https://pypi.org/project/sedonadb/) [![PyPI - Downloads](https://img.shields.io/pypi/dm/sedonadb)](https://pepy.tech/project/sedonadb) [![Downloads](https://static.pepy.tech/personalized-badge/sedonadb?period=total&units=international_system&left_color=black&right_color=brightgreen&left_text=total%20downloads)](https://pepy.tech/project/sedonadb)
-
 SedonaDB is an open-source single-node analytical database engine with **geospatial as a first-class citizen**. It aims to deliver the fastest spatial analytics query speed and the most comprehensive function coverage available.
 
 SedonaDB is perfect for processing smaller to medium datasets on local machines or cloud instances. For distributed workloads, you can leverage the power of SedonaSpark, SedonaFlink, or SedonaSnow.


### PR DESCRIPTION
Remove PyPI download badges from the docs homepage (`docs/index.md`). The badges remain in `README.md` where they render correctly on GitHub.

## Why

The Apache website (`sedona.apache.org`) enforces a Content Security Policy that only allows images from `*.apache.org` and a few other whitelisted domains. Badge images from `img.shields.io` and `static.pepy.tech` are blocked by this CSP, resulting in broken images on the docs homepage.

## Files changed

- `docs/index.md` — Removed badge line
