### PR TITLE
fix: Ensure GPKG metadata consistency in test for GDAL 3.10+

### DIFF
--- a/c/sedona-gdal/src/vector/layer.rs
+++ b/c/sedona-gdal/src/vector/layer.rs
@@ -169,6 +169,7 @@ mod tests {
 
             let write_count = unsafe { GDALDatasetGetLayerCount(dataset.c_dataset()) };
             assert_eq!(write_count, 1);
+            drop(dataset);
 
             let read_dataset = Dataset::open_ex(
                 api,


### PR DESCRIPTION
## Summary
This PR fixes the failing `vector::layer::tests::test_layer_iteration_and_reset` test in `sedona-gdal` for GDAL 3.10+. I encountered this test failure on Fedora Asahi Remix release 42.

## Root Cause

The test failure is rooted in a change introduced in GDAL 3.10.0 (specifically commit [f7224b4c60f7](https://github.com/OSGeo/gdal/commit/f7224b4c60f74fc9076f37141b65ec71f8a4102f)).

- In **GDAL 3.8**, a newly created GPKG layer is inserted into `gpkg_ogr_contents` with `feature_count = NULL`.
- In **GDAL 3.10+**, after GDAL commit `0ea26b22cd0f01689bfd94263331ffc694112a80` (backported to release/3.10 as `f7224b4c60f74fc9076f37141b65ec71f8a4102f`, PR `#11275`, issue `#11274`), a newly created layer is inserted with `feature_count = 0`.

Because `OGRGeoPackageTableLayer::GetFeatureCount()` first consults `gpkg_ogr_contents`, this changes behavior materially:

- `NULL` means "unknown", so GDAL falls back to `SELECT COUNT(*) FROM table`.
- `0` is treated as a valid cached count, so GDAL returns `0` immediately.

In our test, that means:

- the second read-only dataset can already iterate the 3 inserted features;
- but `feature_count(true)` returns the stale cached metadata value `0`.

So the mismatch is specifically: feature iteration sees the rows, but `GetFeatureCount()` trusts stale metadata.

## Implementation

By explicitly `drop(dataset)`ing the writer before opening the reader, we trigger `GDALClose`, which commits all features and accurately updates the `gpkg_ogr_contents` metadata to 3. This approach ensures consistent test results across all GDAL versions by respecting transactional visibility.