### PR TITLE
feat(rust/sedona-functions): Add emoji shorthand for common ST_ functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,45 @@ We welcome contributions! Here's how you can get involved:
 
 SedonaDB is a subproject of **Apache Sedona**, an Apache Software Foundation project. The project is governed by the Apache Software Foundation and subject to all the rules and oversight requirements. SedonaDB is built on top of **Apache Arrow** and **Apache DataFusion** for fast query processing.
 
+### Emoji Aliases
+
+All `ST_` functions support emoji aliases for a more expressive query experience:
+
+| Function | Emoji | | Function | Emoji |
+|---|---|---|---|---|
+| `st_dump` | 💩 | | `st_reverse` | 🔙 |
+| `st_x` | ❌ | | `st_isempty` | 🕳️ |
+| `st_y` | 🤷 | | `st_isclosed` | 🔒 |
+| `st_z` | 💤 | | `st_iscollection` | 🗂️ |
+| `st_m` | Ⓜ️ | | `st_interiorringn` | 💍 |
+| `st_xmin` | ⬅️ | | `st_translate` | 🚚 |
+| `st_xmax` | ➡️ | | `st_numgeometries` | 🔢 |
+| `st_ymin` | ⬇️ | | `st_geometrytype` | 🔍 |
+| `st_ymax` | ⬆️ | | `st_geometryn` | 🎰 |
+| `st_zmin` | 🏝️ | | `st_scale` | ⚖️ |
+| `st_zmax` | 🏔️ | | `st_flipcoordinates` | 🪞 |
+| `st_mmin` | ⏬ | | `st_makeline` | 📏 |
+| `st_mmax` | ⏫ | | `st_pointn` | 👆 |
+| `st_geomfromwkt` | 📝 | | `st_envelope` | ✉️ |
+| `st_geogfromwkt` | 🌏 | | `st_dimension` | 📐 |
+| `st_geomfromewkt` | 📜 | | `st_azimuth` | 🧭 |
+| `st_geomfromwkb` | 📥 | | `st_astext` | 📖 |
+| `st_geomfromwkbunchecked` | 🤞 | | `st_asbinary` | 💾 |
+| `st_geogfromwkb` | 🌐 | | `st_asewkb` | 📦 |
+| `st_geomfromewkb` | 📨 | | `st_affine` | 🎭 |
+| `st_point` | 📍 | | `st_rotate` | 🌀 |
+| `st_geogpoint` | 🌍 | | `st_rotatex` | 🎡 |
+| `st_pointz` | ⛰️ | | `st_rotatey` | 🎠 |
+| `st_pointm` | ⏱️ | | `st_points` | ✨ |
+| `st_pointzm` | 🗻 | | `st_npoints` | #️⃣ |
+| `st_force2d` | 2️⃣ | | `st_hasz` | 🧗 |
+| `st_force3d` | 3️⃣ | | `st_hasm` | ⌚ |
+| `st_force3dm` | 🧊 | | `st_zmflag` | 🚩 |
+| `st_force4d` | 4️⃣ | | `st_startpoint` | 🏁 |
+| `st_srid` | 🆔 | | `st_endpoint` | 🔚 |
+| `st_crs` | 🎯 | | `st_setsrid` | 🏷️ |
+| `st_setcrs` | 📌 | | | |
+
 ### Related Projects
 
 - **[Apache Sedona](https://sedona.apache.org/)** - The main Apache Sedona project for distributed spatial analytics

--- a/rust/sedona-functions/src/st_affine.rs
+++ b/rust/sedona-functions/src/st_affine.rs
@@ -45,7 +45,7 @@ pub fn st_affine_udf() -> SedonaScalarUDF {
             Arc::new(STAffine { is_3d: false }),
         ]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🎭".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_asbinary.rs
+++ b/rust/sedona-functions/src/st_asbinary.rs
@@ -34,7 +34,7 @@ pub fn st_asbinary_udf() -> SedonaScalarUDF {
         ItemCrsKernel::wrap_impl(vec![Arc::new(STAsBinary {})]),
         Volatility::Immutable,
     );
-    udf.with_aliases(vec!["st_aswkb".to_string()])
+    udf.with_aliases(vec!["st_aswkb".to_string(), "st_💾".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_asewkb.rs
+++ b/rust/sedona-functions/src/st_asewkb.rs
@@ -39,7 +39,7 @@ pub fn st_asewkb_udf() -> SedonaScalarUDF {
         "st_asewkb",
         vec![Arc::new(STAsEWKBItemCrs {}), Arc::new(STAsEWKB {})],
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_📦".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_astext.rs
+++ b/rust/sedona-functions/src/st_astext.rs
@@ -36,7 +36,7 @@ pub fn st_astext_udf() -> SedonaScalarUDF {
         ItemCrsKernel::wrap_impl(vec![Arc::new(STAsText {})]),
         Volatility::Immutable,
     );
-    udf.with_aliases(vec!["st_aswkt".to_string()])
+    udf.with_aliases(vec!["st_aswkt".to_string(), "st_📖".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_azimuth.rs
+++ b/rust/sedona-functions/src/st_azimuth.rs
@@ -37,7 +37,7 @@ pub fn st_azimuth_udf() -> SedonaScalarUDF {
         "st_azimuth",
         ItemCrsKernel::wrap_impl(vec![Arc::new(STAzimuth {})]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🧭".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_dimension.rs
+++ b/rust/sedona-functions/src/st_dimension.rs
@@ -35,7 +35,7 @@ pub fn st_dimension_udf() -> SedonaScalarUDF {
         "st_dimension",
         ItemCrsKernel::wrap_impl(vec![Arc::new(STDimension {})]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_📐".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_dump.rs
+++ b/rust/sedona-functions/src/st_dump.rs
@@ -40,7 +40,7 @@ use crate::executor::WkbExecutor;
 ///
 /// Native implementation to get all the points of a geometry as MULTIPOINT
 pub fn st_dump_udf() -> SedonaScalarUDF {
-    SedonaScalarUDF::new("st_dump", vec![Arc::new(STDump)], Volatility::Immutable)
+    SedonaScalarUDF::new("st_dump", vec![Arc::new(STDump)], Volatility::Immutable).with_aliases(vec!["st_💩".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_envelope.rs
+++ b/rust/sedona-functions/src/st_envelope.rs
@@ -50,7 +50,7 @@ pub fn st_envelope_udf() -> SedonaScalarUDF {
         "st_envelope",
         ItemCrsKernel::wrap_impl(vec![Arc::new(STEnvelope {})]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_✉️".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_flipcoordinates.rs
+++ b/rust/sedona-functions/src/st_flipcoordinates.rs
@@ -45,7 +45,7 @@ pub fn st_flipcoordinates_udf() -> SedonaScalarUDF {
         "st_flipcoordinates",
         ItemCrsKernel::wrap_impl(vec![Arc::new(STFlipCoordinates {})]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🪞".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_force_dim.rs
+++ b/rust/sedona-functions/src/st_force_dim.rs
@@ -81,7 +81,7 @@ pub fn st_force2d_udf() -> SedonaScalarUDF {
             Arc::new(STForce2D { is_geography: true }),
         ]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_2️⃣".to_string()])
 }
 
 #[derive(Debug)]
@@ -154,7 +154,7 @@ pub fn st_force3d_udf() -> SedonaScalarUDF {
             Arc::new(STForce3D { is_geography: true }),
         ]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_3️⃣".to_string()])
 }
 
 #[derive(Debug)]
@@ -244,7 +244,7 @@ pub fn st_force3dm_udf() -> SedonaScalarUDF {
             Arc::new(STForce3DM { is_geography: true }),
         ]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🧊".to_string()])
 }
 
 #[derive(Debug)]
@@ -335,7 +335,7 @@ pub fn st_force4d_udf() -> SedonaScalarUDF {
             Arc::new(STForce4D { is_geography: true }),
         ]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_4️⃣".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_geometryn.rs
+++ b/rust/sedona-functions/src/st_geometryn.rs
@@ -42,7 +42,7 @@ pub fn st_geometryn_udf() -> SedonaScalarUDF {
         "st_geometryn",
         ItemCrsKernel::wrap_impl(vec![Arc::new(STGeometryN)]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🎰".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_geometrytype.rs
+++ b/rust/sedona-functions/src/st_geometrytype.rs
@@ -33,7 +33,7 @@ pub fn st_geometry_type_udf() -> SedonaScalarUDF {
         "st_geometrytype",
         ItemCrsKernel::wrap_impl(vec![Arc::new(STGeometryType {})]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🔍".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_geomfromewkb.rs
+++ b/rust/sedona-functions/src/st_geomfromewkb.rs
@@ -42,7 +42,7 @@ pub fn st_geomfromewkb_udf() -> SedonaScalarUDF {
         "st_geomfromewkb",
         vec![Arc::new(STGeomFromEWKB {})],
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_📨".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_geomfromwkb.rs
+++ b/rust/sedona-functions/src/st_geomfromwkb.rs
@@ -40,7 +40,7 @@ pub fn st_geomfromwkb_udf() -> SedonaScalarUDF {
         "st_geomfromwkb",
         vec![sridified_kernel, kernel],
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_📥".to_string()])
 }
 
 /// ST_GeomFromWKBUnchecked() scalar UDF implementation
@@ -54,7 +54,7 @@ pub fn st_geomfromwkbunchecked_udf() -> SedonaScalarUDF {
             out_type: WKB_VIEW_GEOMETRY,
         })],
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🤞".to_string()])
 }
 
 /// ST_GeogFromWKB() scalar UDF implementation
@@ -68,7 +68,7 @@ pub fn st_geogfromwkb_udf() -> SedonaScalarUDF {
             out_type: WKB_VIEW_GEOGRAPHY,
         })],
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🌐".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_geomfromwkt.rs
+++ b/rust/sedona-functions/src/st_geomfromwkt.rs
@@ -56,6 +56,7 @@ pub fn st_geomfromwkt_udf() -> SedonaScalarUDF {
     udf.with_aliases(vec![
         "st_geomfromtext".to_string(),
         "st_geometryfromtext".to_string(),
+        "st_📝".to_string(),
     ])
 }
 
@@ -71,7 +72,7 @@ pub fn st_geogfromwkt_udf() -> SedonaScalarUDF {
         })],
         Volatility::Immutable,
     );
-    udf.with_aliases(vec!["st_geogfromtext".to_string()])
+    udf.with_aliases(vec!["st_geogfromtext".to_string(), "st_🌏".to_string()])
 }
 
 #[derive(Debug)]
@@ -136,7 +137,7 @@ pub fn st_geomfromewkt_udf() -> SedonaScalarUDF {
         "st_geomfromewkt",
         vec![Arc::new(STGeoFromEWKT {})],
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_📜".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_haszm.rs
+++ b/rust/sedona-functions/src/st_haszm.rs
@@ -34,7 +34,7 @@ pub fn st_hasz_udf() -> SedonaScalarUDF {
         "st_hasz",
         ItemCrsKernel::wrap_impl(vec![Arc::new(STHasZm { dim: "z" })]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🧗".to_string()])
 }
 
 pub fn st_hasm_udf() -> SedonaScalarUDF {
@@ -42,7 +42,7 @@ pub fn st_hasm_udf() -> SedonaScalarUDF {
         "st_hasm",
         ItemCrsKernel::wrap_impl(vec![Arc::new(STHasZm { dim: "m" })]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_⌚".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_interiorringn.rs
+++ b/rust/sedona-functions/src/st_interiorringn.rs
@@ -40,7 +40,7 @@ pub fn st_interiorringn_udf() -> SedonaScalarUDF {
         "st_interiorringn",
         ItemCrsKernel::wrap_impl(vec![Arc::new(STInteriorRingN)]),
         datafusion_expr::Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_💍".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_isclosed.rs
+++ b/rust/sedona-functions/src/st_isclosed.rs
@@ -40,7 +40,7 @@ pub fn st_isclosed_udf() -> SedonaScalarUDF {
         "st_isclosed",
         ItemCrsKernel::wrap_impl(vec![Arc::new(STIsClosed {})]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🔒".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_iscollection.rs
+++ b/rust/sedona-functions/src/st_iscollection.rs
@@ -37,7 +37,7 @@ pub fn st_iscollection_udf() -> SedonaScalarUDF {
         "st_iscollection",
         ItemCrsKernel::wrap_impl(vec![Arc::new(STIsCollection {})]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🗂️".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_isempty.rs
+++ b/rust/sedona-functions/src/st_isempty.rs
@@ -34,7 +34,7 @@ pub fn st_isempty_udf() -> SedonaScalarUDF {
         "st_isempty",
         ItemCrsKernel::wrap_impl(vec![Arc::new(STIsEmpty {})]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🕳️".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_makeline.rs
+++ b/rust/sedona-functions/src/st_makeline.rs
@@ -50,7 +50,7 @@ pub fn st_makeline_udf() -> SedonaScalarUDF {
             }),
         ]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_📏".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_numgeometries.rs
+++ b/rust/sedona-functions/src/st_numgeometries.rs
@@ -37,7 +37,7 @@ pub fn st_numgeometries_udf() -> SedonaScalarUDF {
         "st_numgeometries",
         ItemCrsKernel::wrap_impl(vec![Arc::new(STNumGeometries {})]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🔢".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_point.rs
+++ b/rust/sedona-functions/src/st_point.rs
@@ -44,7 +44,7 @@ pub fn st_point_udf() -> SedonaScalarUDF {
         "st_point",
         vec![sridified_kernel, kernel],
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_📍".to_string()])
 }
 
 /// ST_GeogPoint() scalar UDF implementation
@@ -61,7 +61,7 @@ pub fn st_geogpoint_udf() -> SedonaScalarUDF {
         "st_geogpoint",
         vec![sridified_kernel, kernel],
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🌍".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_pointn.rs
+++ b/rust/sedona-functions/src/st_pointn.rs
@@ -44,7 +44,7 @@ pub fn st_pointn_udf() -> SedonaScalarUDF {
         "st_pointn",
         ItemCrsKernel::wrap_impl(vec![Arc::new(STPointN)]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_👆".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_points.rs
+++ b/rust/sedona-functions/src/st_points.rs
@@ -50,7 +50,7 @@ pub fn st_points_udf() -> SedonaScalarUDF {
         "st_points",
         ItemCrsKernel::wrap_impl(vec![Arc::new(STPoints)]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_✨".to_string()])
 }
 
 #[derive(Debug)]
@@ -107,7 +107,7 @@ pub fn st_npoints_udf() -> SedonaScalarUDF {
         "st_npoints",
         ItemCrsKernel::wrap_impl(vec![Arc::new(STNPoints)]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_#️⃣".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_pointzm.rs
+++ b/rust/sedona-functions/src/st_pointzm.rs
@@ -55,7 +55,7 @@ pub fn st_pointz_udf() -> SedonaScalarUDF {
             dim: Dimensions::Xyz,
         })],
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_⛰️".to_string()])
 }
 
 /// ST_PointM() scalar UDF implementation
@@ -69,7 +69,7 @@ pub fn st_pointm_udf() -> SedonaScalarUDF {
             dim: Dimensions::Xym,
         })],
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_⏱️".to_string()])
 }
 
 /// ST_PointZM() scalar UDF implementation
@@ -83,7 +83,7 @@ pub fn st_pointzm_udf() -> SedonaScalarUDF {
             dim: Dimensions::Xyzm,
         })],
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🗻".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_reverse.rs
+++ b/rust/sedona-functions/src/st_reverse.rs
@@ -49,7 +49,7 @@ pub fn st_reverse_udf() -> SedonaScalarUDF {
         "st_reverse",
         ItemCrsKernel::wrap_impl(vec![Arc::new(STReverse)]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🔙".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_rotate.rs
+++ b/rust/sedona-functions/src/st_rotate.rs
@@ -44,7 +44,7 @@ pub fn st_rotate_udf() -> SedonaScalarUDF {
             axis: RotateAxis::Z,
         })]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🌀".to_string()])
 }
 
 /// ST_RotateX() scalar UDF
@@ -57,7 +57,7 @@ pub fn st_rotate_x_udf() -> SedonaScalarUDF {
             axis: RotateAxis::X,
         })]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🎡".to_string()])
 }
 
 /// ST_RotateY() scalar UDF
@@ -70,7 +70,7 @@ pub fn st_rotate_y_udf() -> SedonaScalarUDF {
             axis: RotateAxis::Y,
         })]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🎠".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_scale.rs
+++ b/rust/sedona-functions/src/st_scale.rs
@@ -45,7 +45,7 @@ pub fn st_scale_udf() -> SedonaScalarUDF {
             Arc::new(STScale { is_3d: false }),
         ]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_⚖️".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_setsrid.rs
+++ b/rust/sedona-functions/src/st_setsrid.rs
@@ -56,7 +56,7 @@ pub fn st_set_srid_with_engine_udf(
         "st_setsrid",
         vec![Arc::new(STSetSRID { engine })],
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🏷️".to_string()])
 }
 
 /// ST_SetCRS() scalar UDF implementation without CRS validation
@@ -71,7 +71,7 @@ pub fn st_set_crs_with_engine_udf(
         "st_setcrs",
         vec![Arc::new(STSetCRS { engine })],
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_📌".to_string()])
 }
 
 /// ST_SetSRID() scalar UDF implementation without CRS validation

--- a/rust/sedona-functions/src/st_srid.rs
+++ b/rust/sedona-functions/src/st_srid.rs
@@ -41,7 +41,7 @@ pub fn st_srid_udf() -> SedonaScalarUDF {
         "st_srid",
         vec![Arc::new(StSridItemCrs {}), Arc::new(StSrid {})],
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🆔".to_string()])
 }
 
 /// ST_Crs() scalar UDF implementation
@@ -52,7 +52,7 @@ pub fn st_crs_udf() -> SedonaScalarUDF {
         "st_crs",
         vec![Arc::new(StCrsItemCrs {}), Arc::new(StCrs {})],
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🎯".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_start_point.rs
+++ b/rust/sedona-functions/src/st_start_point.rs
@@ -46,7 +46,7 @@ pub fn st_start_point_udf() -> SedonaScalarUDF {
         "st_startpoint",
         ItemCrsKernel::wrap_impl(vec![Arc::new(STStartOrEndPoint::new(true))]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🏁".to_string()])
 }
 
 /// ST_EndPoint() scalar UDF
@@ -57,7 +57,7 @@ pub fn st_end_point_udf() -> SedonaScalarUDF {
         "st_endpoint",
         ItemCrsKernel::wrap_impl(vec![Arc::new(STStartOrEndPoint::new(false))]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🔚".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_translate.rs
+++ b/rust/sedona-functions/src/st_translate.rs
@@ -47,7 +47,7 @@ pub fn st_translate_udf() -> SedonaScalarUDF {
             Arc::new(STTranslate { is_3d: false }),
         ]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🚚".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_xyzm.rs
+++ b/rust/sedona-functions/src/st_xyzm.rs
@@ -41,7 +41,7 @@ pub fn st_x_udf() -> SedonaScalarUDF {
         "st_x",
         ItemCrsKernel::wrap_impl(vec![Arc::new(STXyzm { dim: "x" })]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_❌".to_string()])
 }
 
 /// ST_Y() scalar UDF implementation
@@ -52,7 +52,7 @@ pub fn st_y_udf() -> SedonaScalarUDF {
         "st_y",
         ItemCrsKernel::wrap_impl(vec![Arc::new(STXyzm { dim: "y" })]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🤷".to_string()])
 }
 
 /// ST_Z() scalar UDF implementation
@@ -63,7 +63,7 @@ pub fn st_z_udf() -> SedonaScalarUDF {
         "st_z",
         ItemCrsKernel::wrap_impl(vec![Arc::new(STXyzm { dim: "z" })]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_💤".to_string()])
 }
 
 /// ST_M() scalar UDF implementation
@@ -74,7 +74,7 @@ pub fn st_m_udf() -> SedonaScalarUDF {
         "st_m",
         ItemCrsKernel::wrap_impl(vec![Arc::new(STXyzm { dim: "m" })]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_Ⓜ️".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_xyzm_minmax.rs
+++ b/rust/sedona-functions/src/st_xyzm_minmax.rs
@@ -41,7 +41,7 @@ pub fn st_xmin_udf() -> SedonaScalarUDF {
             is_max: false,
         })]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_⬅️".to_string()])
 }
 
 pub fn st_xmax_udf() -> SedonaScalarUDF {
@@ -52,7 +52,7 @@ pub fn st_xmax_udf() -> SedonaScalarUDF {
             is_max: true,
         })]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_➡️".to_string()])
 }
 
 pub fn st_ymin_udf() -> SedonaScalarUDF {
@@ -63,7 +63,7 @@ pub fn st_ymin_udf() -> SedonaScalarUDF {
             is_max: false,
         })]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_⬇️".to_string()])
 }
 
 pub fn st_ymax_udf() -> SedonaScalarUDF {
@@ -74,7 +74,7 @@ pub fn st_ymax_udf() -> SedonaScalarUDF {
             is_max: true,
         })]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_⬆️".to_string()])
 }
 
 pub fn st_zmin_udf() -> SedonaScalarUDF {
@@ -85,7 +85,7 @@ pub fn st_zmin_udf() -> SedonaScalarUDF {
             is_max: false,
         })]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🏝️".to_string()])
 }
 
 pub fn st_zmax_udf() -> SedonaScalarUDF {
@@ -96,7 +96,7 @@ pub fn st_zmax_udf() -> SedonaScalarUDF {
             is_max: true,
         })]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🏔️".to_string()])
 }
 
 pub fn st_mmin_udf() -> SedonaScalarUDF {
@@ -107,7 +107,7 @@ pub fn st_mmin_udf() -> SedonaScalarUDF {
             is_max: false,
         })]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_⏬".to_string()])
 }
 
 pub fn st_mmax_udf() -> SedonaScalarUDF {
@@ -118,7 +118,7 @@ pub fn st_mmax_udf() -> SedonaScalarUDF {
             is_max: true,
         })]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_⏫".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona-functions/src/st_zmflag.rs
+++ b/rust/sedona-functions/src/st_zmflag.rs
@@ -35,7 +35,7 @@ pub fn st_zmflag_udf() -> SedonaScalarUDF {
         "st_zmflag",
         ItemCrsKernel::wrap_impl(vec![Arc::new(STZmFlag {})]),
         Volatility::Immutable,
-    )
+    ).with_aliases(vec!["st_🚩".to_string()])
 }
 
 #[derive(Debug)]

--- a/rust/sedona/src/context.rs
+++ b/rust/sedona/src/context.rs
@@ -565,7 +565,7 @@ impl SedonaDialect {
 
 impl Dialect for SedonaDialect {
     fn is_identifier_start(&self, ch: char) -> bool {
-        self.inner.is_identifier_start(ch)
+        self.inner.is_identifier_start(ch) || ch.len_utf8() > 2
     }
 
     fn is_identifier_part(&self, ch: char) -> bool {
@@ -573,7 +573,7 @@ impl Dialect for SedonaDialect {
     }
 
     fn is_delimited_identifier_start(&self, ch: char) -> bool {
-        self.inner.is_delimited_identifier_start(ch)
+        self.inner.is_delimited_identifier_start(ch) || ch.len_utf8() > 2
     }
 
     fn identifier_quote_style(&self, identifier: &str) -> Option<char> {

--- a/rust/sedona/src/context.rs
+++ b/rust/sedona/src/context.rs
@@ -550,6 +550,49 @@ impl Default for SedonaWriteOptions {
     }
 }
 
+/// A custom SQL dialect that wraps an underlying dialect and extends
+/// `is_identifier_part` to accept additional characters.
+#[derive(Debug)]
+struct SedonaDialect {
+    inner: Box<dyn Dialect>,
+}
+
+impl SedonaDialect {
+    fn new(inner: Box<dyn Dialect>) -> Self {
+        Self { inner }
+    }
+}
+
+impl Dialect for SedonaDialect {
+    fn is_identifier_start(&self, ch: char) -> bool {
+        self.inner.is_identifier_start(ch)
+    }
+
+    fn is_identifier_part(&self, ch: char) -> bool {
+        self.inner.is_identifier_part(ch) || ch.len_utf8() > 2
+    }
+
+    fn is_delimited_identifier_start(&self, ch: char) -> bool {
+        self.inner.is_delimited_identifier_start(ch)
+    }
+
+    fn identifier_quote_style(&self, identifier: &str) -> Option<char> {
+        self.inner.identifier_quote_style(identifier)
+    }
+
+    fn supports_string_literal_backslash_escape(&self) -> bool {
+        self.inner.supports_string_literal_backslash_escape()
+    }
+
+    fn supports_filter_during_aggregation(&self) -> bool {
+        self.inner.supports_filter_during_aggregation()
+    }
+
+    fn supports_group_by_expr(&self) -> bool {
+        self.inner.supports_group_by_expr()
+    }
+}
+
 // Because Dialect/dialect_from_str is not marked as Send, using the async
 // function in certain contexts will fail to compile. Here we use a wrapper
 // to ensure that that the Dialect can be specified and parsed in any async
@@ -564,8 +607,9 @@ unsafe impl Send for ThreadSafeDialect {}
 impl ThreadSafeDialect {
     pub fn try_new(dialect: &datafusion::config::Dialect) -> Result<Self> {
         if let Some(box_dialect) = dialect_from_str(dialect) {
+            let sedona_dialect: Box<dyn Dialect> = Box::new(SedonaDialect::new(box_dialect));
             Ok(Self {
-                inner: box_dialect.into(),
+                inner: sedona_dialect.into(),
             })
         } else {
             plan_err!("Unsupported SQL dialect: {dialect}")


### PR DESCRIPTION
As part of our ongoing attempt to innovate on spatial SQL, this PR adds emoji shorthand for most functions which (1) improve expressiveness, (2) helps more SQL fit on one line and (3) reduces the number of bytes required for large SQL queries (important for AI generation).

The notable change is the addition of the custom `Dialect` that relaxes the strict requirement on characters permitted in an identifier sequence, which is a standalone improvement as it also allows other non-ASCII characters in function names as well.

```python
# pip install "apache-sedona[db]"
import sedona.db

sd = sedona.db.connect()
sd.options.interactive = True

# Creators
sd.sql("""
SELECT
    ST_📍(0, 1) AS pt,
    ST_⏱️(0, 1, 2) AS ptm,
    ST_📝('MULTIPOINT Z (0 0 10, 1 1 12)') AS mpt
""").to_view("ex")

# Transformers
sd.sql("SELECT ST_💩(mpt) FROM ex")

# Bounds
sd.sql("""
SELECT
    ST_⬅️(mpt),
    ST_⬇️(mpt),
    ST_➡️(mpt),
    ST_⬆️(mpt),
    ST_🏝️(mpt),
    ST_🏔️(mpt),
    ST_✉️(mpt)
FROM ex
""")

# Affine transform wrappers
sd.sql("""
SELECT
    ST_🚚(mpt, 2, 3),
    ST_🌀(mpt, 45),
    ST_⚖️(mpt, 0.5, 0.25),
    ST_🪞(mpt)
FROM ex
""")
```

Current summary of proposed syntax:


| Function | Emoji | | Function | Emoji |
|---|---|---|---|---|
| `st_dump` | 💩 | | `st_reverse` | 🔙 |
| `st_x` | ❌ | | `st_isempty` | 🕳️ |
| `st_y` | 🤷 | | `st_isclosed` | 🔒 |
| `st_z` | 💤 | | `st_iscollection` | 🗂️ |
| `st_m` | Ⓜ️ | | `st_interiorringn` | 💍 |
| `st_xmin` | ⬅️ | | `st_translate` | 🚚 |
| `st_xmax` | ➡️ | | `st_numgeometries` | 🔢 |
| `st_ymin` | ⬇️ | | `st_geometrytype` | 🔍 |
| `st_ymax` | ⬆️ | | `st_geometryn` | 🎰 |
| `st_zmin` | 🏝️ | | `st_scale` | ⚖️ |
| `st_zmax` | 🏔️ | | `st_flipcoordinates` | 🪞 |
| `st_mmin` | ⏬ | | `st_makeline` | 📏 |
| `st_mmax` | ⏫ | | `st_pointn` | 👆 |
| `st_geomfromwkt` | 📝 | | `st_envelope` | ✉️ |
| `st_geogfromwkt` | 🌏 | | `st_dimension` | 📐 |
| `st_geomfromewkt` | 📜 | | `st_azimuth` | 🧭 |
| `st_geomfromwkb` | 📥 | | `st_astext` | 📖 |
| `st_geomfromwkbunchecked` | 🤞 | | `st_asbinary` | 💾 |
| `st_geogfromwkb` | 🌐 | | `st_asewkb` | 📦 |
| `st_geomfromewkb` | 📨 | | `st_affine` | 🎭 |
| `st_point` | 📍 | | `st_rotate` | 🌀 |
| `st_geogpoint` | 🌍 | | `st_rotatex` | 🎡 |
| `st_pointz` | ⛰️ | | `st_rotatey` | 🎠 |
| `st_pointm` | ⏱️ | | `st_points` | ✨ |
| `st_pointzm` | 🗻 | | `st_npoints` | #️⃣ |
| `st_force2d` | 2️⃣ | | `st_hasz` | 🧗 |
| `st_force3d` | 3️⃣ | | `st_hasm` | ⌚ |
| `st_force3dm` | 🧊 | | `st_zmflag` | 🚩 |
| `st_force4d` | 4️⃣ | | `st_startpoint` | 🏁 |
| `st_srid` | 🆔 | | `st_endpoint` | 🔚 |
| `st_crs` | 🎯 | | `st_setsrid` | 🏷️ |
| `st_setcrs` | 📌 | | | |