### PR TITLE
feat(python/sedonadb): Enable GPU feature in python package and add spatial join tests

### DIFF
--- a/python/sedonadb/Cargo.toml
+++ b/python/sedonadb/Cargo.toml
@@ -29,6 +29,7 @@ crate-type = ["cdylib"]
 default = ["mimalloc"]
 mimalloc = ["dep:mimalloc", "dep:libmimalloc-sys"]
 s2geography = ["sedona/s2geography"]
+gpu = ["sedona/gpu"]
 
 [dependencies]
 adbc_core = { workspace = true }

--- a/python/sedonadb/src/lib.rs
+++ b/python/sedonadb/src/lib.rs
@@ -53,16 +53,17 @@ fn sedona_python_version() -> PyResult<String> {
     Ok(VERSION.to_string())
 }
 
-#[cfg(feature = "s2geography")]
 #[pyfunction]
 fn sedona_python_features() -> PyResult<Vec<String>> {
-    Ok(vec!["s2geography".to_string()])
-}
+    let mut features = vec![];
 
-#[cfg(not(feature = "s2geography"))]
-#[pyfunction]
-fn sedona_python_features() -> PyResult<Vec<String>> {
-    Ok(vec![])
+    #[cfg(feature = "s2geography")]
+    features.push("s2geography".to_string());
+
+    #[cfg(feature = "gpu")]
+    features.push("gpu".to_string());
+
+    Ok(features)
 }
 
 #[pyfunction]

--- a/python/sedonadb/tests/test_sjoin_gpu.py
+++ b/python/sedonadb/tests/test_sjoin_gpu.py
@@ -1,0 +1,339 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import json
+import re
+import warnings
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import pytest
+from sedonadb.testing import PostGIS, SedonaDB, random_geometry
+from shapely.geometry import Point
+
+
+def _enable_gpu_or_skip(eng_sedonadb):
+    try:
+        eng_sedonadb.con.sql("SET gpu.enable = true").execute()
+    except Exception as e:
+        pytest.skip(f"GPU runtime is not available: {e}")
+
+
+@pytest.mark.parametrize(
+    "join_type", ["INNER JOIN", "LEFT OUTER JOIN", "RIGHT OUTER JOIN"]
+)
+@pytest.mark.parametrize(
+    "on",
+    [
+        "ST_Intersects(sjoin_point.geometry, sjoin_polygon.geometry)",
+        "ST_Within(sjoin_point.geometry, sjoin_polygon.geometry)",
+        "ST_Contains(sjoin_polygon.geometry, sjoin_point.geometry)",
+    ],
+)
+def test_spatial_join_gpu(join_type, on):
+    with (
+        SedonaDB.create_or_skip() as eng_sedonadb,
+        PostGIS.create_or_skip() as eng_postgis,
+    ):
+        _enable_gpu_or_skip(eng_sedonadb)
+        df_point = random_geometry("Point", 100, seed=42)
+        df_polygon = random_geometry(
+            "Polygon", 100, hole_rate=0.5, num_vertices=(2, 10), seed=43
+        )
+
+        eng_sedonadb.create_table_arrow("sjoin_point", df_point)
+        eng_sedonadb.create_table_arrow("sjoin_polygon", df_polygon)
+        eng_postgis.create_table_arrow("sjoin_point", df_point)
+        eng_postgis.create_table_arrow("sjoin_polygon", df_polygon)
+
+        sql = f"""
+               SELECT sjoin_point.id id0, sjoin_polygon.id id1
+               FROM sjoin_point {join_type} sjoin_polygon
+               ON {on}
+               ORDER BY id0, id1
+               """
+
+        sedonadb_results = eng_sedonadb.execute_and_collect(sql).to_pandas()
+        assert len(sedonadb_results) > 0
+        eng_postgis.assert_query_result(sql, sedonadb_results)
+
+
+def _plan_text(df):
+    query_plan = df.to_pandas()
+    return "\n".join(query_plan.iloc[:, 1].astype(str).tolist())
+
+
+def _spatial_join_side_file_names(plan_text):
+    """Extract the left/right parquet file names used by `SpatialJoinExec`.
+
+    Example input:
+        SpatialJoinExec: join_type=Inner, on=ST_intersects(geo_right@0, geo_left@0)
+          ProjectionExec: expr=[geometry@0 as geo_right]
+            DataSourceExec: file_groups={1 group: [[.../natural-earth_countries_geo.parquet]]}, projection=[geometry], file_type=parquet
+          ProbeShuffleExec: partitioning=RoundRobinBatch(1)
+            ProjectionExec: expr=[geometry@0 as geo_left]
+              DataSourceExec: file_groups={1 group: [[.../natural-earth_cities_geo.parquet]]}, projection=[geometry], file_type=parquet
+
+    Example output:
+        ["natural-earth_countries_geo", "natural-earth_cities_geo"]
+    """
+    spatial_join_idx = plan_text.find("SpatialJoinExec:")
+    assert spatial_join_idx != -1, plan_text
+
+    file_names = re.findall(
+        r"DataSourceExec:.*?/([^/\]]+)\.parquet", plan_text[spatial_join_idx:]
+    )
+    assert len(file_names) >= 2, plan_text
+    return file_names[:2]
+
+
+@pytest.mark.parametrize(
+    "join_type",
+    [
+        "LEFT SEMI JOIN",
+        "LEFT ANTI JOIN",
+        "RIGHT SEMI JOIN",
+        "RIGHT ANTI JOIN",
+    ],
+)
+@pytest.mark.parametrize(
+    "on",
+    [
+        "ST_Intersects(sjoin_point.geometry, sjoin_polygon.geometry)",
+        "ST_Within(sjoin_point.geometry, sjoin_polygon.geometry)",
+        "ST_Contains(sjoin_polygon.geometry, sjoin_point.geometry)",
+    ],
+)
+def test_spatial_join_semi_anti_gpu(join_type, on):
+    with (
+        SedonaDB.create_or_skip() as eng_sedonadb,
+        PostGIS.create_or_skip() as eng_postgis,
+    ):
+        _enable_gpu_or_skip(eng_sedonadb)
+        options = json.dumps(
+            {
+                "geom_type": "Point",
+                "polygon_hole_rate": 0.5,
+                "num_parts_range": [2, 10],
+                "vertices_per_linestring_range": [2, 10],
+                "seed": 42,
+            }
+        )
+        df_point = eng_sedonadb.execute_and_collect(
+            f"SELECT * FROM sd_random_geometry('{options}') LIMIT 100"
+        )
+        options = json.dumps(
+            {
+                "geom_type": "Polygon",
+                "polygon_hole_rate": 0.5,
+                "num_parts_range": [2, 10],
+                "vertices_per_linestring_range": [2, 10],
+                "seed": 43,
+            }
+        )
+        df_polygon = eng_sedonadb.execute_and_collect(
+            f"SELECT * FROM sd_random_geometry('{options}') LIMIT 100"
+        )
+        eng_sedonadb.create_table_arrow("sjoin_point", df_point)
+        eng_sedonadb.create_table_arrow("sjoin_polygon", df_polygon)
+        eng_postgis.create_table_arrow("sjoin_point", df_point)
+        eng_postgis.create_table_arrow("sjoin_polygon", df_polygon)
+
+        is_left = join_type.startswith("LEFT")
+        is_semi = "SEMI" in join_type
+
+        if is_left:
+            sedona_sql = f"""
+                SELECT sjoin_point.id id0
+                FROM sjoin_point {join_type} sjoin_polygon
+                ON {on}
+                ORDER BY id0
+            """
+            exists = f"EXISTS (SELECT 1 FROM sjoin_polygon WHERE {on})"
+            where = exists if is_semi else f"NOT {exists}"
+            postgis_sql = f"""
+                SELECT sjoin_point.id id0
+                FROM sjoin_point
+                WHERE {where}
+                ORDER BY id0
+            """
+        else:
+            sedona_sql = f"""
+                SELECT sjoin_polygon.id id1
+                FROM sjoin_point {join_type} sjoin_polygon
+                ON {on}
+                ORDER BY id1
+            """
+            exists = f"EXISTS (SELECT 1 FROM sjoin_point WHERE {on})"
+            where = exists if is_semi else f"NOT {exists}"
+            postgis_sql = f"""
+                SELECT sjoin_polygon.id id1
+                FROM sjoin_polygon
+                WHERE {where}
+                ORDER BY id1
+            """
+
+        sedonadb_results = eng_sedonadb.execute_and_collect(sedona_sql).to_pandas()
+        assert len(sedonadb_results) > 0
+        eng_postgis.assert_query_result(postgis_sql, sedonadb_results)
+
+
+@pytest.mark.parametrize(
+    "outer",
+    ["point", "polygon"],
+)
+@pytest.mark.parametrize(
+    "on",
+    [
+        "ST_Intersects(sjoin_point.geometry, sjoin_polygon.geometry)",
+        "ST_Within(sjoin_point.geometry, sjoin_polygon.geometry)",
+    ],
+)
+def test_spatial_mark_join_via_correlated_exists_gpu(outer, on):
+    with (
+        SedonaDB.create_or_skip() as eng_sedonadb,
+        PostGIS.create_or_skip() as eng_postgis,
+    ):
+        _enable_gpu_or_skip(eng_sedonadb)
+        options = json.dumps(
+            {
+                "geom_type": "Point",
+                "polygon_hole_rate": 0.5,
+                "num_parts_range": [2, 10],
+                "vertices_per_linestring_range": [2, 10],
+                "seed": 42,
+            }
+        )
+        df_point = eng_sedonadb.execute_and_collect(
+            f"SELECT * FROM sd_random_geometry('{options}') LIMIT 100"
+        )
+        options = json.dumps(
+            {
+                "geom_type": "Polygon",
+                "polygon_hole_rate": 0.5,
+                "num_parts_range": [2, 10],
+                "vertices_per_linestring_range": [2, 10],
+                "seed": 43,
+            }
+        )
+        df_polygon = eng_sedonadb.execute_and_collect(
+            f"SELECT * FROM sd_random_geometry('{options}') LIMIT 100"
+        )
+        eng_sedonadb.create_table_arrow("sjoin_point", df_point)
+        eng_sedonadb.create_table_arrow("sjoin_polygon", df_polygon)
+        eng_postgis.create_table_arrow("sjoin_point", df_point)
+        eng_postgis.create_table_arrow("sjoin_polygon", df_polygon)
+
+        if outer == "point":
+            sql = f"""
+                SELECT sjoin_point.id id0
+                FROM sjoin_point
+                WHERE sjoin_point.id = 1 OR EXISTS (SELECT 1 FROM sjoin_polygon WHERE {on})
+                ORDER BY id0
+            """
+        else:
+            sql = f"""
+                SELECT sjoin_polygon.id id1, ST_AsBinary(sjoin_polygon.geometry) geom
+                FROM sjoin_polygon
+                WHERE sjoin_polygon.id = 1 OR EXISTS (SELECT 1 FROM sjoin_point WHERE {on})
+                ORDER BY id1
+            """
+
+        query_plan = eng_sedonadb.execute_and_collect(f"EXPLAIN {sql}").to_pandas()
+        plan_text = "\n".join(query_plan.iloc[:, 1].astype(str).tolist())
+        assert any(
+            "SpatialJoinExec" in line and ("LeftMark" in line or "RightMark" in line)
+            for line in plan_text.splitlines()
+        ), plan_text
+
+        sedonadb_results = eng_sedonadb.execute_and_collect(sql).to_pandas()
+        assert len(sedonadb_results) > 0
+        eng_postgis.assert_query_result(sql, sedonadb_results)
+
+
+def test_query_window_in_subquery_gpu():
+    with (
+        SedonaDB.create_or_skip() as eng_sedonadb,
+        PostGIS.create_or_skip() as eng_postgis,
+    ):
+        _enable_gpu_or_skip(eng_sedonadb)
+
+        df_point = random_geometry("Point", 100, seed=100)
+        df_polygon = random_geometry(
+            "Polygon", 100, hole_rate=0.5, num_vertices=(2, 10), size=(50, 60), seed=999
+        )
+
+        eng_sedonadb.create_table_arrow("sjoin_point", df_point)
+        eng_sedonadb.create_table_arrow("sjoin_polygon", df_polygon)
+        eng_postgis.create_table_arrow("sjoin_point", df_point)
+        eng_postgis.create_table_arrow("sjoin_polygon", df_polygon)
+
+        sql = """
+              SELECT id
+              FROM sjoin_point AS L
+              WHERE ST_Intersects(L.geometry, (SELECT R.geometry FROM sjoin_polygon AS R WHERE R.id = 1))
+              ORDER BY id \
+              """
+
+        query_plan = eng_sedonadb.execute_and_collect(f"EXPLAIN {sql}").to_pandas()
+        assert "SpatialJoinExec" in query_plan.iloc[1, 1]
+
+        sedonadb_results = eng_sedonadb.execute_and_collect(sql).to_pandas()
+        assert len(sedonadb_results) > 0
+        eng_postgis.assert_query_result(sql, sedonadb_results)
+
+
+def test_spatial_join_with_pandas_metadata_gpu(con):
+    try:
+        con.sql("SET gpu.enable = true").execute()
+    except Exception as e:
+        pytest.skip(f"GPU runtime is not available: {e}")
+
+    n_points = 1000
+    n_polys = 10
+
+    rng = np.random.Generator(np.random.MT19937(49791))
+    lons = rng.uniform(-6, 2, n_points)
+    lats = rng.uniform(50, 59, n_points)
+    pts_df = pd.DataFrame(
+        {"idx": range(n_points), "geometry": [Point(x, y) for x, y in zip(lons, lats)]}
+    )
+    pts_gdf = gpd.GeoDataFrame(pts_df, crs="EPSG:4326")
+
+    plons = rng.uniform(-6, 2, n_polys)
+    plats = rng.uniform(50, 59, n_polys)
+    poly_centers = gpd.GeoDataFrame(
+        {"geometry": [Point(x, y) for x, y in zip(plons, plats)]}, crs="EPSG:4326"
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        polys_gdf = poly_centers.buffer(0.1).to_frame(name="geometry")
+
+    con.create_data_frame(pts_gdf).to_view("points", overwrite=True)
+    con.create_data_frame(polys_gdf).to_view("polygons", overwrite=True)
+
+    query = """
+            SELECT p.idx
+            FROM points AS p,
+                 polygons AS poly
+            WHERE ST_Intersects(p.geometry, poly.geometry)
+            ORDER BY p.idx \
+            """
+
+    res = con.sql(query).to_pandas()
+    pd.testing.assert_frame_equal(res, pd.DataFrame({"idx": [304, 342, 490, 705]}))

--- a/python/sedonadb/tests/test_sjoin_gpu.py
+++ b/python/sedonadb/tests/test_sjoin_gpu.py
@@ -16,22 +16,10 @@
 # under the License.
 
 import json
-import re
-import warnings
 
-import geopandas as gpd
-import numpy as np
-import pandas as pd
 import pytest
+import sedonadb
 from sedonadb.testing import PostGIS, SedonaDB, random_geometry
-from shapely.geometry import Point
-
-
-def _enable_gpu_or_skip(eng_sedonadb):
-    try:
-        eng_sedonadb.con.sql("SET gpu.enable = true").execute()
-    except Exception as e:
-        pytest.skip(f"GPU runtime is not available: {e}")
 
 
 @pytest.mark.parametrize(
@@ -46,11 +34,13 @@ def _enable_gpu_or_skip(eng_sedonadb):
     ],
 )
 def test_spatial_join_gpu(join_type, on):
+    if "gpu" not in sedonadb.__features__:
+        pytest.skip("GPU feature is not available")
     with (
         SedonaDB.create_or_skip() as eng_sedonadb,
         PostGIS.create_or_skip() as eng_postgis,
     ):
-        _enable_gpu_or_skip(eng_sedonadb)
+        eng_sedonadb.con.sql("SET gpu.enable = true").execute()
         df_point = random_geometry("Point", 100, seed=42)
         df_polygon = random_geometry(
             "Polygon", 100, hole_rate=0.5, num_vertices=(2, 10), seed=43
@@ -73,35 +63,6 @@ def test_spatial_join_gpu(join_type, on):
         eng_postgis.assert_query_result(sql, sedonadb_results)
 
 
-def _plan_text(df):
-    query_plan = df.to_pandas()
-    return "\n".join(query_plan.iloc[:, 1].astype(str).tolist())
-
-
-def _spatial_join_side_file_names(plan_text):
-    """Extract the left/right parquet file names used by `SpatialJoinExec`.
-
-    Example input:
-        SpatialJoinExec: join_type=Inner, on=ST_intersects(geo_right@0, geo_left@0)
-          ProjectionExec: expr=[geometry@0 as geo_right]
-            DataSourceExec: file_groups={1 group: [[.../natural-earth_countries_geo.parquet]]}, projection=[geometry], file_type=parquet
-          ProbeShuffleExec: partitioning=RoundRobinBatch(1)
-            ProjectionExec: expr=[geometry@0 as geo_left]
-              DataSourceExec: file_groups={1 group: [[.../natural-earth_cities_geo.parquet]]}, projection=[geometry], file_type=parquet
-
-    Example output:
-        ["natural-earth_countries_geo", "natural-earth_cities_geo"]
-    """
-    spatial_join_idx = plan_text.find("SpatialJoinExec:")
-    assert spatial_join_idx != -1, plan_text
-
-    file_names = re.findall(
-        r"DataSourceExec:.*?/([^/\]]+)\.parquet", plan_text[spatial_join_idx:]
-    )
-    assert len(file_names) >= 2, plan_text
-    return file_names[:2]
-
-
 @pytest.mark.parametrize(
     "join_type",
     [
@@ -120,11 +81,13 @@ def _spatial_join_side_file_names(plan_text):
     ],
 )
 def test_spatial_join_semi_anti_gpu(join_type, on):
+    if "gpu" not in sedonadb.__features__:
+        pytest.skip("GPU feature is not available")
     with (
         SedonaDB.create_or_skip() as eng_sedonadb,
         PostGIS.create_or_skip() as eng_postgis,
     ):
-        _enable_gpu_or_skip(eng_sedonadb)
+        eng_sedonadb.con.sql("SET gpu.enable = true").execute()
         options = json.dumps(
             {
                 "geom_type": "Point",
@@ -191,149 +154,3 @@ def test_spatial_join_semi_anti_gpu(join_type, on):
         sedonadb_results = eng_sedonadb.execute_and_collect(sedona_sql).to_pandas()
         assert len(sedonadb_results) > 0
         eng_postgis.assert_query_result(postgis_sql, sedonadb_results)
-
-
-@pytest.mark.parametrize(
-    "outer",
-    ["point", "polygon"],
-)
-@pytest.mark.parametrize(
-    "on",
-    [
-        "ST_Intersects(sjoin_point.geometry, sjoin_polygon.geometry)",
-        "ST_Within(sjoin_point.geometry, sjoin_polygon.geometry)",
-    ],
-)
-def test_spatial_mark_join_via_correlated_exists_gpu(outer, on):
-    with (
-        SedonaDB.create_or_skip() as eng_sedonadb,
-        PostGIS.create_or_skip() as eng_postgis,
-    ):
-        _enable_gpu_or_skip(eng_sedonadb)
-        options = json.dumps(
-            {
-                "geom_type": "Point",
-                "polygon_hole_rate": 0.5,
-                "num_parts_range": [2, 10],
-                "vertices_per_linestring_range": [2, 10],
-                "seed": 42,
-            }
-        )
-        df_point = eng_sedonadb.execute_and_collect(
-            f"SELECT * FROM sd_random_geometry('{options}') LIMIT 100"
-        )
-        options = json.dumps(
-            {
-                "geom_type": "Polygon",
-                "polygon_hole_rate": 0.5,
-                "num_parts_range": [2, 10],
-                "vertices_per_linestring_range": [2, 10],
-                "seed": 43,
-            }
-        )
-        df_polygon = eng_sedonadb.execute_and_collect(
-            f"SELECT * FROM sd_random_geometry('{options}') LIMIT 100"
-        )
-        eng_sedonadb.create_table_arrow("sjoin_point", df_point)
-        eng_sedonadb.create_table_arrow("sjoin_polygon", df_polygon)
-        eng_postgis.create_table_arrow("sjoin_point", df_point)
-        eng_postgis.create_table_arrow("sjoin_polygon", df_polygon)
-
-        if outer == "point":
-            sql = f"""
-                SELECT sjoin_point.id id0
-                FROM sjoin_point
-                WHERE sjoin_point.id = 1 OR EXISTS (SELECT 1 FROM sjoin_polygon WHERE {on})
-                ORDER BY id0
-            """
-        else:
-            sql = f"""
-                SELECT sjoin_polygon.id id1, ST_AsBinary(sjoin_polygon.geometry) geom
-                FROM sjoin_polygon
-                WHERE sjoin_polygon.id = 1 OR EXISTS (SELECT 1 FROM sjoin_point WHERE {on})
-                ORDER BY id1
-            """
-
-        query_plan = eng_sedonadb.execute_and_collect(f"EXPLAIN {sql}").to_pandas()
-        plan_text = "\n".join(query_plan.iloc[:, 1].astype(str).tolist())
-        assert any(
-            "SpatialJoinExec" in line and ("LeftMark" in line or "RightMark" in line)
-            for line in plan_text.splitlines()
-        ), plan_text
-
-        sedonadb_results = eng_sedonadb.execute_and_collect(sql).to_pandas()
-        assert len(sedonadb_results) > 0
-        eng_postgis.assert_query_result(sql, sedonadb_results)
-
-
-def test_query_window_in_subquery_gpu():
-    with (
-        SedonaDB.create_or_skip() as eng_sedonadb,
-        PostGIS.create_or_skip() as eng_postgis,
-    ):
-        _enable_gpu_or_skip(eng_sedonadb)
-
-        df_point = random_geometry("Point", 100, seed=100)
-        df_polygon = random_geometry(
-            "Polygon", 100, hole_rate=0.5, num_vertices=(2, 10), size=(50, 60), seed=999
-        )
-
-        eng_sedonadb.create_table_arrow("sjoin_point", df_point)
-        eng_sedonadb.create_table_arrow("sjoin_polygon", df_polygon)
-        eng_postgis.create_table_arrow("sjoin_point", df_point)
-        eng_postgis.create_table_arrow("sjoin_polygon", df_polygon)
-
-        sql = """
-              SELECT id
-              FROM sjoin_point AS L
-              WHERE ST_Intersects(L.geometry, (SELECT R.geometry FROM sjoin_polygon AS R WHERE R.id = 1))
-              ORDER BY id \
-              """
-
-        query_plan = eng_sedonadb.execute_and_collect(f"EXPLAIN {sql}").to_pandas()
-        assert "SpatialJoinExec" in query_plan.iloc[1, 1]
-
-        sedonadb_results = eng_sedonadb.execute_and_collect(sql).to_pandas()
-        assert len(sedonadb_results) > 0
-        eng_postgis.assert_query_result(sql, sedonadb_results)
-
-
-def test_spatial_join_with_pandas_metadata_gpu(con):
-    try:
-        con.sql("SET gpu.enable = true").execute()
-    except Exception as e:
-        pytest.skip(f"GPU runtime is not available: {e}")
-
-    n_points = 1000
-    n_polys = 10
-
-    rng = np.random.Generator(np.random.MT19937(49791))
-    lons = rng.uniform(-6, 2, n_points)
-    lats = rng.uniform(50, 59, n_points)
-    pts_df = pd.DataFrame(
-        {"idx": range(n_points), "geometry": [Point(x, y) for x, y in zip(lons, lats)]}
-    )
-    pts_gdf = gpd.GeoDataFrame(pts_df, crs="EPSG:4326")
-
-    plons = rng.uniform(-6, 2, n_polys)
-    plats = rng.uniform(50, 59, n_polys)
-    poly_centers = gpd.GeoDataFrame(
-        {"geometry": [Point(x, y) for x, y in zip(plons, plats)]}, crs="EPSG:4326"
-    )
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        polys_gdf = poly_centers.buffer(0.1).to_frame(name="geometry")
-
-    con.create_data_frame(pts_gdf).to_view("points", overwrite=True)
-    con.create_data_frame(polys_gdf).to_view("polygons", overwrite=True)
-
-    query = """
-            SELECT p.idx
-            FROM points AS p,
-                 polygons AS poly
-            WHERE ST_Intersects(p.geometry, poly.geometry)
-            ORDER BY p.idx \
-            """
-
-    res = con.sql(query).to_pandas()
-    pd.testing.assert_frame_equal(res, pd.DataFrame({"idx": [304, 342, 490, 705]}))


### PR DESCRIPTION
We’ll eventually need a CI server with a GPU if we want to get serious about GPU support @jiayuasu @paleolimbot . Test results from my server are included below:

Note that this PR depends on https://github.com/apache/sedona-db/pull/766, or the GPU join might not trigger correctly. 

```
(sedona) ubuntu@ip-172-31-42-84:/mnt/data/sedona-db/python/sedonadb$ python -m pytest tests/test_sjoin_gpu.py -vv -s
================================================================================================ test session starts =================================================================================================
platform linux -- Python 3.11.14, pytest-9.0.2, pluggy-1.6.0 -- /home/ubuntu/miniconda3/envs/sedona/bin/python
cachedir: .pytest_cache
rootdir: /mnt/data/sedona-db/python/sedonadb
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 28 items

tests/test_sjoin_gpu.py::test_spatial_join_gpu[ST_Intersects(sjoin_point.geometry, sjoin_polygon.geometry)-INNER JOIN] PASSED
tests/test_sjoin_gpu.py::test_spatial_join_gpu[ST_Intersects(sjoin_point.geometry, sjoin_polygon.geometry)-LEFT OUTER JOIN] PASSED
tests/test_sjoin_gpu.py::test_spatial_join_gpu[ST_Intersects(sjoin_point.geometry, sjoin_polygon.geometry)-RIGHT OUTER JOIN] PASSED
tests/test_sjoin_gpu.py::test_spatial_join_gpu[ST_Within(sjoin_point.geometry, sjoin_polygon.geometry)-INNER JOIN] PASSED
tests/test_sjoin_gpu.py::test_spatial_join_gpu[ST_Within(sjoin_point.geometry, sjoin_polygon.geometry)-LEFT OUTER JOIN] PASSED
tests/test_sjoin_gpu.py::test_spatial_join_gpu[ST_Within(sjoin_point.geometry, sjoin_polygon.geometry)-RIGHT OUTER JOIN] PASSED
tests/test_sjoin_gpu.py::test_spatial_join_gpu[ST_Contains(sjoin_polygon.geometry, sjoin_point.geometry)-INNER JOIN] PASSED
tests/test_sjoin_gpu.py::test_spatial_join_gpu[ST_Contains(sjoin_polygon.geometry, sjoin_point.geometry)-LEFT OUTER JOIN] PASSED
tests/test_sjoin_gpu.py::test_spatial_join_gpu[ST_Contains(sjoin_polygon.geometry, sjoin_point.geometry)-RIGHT OUTER JOIN] PASSED
tests/test_sjoin_gpu.py::test_spatial_join_reordering_can_be_disabled_e2e_gpu PASSED
tests/test_sjoin_gpu.py::test_spatial_join_semi_anti_gpu[ST_Intersects(sjoin_point.geometry, sjoin_polygon.geometry)-LEFT SEMI JOIN] PASSED
tests/test_sjoin_gpu.py::test_spatial_join_semi_anti_gpu[ST_Intersects(sjoin_point.geometry, sjoin_polygon.geometry)-LEFT ANTI JOIN] PASSED
tests/test_sjoin_gpu.py::test_spatial_join_semi_anti_gpu[ST_Intersects(sjoin_point.geometry, sjoin_polygon.geometry)-RIGHT SEMI JOIN] PASSED
tests/test_sjoin_gpu.py::test_spatial_join_semi_anti_gpu[ST_Intersects(sjoin_point.geometry, sjoin_polygon.geometry)-RIGHT ANTI JOIN] PASSED
tests/test_sjoin_gpu.py::test_spatial_join_semi_anti_gpu[ST_Within(sjoin_point.geometry, sjoin_polygon.geometry)-LEFT SEMI JOIN] PASSED
tests/test_sjoin_gpu.py::test_spatial_join_semi_anti_gpu[ST_Within(sjoin_point.geometry, sjoin_polygon.geometry)-LEFT ANTI JOIN] PASSED
tests/test_sjoin_gpu.py::test_spatial_join_semi_anti_gpu[ST_Within(sjoin_point.geometry, sjoin_polygon.geometry)-RIGHT SEMI JOIN] PASSED
tests/test_sjoin_gpu.py::test_spatial_join_semi_anti_gpu[ST_Within(sjoin_point.geometry, sjoin_polygon.geometry)-RIGHT ANTI JOIN] PASSED
tests/test_sjoin_gpu.py::test_spatial_join_semi_anti_gpu[ST_Contains(sjoin_polygon.geometry, sjoin_point.geometry)-LEFT SEMI JOIN] PASSED
tests/test_sjoin_gpu.py::test_spatial_join_semi_anti_gpu[ST_Contains(sjoin_polygon.geometry, sjoin_point.geometry)-LEFT ANTI JOIN] PASSED
tests/test_sjoin_gpu.py::test_spatial_join_semi_anti_gpu[ST_Contains(sjoin_polygon.geometry, sjoin_point.geometry)-RIGHT SEMI JOIN] PASSED
tests/test_sjoin_gpu.py::test_spatial_join_semi_anti_gpu[ST_Contains(sjoin_polygon.geometry, sjoin_point.geometry)-RIGHT ANTI JOIN] PASSED
tests/test_sjoin_gpu.py::test_spatial_mark_join_via_correlated_exists_gpu[ST_Intersects(sjoin_point.geometry, sjoin_polygon.geometry)-point] PASSED
tests/test_sjoin_gpu.py::test_spatial_mark_join_via_correlated_exists_gpu[ST_Intersects(sjoin_point.geometry, sjoin_polygon.geometry)-polygon] PASSED
tests/test_sjoin_gpu.py::test_spatial_mark_join_via_correlated_exists_gpu[ST_Within(sjoin_point.geometry, sjoin_polygon.geometry)-point] PASSED
tests/test_sjoin_gpu.py::test_spatial_mark_join_via_correlated_exists_gpu[ST_Within(sjoin_point.geometry, sjoin_polygon.geometry)-polygon] PASSED
tests/test_sjoin_gpu.py::test_query_window_in_subquery_gpu PASSED
tests/test_sjoin_gpu.py::test_spatial_join_with_pandas_metadata_gpu PASSED
```