### PR TITLE
fix(ci): Fix libgpuspatial version spec for wheels workflow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,10 +154,10 @@ sedona-testing = { version = "0.4.0", path = "rust/sedona-testing" }
 
 # C wrapper crates
 sedona-extension = { version = "0.4.0", path = "c/sedona-extension" }
+sedona-gdal = { version = "0.4.0", path = "c/sedona-gdal", default-features = false }
 sedona-geoarrow-c = { version = "0.4.0", path = "c/sedona-geoarrow-c" }
 sedona-geos = { version = "0.4.0", path = "c/sedona-geos" }
-sedona-gdal = { version = "0.4.0", path = "c/sedona-gdal", default-features = false }
+sedona-libgpuspatial = { version = "0.4.0", path = "c/sedona-libgpuspatial" }
 sedona-proj = { version = "0.4.0", path = "c/sedona-proj", default-features = false }
 sedona-s2geography = { version = "0.4.0", path = "c/sedona-s2geography" }
 sedona-tg = { version = "0.4.0", path = "c/sedona-tg" }
-sedona-libgpuspatial  = { version = "0.4.0", path = "c/sedona-libgpuspatial" }

--- a/ci/scripts/set_dev_version.py
+++ b/ci/scripts/set_dev_version.py
@@ -89,7 +89,7 @@ def main():
     # Update workspace dependencies versions to match the prerelease version
     # Matches both 'sedona' and 'sedona-*' packages (including digits like sedona-s2geography)
     file_regex_replace(
-        r'(sedona(?:-[a-z0-9\-]+)?) = \{ version = "([0-9]+\.[0-9]+\.[0-9]+)", path',
+        r'(sedona(?:-[a-z0-9\-]+)?)\s*=\s*\{\s*version\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)", path',
         f'\\1 = {{ version = "\\2-alpha{dev_distance}", path',
         src_path("Cargo.toml"),
     )


### PR DESCRIPTION
The wheels workflow was failing:

```
  cargo 1.95.0 (f2d3ce0bd 2026-03-21)
  Running `maturin pep517 build-wheel -i /tmp/build-env-1p9hnzh9/bin/python --compatibility off --features s2geography,pyo3/extension-module`
      Updating crates.io index
  error: failed to select a version for the requirement `sedona-libgpuspatial = "^0.4.0"`
  candidate versions found which didn't match: 0.4.0-alpha52
  location searched: /project/c/sedona-libgpuspatial
  required by package `sedona-spatial-join-gpu v0.4.0-alpha52 (/project/rust/sedona-spatial-join-gpu)`
  if you are looking for the prerelease package it needs to be specified explicitly
      sedona-libgpuspatial = { version = "0.4.0-alpha52" }
  💥 maturin failed
    Caused by: Cargo metadata failed. Does your crate compile with `cargo build`?
    Caused by: `cargo metadata` exited with an error: 
  Error: command ['maturin', 'pep517', 'build-wheel', '-i', '/tmp/build-env-1p9hnzh9/bin/python', '--compatibility', 'off', '--features', 's2geography,pyo3/extension-module'] returned non-zero exit status 1

```

This was becase set_dev_version.py has a very specifically defined regex that expected a single space where there were two. I've made it back into a single space but also tried to make the regex a little more lenient.

Briefly, we do this so that we can set a dev version so that when we upload the dev build wheels it looks like a new version.