### PR TITLE
 chore(ci): Provide valid location for bigquery cache for wheel tests

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -91,6 +91,7 @@ jobs:
           CIBW_BUILD: "*-win_amd64"
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas
           CIBW_TEST_COMMAND: pytest {package}/tests -vv
+          CIBW_ENVIRONMENT: SEDONADB_BIGQUERY_TEST_CACHE_PATH={project}/python/sedonadb/tests/geography/bigquery_cache.yml
 
       - uses: actions/upload-artifact@v7
         with:
@@ -144,6 +145,7 @@ jobs:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas duckdb
           CIBW_TEST_COMMAND: pytest {package}/tests -vv
+          CIBW_ENVIRONMENT: SEDONADB_BIGQUERY_TEST_CACHE_PATH={project}/python/sedonadb/tests/geography/bigquery_cache.yml
 
       - uses: actions/upload-artifact@v7
         with:
@@ -197,6 +199,7 @@ jobs:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas duckdb
           CIBW_TEST_COMMAND: pytest {package}/tests -vv
+          CIBW_ENVIRONMENT: SEDONADB_BIGQUERY_TEST_CACHE_PATH={project}/python/sedonadb/tests/geography/bigquery_cache.yml
           SEDONADB_MACOS_ARCH: x86_64
 
       - uses: actions/upload-artifact@v7
@@ -245,6 +248,7 @@ jobs:
           CIBW_SKIP: "*musllinux*"
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas duckdb
           CIBW_TEST_COMMAND: pytest {package}/tests -vv
+          CIBW_ENVIRONMENT: SEDONADB_BIGQUERY_TEST_CACHE_PATH={project}/python/sedonadb/tests/geography/bigquery_cache.yml
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -91,7 +91,6 @@ jobs:
           CIBW_BUILD: "*-win_amd64"
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas
           CIBW_TEST_COMMAND: pytest {package}/tests -vv
-          CIBW_ENVIRONMENT: SEDONADB_BIGQUERY_TEST_CACHE_PATH={project}/python/sedonadb/tests/geography/bigquery_cache.yml
 
       - uses: actions/upload-artifact@v7
         with:
@@ -145,7 +144,6 @@ jobs:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas duckdb
           CIBW_TEST_COMMAND: pytest {package}/tests -vv
-          CIBW_ENVIRONMENT: SEDONADB_BIGQUERY_TEST_CACHE_PATH={project}/python/sedonadb/tests/geography/bigquery_cache.yml
 
       - uses: actions/upload-artifact@v7
         with:
@@ -199,7 +197,6 @@ jobs:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas duckdb
           CIBW_TEST_COMMAND: pytest {package}/tests -vv
-          CIBW_ENVIRONMENT: SEDONADB_BIGQUERY_TEST_CACHE_PATH={project}/python/sedonadb/tests/geography/bigquery_cache.yml
           SEDONADB_MACOS_ARCH: x86_64
 
       - uses: actions/upload-artifact@v7
@@ -248,7 +245,6 @@ jobs:
           CIBW_SKIP: "*musllinux*"
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas duckdb
           CIBW_TEST_COMMAND: pytest {package}/tests -vv
-          CIBW_ENVIRONMENT: SEDONADB_BIGQUERY_TEST_CACHE_PATH={project}/python/sedonadb/tests/geography/bigquery_cache.yml
 
       - uses: actions/upload-artifact@v7
         with:

--- a/python/sedonadb/python/sedonadb/testing.py
+++ b/python/sedonadb/python/sedonadb/testing.py
@@ -674,13 +674,19 @@ class BigQuery(DBEngine):
 
     Unless modifying these tests, the cached results should allow these tests
     to run without an active connection (and should allow tests to run locally
-    much faster as opening a connection to BigQuery is slow).
+    much faster as opening a connection to BigQuery is slow). The cache location
+    can be manually set using the SEDONADB_BIGQUERY_TEST_CACHE_PATH environment
+    variable.
     """
 
     _CACHE_DIR = Path(__file__).resolve().parent.parent.parent / "tests" / "geography"
     _shared_cache: "ArrowSQLCache | None" = None
 
     def __init__(self, cache_path: "Path | None" = None):
+        if cache_path is None:
+            env_cache = os.environ.get("SEDONADB_BIGQUERY_TEST_CACHE_PATH")
+            if env_cache:
+                cache_path = Path(env_cache)
         self._cache_path = cache_path or self._CACHE_DIR / "bigquery_cache.yml"
         if cache_path is not None or BigQuery._shared_cache is None:
             BigQuery._shared_cache = ArrowSQLCache("bigquery", self._cache_path)

--- a/python/sedonadb/python/sedonadb/testing.py
+++ b/python/sedonadb/python/sedonadb/testing.py
@@ -674,20 +674,27 @@ class BigQuery(DBEngine):
 
     Unless modifying these tests, the cached results should allow these tests
     to run without an active connection (and should allow tests to run locally
-    much faster as opening a connection to BigQuery is slow). The cache location
-    can be manually set using the SEDONADB_BIGQUERY_TEST_CACHE_PATH environment
-    variable.
+    much faster as opening a connection to BigQuery is slow).
     """
 
-    _CACHE_DIR = Path(__file__).resolve().parent.parent.parent / "tests" / "geography"
+    _CACHE_DIR: "Path | None" = None
     _shared_cache: "ArrowSQLCache | None" = None
 
+    @classmethod
+    def set_cache_dir(cls, cache_dir: "Path | str") -> None:
+        """Set the directory containing bigquery_cache.yml.
+
+        Call this before any BigQuery instances are created to configure
+        where the cache file is located. This is typically called from a
+        conftest.py in the test directory.
+        """
+        cls._CACHE_DIR = Path(cache_dir)
+        cls._shared_cache = None  # Reset so next instance uses new path
+
     def __init__(self, cache_path: "Path | None" = None):
-        if cache_path is None:
-            env_cache = os.environ.get("SEDONADB_BIGQUERY_TEST_CACHE_PATH")
-            if env_cache:
-                cache_path = Path(env_cache)
-        self._cache_path = cache_path or self._CACHE_DIR / "bigquery_cache.yml"
+        if cache_path is None and BigQuery._CACHE_DIR is not None:
+            cache_path = BigQuery._CACHE_DIR / "bigquery_cache.yml"
+        self._cache_path = cache_path
         if cache_path is not None or BigQuery._shared_cache is None:
             BigQuery._shared_cache = ArrowSQLCache("bigquery", self._cache_path)
         self._file_cache = BigQuery._shared_cache

--- a/python/sedonadb/tests/geography/conftest.py
+++ b/python/sedonadb/tests/geography/conftest.py
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from pathlib import Path
+from sedonadb.testing import BigQuery
+
+# Set the BigQuery cache directory based on this file's location.
+# This ensures the cache is found when tests run from an installed wheel
+# (where the testing.py module's relative path calculation would fail).
+BigQuery.set_cache_dir(Path(__file__).resolve().parent)


### PR DESCRIPTION
After #756 we have tests that include cached BigQuery results. These work with a normal `pytest` invocation but in CI these don't work because of how the tests and testing module are run with cibuildwheel.

This PR uses a conftest.py to set the location, which works locally and in the wheel build