### PR TITLE
docs: add new GPU acceleration guide for spatial joins

### DIFF
--- a/docs/gpu-acceleration.ipynb
+++ b/docs/gpu-acceleration.ipynb
@@ -1,0 +1,569 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# GPU Acceleration for Spatial Join\n",
+    "\n",
+    "SedonaDB supports GPU-accelerated spatial joins with NVIDIA GPUs. The\n",
+    "key innovation is using NVIDIA RT cores for spatial query acceleration, which significantly reduces\n",
+    "candidate search cost and predicate evaluation.\n",
+    "\n",
+    "> **Prerequisites:** GPU acceleration requires a SedonaDB build with GPU support, NVIDIA CUDA 12+\n",
+    "> on a GPU with compute capability 7.5 or higher.\n",
+    "> The feature works with or without dedicated RT cores. When RT cores are not available, NVIDA OptiX\n",
+    "> emulates ray tracing on CUDA cores."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Why This Matters\n",
+    "\n",
+    "Spatial joins are often bottlenecked by candidate generation and exact refinement. SedonaDB's GPU\n",
+    "path targets both phases:\n",
+    "\n",
+    "- RT-core acceleration for high-throughput spatial filtering.\n",
+    "- A geometry-aware refinement pipeline, including a heavily optimized point-in-polygon (PIP) path."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Filtering and Refining Stages\n",
+    "\n",
+    "The GPU-based join follows SedonaDB's two-stage execution model:\n",
+    "\n",
+    "1. **Filtering stage**\n",
+    "   - Runs on NVIDIA RT cores [1].\n",
+    "   - Quickly generates candidate geometry pairs that intersect.\n",
+    "\n",
+    "2. **Refining stage**\n",
+    "   - Runs exact predicate checks on candidates.\n",
+    "   - For point-polygon geometry pairs, refinement is heavily optimized and accelerated with RT-core-backed\n",
+    "     ray-tracing techniques [2].\n",
+    "   - For other spatial join patterns, refinement runs on CUDA-core kernels. We will gradually expand the RT acceleration coverage in future releases."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Supported Predicates and Fallback Behavior\n",
+    "\n",
+    "GPU spatial join currently supports relation predicates:\n",
+    "\n",
+    "- `ST_Intersects`\n",
+    "- `ST_Contains`\n",
+    "- `ST_Within`\n",
+    "- `ST_Covers`\n",
+    "- `ST_CoveredBy`\n",
+    "- `ST_Touches`\n",
+    "- `ST_Equals`\n",
+    "\n",
+    "Not currently supported on the GPU path:\n",
+    "\n",
+    "- Distance predicates (for example, `ST_DWithin`)\n",
+    "- KNN / KNN join predicates\n",
+    "- GeometryCollection\n",
+    "\n",
+    "When `gpu.fallback_to_cpu = true` (default), unsupported predicates fall back to CPU spatial join.\n",
+    "When `gpu.fallback_to_cpu = false`, unsupported predicates fail the query."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Install from Source with the GPU Feature\n",
+    "\n",
+    "If you build the Python package from source, enable GPU at build time and configure the CUDA\n",
+    "environment before running `MATURIN_PEP517_ARGS=\"--features gpu\" pip install`.\n",
+    "\n",
+    "Common environment variables used by the GPU build:\n",
+    "\n",
+    "- `CUDA_HOME`: points to your CUDA toolkit root.\n",
+    "- `CMAKE_CUDA_ARCHITECTURES`: CUDA SM targets (default falls back to `86;89` if not set). Change this according to your GPU architecture.\n",
+    "\n",
+    "- `LIBGPUSPATIAL_LOGGING_LEVEL`: Logging level, including `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `CRITICAL`.\n",
+    "- `GPUSPATIAL_PROFILING=ON`: Profiling mode (`ON`, `OFF`) to compile profiling instrumentation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Enable GPU Join with SQL `SET`\n",
+    "\n",
+    "The GPU join is disabled by default even if you enabled the GPU feature at build time. To enable GPU acceleration for spatial joins, set the `gpu.enable` option to `true`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sedonadb\n",
+    "\n",
+    "ctx = sedonadb.connect()\n",
+    "\n",
+    "ctx.sql(\"SET gpu.enable = true\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Performance Tuning and Special Cautions\n",
+    "\n",
+    "To keep the GPU efficiently utilized, use larger execution batches:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ctx.sql(\"SET datafusion.execution.batch_size = 100000\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Important guidance:\n",
+    "\n",
+    "- A large batch size (for example, `100000`) is often necessary for good GPU throughput.\n",
+    "- For highest GPU performance, spilling should be disabled (for example, set `sd.options.memory_limit = \"unlimited\"` before running queries).\n",
+    "- Small joins may not amortize GPU overhead and can be slower than CPU execution.\n",
+    "- Start with defaults for other `gpu.*` options, then tune based on measured workload behavior."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## GPU Options\n",
+    "\n",
+    "The following session options are available under the `gpu.` prefix:\n",
+    "\n",
+    "- `gpu.enable` (bool, default `false`): enable GPU spatial join.\n",
+    "- `gpu.concat_build` (bool, default `true`): concatenate geometry buffers before GPU processing.\n",
+    "- `gpu.device_id` (int, default `0`): CUDA device ID.\n",
+    "- `gpu.fallback_to_cpu` (bool, default `true`): use CPU path when GPU path is unavailable/unsupported.\n",
+    "- `gpu.use_memory_pool` (bool, default `true`): use CUDA memory pool.\n",
+    "- `gpu.memory_pool_init_percentage` (int, default `50`): initial CUDA memory pool size as a percentage of total GPU memory.\n",
+    "- `gpu.pipeline_batches` (int, default `1`): overlap parsing and refinement across batches.\n",
+    "- `gpu.compress_bvh` (bool, default `false`): compress BVH to reduce memory usage (can reduce performance).\n",
+    "\n",
+    "Example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sedonadb\n",
+    "\n",
+    "ctx = sedonadb.connect()\n",
+    "\n",
+    "ctx.sql(\"SET gpu.enable = true\")\n",
+    "ctx.sql(\"SET gpu.device_id = 0\")\n",
+    "ctx.sql(\"SET gpu.use_memory_pool = true\")\n",
+    "ctx.sql(\"SET gpu.memory_pool_init_percentage = 60\")\n",
+    "ctx.sql(\"SET gpu.pipeline_batches = 2\")\n",
+    "ctx.sql(\"SET gpu.compress_bvh = false\")\n",
+    "ctx.sql(\"SET datafusion.execution.batch_size = 100000\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mon Apr 20 19:26:08 2026       \n",
+      "+-----------------------------------------------------------------------------------------+\n",
+      "| NVIDIA-SMI 580.105.08             Driver Version: 580.105.08     CUDA Version: 13.0     |\n",
+      "+-----------------------------------------+------------------------+----------------------+\n",
+      "| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |\n",
+      "| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |\n",
+      "|                                         |                        |               MIG M. |\n",
+      "|=========================================+========================+======================|\n",
+      "|   0  NVIDIA L4                      On  |   00000000:31:00.0 Off |                    0 |\n",
+      "| N/A   36C    P8             19W /   72W |       0MiB /  23034MiB |      0%      Default |\n",
+      "|                                         |                        |                  N/A |\n",
+      "+-----------------------------------------+------------------------+----------------------+\n",
+      "\n",
+      "+-----------------------------------------------------------------------------------------+\n",
+      "| Processes:                                                                              |\n",
+      "|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |\n",
+      "|        ID   ID                                                               Usage      |\n",
+      "|=========================================================================================|\n",
+      "|  No running processes found                                                             |\n",
+      "+-----------------------------------------------------------------------------------------+\n"
+     ]
+    }
+   ],
+   "source": [
+    "!nvidia-smi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f61963ba7f544dd1893c8e2b06a4e36b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading (incomplete total...): 0.00B [00:00, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ae7cc720cd314a738216d16440984434",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Fetching 8 files:   0%|          | 0/8 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'/mnt/data/sedona-db/docs/hf-data'"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from huggingface_hub import snapshot_download\n",
+    "\n",
+    "snapshot_download(\n",
+    "    repo_id=\"apache-sedona/spatialbench\",\n",
+    "    repo_type=\"dataset\",\n",
+    "    local_dir=\"hf-data\",\n",
+    "    allow_patterns=[\"v0.1.0/sf1/zone/*\", \"v0.1.0/sf1/trip/*\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sedonadb\n",
+    "\n",
+    "ctx = sedonadb.connect()\n",
+    "ctx.options.memory_limit = \"unlimited\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<sedonadb.dataframe.DataFrame object at 0x7ff5213d96d0>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ctx.sql(\"\"\"\n",
+    "    CREATE EXTERNAL TABLE zone\n",
+    "    STORED AS PARQUET\n",
+    "    LOCATION 'hf-data/v0.1.0/sf1/zone/'\n",
+    "\"\"\")\n",
+    "ctx.sql(\"\"\"\n",
+    "    CREATE EXTERNAL TABLE trip\n",
+    "    STORED AS PARQUET\n",
+    "    LOCATION 'hf-data/v0.1.0/sf1/trip/'\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<h3>🚀 Running Spatial Benchmark...</h3>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9bb04f6f098d45c690ee3267196ac846",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output(layout=Layout(border_bottom='1px solid #ccc', border_left='1px solid #ccc', border_right='1px solid #cc…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c8acccbeb09147cbb8f56db7423778d8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "CPU Executions:   0%|          | 0/6 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fa04532f673945598267fee06055a1d9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "GPU Executions:   0%|          | 0/6 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h3>📊 Benchmark Results (Averaged over 5 runs)</h3>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    <table style=\"width: 60%; text-align: center; border-collapse: collapse; font-family: sans-serif; margin-top: 15px;\">\n",
+       "        <tr style=\"background-color: #f8f9fa; border-bottom: 2px solid #dee2e6;\">\n",
+       "            <th style=\"padding: 12px; border: 1px solid #dee2e6;\">Mode</th>\n",
+       "            <th style=\"padding: 12px; border: 1px solid #dee2e6;\">Average Time (s)</th>\n",
+       "            <th style=\"padding: 12px; border: 1px solid #dee2e6;\">Speedup</th>\n",
+       "        </tr>\n",
+       "        <tr>\n",
+       "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\"><b>CPU</b> (Baseline)</td>\n",
+       "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\">21.5221</td>\n",
+       "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\">1.00x</td>\n",
+       "        </tr>\n",
+       "        <tr>\n",
+       "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\"><b>GPU</b></td>\n",
+       "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\">2.8889</td>\n",
+       "            <td style=\"padding: 12px; border: 1px solid #dee2e6; color: green; font-weight: bold;\">7.45x</td>\n",
+       "        </tr>\n",
+       "    </table>\n",
+       "    "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import time\n",
+    "from tqdm.notebook import tqdm\n",
+    "from IPython.display import display, HTML\n",
+    "import ipywidgets as widgets\n",
+    "\n",
+    "\n",
+    "def interactive_spatial_benchmark(ctx, runs=6):\n",
+    "    query = \"\"\"\n",
+    "    SELECT COUNT(*) AS cross_zone_trip_count\n",
+    "    FROM trip t\n",
+    "        JOIN zone pickup_zone\n",
+    "            ON ST_Within(ST_GeomFromWKB(t.t_pickuploc), ST_GeomFromWKB(pickup_zone.z_boundary))\n",
+    "        JOIN zone dropoff_zone\n",
+    "            ON ST_Within(ST_GeomFromWKB(t.t_dropoffloc), ST_GeomFromWKB(dropoff_zone.z_boundary))\n",
+    "    WHERE pickup_zone.z_zonekey != dropoff_zone.z_zonekey\n",
+    "    \"\"\"\n",
+    "\n",
+    "    modes = [(\"CPU\", \"false\"), (\"GPU\", \"true\")]\n",
+    "    averages = {}\n",
+    "\n",
+    "    # 1. Create a scrollable widget to catch the verbose `.show()` output\n",
+    "    log_output = widgets.Output(\n",
+    "        layout={\"border\": \"1px solid #ccc\", \"height\": \"150px\", \"overflow_y\": \"auto\"}\n",
+    "    )\n",
+    "    display(HTML(\"<h3>🚀 Running Spatial Benchmark...</h3>\"))\n",
+    "    display(log_output)\n",
+    "\n",
+    "    # 2. Execute the Benchmark\n",
+    "    for mode_name, gpu_flag in modes:\n",
+    "        ctx.sql(f\"SET gpu.enable = {gpu_flag}\")\n",
+    "        if gpu_flag:\n",
+    "            ctx.sql(\n",
+    "                \"SET datafusion.execution.batch_size = 2000000\"\n",
+    "            )  # Increase batch size\n",
+    "        else:\n",
+    "            ctx.sql(\"SET datafusion.execution.batch_size = 8192\")  # Default\n",
+    "        execution_times = []\n",
+    "\n",
+    "        # Display a Jupyter-native progress bar\n",
+    "        for i in tqdm(range(runs), desc=f\"{mode_name} Executions\"):\n",
+    "            start_time = time.time()\n",
+    "\n",
+    "            result = ctx.sql(query)\n",
+    "\n",
+    "            # Execute physical plan and catch the output inside our widget\n",
+    "            with log_output:\n",
+    "                print(f\"--- {mode_name} Run {i + 1} ---\")\n",
+    "                result.show()\n",
+    "\n",
+    "            elapsed = time.time() - start_time\n",
+    "\n",
+    "            # Record everything except the first run (warmup)\n",
+    "            if i > 0:\n",
+    "                execution_times.append(elapsed)\n",
+    "\n",
+    "        # Calculate average\n",
+    "        averages[mode_name] = sum(execution_times) / len(execution_times)\n",
+    "\n",
+    "    # 3. Clean up the UI\n",
+    "    log_output.clear_output()\n",
+    "    log_output.layout.display = \"none\"\n",
+    "\n",
+    "    # 4. Generate Table Results\n",
+    "    cpu_avg = averages[\"CPU\"]\n",
+    "    gpu_avg = averages[\"GPU\"]\n",
+    "\n",
+    "    # Calculate speedup (using CPU as the 1.0x baseline)\n",
+    "    cpu_speedup = 1.0\n",
+    "    gpu_speedup = cpu_avg / gpu_avg if gpu_avg > 0 else 0\n",
+    "\n",
+    "    # Color code the GPU speedup (green if faster, red if slower)\n",
+    "    gpu_color = \"green\" if gpu_speedup >= 1.0 else \"red\"\n",
+    "\n",
+    "    html_table = f\"\"\"\n",
+    "    <table style=\"width: 60%; text-align: center; border-collapse: collapse; font-family: sans-serif; margin-top: 15px;\">\n",
+    "        <tr style=\"background-color: #f8f9fa; border-bottom: 2px solid #dee2e6;\">\n",
+    "            <th style=\"padding: 12px; border: 1px solid #dee2e6;\">Mode</th>\n",
+    "            <th style=\"padding: 12px; border: 1px solid #dee2e6;\">Average Time (s)</th>\n",
+    "            <th style=\"padding: 12px; border: 1px solid #dee2e6;\">Speedup</th>\n",
+    "        </tr>\n",
+    "        <tr>\n",
+    "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\"><b>CPU</b> (Baseline)</td>\n",
+    "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\">{cpu_avg:.4f}</td>\n",
+    "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\">{cpu_speedup:.2f}x</td>\n",
+    "        </tr>\n",
+    "        <tr>\n",
+    "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\"><b>GPU</b></td>\n",
+    "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\">{gpu_avg:.4f}</td>\n",
+    "            <td style=\"padding: 12px; border: 1px solid #dee2e6; color: {gpu_color}; font-weight: bold;\">{gpu_speedup:.2f}x</td>\n",
+    "        </tr>\n",
+    "    </table>\n",
+    "    \"\"\"\n",
+    "\n",
+    "    display(HTML(\"<h3>📊 Benchmark Results (Averaged over 5 runs)</h3>\"))\n",
+    "    display(HTML(html_table))\n",
+    "\n",
+    "\n",
+    "# --- Execution Block ---\n",
+    "# Run the interactive function with your Sedona Context\n",
+    "interactive_spatial_benchmark(ctx)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "1. Geng, Liang, Rubao Lee, and Xiaodong Zhang. \"Librts: A spatial indexing library by ray tracing.\" Proceedings of the 30th ACM SIGPLAN Annual Symposium on Principles and Practice of Parallel Programming. 2025.\n",
+    "2. Geng, Liang, Rubao Lee, and Xiaodong Zhang. \"Rayjoin: Fast and precise spatial join.\" Proceedings of the 38th ACM International Conference on Supercomputing. 2024."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/gpu-acceleration.md
+++ b/docs/gpu-acceleration.md
@@ -1,3 +1,22 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
 # GPU Acceleration for Spatial Join
 
 SedonaDB supports GPU-accelerated spatial joins with NVIDIA GPUs. The

--- a/docs/gpu-acceleration.md
+++ b/docs/gpu-acceleration.md
@@ -1,0 +1,145 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# GPU Acceleration for Spatial Join
+
+SedonaDB supports GPU-accelerated spatial joins with NVIDIA GPUs. The
+key innovation is using NVIDIA RT cores for spatial query acceleration, which significantly reduces
+candidate search cost and predicate evaluation.
+
+> **Prerequisites:** GPU acceleration requires a SedonaDB build with GPU support, NVIDIA CUDA 12+
+> on a GPU with compute capability 7.5 or higher.
+> The feature works with or without dedicated RT cores. When RT cores are not available, NVIDA OptiX
+> emulates ray tracing on CUDA cores.
+
+## Why This Matters
+
+Spatial joins are often bottlenecked by candidate generation and exact refinement. SedonaDB's GPU
+path targets both phases:
+
+- RT-core acceleration for high-throughput spatial filtering.
+- A geometry-aware refinement pipeline, including a heavily optimized point-in-polygon (PIP) path.
+
+## Filtering and Refining Stages
+
+The GPU-based join follows SedonaDB's two-stage execution model:
+
+1. **Filtering stage**
+   - Runs on NVIDIA RT cores [1].
+   - Quickly generates candidate geometry pairs that intersect.
+
+2. **Refining stage**
+   - Runs exact predicate checks on candidates.
+   - For point-polygon geometry pairs, refinement is heavily optimized and accelerated with RT-core-backed
+     ray-tracing techniques [2].
+   - For other spatial join patterns, refinement runs on CUDA-core kernels. We will gradually expand the RT acceleration coverage in future releases.
+
+## Supported Predicates and Fallback Behavior
+
+GPU spatial join currently supports relation predicates:
+
+- `ST_Intersects`
+- `ST_Contains`
+- `ST_Within`
+- `ST_Covers`
+- `ST_CoveredBy`
+- `ST_Touches`
+- `ST_Equals`
+
+Not currently supported on the GPU path:
+
+- Distance predicates (for example, `ST_DWithin`)
+- KNN / KNN join predicates
+- GeometryCollection
+
+When `gpu.fallback_to_cpu = true` (default), unsupported predicates fall back to CPU spatial join.
+When `gpu.fallback_to_cpu = false`, unsupported predicates fail the query.
+
+## Install from Source with the GPU Feature
+
+If you build the Python package from source, enable GPU at build time and configure the CUDA
+environment before running `MATURIN_PEP517_ARGS="--features gpu" pip install`.
+
+Common environment variables used by the GPU build:
+
+- `CUDA_HOME`: points to your CUDA toolkit root.
+- `CMAKE_CUDA_ARCHITECTURES`: CUDA SM targets (default falls back to `86;89` if not set). Change this according to your GPU architecture.
+
+- `LIBGPUSPATIAL_LOGGING_LEVEL`: Logging level, including `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `CRITICAL`.
+- `GPUSPATIAL_PROFILING=ON`: Profiling mode (`ON`, `OFF`) to compile profiling instrumentation.
+
+
+
+## Enable GPU Join with SQL `SET`
+The GPU join is disabled by default even if you enabled the GPU feature at build time. To enable GPU acceleration for spatial joins, set the `gpu.enable` option to `true`:
+```python
+import sedona.db
+
+sd = sedona.db.connect()
+
+sd.sql("SET gpu.enable = true").execute()
+```
+
+## Performance Tuning and Special Cautions
+
+To keep the GPU efficiently utilized, use larger execution batches:
+
+```python
+sd.sql("SET datafusion.execution.batch_size = 100000").execute()
+```
+
+Important guidance:
+
+- A large batch size (for example, `100000`) is often necessary for good GPU throughput.
+- For highest GPU performance, spilling should be disabled (for example, set `sd.options.memory_limit = "unlimited"` before running queries).
+- Small joins may not amortize GPU overhead and can be slower than CPU execution.
+- Start with defaults for other `gpu.*` options, then tune based on measured workload behavior.
+
+## GPU Options
+
+The following session options are available under the `gpu.` prefix:
+
+- `gpu.enable` (bool, default `false`): enable GPU spatial join.
+- `gpu.concat_build` (bool, default `true`): concatenate geometry buffers before GPU processing.
+- `gpu.device_id` (int, default `0`): CUDA device ID.
+- `gpu.fallback_to_cpu` (bool, default `true`): use CPU path when GPU path is unavailable/unsupported.
+- `gpu.use_memory_pool` (bool, default `true`): use CUDA memory pool.
+- `gpu.memory_pool_init_percentage` (int, default `50`): initial CUDA memory pool size as a percentage of total GPU memory.
+- `gpu.pipeline_batches` (int, default `1`): overlap parsing and refinement across batches.
+- `gpu.compress_bvh` (bool, default `false`): compress BVH to reduce memory usage (can reduce performance).
+
+Example:
+
+```python
+import sedona.db
+
+sd = sedona.db.connect()
+
+sd.sql("SET gpu.enable = true").execute()
+sd.sql("SET gpu.device_id = 0").execute()
+sd.sql("SET gpu.use_memory_pool = true").execute()
+sd.sql("SET gpu.memory_pool_init_percentage = 60").execute()
+sd.sql("SET gpu.pipeline_batches = 2").execute()
+sd.sql("SET gpu.compress_bvh = false").execute()
+sd.sql("SET datafusion.execution.batch_size = 100000").execute()
+```
+
+## References
+1. Geng, Liang, Rubao Lee, and Xiaodong Zhang. "Librts: A spatial indexing library by ray tracing." Proceedings of the 30th ACM SIGPLAN Annual Symposium on Principles and Practice of Parallel Programming. 2025.
+2. Geng, Liang, Rubao Lee, and Xiaodong Zhang. "Rayjoin: Fast and precise spatial join." Proceedings of the 38th ACM International Conference on Supercomputing. 2024.

--- a/docs/gpu-acceleration.md
+++ b/docs/gpu-acceleration.md
@@ -1,22 +1,3 @@
-<!---
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
--->
-
 # GPU Acceleration for Spatial Join
 
 SedonaDB supports GPU-accelerated spatial joins with NVIDIA GPUs. The
@@ -84,24 +65,26 @@ Common environment variables used by the GPU build:
 - `LIBGPUSPATIAL_LOGGING_LEVEL`: Logging level, including `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `CRITICAL`.
 - `GPUSPATIAL_PROFILING=ON`: Profiling mode (`ON`, `OFF`) to compile profiling instrumentation.
 
-
-
 ## Enable GPU Join with SQL `SET`
+
 The GPU join is disabled by default even if you enabled the GPU feature at build time. To enable GPU acceleration for spatial joins, set the `gpu.enable` option to `true`:
+
+
 ```python
-import sedona.db
+import sedonadb
 
-sd = sedona.db.connect()
+ctx = sedonadb.connect()
 
-sd.sql("SET gpu.enable = true").execute()
+ctx.sql("SET gpu.enable = true")
 ```
 
 ## Performance Tuning and Special Cautions
 
 To keep the GPU efficiently utilized, use larger execution batches:
 
+
 ```python
-sd.sql("SET datafusion.execution.batch_size = 100000").execute()
+ctx.sql("SET datafusion.execution.batch_size = 100000")
 ```
 
 Important guidance:
@@ -126,20 +109,253 @@ The following session options are available under the `gpu.` prefix:
 
 Example:
 
+
 ```python
-import sedona.db
+import sedonadb
 
-sd = sedona.db.connect()
+ctx = sedonadb.connect()
 
-sd.sql("SET gpu.enable = true").execute()
-sd.sql("SET gpu.device_id = 0").execute()
-sd.sql("SET gpu.use_memory_pool = true").execute()
-sd.sql("SET gpu.memory_pool_init_percentage = 60").execute()
-sd.sql("SET gpu.pipeline_batches = 2").execute()
-sd.sql("SET gpu.compress_bvh = false").execute()
-sd.sql("SET datafusion.execution.batch_size = 100000").execute()
+ctx.sql("SET gpu.enable = true")
+ctx.sql("SET gpu.device_id = 0")
+ctx.sql("SET gpu.use_memory_pool = true")
+ctx.sql("SET gpu.memory_pool_init_percentage = 60")
+ctx.sql("SET gpu.pipeline_batches = 2")
+ctx.sql("SET gpu.compress_bvh = false")
+ctx.sql("SET datafusion.execution.batch_size = 100000")
 ```
 
+## Example
+
+
+```python
+!nvidia-smi
+```
+
+    Mon Apr 20 19:26:08 2026
+    +-----------------------------------------------------------------------------------------+
+    | NVIDIA-SMI 580.105.08             Driver Version: 580.105.08     CUDA Version: 13.0     |
+    +-----------------------------------------+------------------------+----------------------+
+    | GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+    | Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+    |                                         |                        |               MIG M. |
+    |=========================================+========================+======================|
+    |   0  NVIDIA L4                      On  |   00000000:31:00.0 Off |                    0 |
+    | N/A   36C    P8             19W /   72W |       0MiB /  23034MiB |      0%      Default |
+    |                                         |                        |                  N/A |
+    +-----------------------------------------+------------------------+----------------------+
+
+    +-----------------------------------------------------------------------------------------+
+    | Processes:                                                                              |
+    |  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+    |        ID   ID                                                               Usage      |
+    |=========================================================================================|
+    |  No running processes found                                                             |
+    +-----------------------------------------------------------------------------------------+
+
+
+
+```python
+from huggingface_hub import snapshot_download
+import os
+
+snapshot_download(
+  repo_id='apache-sedona/spatialbench',
+  repo_type='dataset',
+  local_dir='hf-data',
+  allow_patterns=[
+    "v0.1.0/sf1/zone/*",
+    "v0.1.0/sf1/trip/*"],
+)
+```
+
+
+    Downloading (incomplete total...): 0.00B [00:00, ?B/s]
+
+
+
+    Fetching 8 files:   0%|          | 0/8 [00:00<?, ?it/s]
+
+
+    Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
+
+
+
+
+
+    '/mnt/data/sedona-db/docs/hf-data'
+
+
+
+
+```python
+import sedonadb
+
+ctx = sedonadb.connect()
+ctx.options.memory_limit = "unlimited"
+```
+
+
+```python
+ctx.sql(f"""
+    CREATE EXTERNAL TABLE zone
+    STORED AS PARQUET
+    LOCATION 'hf-data/v0.1.0/sf1/zone/'
+""")
+ctx.sql(f"""
+    CREATE EXTERNAL TABLE trip
+    STORED AS PARQUET
+    LOCATION 'hf-data/v0.1.0/sf1/trip/'
+""")
+```
+
+
+
+
+    <sedonadb.dataframe.DataFrame object at 0x7ff5213d96d0>
+
+
+
+
+```python
+import time
+from tqdm.notebook import tqdm
+from IPython.display import display, HTML
+import ipywidgets as widgets
+
+def interactive_spatial_benchmark(ctx, runs=6):
+    query = """
+    SELECT COUNT(*) AS cross_zone_trip_count
+    FROM trip t
+        JOIN zone pickup_zone
+            ON ST_Within(ST_GeomFromWKB(t.t_pickuploc), ST_GeomFromWKB(pickup_zone.z_boundary))
+        JOIN zone dropoff_zone
+            ON ST_Within(ST_GeomFromWKB(t.t_dropoffloc), ST_GeomFromWKB(dropoff_zone.z_boundary))
+    WHERE pickup_zone.z_zonekey != dropoff_zone.z_zonekey
+    """
+
+    modes = [("CPU", "false"), ("GPU", "true")]
+    averages = {}
+
+    # 1. Create a scrollable widget to catch the verbose `.show()` output
+    log_output = widgets.Output(layout={'border': '1px solid #ccc', 'height': '150px', 'overflow_y': 'auto'})
+    display(HTML("<h3>🚀 Running Spatial Benchmark...</h3>"))
+    display(log_output)
+
+    # 2. Execute the Benchmark
+    for mode_name, gpu_flag in modes:
+        ctx.sql(f"SET gpu.enable = {gpu_flag}")
+        if gpu_flag:
+            ctx.sql("SET datafusion.execution.batch_size = 2000000") # Increase batch size
+        else:
+            ctx.sql("SET datafusion.execution.batch_size = 8192") # Default
+        execution_times = []
+
+        # Display a Jupyter-native progress bar
+        for i in tqdm(range(runs), desc=f"{mode_name} Executions"):
+            start_time = time.time()
+
+            result = ctx.sql(query)
+
+            # Execute physical plan and catch the output inside our widget
+            with log_output:
+                print(f"--- {mode_name} Run {i+1} ---")
+                result.show()
+
+            elapsed = time.time() - start_time
+
+            # Record everything except the first run (warmup)
+            if i > 0:
+                execution_times.append(elapsed)
+
+        # Calculate average
+        averages[mode_name] = sum(execution_times) / len(execution_times)
+
+    # 3. Clean up the UI
+    log_output.clear_output()
+    log_output.layout.display = 'none'
+
+    # 4. Generate Table Results
+    cpu_avg = averages["CPU"]
+    gpu_avg = averages["GPU"]
+
+    # Calculate speedup (using CPU as the 1.0x baseline)
+    cpu_speedup = 1.0
+    gpu_speedup = cpu_avg / gpu_avg if gpu_avg > 0 else 0
+
+    # Color code the GPU speedup (green if faster, red if slower)
+    gpu_color = "green" if gpu_speedup >= 1.0 else "red"
+
+    html_table = f"""
+    <table style="width: 60%; text-align: center; border-collapse: collapse; font-family: sans-serif; margin-top: 15px;">
+        <tr style="background-color: #f8f9fa; border-bottom: 2px solid #dee2e6;">
+            <th style="padding: 12px; border: 1px solid #dee2e6;">Mode</th>
+            <th style="padding: 12px; border: 1px solid #dee2e6;">Average Time (s)</th>
+            <th style="padding: 12px; border: 1px solid #dee2e6;">Speedup</th>
+        </tr>
+        <tr>
+            <td style="padding: 12px; border: 1px solid #dee2e6;"><b>CPU</b> (Baseline)</td>
+            <td style="padding: 12px; border: 1px solid #dee2e6;">{cpu_avg:.4f}</td>
+            <td style="padding: 12px; border: 1px solid #dee2e6;">{cpu_speedup:.2f}x</td>
+        </tr>
+        <tr>
+            <td style="padding: 12px; border: 1px solid #dee2e6;"><b>GPU</b></td>
+            <td style="padding: 12px; border: 1px solid #dee2e6;">{gpu_avg:.4f}</td>
+            <td style="padding: 12px; border: 1px solid #dee2e6; color: {gpu_color}; font-weight: bold;">{gpu_speedup:.2f}x</td>
+        </tr>
+    </table>
+    """
+
+    display(HTML("<h3>📊 Benchmark Results (Averaged over 5 runs)</h3>"))
+    display(HTML(html_table))
+
+# --- Execution Block ---
+# Run the interactive function with your Sedona Context
+interactive_spatial_benchmark(ctx)
+```
+
+
+<h3>🚀 Running Spatial Benchmark...</h3>
+
+
+
+    Output(layout=Layout(border_bottom='1px solid #ccc', border_left='1px solid #ccc', border_right='1px solid #cc…
+
+
+
+    CPU Executions:   0%|          | 0/6 [00:00<?, ?it/s]
+
+
+
+    GPU Executions:   0%|          | 0/6 [00:00<?, ?it/s]
+
+
+
+<h3>📊 Benchmark Results (Averaged over 5 runs)</h3>
+
+
+
+
+<table style="width: 60%; text-align: center; border-collapse: collapse; font-family: sans-serif; margin-top: 15px;">
+    <tr style="background-color: #f8f9fa; border-bottom: 2px solid #dee2e6;">
+        <th style="padding: 12px; border: 1px solid #dee2e6;">Mode</th>
+        <th style="padding: 12px; border: 1px solid #dee2e6;">Average Time (s)</th>
+        <th style="padding: 12px; border: 1px solid #dee2e6;">Speedup</th>
+    </tr>
+    <tr>
+        <td style="padding: 12px; border: 1px solid #dee2e6;"><b>CPU</b> (Baseline)</td>
+        <td style="padding: 12px; border: 1px solid #dee2e6;">21.5221</td>
+        <td style="padding: 12px; border: 1px solid #dee2e6;">1.00x</td>
+    </tr>
+    <tr>
+        <td style="padding: 12px; border: 1px solid #dee2e6;"><b>GPU</b></td>
+        <td style="padding: 12px; border: 1px solid #dee2e6;">2.8889</td>
+        <td style="padding: 12px; border: 1px solid #dee2e6; color: green; font-weight: bold;">7.45x</td>
+    </tr>
+</table>
+
+
+
 ## References
+
 1. Geng, Liang, Rubao Lee, and Xiaodong Zhang. "Librts: A spatial indexing library by ray tracing." Proceedings of the 30th ACM SIGPLAN Annual Symposium on Principles and Practice of Parallel Programming. 2025.
 2. Geng, Liang, Rubao Lee, and Xiaodong Zhang. "Rayjoin: Fast and precise spatial join." Proceedings of the 38th ACM International Conference on Supercomputing. 2024.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
       - Programming Guide: programming-guide.md
       - Configurations:
         - Memory Management and Spilling: memory-management.md
+        - GPU acceleration: gpu-acceleration.md
       - API:
         - Python: reference/python.md
         - SQL: reference/sql/index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,7 +39,7 @@ nav:
       - Programming Guide: programming-guide.md
       - Configurations:
         - Memory Management and Spilling: memory-management.md
-        - GPU acceleration: gpu-acceleration.md
+        - GPU Acceleration: gpu-acceleration.md
       - API:
         - Python: reference/python.md
         - SQL: reference/sql/index.md


### PR DESCRIPTION
## What this PR does

This PR adds a new documentation page at `docs/gpu-acceleration.ipynb` and `docs/gpu-acceleration.md` that introduces GPU-accelerated spatial joins in SedonaDB.

## Highlights

- Adds prerequisites for GPU usage (CUDA/version, compute capability, RT core notes).
- Documents GPU join execution model (filtering + refinement) and supported predicates.
- Explains fallback behavior with `gpu.fallback_to_cpu`.
- Provides build-from-source guidance for GPU (`MATURIN_PEP517_ARGS="--features gpu"`), including related environment variables.
- Adds runtime configuration examples for `gpu.*` options and batch-size tuning.
- Includes a complete example workflow:
  - check GPU availability (`nvidia-smi`)
  - download sample data
  - create external tables
  - run CPU vs GPU benchmark in notebook-style code
  - display timing/speedup output

## Why

Users need a practical, end-to-end guide to enable, tune, and validate GPU spatial join performance.

## Scope

- Documentation only
- New file: `docs/gpu-acceleration.md`
- No runtime/engine behavior changes

## Notes

Benchmark numbers shown in the example are environment-dependent and should be treated as illustrative.