### PR TITLE
feat(python/sedonadb): Support specifying layer name and accessing sub-paths inside archives when working with pyogrio sources.

### DIFF
--- a/python/sedonadb/python/sedonadb/context.py
+++ b/python/sedonadb/python/sedonadb/context.py
@@ -287,7 +287,10 @@ class SedonaContext:
             options: An optional mapping of key/value pairs passed to
                 pyogrio/GDAL. Supports pyogrio keyword arguments (e.g.,
                 ``layer``, ``where``, ``sql``, ``max_features``) as well
-                as GDAL driver-specific dataset open options.
+                as GDAL driver-specific dataset open options. Additionally,
+                ``path_suffix`` can append a subpath to the resolved
+                GDAL source (e.g., ``{"path_suffix": "data.gdb"}`` for
+                a GDB stored inside a .zip file).
             extension: An optional file extension (e.g., `"fgb"`) used when
                 `table_paths` specifies one or more directories or a glob
                 that does not enforce a file extension.

--- a/python/sedonadb/python/sedonadb/context.py
+++ b/python/sedonadb/python/sedonadb/context.py
@@ -284,8 +284,10 @@ class SedonaContext:
             table_paths: A str, Path, or iterable of paths containing URLs or
                 paths. Globs (i.e., `path/*.gpkg`), directories, and zipped
                 versions of otherwise readable files are supported.
-            options: An optional mapping of key/value pairs (open options)
-                passed to GDAL/OGR.
+            options: An optional mapping of key/value pairs passed to
+                pyogrio/GDAL. Supports pyogrio keyword arguments (e.g.,
+                ``layer``, ``where``, ``sql``, ``max_features``) as well
+                as GDAL driver-specific dataset open options.
             extension: An optional file extension (e.g., `"fgb"`) used when
                 `table_paths` specifies one or more directories or a glob
                 that does not enforce a file extension.

--- a/python/sedonadb/python/sedonadb/datasource.py
+++ b/python/sedonadb/python/sedonadb/datasource.py
@@ -144,7 +144,7 @@ class PyogrioFormatSpec(ExternalFormatSpec):
         if ogr_src.endswith(".zip"):
             ogr_src = f"/vsizip/{ogr_src}"
 
-        path_suffix = self._options.pop("path_suffix", None)
+        path_suffix = self._options.get("path_suffix")
         if path_suffix is not None:
             ogr_src = f"{ogr_src}/{path_suffix}"
 
@@ -170,6 +170,7 @@ class PyogrioFormatSpec(ExternalFormatSpec):
 
         ogr_kwargs = {**self._options}
         ogr_kwargs.update(columns=columns, batch_size=batch_size, bbox=bbox)
+        ogr_kwargs.pop("path_suffix", None)
 
         return PyogrioReaderShelter(
             pyogrio.raw.open_arrow(ogr_src, **ogr_kwargs),

--- a/python/sedonadb/python/sedonadb/datasource.py
+++ b/python/sedonadb/python/sedonadb/datasource.py
@@ -144,6 +144,10 @@ class PyogrioFormatSpec(ExternalFormatSpec):
         if ogr_src.endswith(".zip"):
             ogr_src = f"/vsizip/{ogr_src}"
 
+        path_suffix = self._options.pop("path_suffix", None)
+        if path_suffix is not None:
+            ogr_src = f"{ogr_src}/{path_suffix}"
+
         if args.is_projected():
             file_columns = args.file_schema.names
             columns = [file_columns[i] for i in args.file_projection]

--- a/python/sedonadb/python/sedonadb/datasource.py
+++ b/python/sedonadb/python/sedonadb/datasource.py
@@ -164,10 +164,11 @@ class PyogrioFormatSpec(ExternalFormatSpec):
         else:
             bbox = None
 
+        ogr_kwargs = {**self._options}
+        ogr_kwargs.update(columns=columns, batch_size=batch_size, bbox=bbox)
+
         return PyogrioReaderShelter(
-            pyogrio.raw.ogr_open_arrow(
-                ogr_src, {}, columns=columns, batch_size=batch_size, bbox=bbox
-            ),
+            pyogrio.raw.open_arrow(ogr_src, **ogr_kwargs),
             columns,
         )
 

--- a/python/sedonadb/tests/io/test_pyogrio.py
+++ b/python/sedonadb/tests/io/test_pyogrio.py
@@ -18,6 +18,7 @@
 import io
 import tempfile
 import warnings
+import zipfile
 from pathlib import Path
 
 import geoarrow.pyarrow as ga
@@ -143,6 +144,27 @@ def test_read_ogr_layer_selection(con):
         # Reading with the correct layer name should work
         geopandas.testing.assert_geodataframe_equal(
             con.read_pyogrio(gpkg_path, options={"layer": "my_layer"}).to_pandas(),
+            gdf,
+        )
+
+
+def test_read_ogr_path_suffix(con):
+    series = geopandas.GeoSeries.from_xy([0, 1], [1, 2], crs="EPSG:3857")
+    gdf = geopandas.GeoDataFrame({"val": ["a", "b"], "wkb_geometry": series})
+    gdf = gdf.set_geometry(gdf["wkb_geometry"])
+
+    with tempfile.TemporaryDirectory() as td:
+        gpkg_path = f"{td}/data.gpkg"
+        gdf.to_file(gpkg_path)
+
+        zip_path = f"{td}/archive.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.write(gpkg_path, "nested/data.gpkg")
+
+        geopandas.testing.assert_geodataframe_equal(
+            con.read_pyogrio(
+                zip_path, options={"path_suffix": "nested/data.gpkg"}
+            ).to_pandas(),
             gdf,
         )
 

--- a/python/sedonadb/tests/io/test_pyogrio.py
+++ b/python/sedonadb/tests/io/test_pyogrio.py
@@ -131,6 +131,22 @@ def test_read_ogr_filter(con):
         )
 
 
+def test_read_ogr_layer_selection(con):
+    series = geopandas.GeoSeries.from_xy([0, 1], [1, 2], crs="EPSG:3857")
+    gdf = geopandas.GeoDataFrame({"val": ["a", "b"], "wkb_geometry": series})
+    gdf = gdf.set_geometry(gdf["wkb_geometry"])
+
+    with tempfile.TemporaryDirectory() as td:
+        gpkg_path = f"{td}/test.gpkg"
+        gdf.to_file(gpkg_path, layer="my_layer")
+
+        # Reading with the correct layer name should work
+        geopandas.testing.assert_geodataframe_equal(
+            con.read_pyogrio(gpkg_path, options={"layer": "my_layer"}).to_pandas(),
+            gdf,
+        )
+
+
 def test_read_ogr_file_not_found(con):
     with pytest.raises(
         sedonadb._lib.SedonaError, match="Can't infer schema for zero objects"

--- a/python/sedonadb/tests/io/test_pyogrio.py
+++ b/python/sedonadb/tests/io/test_pyogrio.py
@@ -134,8 +134,8 @@ def test_read_ogr_filter(con):
 
 def test_read_ogr_layer_selection(con):
     series = geopandas.GeoSeries.from_xy([0, 1], [1, 2], crs="EPSG:3857")
-    gdf = geopandas.GeoDataFrame({"val": ["a", "b"], "wkb_geometry": series})
-    gdf = gdf.set_geometry(gdf["wkb_geometry"])
+    gdf = geopandas.GeoDataFrame({"val": ["a", "b"], "geom": series})
+    gdf = gdf.set_geometry(gdf["geom"])
 
     with tempfile.TemporaryDirectory() as td:
         gpkg_path = f"{td}/test.gpkg"
@@ -150,8 +150,8 @@ def test_read_ogr_layer_selection(con):
 
 def test_read_ogr_path_suffix(con):
     series = geopandas.GeoSeries.from_xy([0, 1], [1, 2], crs="EPSG:3857")
-    gdf = geopandas.GeoDataFrame({"val": ["a", "b"], "wkb_geometry": series})
-    gdf = gdf.set_geometry(gdf["wkb_geometry"])
+    gdf = geopandas.GeoDataFrame({"val": ["a", "b"], "geom": series})
+    gdf = gdf.set_geometry(gdf["geom"])
 
     with tempfile.TemporaryDirectory() as td:
         gpkg_path = f"{td}/data.gpkg"


### PR DESCRIPTION
## Summary

- Enables passing pyogrio keyword arguments (e.g., `layer`, `where`, `sql`, `max_features`) through `read_pyogrio(options=...)` by switching from the internal `pyogrio.raw.ogr_open_arrow()` to the public `pyogrio.raw.open_arrow()` API, which accepts these as keyword arguments directly including specifying the `layer=` flag to handle multi-layer files (#772)

- Adds a `path_suffix` option to append a subpath to the resolved GDAL source, enabling reading of formats like FileGeoDatabase (`.gdb`) stored inside `.zip` archives (e.g., `options={"path_suffix": 'subdir/test.gdb')`). This is equivalent to running `ogrinfo /vsizip/test.zip/subdir/test.gdb`.

### Motivation

Previously, `read_pyogrio()` had no way to pass options through to pyogrio, making it impossible to select a specific layer in a multi-layer file or use GDAL driver-specific open options. For example, reading a named layer from a GeoPackage now works:

```python
con.read_pyogrio("file.gpkg", options={"layer": "my_layer"})
```

For formats like FileGeoDatabase distributed inside .zip archives, GDAL expects a path of the form `/vsizip/archive.zip/data.gdb`. Because the file listing infrastructure resolves real filesystem paths before the Python reader runs, passing a full `/vsizip/...` path directly fails. The path_suffix option bridges this gap:

```python
con.read_pyogrio("path/to/file.zip", options={"path_suffix": "data.gdb"})
```