### PR TITLE
fix(ci): Fix Windows build path limits and unify rust-cache configuration

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -83,6 +83,13 @@ jobs:
           rustup toolchain install stable-x86_64-pc-windows-gnu --no-self-update
           rustup default stable-x86_64-pc-windows-gnu
 
+      - name: Enable Long Paths support (Windows)
+        if: matrix.config.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          git config --system core.longpaths true
+          New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
+
       - name: Install dependencies (Linux)
         if: matrix.config.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install -y libgeos-dev

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -83,13 +83,6 @@ jobs:
           rustup toolchain install stable-x86_64-pc-windows-gnu --no-self-update
           rustup default stable-x86_64-pc-windows-gnu
 
-      - name: Enable Long Paths support (Windows)
-        if: matrix.config.os == 'windows-latest'
-        shell: pwsh
-        run: |
-          git config --system core.longpaths true
-          New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
-
       - name: Install dependencies (Linux)
         if: matrix.config.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install -y libgeos-dev
@@ -98,21 +91,23 @@ jobs:
         if: matrix.config.os == 'macos-latest'
         run: brew install geos
 
+      # Dynamically set a short target directory on Windows to bypass 260-char MinGW limits,
+      # while keeping paths standard on Mac/Linux.
+      - name: Configure Target Directory
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            echo "SEDONADB_TARGET_DIR=D:/a/t" >> $GITHUB_ENV
+            echo "CACHE_WORKSPACE=. -> D:/a/t" >> $GITHUB_ENV
+          else
+            echo "SEDONADB_TARGET_DIR=$(pwd)/r/sedonadb/src/rust/target" >> $GITHUB_ENV
+            echo "CACHE_WORKSPACE=. -> r/sedonadb/src/rust/target" >> $GITHUB_ENV
+          fi
+
       - uses: Swatinem/rust-cache@v2
         with:
-          # Update this key to force a new cache
           prefix-key: "r-v4"
-          # The R package uses its own target directory
-          workspaces: ". -> r/sedonadb/src/rust/target"
-
-      # Explicitly specify for Windows, which otherwise chooses a shorter version
-      # to work around a path length limitation when building from longer starting paths.
-      # This allows us to use a common cache configuration for Windows, MacOS, and Linux
-      - name: Set R/Rust target directory
-        if: matrix.config.os == 'windows-latest'
-        run: |
-          echo "SEDONADB_TARGET_DIR=$(pwd -W)/r/sedonadb/src/rust/target" >> $GITHUB_ENV
-        shell: bash
+          workspaces: ${{ env.CACHE_WORKSPACE }}
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:


### PR DESCRIPTION
The Windows CI pipeline is currently failing on a forked repo (https://github.com/wherobots/sedona-db-gpu-tester/actions/runs/24955442999/job/73072769657) during the compilation of the sedonadb package, specifically when building the aws-lc-sys Rust dependency.

The root cause is the default Windows MAX_PATH limitation (260 characters). Because Cargo and CMake create deeply nested build directories, the absolute path for target artifacts exceeds this limit. This causes the compiler (GCC/MSYS2) to silently fail to create directory trees, resulting in a fatal file IO error when it tries to write the dependency (.d) files.

Changes

- Dynamic Target Directory: Added a Configure Target Directory step that sets a dynamically shortened SEDONADB_TARGET_DIR on Windows (D:/a/t) to safely bypass the compiler's 260-character limit. Mac and Linux continue to use the standard repository path.

- Dynamic Cache Workspace: Extracted the cache mapping into a new CACHE_WORKSPACE environment variable. This allows the Swatinem/rust-cache@v2 action to correctly locate and cache the build artifacts across all platforms, preserving the caching optimization the original workflow intended