### PR TITLE
feat(c/sedona-geos): Adds ST_Normalize(geometry) in c/sedona-geos using GEOS

### DIFF
--- a/c/sedona-geos/src/lib.rs
+++ b/c/sedona-geos/src/lib.rs
@@ -38,6 +38,7 @@ mod st_line_merge;
 mod st_makevalid;
 mod st_minimumclearance;
 mod st_minimumclearance_line;
+mod st_normalize;
 mod st_nrings;
 mod st_numinteriorrings;
 mod st_numpoints;

--- a/c/sedona-geos/src/register.rs
+++ b/c/sedona-geos/src/register.rs
@@ -67,6 +67,7 @@ pub fn scalar_kernels() -> Vec<(&'static str, Vec<ScalarKernelRef>)> {
         "st_makevalid" => crate::st_makevalid::st_make_valid_impl,
         "st_minimumclearance" => crate::st_minimumclearance::st_minimum_clearance_impl,
         "st_minimumclearanceline" => crate::st_minimumclearance_line::st_minimum_clearance_line_impl,
+        "st_normalize" => crate::st_normalize::st_normalize_impl,
         "st_nrings" => crate::st_nrings::st_nrings_impl,
         "st_numinteriorrings" => crate::st_numinteriorrings::st_num_interior_rings_impl,
         "st_numpoints" => crate::st_numpoints::st_num_points_impl,

--- a/c/sedona-geos/src/st_normalize.rs
+++ b/c/sedona-geos/src/st_normalize.rs
@@ -1,0 +1,180 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+use std::sync::Arc;
+
+use arrow_array::builder::BinaryBuilder;
+use datafusion_common::{error::Result, DataFusionError};
+use datafusion_expr::ColumnarValue;
+use sedona_expr::{
+    item_crs::ItemCrsKernel,
+    scalar_udf::{ScalarKernelRef, SedonaScalarKernel},
+};
+use sedona_geometry::wkb_factory::WKB_MIN_PROBABLE_BYTES;
+use sedona_schema::{
+    datatypes::{SedonaType, WKB_GEOMETRY},
+    matchers::ArgMatcher,
+};
+
+use crate::executor::GeosExecutor;
+use crate::geos_to_wkb::write_geos_geometry;
+
+/// ST_Normalize() implementation using the geos crate
+pub fn st_normalize_impl() -> Vec<ScalarKernelRef> {
+    ItemCrsKernel::wrap_impl(STNormalize {})
+}
+
+#[derive(Debug)]
+struct STNormalize {}
+
+impl SedonaScalarKernel for STNormalize {
+    fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
+        let matcher = ArgMatcher::new(vec![ArgMatcher::is_geometry()], WKB_GEOMETRY);
+
+        matcher.match_args(args)
+    }
+
+    fn invoke_batch(
+        &self,
+        arg_types: &[SedonaType],
+        args: &[ColumnarValue],
+    ) -> Result<ColumnarValue> {
+        let executor = GeosExecutor::new(arg_types, args);
+        let mut builder = BinaryBuilder::with_capacity(
+            executor.num_iterations(),
+            WKB_MIN_PROBABLE_BYTES * executor.num_iterations(),
+        );
+        executor.execute_wkb_void(|maybe_wkb| {
+            match maybe_wkb {
+                Some(wkb) => {
+                    invoke_scalar(&wkb, &mut builder)?;
+                    builder.append_value([]);
+                }
+                _ => builder.append_null(),
+            }
+
+            Ok(())
+        })?;
+
+        executor.finish(Arc::new(builder.finish()))
+    }
+}
+
+fn invoke_scalar(geos_geom: &geos::Geometry, writer: &mut impl std::io::Write) -> Result<()> {
+    let mut geometry = Clone::clone(geos_geom);
+    geometry
+        .normalize()
+        .map_err(|e| DataFusionError::Execution(format!("Failed to normalize geometry: {e}")))?;
+
+    write_geos_geometry(&geometry, writer)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion_common::ScalarValue;
+    use geos::{Geom, Geometry};
+    use rstest::rstest;
+    use sedona_expr::scalar_udf::SedonaScalarUDF;
+    use sedona_schema::datatypes::{WKB_GEOMETRY, WKB_GEOMETRY_ITEM_CRS, WKB_VIEW_GEOMETRY};
+    use sedona_testing::testers::ScalarUdfTester;
+
+    use super::*;
+
+    #[rstest]
+    fn udf(#[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType) {
+        let udf = SedonaScalarUDF::from_impl("st_normalize", st_normalize_impl());
+        let tester = ScalarUdfTester::new(udf.into(), vec![sedona_type.clone()]);
+
+        tester.assert_return_type(WKB_GEOMETRY);
+
+        let input_wkt = "POLYGON((1 1, 1 0, 0 0, 0 1, 1 1))";
+        let expected_wkt = "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))";
+
+        let result = tester.invoke_scalar(input_wkt).unwrap();
+        tester.assert_scalar_result_equals(result, expected_wkt);
+
+        let result = tester
+            .invoke_scalar("MULTILINESTRING ((2 2, 1 1), (4 4, 3 3))")
+            .unwrap();
+        tester.assert_scalar_result_equals(result, "MULTILINESTRING ((3 3, 4 4), (1 1, 2 2))");
+
+        let result = tester.invoke_scalar(ScalarValue::Null).unwrap();
+        assert!(result.is_null());
+
+        let batch_input = vec![
+            Some("POINT(2 1)"),
+            None,
+            Some("POLYGON((1 1, 1 0, 0 0, 0 1, 1 1))"),
+            Some("MULTILINESTRING ((2 2, 1 1), (4 4, 3 3))"),
+        ];
+
+        let batch_result = tester.invoke_wkb_array(batch_input).unwrap();
+        assert_eq!(batch_result.len(), 4);
+
+        assert!(batch_result.is_null(1));
+
+        let expected = sedona_testing::create::create_array(
+            &[
+                Some("POINT (2 1)"),
+                None,
+                Some("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))"),
+                Some("MULTILINESTRING ((3 3, 4 4), (1 1, 2 2))"),
+            ],
+            &WKB_GEOMETRY,
+        );
+        sedona_testing::compare::assert_array_equal(&batch_result, &expected);
+    }
+
+    #[rstest]
+    fn udf_invoke_item_crs(#[values(WKB_GEOMETRY_ITEM_CRS.clone())] sedona_type: SedonaType) {
+        let udf = SedonaScalarUDF::from_impl("st_normalize", st_normalize_impl());
+        let tester = ScalarUdfTester::new(udf.into(), vec![sedona_type.clone()]);
+
+        tester.assert_return_type(sedona_type);
+
+        let result = tester
+            .invoke_scalar("POLYGON((1 1, 1 0, 0 0, 0 1, 1 1))")
+            .unwrap();
+        tester.assert_scalar_result_equals(result, "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))");
+    }
+
+    #[rstest]
+    fn udf_already_normalized(#[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType) {
+        let udf = SedonaScalarUDF::from_impl("st_normalize", st_normalize_impl());
+        let tester = ScalarUdfTester::new(udf.into(), vec![sedona_type]);
+        let already_normal = "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))";
+        let result = tester.invoke_scalar(already_normal).unwrap();
+        tester.assert_scalar_result_equals(result, already_normal);
+    }
+
+    #[test]
+    fn invoke_scalar_normalizes_via_geos_without_mutating_input() {
+        let geom = Geometry::new_from_wkt("POLYGON((1 1, 1 0, 0 0, 0 1, 1 1))").unwrap();
+        let original_wkt = geom.to_wkt().unwrap();
+
+        let mut normalized_wkb = Vec::new();
+        invoke_scalar(&geom, &mut normalized_wkb).unwrap();
+
+        let normalized = Geometry::new_from_wkb(&normalized_wkb).unwrap();
+        assert_eq!(
+            normalized.to_wkt().unwrap(),
+            "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))"
+        );
+
+        assert_eq!(geom.to_wkt().unwrap(), original_wkt);
+    }
+}

--- a/docs/reference/sql/st_normalize.qmd
+++ b/docs/reference/sql/st_normalize.qmd
@@ -1,0 +1,34 @@
+---
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+title: ST_Normalize
+description: Returns the geometry in its canonical form.
+kernels:
+  - returns: geometry
+    args: [geometry]
+---
+
+## Examples
+
+```sql
+SELECT ST_AsText(
+  ST_Normalize(
+    ST_GeomFromWKT('POLYGON((10 10, 10 0, 0 0, 0 10, 10 10))')
+  )
+);
+```

--- a/python/sedonadb/tests/functions/test_functions.py
+++ b/python/sedonadb/tests/functions/test_functions.py
@@ -2309,6 +2309,89 @@ def test_st_length(eng, geom, expected):
     ("geom", "expected"),
     [
         (None, None),
+        ("POINT EMPTY", "POINT EMPTY"),
+        ("LINESTRING EMPTY", "LINESTRING EMPTY"),
+        ("POLYGON EMPTY", "POLYGON EMPTY"),
+        ("MULTIPOINT EMPTY", "MULTIPOINT EMPTY"),
+        ("MULTILINESTRING EMPTY", "MULTILINESTRING EMPTY"),
+        ("MULTIPOLYGON EMPTY", "MULTIPOLYGON EMPTY"),
+        ("GEOMETRYCOLLECTION EMPTY", "GEOMETRYCOLLECTION EMPTY"),
+        ("POINT (0 0)", "POINT (0 0)"),
+        ("LINESTRING (0 0, 1 1)", "LINESTRING (0 0, 1 1)"),
+        (
+            "POLYGON ((1 1, 1 0, 0 0, 0 1, 1 1))",
+            "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))",
+        ),
+        (
+            "POLYGON ((5 5, 5 0, 0 0, 0 5, 5 5), (4 4, 1 4, 1 1, 4 1, 4 4))",
+            "POLYGON ((0 0, 0 5, 5 5, 5 0, 0 0), (1 1, 4 1, 4 4, 1 4, 1 1))",
+        ),
+        ("MULTIPOINT ((2 2), (1 1), (0 0))", "MULTIPOINT ((2 2), (1 1), (0 0))"),
+        (
+            "MULTILINESTRING ((2 2, 1 1), (4 4, 3 3))",
+            "MULTILINESTRING ((3 3, 4 4), (1 1, 2 2))",
+        ),
+        (
+            "MULTIPOLYGON (((3 3, 3 2, 2 2, 2 3, 3 3)), ((1 1, 1 0, 0 0, 0 1, 1 1)))",
+            "MULTIPOLYGON (((2 2, 2 3, 3 3, 3 2, 2 2)), ((0 0, 0 1, 1 1, 1 0, 0 0)))",
+        ),
+        (
+            "GEOMETRYCOLLECTION (LINESTRING (2 2, 1 1), POLYGON ((1 1, 1 0, 0 0, 0 1, 1 1)), POINT (5 5))",
+            "GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)), LINESTRING (1 1, 2 2), POINT (5 5))",
+        ),
+        # Already-normalized input should be unchanged
+        (
+            "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))",
+            "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))",
+        ),
+        # Z coordinates must survive normalization reordering
+        (
+            "POLYGON Z ((1 1 5, 1 0 5, 0 0 5, 0 1 5, 1 1 5))",
+            "POLYGON Z ((0 0 5, 0 1 5, 1 1 5, 1 0 5, 0 0 5))",
+        ),
+        # SedonaDB preserves M; PostGIS drops it during ST_Normalize in this environment
+        (
+            "POLYGON M ((1 1 7, 1 0 7, 0 0 7, 0 1 7, 1 1 7))",
+            "POLYGON M ((0 0 7, 0 1 7, 1 1 7, 1 0 7, 0 0 7))",
+        ),
+        # SedonaDB preserves ZM; PostGIS drops M during ST_Normalize in this environment
+        (
+            "POLYGON ZM ((1 1 5 7, 1 0 5 7, 0 0 5 7, 0 1 5 7, 1 1 5 7))",
+            "POLYGON ZM ((0 0 5 7, 0 1 5 7, 1 1 5 7, 1 0 5 7, 0 0 5 7))",
+        ),
+    ],
+)
+def test_st_normalize(eng, geom, expected):
+    eng = eng.create_or_skip()
+    if isinstance(eng, PostGIS):
+        # PostGIS drops M during ST_Normalize for these cases in our test environment.
+        if geom == "POLYGON M ((1 1 7, 1 0 7, 0 0 7, 0 1 7, 1 1 7))":
+            expected = "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))"
+        elif geom == "POLYGON ZM ((1 1 5 7, 1 0 5 7, 0 0 5 7, 0 1 5 7, 1 1 5 7))":
+            expected = "POLYGON Z ((0 0 5, 0 1 5, 1 1 5, 1 0 5, 0 0 5))"
+
+    if isinstance(eng, PostGIS) and expected is not None:
+        # Normalize expected WKT to PostGIS's compact ST_AsText formatting.
+        expected = expected.replace(", ", ",")
+        expected = expected.replace(" (", "(")
+        expected = expected.replace(r"ZM(", r"ZM (")
+        expected = expected.replace(r"M(", r"M (")
+        expected = expected.replace(r"Z(", r"Z (")
+
+    if isinstance(eng, SedonaDB) and expected is not None:
+        expected = expected.replace(", ", ",")
+        expected = expected.replace(" (", "(")
+
+    eng.assert_query_result(
+        f"SELECT ST_AsText(ST_Normalize({geom_or_null(geom)}))", expected
+    )
+
+
+@pytest.mark.parametrize("eng", [SedonaDB, PostGIS])
+@pytest.mark.parametrize(
+    ("geom", "expected"),
+    [
+        (None, None),
         ("POINT EMPTY", 0),
         ("LINESTRING EMPTY", 0),
         ("POLYGON EMPTY", 0),


### PR DESCRIPTION
## Pull Request: Implement ST_Normalize

## Description
This PR introduces the `ST_Normalize` function, leveraging the **GEOS** library. `ST_Normalize` returns a geometry in its normalized (canonical) form, ensuring consistent representation across different processing steps.

## Key Changes
* **GEOS Integration**: Implemented the core normalization logic using GEOS.
* **Rust Unit Tests**
* **Python Integration Tests**
* **PostGIS Compatibility**: Specific integration tests added to document and verify behavior regarding **M** and **ZM** coordinates, matching PostGIS expectations.

## Tracking
This work is part of the following development tracks:
* **Epic:** #174 (ST function coverage)
* **Feature:** #224 (Implement functions using GEOS library)

