### PR TITLE
feat(rust/sedona-expr): Add pruning capability for geography type

### DIFF
--- a/python/sedonadb/src/datasource.rs
+++ b/python/sedonadb/src/datasource.rs
@@ -30,7 +30,7 @@ use sedona_datasource::{
     spec::{ExternalFormatSpec, Object, OpenReaderArgs},
     utility::ProjectedRecordBatchReader,
 };
-use sedona_expr::spatial_filter::SpatialFilter;
+use sedona_expr::spatial_filter::SpatialFilterFactory;
 use sedona_geometry::interval::IntervalTrait;
 
 use crate::{
@@ -284,7 +284,8 @@ impl PyFilter {
         &self,
         column_name: &str,
     ) -> Result<Option<(f64, f64, f64, f64)>, PySedonaError> {
-        let filter = SpatialFilter::try_from_expr(&self.inner)?;
+        let factory = SpatialFilterFactory::default();
+        let filter = factory.try_from_expr(&self.inner)?;
         let filter_bbox = filter.filter_bbox(column_name);
         if filter_bbox.x().is_full() || filter_bbox.y().is_full() {
             Ok(None)

--- a/python/sedonadb/tests/io/test_parquet.py
+++ b/python/sedonadb/tests/io/test_parquet.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import json
+import re
 import tempfile
 from pathlib import Path
 
@@ -664,3 +665,88 @@ def test_read_parquet_validate_wkb_partial_invalid_rows(con, tmp_path):
         con.read_parquet(
             path, geometry_columns=geometry_columns, validate=True
         ).to_arrow_table()
+
+
+def test_prune_geography_parquet():
+    """Test that geography parquet files can be pruned with statistics crossing the antimeridian."""
+    if "s2geography" not in sedonadb.__features__:
+        pytest.skip("Python package built without s2geography")
+
+    con = sedonadb.connect()
+
+    # Create random points crossing the antimeridian (bounds=[170, 10, 190, 30]
+    # which wraps to [170, 10, -170, 30])
+    con.funcs.table.sd_random_geometry(
+        "Point", 100_000, seed=42, bounds=[170, 10, 190, 30]
+    ).to_view("pts", overwrite=True)
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp_parquet = Path(td) / "geog.parquet"
+
+        # Write as geography with small row groups to enable pruning
+        con.sql(
+            "SELECT ST_SetSRID(ST_GeogFromWKB(ST_AsBinary(geometry)), 4326) as geog FROM pts"
+        ).to_parquet(
+            tmp_parquet,
+            geoparquet_version="2.0",
+            max_row_group_size=10_000,
+            sort_by=["geog"],
+        )
+
+        # Verify the parquet file has geography statistics with antimeridian wraparound
+        f = parquet.ParquetFile(tmp_parquet)
+        assert f.metadata.num_row_groups > 1
+
+        # Check that at least one row group has wraparound statistics (xmin > xmax)
+        has_wraparound = False
+        for i in range(f.metadata.num_row_groups):
+            stats = f.metadata.row_group(i).column(0).geo_statistics
+            if stats is not None and stats.xmin > stats.xmax:
+                has_wraparound = True
+                break
+        assert has_wraparound, (
+            "Expected at least one row group with antimeridian wraparound"
+        )
+
+        # Query 1: Query crossing the antimeridian - should match results
+        query_antimeridian = f"""
+            SELECT * FROM "{tmp_parquet}" WHERE
+            ST_Intersects(geog, ST_SetSRID(ST_GeogFromText(
+                'POLYGON ((179 20, -179 20, -179 22, 179 22, 179 20))'
+            ), 4326))
+        """
+        result_count = con.sql(query_antimeridian).count()
+        assert result_count > 0, "Expected results from antimeridian-crossing query"
+
+        # Query 2: Query a small region that should only match some row groups
+        # This queries the far west side (around 170-172 longitude)
+        query_partial = f"""
+            SELECT * FROM "{tmp_parquet}" WHERE
+            ST_Intersects(geog, ST_SetSRID(ST_GeogFromText(
+                'POLYGON ((170 10, 172 10, 172 12, 170 12, 170 10))'
+            ), 4326))
+        """
+
+        # Verify the query returns results
+        result_count = con.sql(query_partial).count()
+        assert result_count > 0, "Expected some results from partial region query"
+
+        # Verify pruning occurred via EXPLAIN ANALYZE
+        explained = con.sql(query_partial).explain("analyze").to_pandas()
+        plan_text = explained.iloc[0, 1]
+
+        # Check that spatial pruning metrics are reported
+        assert "row_groups_spatial_pruned" in plan_text, (
+            "Expected row_groups_spatial_pruned in explain output"
+        )
+
+        # Verify that pruning actually reduced the number of row groups scanned
+        match = re.search(
+            r"row_groups_spatial_pruned=(\d+) total .* (\d+) matched", plan_text
+        )
+        if match:
+            total = int(match.group(1))
+            matched = int(match.group(2))
+            assert matched < total, (
+                f"Expected pruning to reduce row groups: {matched} matched out of {total}"
+            )

--- a/python/sedonadb/tests/io/test_parquet.py
+++ b/python/sedonadb/tests/io/test_parquet.py
@@ -675,9 +675,10 @@ def test_prune_geography_parquet():
     con = sedonadb.connect()
 
     # Create random points crossing the antimeridian (bounds=[170, 10, 190, 30]
-    # which wraps to [170, 10, -170, 30])
+    # which wraps to [170, 10, -170, 30]). Create a non-trivial number of row groups
+    # so we can check pruning.
     con.funcs.table.sd_random_geometry(
-        "Point", 100_000, seed=42, bounds=[170, 10, 190, 30]
+        "Point", 100_000, seed=59837, bounds=[170, 10, 190, 30]
     ).to_view("pts", overwrite=True)
 
     with tempfile.TemporaryDirectory() as td:
@@ -744,9 +745,13 @@ def test_prune_geography_parquet():
         match = re.search(
             r"row_groups_spatial_pruned=(\d+) total .* (\d+) matched", plan_text
         )
-        if match:
-            total = int(match.group(1))
-            matched = int(match.group(2))
-            assert matched < total, (
-                f"Expected pruning to reduce row groups: {matched} matched out of {total}"
-            )
+
+        # Make sure we actually had a match
+        assert match
+
+        # Check that we actually reduced row groups with spatial pruning
+        total = int(match.group(1))
+        matched = int(match.group(2))
+        assert matched < total, (
+            f"Expected pruning to reduce row groups: {matched} matched out of {total}"
+        )

--- a/python/sedonadb/tests/io/test_parquet.py
+++ b/python/sedonadb/tests/io/test_parquet.py
@@ -504,16 +504,16 @@ def test_write_geoparquet_2_0(con, geoarrow_data):
         assert table_roundtrip == table
 
         # Check for metadata and logical type
-        file = parquet.ParquetFile(tmp_parquet)
-        file_kv_metadata = file.metadata.metadata
-        assert b"geo" in file_kv_metadata
-        geo_metadata = json.loads(file_kv_metadata[b"geo"])
-        assert geo_metadata["version"] == "2.0.0"
+        with parquet.ParquetFile(tmp_parquet) as file:
+            file_kv_metadata = file.metadata.metadata
+            assert b"geo" in file_kv_metadata
+            geo_metadata = json.loads(file_kv_metadata[b"geo"])
+            assert geo_metadata["version"] == "2.0.0"
 
-        assert (
-            file.metadata.schema.column(2).logical_type.to_json()
-            == '{"Type": "Geometry"}'
-        )
+            assert (
+                file.metadata.schema.column(2).logical_type.to_json()
+                == '{"Type": "Geometry"}'
+            )
 
 
 def test_write_geoparquet_no_metadata(con, geoarrow_data):

--- a/rust/sedona-expr/src/spatial_filter.rs
+++ b/rust/sedona-expr/src/spatial_filter.rs
@@ -14,10 +14,10 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, fmt::Debug, sync::Arc};
 
 use arrow_schema::{DataType, Schema};
-use datafusion_common::{DataFusionError, Result, ScalarValue};
+use datafusion_common::{exec_datafusion_err, DataFusionError, Result, ScalarValue};
 use datafusion_expr::Operator;
 use datafusion_physical_expr::{
     expressions::{BinaryExpr, Column, Literal},
@@ -30,7 +30,10 @@ use sedona_geometry::{
     bounds::wkb_bounds_xy,
     interval::{Interval, IntervalTrait},
 };
-use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher, schema::SedonaSchema};
+use sedona_schema::{
+    datatypes::{Edges, SedonaType},
+    schema::SedonaSchema,
+};
 
 use crate::{
     metadata_preserving_column::MetadataPreservingColumn,
@@ -180,10 +183,26 @@ impl SpatialFilter {
     }
 }
 
-#[derive(Debug, Default, Clone)]
-pub struct SpatialFilterFactory {}
+#[derive(Debug, Clone)]
+pub struct SpatialFilterFactory {
+    literal_bounders: Vec<Arc<dyn LiteralBounder>>,
+}
+
+impl Default for SpatialFilterFactory {
+    fn default() -> Self {
+        Self {
+            literal_bounders: vec![Arc::new(DefaultLiteralBounder)],
+        }
+    }
+}
 
 impl SpatialFilterFactory {
+    /// Add a [LiteralBounder] (e.g., that can handle non-planar edges)
+    pub fn with_bounder(mut self, literal_bounder: Arc<dyn LiteralBounder>) -> Self {
+        self.literal_bounders.push(literal_bounder);
+        self
+    }
+
     /// Construct a SpatialPredicate from a [PhysicalExpr]
     ///
     /// Parses expr to extract known expressions we can evaluate against statistics.
@@ -244,7 +263,7 @@ impl SpatialFilterFactory {
                         if !self.is_prunable_geospatial_literal(literal) {
                             return Ok(Some(SpatialFilter::Unknown));
                         }
-                        match self.literal_bounds(literal) {
+                        match self.literal_bounds(literal, None) {
                             Ok(literal_bounds) => Ok(Some(SpatialFilter::Intersects(
                                 column.clone(),
                                 literal_bounds,
@@ -267,7 +286,7 @@ impl SpatialFilterFactory {
                         if !self.is_prunable_geospatial_literal(literal) {
                             return Ok(Some(SpatialFilter::Unknown));
                         }
-                        match self.literal_bounds(literal) {
+                        match self.literal_bounds(literal, None) {
                             Ok(literal_bounds) => {
                                 Ok(Some(SpatialFilter::Covers(column.clone(), literal_bounds)))
                             }
@@ -289,7 +308,7 @@ impl SpatialFilterFactory {
                         if !self.is_prunable_geospatial_literal(literal) {
                             return Ok(Some(SpatialFilter::Unknown));
                         }
-                        match self.literal_bounds(literal) {
+                        match self.literal_bounds(literal, None) {
                             Ok(literal_bounds) => Ok(Some(SpatialFilter::Intersects(
                                 column.clone(),
                                 literal_bounds,
@@ -302,7 +321,7 @@ impl SpatialFilterFactory {
                         if !self.is_prunable_geospatial_literal(literal) {
                             return Ok(Some(SpatialFilter::Unknown));
                         }
-                        match self.literal_bounds(literal) {
+                        match self.literal_bounds(literal, None) {
                             Ok(literal_bounds) => {
                                 Ok(Some(SpatialFilter::Covers(column.clone(), literal_bounds)))
                             }
@@ -325,7 +344,7 @@ impl SpatialFilterFactory {
                         if !self.is_prunable_geospatial_literal(literal) {
                             return Ok(Some(SpatialFilter::Unknown));
                         }
-                        match self.literal_bounds(literal) {
+                        match self.literal_bounds(literal, None) {
                             Ok(literal_bounds) => {
                                 Ok(Some(SpatialFilter::Covers(column.clone(), literal_bounds)))
                             }
@@ -338,7 +357,7 @@ impl SpatialFilterFactory {
                         if !self.is_prunable_geospatial_literal(literal) {
                             return Ok(Some(SpatialFilter::Unknown));
                         }
-                        match self.literal_bounds(literal) {
+                        match self.literal_bounds(literal, None) {
                             Ok(literal_bounds) => Ok(Some(SpatialFilter::Intersects(
                                 column.clone(),
                                 literal_bounds,
@@ -386,24 +405,27 @@ impl SpatialFilterFactory {
                 if !self.is_prunable_geospatial_literal(literal) {
                     return Ok(Some(SpatialFilter::Unknown));
                 }
-                match (
-                    self.literal_bounds(literal),
-                    distance.value().cast_to(&DataType::Float64)?,
-                ) {
-                    (Ok(literal_bounds), distance_scalar_value) => {
-                        let ScalarValue::Float64(Some(dist)) = distance_scalar_value else {
-                            return Ok(None);
-                        };
-                        if dist.is_nan() || dist < 0.0 {
-                            return Ok(None);
-                        }
-                        let expanded_bounds = literal_bounds.expand_by(dist);
+
+                let ScalarValue::Float64(distance_opt) =
+                    distance.value().cast_to(&DataType::Float64)?
+                else {
+                    return sedona_internal_err!("Unexpected cast result from scalar distance");
+                };
+
+                // TODO: check...some of these cases possibly should return LiteralFalse
+                if let Some(distance) = distance_opt {
+                    if distance.is_nan() || distance < 0.0 {
+                        Ok(None)
+                    } else {
+                        let expanded_bounds = self.literal_bounds(literal, Some(distance))?;
                         Ok(Some(SpatialFilter::Intersects(
                             column.clone(),
                             expanded_bounds,
                         )))
                     }
-                    (Err(e), _) => Err(DataFusionError::External(Box::new(e))),
+                } else {
+                    // Null distance
+                    Ok(None)
                 }
             }
             // Not between a literal and a column
@@ -411,8 +433,6 @@ impl SpatialFilterFactory {
         }
     }
 
-    /// Our current spatial data pruning implementation does not correctly handle geography data.
-    /// We therefore only consider geometry data type for pruning.
     fn is_prunable_geospatial_literal(&self, literal: &Literal) -> bool {
         let Ok(literal_field) = literal.return_field(&Schema::empty()) else {
             return false;
@@ -420,27 +440,83 @@ impl SpatialFilterFactory {
         let Ok(sedona_type) = SedonaType::from_storage_field(&literal_field) else {
             return false;
         };
-        let matcher = ArgMatcher::is_geometry();
-        matcher.match_type(&sedona_type)
+
+        self.literal_bounders
+            .iter()
+            .any(|bounder| bounder.can_bound(&sedona_type))
     }
 
-    fn literal_bounds(&self, literal: &Literal) -> Result<BoundingBox> {
+    fn literal_bounds(&self, literal: &Literal, distance: Option<f64>) -> Result<BoundingBox> {
         let literal_field = literal.return_field(&Schema::empty())?;
         let sedona_type = SedonaType::from_storage_field(&literal_field)?;
+        for bounder in &self.literal_bounders {
+            if bounder.can_bound(&sedona_type) {
+                return bounder.bound_scalar(literal.value(), &sedona_type, distance);
+            }
+        }
+
+        sedona_internal_err!("Can't resolve bounder for type {sedona_type}")
+    }
+}
+
+/// Extendable bounder for literal values
+///
+/// Used to compute the bounds of any literals encountered with pluggable support for extra types.
+pub trait LiteralBounder: Debug {
+    /// Returns true if this bounder can handle the requested type
+    fn can_bound(&self, sedona_type: &SedonaType) -> bool;
+
+    /// Bound a value of the given type
+    fn bound_scalar(
+        &self,
+        value: &ScalarValue,
+        sedona_type: &SedonaType,
+        distance: Option<f64>,
+    ) -> Result<BoundingBox>;
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct DefaultLiteralBounder;
+
+impl LiteralBounder for DefaultLiteralBounder {
+    fn can_bound(&self, sedona_type: &SedonaType) -> bool {
+        matches!(
+            sedona_type,
+            SedonaType::Wkb(Edges::Planar, _) | SedonaType::WkbView(Edges::Planar, _)
+        )
+    }
+
+    fn bound_scalar(
+        &self,
+        value: &ScalarValue,
+        sedona_type: &SedonaType,
+        distance: Option<f64>,
+    ) -> Result<BoundingBox> {
         match &sedona_type {
-            SedonaType::Wkb(_, _) | SedonaType::WkbView(_, _) => match literal.value() {
-                ScalarValue::Binary(maybe_vec) | ScalarValue::BinaryView(maybe_vec) => {
-                    if let Some(vec) = maybe_vec {
-                        return wkb_bounds_xy(vec)
-                            .map_err(|e| DataFusionError::External(Box::new(e)));
+            SedonaType::Wkb(Edges::Planar, _) | SedonaType::WkbView(Edges::Planar, _) => {
+                match value {
+                    ScalarValue::Binary(maybe_vec) | ScalarValue::BinaryView(maybe_vec) => {
+                        if let Some(vec) = maybe_vec {
+                            let out = wkb_bounds_xy(vec).map_err(|e| {
+                                exec_datafusion_err!(
+                                    "Error computing bounds for literal in pruning expression: {e}"
+                                )
+                            })?;
+
+                            if let Some(distance) = distance {
+                                return Ok(out.expand_by(distance));
+                            } else {
+                                return Ok(out);
+                            }
+                        }
                     }
+                    _ => {}
                 }
-                _ => {}
-            },
+            }
             _ => {}
         }
 
-        sedona_internal_err!("Unexpected scalar type in filter expression ({literal:?})")
+        sedona_internal_err!("Unexpected scalar type in filter expression ({sedona_type:?})")
     }
 }
 
@@ -600,7 +676,7 @@ mod test {
             create_scalar(Some("POINT (1 2)"), &WKB_GEOMETRY),
             Some(storage_field.metadata().into()),
         );
-        let bounds = factory.literal_bounds(&literal).unwrap();
+        let bounds = factory.literal_bounds(&literal, None).unwrap();
 
         let stats_no_info = TableGeoStatistics::from(GeoStatistics::unspecified());
         let stats_intersecting = TableGeoStatistics::from(
@@ -626,7 +702,9 @@ mod test {
 
         let unrelated_literal = Literal::new(ScalarValue::Null);
 
-        let err = factory.literal_bounds(&unrelated_literal).unwrap_err();
+        let err = factory
+            .literal_bounds(&unrelated_literal, None)
+            .unwrap_err();
         assert!(err
             .message()
             .contains("Unexpected scalar type in filter expression"));
@@ -640,7 +718,7 @@ mod test {
             create_scalar(Some("POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0))"), &WKB_GEOMETRY),
             Some(storage_field.metadata().into()),
         );
-        let bounds = factory.literal_bounds(&literal).unwrap();
+        let bounds = factory.literal_bounds(&literal, None).unwrap();
 
         let stats_no_info = TableGeoStatistics::from(GeoStatistics::unspecified());
         let stats_covered = TableGeoStatistics::from(

--- a/rust/sedona-expr/src/spatial_filter.rs
+++ b/rust/sedona-expr/src/spatial_filter.rs
@@ -178,45 +178,53 @@ impl SpatialFilter {
         let maybe_rhs = rhs.evaluate_internal(table_stats)?;
         Ok(maybe_lhs || maybe_rhs)
     }
+}
 
+#[derive(Debug, Default, Clone)]
+pub struct SpatialFilterFactory {}
+
+impl SpatialFilterFactory {
     /// Construct a SpatialPredicate from a [PhysicalExpr]
     ///
     /// Parses expr to extract known expressions we can evaluate against statistics.
-    pub fn try_from_expr(expr: &Arc<dyn PhysicalExpr>) -> Result<Self> {
-        if let Some(spatial_filter) = Self::try_from_range_predicate(expr)? {
+    pub fn try_from_expr(&self, expr: &Arc<dyn PhysicalExpr>) -> Result<SpatialFilter> {
+        if let Some(spatial_filter) = self.try_from_range_predicate(expr)? {
             Ok(spatial_filter)
-        } else if let Some(spatial_filter) = Self::try_from_distance_predicate(expr)? {
+        } else if let Some(spatial_filter) = self.try_from_distance_predicate(expr)? {
             Ok(spatial_filter)
         } else if let Some(binary_expr) = expr.as_any().downcast_ref::<BinaryExpr>() {
             match binary_expr.op() {
-                Operator::And => Ok(Self::And(
-                    Box::new(Self::try_from_expr(binary_expr.left())?),
-                    Box::new(Self::try_from_expr(binary_expr.right())?),
+                Operator::And => Ok(SpatialFilter::And(
+                    Box::new(self.try_from_expr(binary_expr.left())?),
+                    Box::new(self.try_from_expr(binary_expr.right())?),
                 )),
-                Operator::Or => Ok(Self::Or(
-                    Box::new(Self::try_from_expr(binary_expr.left())?),
-                    Box::new(Self::try_from_expr(binary_expr.right())?),
+                Operator::Or => Ok(SpatialFilter::Or(
+                    Box::new(self.try_from_expr(binary_expr.left())?),
+                    Box::new(self.try_from_expr(binary_expr.right())?),
                 )),
                 // Not a binary expression we know about
-                _ => Ok(Self::Unknown),
+                _ => Ok(SpatialFilter::Unknown),
             }
         } else if let Some(literal) = expr.as_any().downcast_ref::<Literal>() {
             if let ScalarValue::Boolean(Some(value)) = literal.value() {
                 match value {
-                    true => Ok(Self::Unknown),
-                    false => Ok(Self::LiteralFalse),
+                    true => Ok(SpatialFilter::Unknown),
+                    false => Ok(SpatialFilter::LiteralFalse),
                 }
             } else {
                 // Not a literal we know about
-                Ok(Self::Unknown)
+                Ok(SpatialFilter::Unknown)
             }
         } else {
             // Not an expression we know about
-            Ok(Self::Unknown)
+            Ok(SpatialFilter::Unknown)
         }
     }
 
-    fn try_from_range_predicate(expr: &Arc<dyn PhysicalExpr>) -> Result<Option<Self>> {
+    fn try_from_range_predicate(
+        &self,
+        expr: &Arc<dyn PhysicalExpr>,
+    ) -> Result<Option<SpatialFilter>> {
         let Some(scalar_fun) = expr.as_any().downcast_ref::<ScalarFunctionExpr>() else {
             return Ok(None);
         };
@@ -233,18 +241,19 @@ impl SpatialFilter {
                 match (&args[0], &args[1]) {
                     (ArgRef::Col(column), ArgRef::Lit(literal))
                     | (ArgRef::Lit(literal), ArgRef::Col(column)) => {
-                        if !is_prunable_geospatial_literal(literal) {
-                            return Ok(Some(Self::Unknown));
+                        if !self.is_prunable_geospatial_literal(literal) {
+                            return Ok(Some(SpatialFilter::Unknown));
                         }
-                        match literal_bounds(literal) {
-                            Ok(literal_bounds) => {
-                                Ok(Some(Self::Intersects(column.clone(), literal_bounds)))
-                            }
+                        match self.literal_bounds(literal) {
+                            Ok(literal_bounds) => Ok(Some(SpatialFilter::Intersects(
+                                column.clone(),
+                                literal_bounds,
+                            ))),
                             Err(e) => Err(DataFusionError::External(Box::new(e))),
                         }
                     }
                     // Not between a literal and a column
-                    _ => Ok(Some(Self::Unknown)),
+                    _ => Ok(Some(SpatialFilter::Unknown)),
                 }
             }
             "st_equals" => {
@@ -255,18 +264,18 @@ impl SpatialFilter {
                 match (&args[0], &args[1]) {
                     (ArgRef::Col(column), ArgRef::Lit(literal))
                     | (ArgRef::Lit(literal), ArgRef::Col(column)) => {
-                        if !is_prunable_geospatial_literal(literal) {
-                            return Ok(Some(Self::Unknown));
+                        if !self.is_prunable_geospatial_literal(literal) {
+                            return Ok(Some(SpatialFilter::Unknown));
                         }
-                        match literal_bounds(literal) {
+                        match self.literal_bounds(literal) {
                             Ok(literal_bounds) => {
-                                Ok(Some(Self::Covers(column.clone(), literal_bounds)))
+                                Ok(Some(SpatialFilter::Covers(column.clone(), literal_bounds)))
                             }
                             Err(e) => Err(DataFusionError::External(Box::new(e))),
                         }
                     }
                     // Not between a literal and a column
-                    _ => Ok(Some(Self::Unknown)),
+                    _ => Ok(Some(SpatialFilter::Unknown)),
                 }
             }
             "st_within" | "st_covered_by" | "st_coveredby" => {
@@ -277,30 +286,31 @@ impl SpatialFilter {
                 match (&args[0], &args[1]) {
                     (ArgRef::Col(column), ArgRef::Lit(literal)) => {
                         // column within/covered_by literal -> Intersects filter
-                        if !is_prunable_geospatial_literal(literal) {
-                            return Ok(Some(Self::Unknown));
+                        if !self.is_prunable_geospatial_literal(literal) {
+                            return Ok(Some(SpatialFilter::Unknown));
                         }
-                        match literal_bounds(literal) {
-                            Ok(literal_bounds) => {
-                                Ok(Some(Self::Intersects(column.clone(), literal_bounds)))
-                            }
+                        match self.literal_bounds(literal) {
+                            Ok(literal_bounds) => Ok(Some(SpatialFilter::Intersects(
+                                column.clone(),
+                                literal_bounds,
+                            ))),
                             Err(e) => Err(DataFusionError::External(Box::new(e))),
                         }
                     }
                     (ArgRef::Lit(literal), ArgRef::Col(column)) => {
                         // literal within/covered_by column -> Covers filter
-                        if !is_prunable_geospatial_literal(literal) {
-                            return Ok(Some(Self::Unknown));
+                        if !self.is_prunable_geospatial_literal(literal) {
+                            return Ok(Some(SpatialFilter::Unknown));
                         }
-                        match literal_bounds(literal) {
+                        match self.literal_bounds(literal) {
                             Ok(literal_bounds) => {
-                                Ok(Some(Self::Covers(column.clone(), literal_bounds)))
+                                Ok(Some(SpatialFilter::Covers(column.clone(), literal_bounds)))
                             }
                             Err(e) => Err(DataFusionError::External(Box::new(e))),
                         }
                     }
                     // Not between a literal and a column
-                    _ => Ok(Some(Self::Unknown)),
+                    _ => Ok(Some(SpatialFilter::Unknown)),
                 }
             }
             "st_contains" | "st_covers" => {
@@ -312,12 +322,12 @@ impl SpatialFilter {
                     (ArgRef::Col(column), ArgRef::Lit(literal)) => {
                         // column contains/covers literal -> Covers filter
                         // (column's bbox must fully cover literal's bbox)
-                        if !is_prunable_geospatial_literal(literal) {
-                            return Ok(Some(Self::Unknown));
+                        if !self.is_prunable_geospatial_literal(literal) {
+                            return Ok(Some(SpatialFilter::Unknown));
                         }
-                        match literal_bounds(literal) {
+                        match self.literal_bounds(literal) {
                             Ok(literal_bounds) => {
-                                Ok(Some(Self::Covers(column.clone(), literal_bounds)))
+                                Ok(Some(SpatialFilter::Covers(column.clone(), literal_bounds)))
                             }
                             Err(e) => Err(DataFusionError::External(Box::new(e))),
                         }
@@ -325,18 +335,19 @@ impl SpatialFilter {
                     (ArgRef::Lit(literal), ArgRef::Col(column)) => {
                         // literal contains/covers column -> Intersects filter
                         // (if literal contains column, they must at least intersect)
-                        if !is_prunable_geospatial_literal(literal) {
-                            return Ok(Some(Self::Unknown));
+                        if !self.is_prunable_geospatial_literal(literal) {
+                            return Ok(Some(SpatialFilter::Unknown));
                         }
-                        match literal_bounds(literal) {
-                            Ok(literal_bounds) => {
-                                Ok(Some(Self::Intersects(column.clone(), literal_bounds)))
-                            }
+                        match self.literal_bounds(literal) {
+                            Ok(literal_bounds) => Ok(Some(SpatialFilter::Intersects(
+                                column.clone(),
+                                literal_bounds,
+                            ))),
                             Err(e) => Err(DataFusionError::External(Box::new(e))),
                         }
                     }
                     // Not between a literal and a column
-                    _ => Ok(Some(Self::Unknown)),
+                    _ => Ok(Some(SpatialFilter::Unknown)),
                 }
             }
             "st_hasz" => {
@@ -345,15 +356,18 @@ impl SpatialFilter {
                 }
 
                 match &args[0] {
-                    ArgRef::Col(column) => Ok(Some(Self::HasZ(column.clone()))),
-                    _ => Ok(Some(Self::Unknown)),
+                    ArgRef::Col(column) => Ok(Some(SpatialFilter::HasZ(column.clone()))),
+                    _ => Ok(Some(SpatialFilter::Unknown)),
                 }
             }
             _ => Ok(None),
         }
     }
 
-    fn try_from_distance_predicate(expr: &Arc<dyn PhysicalExpr>) -> Result<Option<Self>> {
+    fn try_from_distance_predicate(
+        &self,
+        expr: &Arc<dyn PhysicalExpr>,
+    ) -> Result<Option<SpatialFilter>> {
         let Some(ParsedDistancePredicate {
             arg0,
             arg1,
@@ -369,11 +383,11 @@ impl SpatialFilter {
         match (&args[0], &args[1], &args[2]) {
             (ArgRef::Col(column), ArgRef::Lit(literal), ArgRef::Lit(distance))
             | (ArgRef::Lit(literal), ArgRef::Col(column), ArgRef::Lit(distance)) => {
-                if !is_prunable_geospatial_literal(literal) {
-                    return Ok(Some(Self::Unknown));
+                if !self.is_prunable_geospatial_literal(literal) {
+                    return Ok(Some(SpatialFilter::Unknown));
                 }
                 match (
-                    literal_bounds(literal),
+                    self.literal_bounds(literal),
                     distance.value().cast_to(&DataType::Float64)?,
                 ) {
                     (Ok(literal_bounds), distance_scalar_value) => {
@@ -384,14 +398,49 @@ impl SpatialFilter {
                             return Ok(None);
                         }
                         let expanded_bounds = literal_bounds.expand_by(dist);
-                        Ok(Some(Self::Intersects(column.clone(), expanded_bounds)))
+                        Ok(Some(SpatialFilter::Intersects(
+                            column.clone(),
+                            expanded_bounds,
+                        )))
                     }
                     (Err(e), _) => Err(DataFusionError::External(Box::new(e))),
                 }
             }
             // Not between a literal and a column
-            _ => Ok(Some(Self::Unknown)),
+            _ => Ok(Some(SpatialFilter::Unknown)),
         }
+    }
+
+    /// Our current spatial data pruning implementation does not correctly handle geography data.
+    /// We therefore only consider geometry data type for pruning.
+    fn is_prunable_geospatial_literal(&self, literal: &Literal) -> bool {
+        let Ok(literal_field) = literal.return_field(&Schema::empty()) else {
+            return false;
+        };
+        let Ok(sedona_type) = SedonaType::from_storage_field(&literal_field) else {
+            return false;
+        };
+        let matcher = ArgMatcher::is_geometry();
+        matcher.match_type(&sedona_type)
+    }
+
+    fn literal_bounds(&self, literal: &Literal) -> Result<BoundingBox> {
+        let literal_field = literal.return_field(&Schema::empty())?;
+        let sedona_type = SedonaType::from_storage_field(&literal_field)?;
+        match &sedona_type {
+            SedonaType::Wkb(_, _) | SedonaType::WkbView(_, _) => match literal.value() {
+                ScalarValue::Binary(maybe_vec) | ScalarValue::BinaryView(maybe_vec) => {
+                    if let Some(vec) = maybe_vec {
+                        return wkb_bounds_xy(vec)
+                            .map_err(|e| DataFusionError::External(Box::new(e)));
+                    }
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+
+        sedona_internal_err!("Unexpected scalar type in filter expression ({literal:?})")
     }
 }
 
@@ -477,37 +526,6 @@ enum ArgRef<'a> {
     Other,
 }
 
-/// Our current spatial data pruning implementation does not correctly handle geography data.
-/// We therefore only consider geometry data type for pruning.
-fn is_prunable_geospatial_literal(literal: &Literal) -> bool {
-    let Ok(literal_field) = literal.return_field(&Schema::empty()) else {
-        return false;
-    };
-    let Ok(sedona_type) = SedonaType::from_storage_field(&literal_field) else {
-        return false;
-    };
-    let matcher = ArgMatcher::is_geometry();
-    matcher.match_type(&sedona_type)
-}
-
-fn literal_bounds(literal: &Literal) -> Result<BoundingBox> {
-    let literal_field = literal.return_field(&Schema::empty())?;
-    let sedona_type = SedonaType::from_storage_field(&literal_field)?;
-    match &sedona_type {
-        SedonaType::Wkb(_, _) | SedonaType::WkbView(_, _) => match literal.value() {
-            ScalarValue::Binary(maybe_vec) | ScalarValue::BinaryView(maybe_vec) => {
-                if let Some(vec) = maybe_vec {
-                    return wkb_bounds_xy(vec).map_err(|e| DataFusionError::External(Box::new(e)));
-                }
-            }
-            _ => {}
-        },
-        _ => {}
-    }
-
-    sedona_internal_err!("Unexpected scalar type in filter expression ({literal:?})")
-}
-
 fn parse_args(args: &[Arc<dyn PhysicalExpr>]) -> Vec<ArgRef<'_>> {
     args.iter().map(parse_arg).collect::<Vec<_>>()
 }
@@ -576,12 +594,13 @@ mod test {
 
     #[test]
     fn predicate_intersects() {
+        let factory = SpatialFilterFactory::default();
         let storage_field = WKB_GEOMETRY.to_storage_field("", true).unwrap();
         let literal = Literal::new_with_metadata(
             create_scalar(Some("POINT (1 2)"), &WKB_GEOMETRY),
             Some(storage_field.metadata().into()),
         );
-        let bounds = literal_bounds(&literal).unwrap();
+        let bounds = factory.literal_bounds(&literal).unwrap();
 
         let stats_no_info = TableGeoStatistics::from(GeoStatistics::unspecified());
         let stats_intersecting = TableGeoStatistics::from(
@@ -607,7 +626,7 @@ mod test {
 
         let unrelated_literal = Literal::new(ScalarValue::Null);
 
-        let err = literal_bounds(&unrelated_literal).unwrap_err();
+        let err = factory.literal_bounds(&unrelated_literal).unwrap_err();
         assert!(err
             .message()
             .contains("Unexpected scalar type in filter expression"));
@@ -615,12 +634,13 @@ mod test {
 
     #[test]
     fn predicate_covers() {
+        let factory = SpatialFilterFactory::default();
         let storage_field = WKB_GEOMETRY.to_storage_field("", true).unwrap();
         let literal = Literal::new_with_metadata(
             create_scalar(Some("POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0))"), &WKB_GEOMETRY),
             Some(storage_field.metadata().into()),
         );
-        let bounds = literal_bounds(&literal).unwrap();
+        let bounds = factory.literal_bounds(&literal).unwrap();
 
         let stats_no_info = TableGeoStatistics::from(GeoStatistics::unspecified());
         let stats_covered = TableGeoStatistics::from(
@@ -723,12 +743,13 @@ mod test {
 
     #[test]
     fn predicate_from_expr_errors() {
+        let factory = SpatialFilterFactory::default();
         let literal: Arc<dyn PhysicalExpr> = Arc::new(Literal::new(ScalarValue::Null));
         let unrelated = dummy_unrelated();
 
         // Not a scalar function
         assert!(matches!(
-            SpatialFilter::try_from_expr(&literal).unwrap(),
+            factory.try_from_expr(&literal).unwrap(),
             SpatialFilter::Unknown
         ));
 
@@ -741,7 +762,7 @@ mod test {
             Arc::new(ConfigOptions::default()),
         ));
         assert!(matches!(
-            SpatialFilter::try_from_expr(&expr_no_args).unwrap(),
+            factory.try_from_expr(&expr_no_args).unwrap(),
             SpatialFilter::Unknown
         ));
     }
@@ -750,6 +771,7 @@ mod test {
     fn predicate_from_expr_commutative_intersects_functions(
         #[values("st_intersects", "st_touches", "st_crosses", "st_overlaps")] func_name: &str,
     ) {
+        let factory = SpatialFilterFactory::default();
         let column: Arc<dyn PhysicalExpr> = Arc::new(Column::new("geometry", 0));
         let storage_field = WKB_GEOMETRY.to_storage_field("", true).unwrap();
         let literal: Arc<dyn PhysicalExpr> = Arc::new(Literal::new_with_metadata(
@@ -766,7 +788,7 @@ mod test {
             Arc::new(Field::new("", DataType::Boolean, true)),
             Arc::new(ConfigOptions::default()),
         ));
-        let predicate = SpatialFilter::try_from_expr(&expr).unwrap();
+        let predicate = factory.try_from_expr(&expr).unwrap();
         assert!(
             matches!(predicate, SpatialFilter::Intersects(_, _)),
             "Function {func_name} should produce Intersects filter"
@@ -780,7 +802,7 @@ mod test {
             Arc::new(Field::new("", DataType::Boolean, true)),
             Arc::new(ConfigOptions::default()),
         ));
-        let predicate_reversed = SpatialFilter::try_from_expr(&expr_reversed).unwrap();
+        let predicate_reversed = factory.try_from_expr(&expr_reversed).unwrap();
         assert!(
             matches!(predicate_reversed, SpatialFilter::Intersects(_, _)),
             "Function {func_name} with reversed args should produce Intersects filter"
@@ -789,6 +811,7 @@ mod test {
 
     #[rstest]
     fn predicate_from_expr_equals_function(#[values("st_equals")] func_name: &str) {
+        let factory = SpatialFilterFactory::default();
         let column: Arc<dyn PhysicalExpr> = Arc::new(Column::new("geometry", 0));
         let storage_field = WKB_GEOMETRY.to_storage_field("", true).unwrap();
         let literal: Arc<dyn PhysicalExpr> = Arc::new(Literal::new_with_metadata(
@@ -805,7 +828,7 @@ mod test {
             Arc::new(Field::new("", DataType::Boolean, true)),
             Arc::new(ConfigOptions::default()),
         ));
-        let predicate = SpatialFilter::try_from_expr(&expr).unwrap();
+        let predicate = factory.try_from_expr(&expr).unwrap();
         assert!(
             matches!(predicate, SpatialFilter::Covers(_, _)),
             "Function {func_name} should produce Covers filter"
@@ -819,7 +842,7 @@ mod test {
             Arc::new(Field::new("", DataType::Boolean, true)),
             Arc::new(ConfigOptions::default()),
         ));
-        let predicate_reversed = SpatialFilter::try_from_expr(&expr_reversed).unwrap();
+        let predicate_reversed = factory.try_from_expr(&expr_reversed).unwrap();
         assert!(
             matches!(predicate_reversed, SpatialFilter::Covers(_, _)),
             "Function {func_name} with reversed args should produce Covers filter"
@@ -830,6 +853,7 @@ mod test {
     fn predicate_from_expr_within_covered_by_functions(
         #[values("st_within", "st_covered_by", "st_coveredby")] func_name: &str,
     ) {
+        let factory = SpatialFilterFactory::default();
         let column: Arc<dyn PhysicalExpr> = Arc::new(Column::new("geometry", 0));
         let storage_field = WKB_GEOMETRY.to_storage_field("", true).unwrap();
         let literal: Arc<dyn PhysicalExpr> = Arc::new(Literal::new_with_metadata(
@@ -846,7 +870,7 @@ mod test {
             Arc::new(Field::new("", DataType::Boolean, true)),
             Arc::new(ConfigOptions::default()),
         ));
-        let predicate = SpatialFilter::try_from_expr(&expr).unwrap();
+        let predicate = factory.try_from_expr(&expr).unwrap();
         assert!(
             matches!(predicate, SpatialFilter::Intersects(_, _)),
             "Function {func_name} should produce Intersects filter"
@@ -860,7 +884,7 @@ mod test {
             Arc::new(Field::new("", DataType::Boolean, true)),
             Arc::new(ConfigOptions::default()),
         ));
-        let predicate_reversed = SpatialFilter::try_from_expr(&expr_reversed).unwrap();
+        let predicate_reversed = factory.try_from_expr(&expr_reversed).unwrap();
         assert!(
             matches!(predicate_reversed, SpatialFilter::Covers(_, _)),
             "Function {func_name} with reversed args should produce Covers filter"
@@ -871,6 +895,7 @@ mod test {
     fn predicate_from_expr_contains_covers_functions(
         #[values("st_contains", "st_covers")] func_name: &str,
     ) {
+        let factory = SpatialFilterFactory::default();
         let column: Arc<dyn PhysicalExpr> = Arc::new(Column::new("geometry", 0));
         let storage_field = WKB_GEOMETRY.to_storage_field("", true).unwrap();
         let literal: Arc<dyn PhysicalExpr> = Arc::new(Literal::new_with_metadata(
@@ -888,7 +913,7 @@ mod test {
             Arc::new(Field::new("", DataType::Boolean, true)),
             Arc::new(ConfigOptions::default()),
         ));
-        let predicate = SpatialFilter::try_from_expr(&expr).unwrap();
+        let predicate = factory.try_from_expr(&expr).unwrap();
         assert!(
             matches!(predicate, SpatialFilter::Covers(_, _)),
             "Function {func_name} should produce CoveredBy filter"
@@ -903,7 +928,7 @@ mod test {
             Arc::new(Field::new("", DataType::Boolean, true)),
             Arc::new(ConfigOptions::default()),
         ));
-        let predicate_reversed = SpatialFilter::try_from_expr(&expr_reversed).unwrap();
+        let predicate_reversed = factory.try_from_expr(&expr_reversed).unwrap();
         assert!(
             matches!(predicate_reversed, SpatialFilter::Intersects(_, _)),
             "Function {func_name} with reversed args should produce Intersects filter"
@@ -912,6 +937,7 @@ mod test {
 
     #[test]
     fn predicate_from_expr_distance_functions() {
+        let factory = SpatialFilterFactory::default();
         let column: Arc<dyn PhysicalExpr> = Arc::new(Column::new("geometry", 0));
         let storage_field = WKB_GEOMETRY.to_storage_field("", true).unwrap();
         let literal: Arc<dyn PhysicalExpr> = Arc::new(Literal::new_with_metadata(
@@ -930,7 +956,7 @@ mod test {
             Arc::new(Field::new("", DataType::Boolean, true)),
             Arc::new(ConfigOptions::default()),
         ));
-        let predicate = SpatialFilter::try_from_expr(&dwithin_expr).unwrap();
+        let predicate = factory.try_from_expr(&dwithin_expr).unwrap();
         assert!(
             matches!(predicate, SpatialFilter::Intersects(_, _)),
             "ST_DWithin should produce Intersects filter with expanded bounds"
@@ -944,7 +970,7 @@ mod test {
             Arc::new(Field::new("", DataType::Boolean, true)),
             Arc::new(ConfigOptions::default()),
         ));
-        let predicate_reversed = SpatialFilter::try_from_expr(&dwithin_expr_reversed).unwrap();
+        let predicate_reversed = factory.try_from_expr(&dwithin_expr_reversed).unwrap();
         assert!(
             matches!(predicate_reversed, SpatialFilter::Intersects(_, _)),
             "ST_DWithin with reversed args should produce Intersects filter"
@@ -964,7 +990,7 @@ mod test {
             Operator::LtEq,
             distance_literal.clone(),
         ));
-        let predicate = SpatialFilter::try_from_expr(&comparison_expr).unwrap();
+        let predicate = factory.try_from_expr(&comparison_expr).unwrap();
         assert!(
             matches!(predicate, SpatialFilter::Intersects(_, _)),
             "ST_Distance <= threshold should produce Intersects filter"
@@ -976,7 +1002,7 @@ mod test {
             Operator::GtEq,
             distance_expr.clone(),
         ));
-        let predicate_reversed = SpatialFilter::try_from_expr(&comparison_expr_reversed).unwrap();
+        let predicate_reversed = factory.try_from_expr(&comparison_expr_reversed).unwrap();
         assert!(
             matches!(predicate_reversed, SpatialFilter::Intersects(_, _)),
             "threshold >= ST_Distance should produce Intersects filter"
@@ -993,7 +1019,7 @@ mod test {
             Arc::new(Field::new("", DataType::Boolean, true)),
             Arc::new(ConfigOptions::default()),
         ));
-        let predicate = SpatialFilter::try_from_expr(&dwithin_expr).unwrap();
+        let predicate = factory.try_from_expr(&dwithin_expr).unwrap();
         assert!(
             matches!(predicate, SpatialFilter::Unknown),
             "Negative distance should result in Unknown filter"
@@ -1009,7 +1035,7 @@ mod test {
             Arc::new(Field::new("", DataType::Boolean, true)),
             Arc::new(ConfigOptions::default()),
         ));
-        let predicate_nan = SpatialFilter::try_from_expr(&dwithin_expr_nan).unwrap();
+        let predicate_nan = factory.try_from_expr(&dwithin_expr_nan).unwrap();
         assert!(
             matches!(predicate_nan, SpatialFilter::Unknown),
             "NaN distance should result in Unknown filter"
@@ -1032,6 +1058,7 @@ mod test {
         )]
         func_name: &str,
     ) {
+        let factory = SpatialFilterFactory::default();
         let literal: Arc<dyn PhysicalExpr> = Arc::new(Literal::new(ScalarValue::Null));
         let st_intersects = create_dummy_spatial_function(func_name, 2);
 
@@ -1043,7 +1070,8 @@ mod test {
             Arc::new(Field::new("", DataType::Boolean, true)),
             Arc::new(ConfigOptions::default()),
         ));
-        assert!(SpatialFilter::try_from_expr(&expr_no_args)
+        assert!(factory
+            .try_from_expr(&expr_no_args)
             .unwrap_err()
             .message()
             .contains("unexpected argument count"));
@@ -1057,7 +1085,7 @@ mod test {
             Arc::new(ConfigOptions::default()),
         ));
         assert!(matches!(
-            SpatialFilter::try_from_expr(&expr_wrong_types).unwrap(),
+            factory.try_from_expr(&expr_wrong_types).unwrap(),
             SpatialFilter::Unknown
         ));
     }
@@ -1078,6 +1106,7 @@ mod test {
         )]
         func_name: &str,
     ) {
+        let factory = SpatialFilterFactory::default();
         let column: Arc<dyn PhysicalExpr> = Arc::new(Column::new("geometry", 0));
         let storage_field = WKB_GEOGRAPHY.to_storage_field("", true).unwrap();
         let literal: Arc<dyn PhysicalExpr> = Arc::new(Literal::new_with_metadata(
@@ -1093,7 +1122,7 @@ mod test {
             Arc::new(Field::new("", DataType::Boolean, true)),
             Arc::new(ConfigOptions::default()),
         ));
-        let predicate = SpatialFilter::try_from_expr(&expr).unwrap();
+        let predicate = factory.try_from_expr(&expr).unwrap();
         assert!(
             matches!(predicate, SpatialFilter::Unknown),
             "Function {func_name} involving geography should produce Unknown filter"
@@ -1102,6 +1131,7 @@ mod test {
 
     #[test]
     fn distance_predicate_involving_geography_should_be_transformed_to_unknown() {
+        let factory = SpatialFilterFactory::default();
         let column: Arc<dyn PhysicalExpr> = Arc::new(Column::new("geometry", 0));
         let storage_field = WKB_GEOGRAPHY.to_storage_field("", true).unwrap();
         let literal: Arc<dyn PhysicalExpr> = Arc::new(Literal::new_with_metadata(
@@ -1120,7 +1150,7 @@ mod test {
             Arc::new(Field::new("", DataType::Boolean, true)),
             Arc::new(ConfigOptions::default()),
         ));
-        let predicate = SpatialFilter::try_from_expr(&dwithin_expr).unwrap();
+        let predicate = factory.try_from_expr(&dwithin_expr).unwrap();
         assert!(
             matches!(predicate, SpatialFilter::Unknown),
             "ST_DWithin involving geography should produce Unknown filter"
@@ -1134,7 +1164,7 @@ mod test {
             Arc::new(Field::new("", DataType::Boolean, true)),
             Arc::new(ConfigOptions::default()),
         ));
-        let predicate_reversed = SpatialFilter::try_from_expr(&dwithin_expr_reversed).unwrap();
+        let predicate_reversed = factory.try_from_expr(&dwithin_expr_reversed).unwrap();
         assert!(
             matches!(predicate_reversed, SpatialFilter::Unknown),
             "ST_DWithin involving geography should produce Unknown filter"
@@ -1154,7 +1184,7 @@ mod test {
             Operator::LtEq,
             distance_literal.clone(),
         ));
-        let predicate = SpatialFilter::try_from_expr(&comparison_expr).unwrap();
+        let predicate = factory.try_from_expr(&comparison_expr).unwrap();
         assert!(
             matches!(predicate, SpatialFilter::Unknown),
             "ST_Distance <= threshold involving geography should produce Unknown filter"
@@ -1166,7 +1196,7 @@ mod test {
             Operator::GtEq,
             distance_expr.clone(),
         ));
-        let predicate_reversed = SpatialFilter::try_from_expr(&comparison_expr_reversed).unwrap();
+        let predicate_reversed = factory.try_from_expr(&comparison_expr_reversed).unwrap();
         assert!(
             matches!(predicate_reversed, SpatialFilter::Unknown),
             "threshold >= ST_Distance involving geography should produce Unknown filter"
@@ -1175,6 +1205,7 @@ mod test {
 
     #[test]
     fn predicate_from_expr_has_z() {
+        let factory = SpatialFilterFactory::default();
         let column: Arc<dyn PhysicalExpr> = Arc::new(Column::new("geometry", 0));
         let has_z = dummy_st_hasz();
 
@@ -1185,12 +1216,13 @@ mod test {
             Arc::new(Field::new("", DataType::Boolean, true)),
             Arc::new(ConfigOptions::default()),
         ));
-        let predicate = SpatialFilter::try_from_expr(&expr).unwrap();
+        let predicate = factory.try_from_expr(&expr).unwrap();
         assert!(matches!(predicate, SpatialFilter::HasZ(_)));
     }
 
     #[test]
     fn predicate_from_has_z_errors() {
+        let factory = SpatialFilterFactory::default();
         let literal: Arc<dyn PhysicalExpr> = Arc::new(Literal::new(ScalarValue::Null));
         let has_z = dummy_st_hasz();
 
@@ -1201,7 +1233,8 @@ mod test {
             Arc::new(Field::new("", DataType::Boolean, true)),
             Arc::new(ConfigOptions::default()),
         ));
-        assert!(SpatialFilter::try_from_expr(&expr_no_args)
+        assert!(factory
+            .try_from_expr(&expr_no_args)
             .unwrap_err()
             .message()
             .contains("unexpected argument count"));
@@ -1215,13 +1248,14 @@ mod test {
             Arc::new(ConfigOptions::default()),
         ));
         assert!(matches!(
-            SpatialFilter::try_from_expr(&expr_wrong_types).unwrap(),
+            factory.try_from_expr(&expr_wrong_types).unwrap(),
             SpatialFilter::Unknown
         ));
     }
 
     #[test]
     fn predicate_from_binary() {
+        let factory = SpatialFilterFactory::default();
         let literal_false: Arc<dyn PhysicalExpr> =
             Arc::new(Literal::new(ScalarValue::Boolean(Some(false))));
         let literal_true: Arc<dyn PhysicalExpr> =
@@ -1237,14 +1271,14 @@ mod test {
             literal_true.clone(),
         ));
 
-        if let SpatialFilter::And(lhs, rhs) = SpatialFilter::try_from_expr(&binary_and).unwrap() {
+        if let SpatialFilter::And(lhs, rhs) = factory.try_from_expr(&binary_and).unwrap() {
             assert!(matches!(*lhs, SpatialFilter::LiteralFalse));
             assert!(matches!(*rhs, SpatialFilter::Unknown));
         } else {
             panic!("Parse incorrect!")
         }
 
-        if let SpatialFilter::Or(lhs, rhs) = SpatialFilter::try_from_expr(&binary_or).unwrap() {
+        if let SpatialFilter::Or(lhs, rhs) = factory.try_from_expr(&binary_or).unwrap() {
             assert!(matches!(*lhs, SpatialFilter::LiteralFalse));
             assert!(matches!(*rhs, SpatialFilter::Unknown));
         } else {

--- a/rust/sedona-expr/src/spatial_filter.rs
+++ b/rust/sedona-expr/src/spatial_filter.rs
@@ -705,9 +705,12 @@ mod test {
         let err = factory
             .literal_bounds(&unrelated_literal, None)
             .unwrap_err();
-        assert!(err
-            .message()
-            .contains("Unexpected scalar type in filter expression"));
+        assert!(
+            err.message()
+                .contains("Can't resolve bounder for type Null"),
+            "Actual error was:\n{}",
+            err.message()
+        );
     }
 
     #[test]

--- a/rust/sedona-expr/src/spatial_filter.rs
+++ b/rust/sedona-expr/src/spatial_filter.rs
@@ -183,6 +183,7 @@ impl SpatialFilter {
     }
 }
 
+/// Factory for creating [SpatialFilter] objects from expressions
 #[derive(Debug, Clone)]
 pub struct SpatialFilterFactory {
     literal_bounders: Vec<Arc<dyn LiteralBounder>>,
@@ -412,7 +413,6 @@ impl SpatialFilterFactory {
                     return sedona_internal_err!("Unexpected cast result from scalar distance");
                 };
 
-                // TODO: check...some of these cases possibly should return LiteralFalse
                 if let Some(distance) = distance_opt {
                     if distance.is_nan() || distance < 0.0 {
                         Ok(None)

--- a/rust/sedona-geoparquet/src/file_opener.rs
+++ b/rust/sedona-geoparquet/src/file_opener.rs
@@ -56,6 +56,7 @@ use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
 use crate::{
     metadata::{GeoParquetColumnEncoding, GeoParquetMetadata},
     options::TableGeoParquetOptions,
+    statistics_accumulator::GeographyLiteralBounder,
 };
 
 #[derive(Clone)]
@@ -136,7 +137,8 @@ impl FileOpener for GeoParquetFileOpener {
 
             if self_clone.enable_pruning {
                 if let Some(predicate) = self_clone.predicate.as_ref() {
-                    let factory = SpatialFilterFactory::default();
+                    let factory = SpatialFilterFactory::default()
+                        .with_bounder(Arc::new(GeographyLiteralBounder));
                     let spatial_filter = factory.try_from_expr(predicate)?;
 
                     if let Some(geoparquet_metadata) = maybe_geoparquet_metadata.as_ref() {

--- a/rust/sedona-geoparquet/src/file_opener.rs
+++ b/rust/sedona-geoparquet/src/file_opener.rs
@@ -139,6 +139,7 @@ impl FileOpener for GeoParquetFileOpener {
                 if let Some(predicate) = self_clone.predicate.as_ref() {
                     let factory = SpatialFilterFactory::default()
                         .with_bounder(Arc::new(GeographyLiteralBounder));
+
                     let spatial_filter = factory.try_from_expr(predicate)?;
 
                     if let Some(geoparquet_metadata) = maybe_geoparquet_metadata.as_ref() {

--- a/rust/sedona-geoparquet/src/file_opener.rs
+++ b/rust/sedona-geoparquet/src/file_opener.rs
@@ -43,7 +43,7 @@ use parquet::{
     geospatial::statistics::GeospatialStatistics,
 };
 use sedona_expr::{
-    spatial_filter::{SpatialFilter, TableGeoStatistics},
+    spatial_filter::{SpatialFilter, SpatialFilterFactory, TableGeoStatistics},
     statistics::GeoStatistics,
 };
 use sedona_geometry::{
@@ -136,7 +136,8 @@ impl FileOpener for GeoParquetFileOpener {
 
             if self_clone.enable_pruning {
                 if let Some(predicate) = self_clone.predicate.as_ref() {
-                    let spatial_filter = SpatialFilter::try_from_expr(predicate)?;
+                    let factory = SpatialFilterFactory::default();
+                    let spatial_filter = factory.try_from_expr(predicate)?;
 
                     if let Some(geoparquet_metadata) = maybe_geoparquet_metadata.as_ref() {
                         filter_access_plan_using_geoparquet_file_metadata(

--- a/rust/sedona-geoparquet/src/statistics_accumulator.rs
+++ b/rust/sedona-geoparquet/src/statistics_accumulator.rs
@@ -17,7 +17,7 @@
 
 use std::sync::Arc;
 
-use datafusion_common::{exec_datafusion_err, Result, ScalarValue};
+use datafusion_common::{Result, ScalarValue};
 use parquet::{
     basic::LogicalType,
     geospatial::accumulator::{
@@ -70,6 +70,23 @@ impl GeoStatsAccumulatorFactory for SedonaGeoStatsAccumulatorFactory {
 #[derive(Debug, Default)]
 pub struct GeographyLiteralBounder;
 
+#[cfg(not(feature = "s2geography"))]
+impl LiteralBounder for GeographyLiteralBounder {
+    fn can_bound(&self, _sedona_type: &SedonaType) -> bool {
+        false
+    }
+
+    fn bound_scalar(
+        &self,
+        _value: &ScalarValue,
+        _sedona_type: &SedonaType,
+        _distance: Option<f64>,
+    ) -> Result<sedona_geometry::bounding_box::BoundingBox> {
+        sedona_internal_err!("dummy bound_scalar() should not be called")
+    }
+}
+
+#[cfg(feature = "s2geography")]
 impl LiteralBounder for GeographyLiteralBounder {
     fn can_bound(&self, sedona_type: &SedonaType) -> bool {
         matches!(
@@ -93,10 +110,14 @@ impl LiteralBounder for GeographyLiteralBounder {
                         let mut bounder = sedona_s2geography::rect_bounder::RectBounder::new();
                         let mut factory = sedona_s2geography::geography::GeographyFactory::new();
                         let geog = factory.from_wkb(vec).map_err(|e| {
-                            exec_datafusion_err!("Error parsing geography literal: {e}")
+                            datafusion_common::exec_datafusion_err!(
+                                "Error parsing geography literal: {e}"
+                            )
                         })?;
                         bounder.bound(&geog).map_err(|e| {
-                            exec_datafusion_err!("Error bounding geography literal: {e}")
+                            datafusion_common::exec_datafusion_err!(
+                                "Error bounding geography literal: {e}"
+                            )
                         })?;
 
                         if let Some(distance) = distance {
@@ -104,7 +125,9 @@ impl LiteralBounder for GeographyLiteralBounder {
                         }
 
                         if let Some((xmin, ymin, xmax, ymax)) = bounder.finish().map_err(|e| {
-                            exec_datafusion_err!("Error finishing geography bounds: {e}")
+                            datafusion_common::exec_datafusion_err!(
+                                "Error finishing geography bounds: {e}"
+                            )
                         })? {
                             return Ok(sedona_geometry::bounding_box::BoundingBox::xy(
                                 (xmin, xmax),

--- a/rust/sedona-geoparquet/src/statistics_accumulator.rs
+++ b/rust/sedona-geoparquet/src/statistics_accumulator.rs
@@ -17,7 +17,7 @@
 
 use std::sync::Arc;
 
-use datafusion_common::Result;
+use datafusion_common::{exec_datafusion_err, Result, ScalarValue};
 use parquet::{
     basic::LogicalType,
     geospatial::accumulator::{
@@ -26,6 +26,9 @@ use parquet::{
     },
     schema::types::ColumnDescPtr,
 };
+use sedona_common::sedona_internal_err;
+use sedona_expr::spatial_filter::LiteralBounder;
+use sedona_schema::datatypes::SedonaType;
 
 pub struct SedonaGeoStatsAccumulatorFactory;
 
@@ -61,6 +64,63 @@ impl GeoStatsAccumulatorFactory for SedonaGeoStatsAccumulatorFactory {
         }
 
         Box::new(VoidGeoStatsAccumulator::default())
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct GeographyLiteralBounder;
+
+impl LiteralBounder for GeographyLiteralBounder {
+    fn can_bound(&self, sedona_type: &SedonaType) -> bool {
+        matches!(
+            sedona_type,
+            SedonaType::Wkb(sedona_schema::datatypes::Edges::Spherical, _)
+                | SedonaType::WkbView(sedona_schema::datatypes::Edges::Spherical, _)
+        )
+    }
+
+    fn bound_scalar(
+        &self,
+        value: &ScalarValue,
+        sedona_type: &SedonaType,
+        distance: Option<f64>,
+    ) -> Result<sedona_geometry::bounding_box::BoundingBox> {
+        match &sedona_type {
+            SedonaType::Wkb(sedona_schema::datatypes::Edges::Spherical, _)
+            | SedonaType::WkbView(sedona_schema::datatypes::Edges::Spherical, _) => match value {
+                ScalarValue::Binary(maybe_vec) | ScalarValue::BinaryView(maybe_vec) => {
+                    if let Some(vec) = maybe_vec {
+                        let mut bounder = sedona_s2geography::rect_bounder::RectBounder::new();
+                        let mut factory = sedona_s2geography::geography::GeographyFactory::new();
+                        let geog = factory.from_wkb(vec).map_err(|e| {
+                            exec_datafusion_err!("Error parsing geography literal: {e}")
+                        })?;
+                        bounder.bound(&geog).map_err(|e| {
+                            exec_datafusion_err!("Error bounding geography literal: {e}")
+                        })?;
+
+                        if let Some(distance) = distance {
+                            bounder.expand_by_distance(distance);
+                        }
+
+                        if let Some((xmin, ymin, xmax, ymax)) = bounder.finish().map_err(|e| {
+                            exec_datafusion_err!("Error finishing geography bounds: {e}")
+                        })? {
+                            return Ok(sedona_geometry::bounding_box::BoundingBox::xy(
+                                (xmin, xmax),
+                                (ymin, ymax),
+                            ));
+                        } else {
+                            return Ok(sedona_geometry::bounding_box::BoundingBox::empty());
+                        }
+                    }
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+
+        sedona_internal_err!("Unexpected scalar type in filter expression ({sedona_type:?})")
     }
 }
 

--- a/rust/sedona-geoparquet/src/statistics_accumulator.rs
+++ b/rust/sedona-geoparquet/src/statistics_accumulator.rs
@@ -30,6 +30,7 @@ use sedona_common::sedona_internal_err;
 use sedona_expr::spatial_filter::LiteralBounder;
 use sedona_schema::datatypes::SedonaType;
 
+/// Factory for Parquet GeoStatsAccumulators that can handle Geography
 pub struct SedonaGeoStatsAccumulatorFactory;
 
 impl SedonaGeoStatsAccumulatorFactory {
@@ -67,6 +68,7 @@ impl GeoStatsAccumulatorFactory for SedonaGeoStatsAccumulatorFactory {
     }
 }
 
+/// LiteralBounder implementation capable of bounding geography scalars
 #[derive(Debug, Default)]
 pub struct GeographyLiteralBounder;
 

--- a/rust/sedona-geoparquet/src/statistics_accumulator.rs
+++ b/rust/sedona-geoparquet/src/statistics_accumulator.rs
@@ -133,10 +133,11 @@ impl LiteralBounder for GeographyLiteralBounder {
                                 (xmin, xmax),
                                 (ymin, ymax),
                             ));
-                        } else {
-                            return Ok(sedona_geometry::bounding_box::BoundingBox::empty());
                         }
                     }
+
+                    // Null scalar or empty geography returns an empty bounding box
+                    return Ok(sedona_geometry::bounding_box::BoundingBox::empty());
                 }
                 _ => {}
             },
@@ -248,5 +249,207 @@ impl GeoStatsAccumulator for GeographyGeoStatsAccumulator {
         Some(Box::new(
             parquet::geospatial::statistics::GeospatialStatistics::new(Some(bbox), geometry_types),
         ))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use parquet::geospatial::bounding_box::BoundingBox;
+    use parquet_geospatial::testing::{wkb_point_xy, wkb_point_xyzm};
+    use sedona_schema::datatypes::{WKB_GEOGRAPHY, WKB_VIEW_GEOGRAPHY};
+    use sedona_testing::create::create_scalar;
+
+    #[test]
+    fn test_factory() {}
+
+    #[cfg(feature = "s2geography")]
+    #[test]
+    fn test_literal_bounder() {
+        use sedona_geometry::interval::IntervalTrait;
+
+        for sedona_type in [WKB_GEOGRAPHY, WKB_VIEW_GEOGRAPHY] {
+            let bounder = GeographyLiteralBounder;
+            assert!(bounder.can_bound(&sedona_type));
+
+            let scalar = create_scalar(Some("MULTIPOINT ((-179 42), (179 43))"), &sedona_type);
+
+            // Check approximate raw bounds
+            let raw_bounds = bounder.bound_scalar(&scalar, &sedona_type, None).unwrap();
+            assert!(raw_bounds.x().is_wraparound());
+            assert!(raw_bounds.x().lo() > 178.99999 && raw_bounds.x().lo() <= 179.0);
+            assert!(raw_bounds.x().hi() >= -179.0 && raw_bounds.x().hi() < -178.99999);
+            assert!(raw_bounds.y().lo() > 41.0 && raw_bounds.y().lo() <= 42.0);
+            assert!(raw_bounds.y().hi() >= 43.0 && raw_bounds.y().hi() < 44.0);
+
+            // Check that expanded bounds are bigger (100 km ~ 0.9 degrees)
+            let expanded_bounds = bounder
+                .bound_scalar(&scalar, &sedona_type, Some(100000.0))
+                .unwrap();
+            assert!(expanded_bounds.x().is_wraparound());
+            assert!(raw_bounds.x().lo() - expanded_bounds.x().lo() > 0.5);
+            assert!(expanded_bounds.x().hi() - raw_bounds.x().hi() > 0.5);
+            assert!(raw_bounds.y().lo() - expanded_bounds.y().lo() > 0.5);
+            assert!(expanded_bounds.y().hi() - raw_bounds.y().hi() > 0.5);
+
+            let null_scalar = create_scalar(None, &sedona_type);
+            let null_bounds = bounder
+                .bound_scalar(&null_scalar, &sedona_type, None)
+                .unwrap();
+            assert!(null_bounds.is_empty());
+        }
+    }
+
+    #[cfg(not(feature = "s2geography"))]
+    #[test]
+    fn test_literal_bounder() {
+        for sedona_type in [WKB_GEOGRAPHY, WKB_VIEW_GEOGRAPHY] {
+            let scalar = create_scalar(Some("MULTIPOINT ((-179 42), (179 43))"), &sedona_type);
+            let bounder = GeographyLiteralBounder;
+            assert!(!bounder.can_bound(&sedona_type));
+            bounder
+                .bound_scalar(&scalar, &sedona_type, None)
+                .unwrap_err();
+        }
+    }
+
+    #[cfg(feature = "s2geography")]
+    fn assert_bbox_contains(actual: &BoundingBox, expected: &BoundingBox, epsilon: f64) {
+        // actual.xmin should be <= expected.xmin (can be slightly smaller)
+        assert!(
+            expected.get_xmin() - actual.get_xmin() >= 0.0
+                && expected.get_xmin() - actual.get_xmin() < epsilon,
+            "x_min mismatch: actual {} should be <= expected {} (within {})",
+            actual.get_xmin(),
+            expected.get_xmin(),
+            epsilon
+        );
+        // actual.xmax should be >= expected.xmax (can be slightly larger)
+        assert!(
+            actual.get_xmax() - expected.get_xmax() >= 0.0
+                && actual.get_xmax() - expected.get_xmax() < epsilon,
+            "x_max mismatch: actual {} should be >= expected {} (within {})",
+            actual.get_xmax(),
+            expected.get_xmax(),
+            epsilon
+        );
+        // actual.ymin should be <= expected.ymin (can be slightly smaller)
+        assert!(
+            expected.get_ymin() - actual.get_ymin() >= 0.0
+                && expected.get_ymin() - actual.get_ymin() < epsilon,
+            "y_min mismatch: actual {} should be <= expected {} (within {})",
+            actual.get_ymin(),
+            expected.get_ymin(),
+            epsilon
+        );
+        // actual.ymax should be >= expected.ymax (can be slightly larger)
+        assert!(
+            actual.get_ymax() - expected.get_ymax() >= 0.0
+                && actual.get_ymax() - expected.get_ymax() < epsilon,
+            "y_max mismatch: actual {} should be >= expected {} (within {})",
+            actual.get_ymax(),
+            expected.get_ymax(),
+            epsilon
+        );
+
+        assert_eq!(actual.get_zmin(), expected.get_zmin(), "z_min mismatch");
+        assert_eq!(actual.get_zmax(), expected.get_zmax(), "z_max mismatch");
+        assert_eq!(actual.get_mmin(), expected.get_mmin(), "m_min mismatch");
+        assert_eq!(actual.get_mmax(), expected.get_mmax(), "m_max mismatch");
+    }
+
+    #[cfg(feature = "s2geography")]
+    #[test]
+    fn test_geography_accumulator() {
+        // The geography bounder produces slightly expanded bounds compared to the
+        // geometry bounder due to spherical interpolation along geodesics.
+        const EPSILON: f64 = 1e-10;
+        let mut accumulator = GeographyGeoStatsAccumulator::default();
+
+        // A fresh instance should be able to bound input
+        assert!(accumulator.is_valid());
+        accumulator.update_wkb(&wkb_point_xy(1.0, 2.0));
+        accumulator.update_wkb(&wkb_point_xy(11.0, 12.0));
+        let stats = accumulator.finish().unwrap();
+        assert_eq!(stats.geospatial_types().unwrap(), &vec![1]);
+        assert_bbox_contains(
+            stats.bounding_box().unwrap(),
+            &BoundingBox::new(1.0, 11.0, 2.0, 12.0),
+            EPSILON,
+        );
+
+        // finish() should have reset the bounder such that the first values
+        // aren't when computing the next bound of statistics.
+        assert!(accumulator.is_valid());
+        accumulator.update_wkb(&wkb_point_xy(21.0, 22.0));
+        accumulator.update_wkb(&wkb_point_xy(31.0, 32.0));
+        let stats = accumulator.finish().unwrap();
+        assert_eq!(stats.geospatial_types().unwrap(), &vec![1]);
+        assert_bbox_contains(
+            stats.bounding_box().unwrap(),
+            &BoundingBox::new(21.0, 31.0, 22.0, 32.0),
+            EPSILON,
+        );
+
+        // When an accumulator encounters invalid input, it reports is_valid() false
+        // and does not compute subsequent statistics
+        assert!(accumulator.is_valid());
+        accumulator.update_wkb(&wkb_point_xy(41.0, 42.0));
+        accumulator.update_wkb("these bytes are not WKB".as_bytes());
+        assert!(!accumulator.is_valid());
+        assert!(accumulator.finish().is_none());
+
+        // Subsequent rounds of accumulation should work as expected
+        assert!(accumulator.is_valid());
+        accumulator.update_wkb(&wkb_point_xy(41.0, 42.0));
+        accumulator.update_wkb(&wkb_point_xy(51.0, 52.0));
+        let stats = accumulator.finish().unwrap();
+        assert_eq!(stats.geospatial_types().unwrap(), &vec![1]);
+        assert_bbox_contains(
+            stats.bounding_box().unwrap(),
+            &BoundingBox::new(41.0, 51.0, 42.0, 52.0),
+            EPSILON,
+        );
+
+        // Antimeridian-crossing input should result in a wraparound box
+        assert!(accumulator.is_valid());
+        accumulator.update_wkb(&wkb_point_xy(-179.0, 42.0));
+        accumulator.update_wkb(&wkb_point_xy(179.0, 52.0));
+        let stats = accumulator.finish().unwrap();
+        assert!(
+            stats.bounding_box().unwrap().get_xmin() > stats.bounding_box().unwrap().get_xmax()
+        );
+
+        // When there was no input at all (occurs in the all null case), both geometry
+        // types and bounding box will be None. This is because Parquet Thrift statistics
+        // have no mechanism to communicate "empty". (The all null situation may be determined
+        // from the null count in this case).
+        assert!(accumulator.is_valid());
+        let stats = accumulator.finish().unwrap();
+        assert!(stats.geospatial_types().is_none());
+        assert!(stats.bounding_box().is_none());
+
+        // When there was 100% "empty" input (i.e., non-null geometries without
+        // coordinates), there should be statistics with geometry types but no
+        // bounding box.
+        assert!(accumulator.is_valid());
+        accumulator.update_wkb(&wkb_point_xy(f64::NAN, f64::NAN));
+        let stats = accumulator.finish().unwrap();
+        assert_eq!(stats.geospatial_types().unwrap(), &vec![1]);
+        assert!(stats.bounding_box().is_none());
+
+        // If Z and/or M are present, they should be reported in the bounding box
+        assert!(accumulator.is_valid());
+        accumulator.update_wkb(&wkb_point_xyzm(1.0, 2.0, 3.0, 4.0));
+        accumulator.update_wkb(&wkb_point_xyzm(5.0, 6.0, 7.0, 8.0));
+        let stats = accumulator.finish().unwrap();
+        assert_eq!(stats.geospatial_types().unwrap(), &vec![3001]);
+        assert_bbox_contains(
+            stats.bounding_box().unwrap(),
+            &BoundingBox::new(1.0, 5.0, 2.0, 6.0)
+                .with_zrange(3.0, 7.0)
+                .with_mrange(4.0, 8.0),
+            EPSILON,
+        );
     }
 }

--- a/rust/sedona-pointcloud/src/las/opener.rs
+++ b/rust/sedona-pointcloud/src/las/opener.rs
@@ -26,7 +26,7 @@ use datafusion_physical_expr::PhysicalExpr;
 use datafusion_pruning::PruningPredicate;
 use futures::StreamExt;
 
-use sedona_expr::spatial_filter::SpatialFilter;
+use sedona_expr::spatial_filter::SpatialFilterFactory;
 use sedona_geometry::bounding_box::BoundingBox;
 
 use crate::las::{
@@ -78,9 +78,10 @@ impl FileOpener for LasOpener {
                 PruningPredicate::try_new(physical_expr, schema.clone()).ok()
             });
 
+            let factory = SpatialFilterFactory::default();
             let spatial_filter = pruning_predicate
                 .as_ref()
-                .and_then(|p| SpatialFilter::try_from_expr(p.orig_expr()).ok());
+                .and_then(|p| factory.try_from_expr(p.orig_expr()).ok());
 
             // file pruning
             if let Some(pruning_predicate) = &pruning_predicate {


### PR DESCRIPTION
Stacked on https://github.com/apache/sedona-db/pull/805, since without the ability to write the geography type with statistics there is no meaningful way to test this!