### PR TITLE
feat(python/sedonadb): add Expr foundation

### DIFF
--- a/python/sedonadb/python/sedonadb/expr/__init__.py
+++ b/python/sedonadb/python/sedonadb/expr/__init__.py
@@ -14,3 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+from sedonadb.expr.expression import Expr, col, lit
+from sedonadb.expr.literal import Literal
+
+__all__ = ["Expr", "Literal", "col", "lit"]

--- a/python/sedonadb/python/sedonadb/expr/__init__.py
+++ b/python/sedonadb/python/sedonadb/expr/__init__.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from sedonadb.expr.expression import Expr, col, lit
-from sedonadb.expr.literal import Literal
+from sedonadb.expr.expression import Expr, col
+from sedonadb.expr.literal import Literal, lit
 
 __all__ = ["Expr", "Literal", "col", "lit"]

--- a/python/sedonadb/python/sedonadb/expr/__init__.py
+++ b/python/sedonadb/python/sedonadb/expr/__init__.py
@@ -16,6 +16,11 @@
 # under the License.
 
 from sedonadb.expr.expression import Expr, col
-from sedonadb.expr.literal import Literal, lit
+from sedonadb.expr.literal import Literal
 
-__all__ = ["Expr", "Literal", "col", "lit"]
+# Note: `lit` is intentionally not re-exported here. It returns a `Literal`
+# (the lazy parameterized-query wrapper), not an `Expr`. Users who need it
+# import it directly from `sedonadb.expr.literal`, matching its role as a
+# SQL-parameter helper rather than part of the Expr construction surface.
+
+__all__ = ["Expr", "Literal", "col"]

--- a/python/sedonadb/python/sedonadb/expr/expression.py
+++ b/python/sedonadb/python/sedonadb/expr/expression.py
@@ -60,8 +60,13 @@ class Expr:
         return Expr(self._impl.cast(target))
 
     def is_null(self) -> "Expr":
-        """Return a boolean expression that is true where this expression is
-        null (matches both SQL NULL and floating-point NaN)."""
+        """Return a boolean expression that is true where this expression
+        is SQL NULL.
+
+        Note that floating-point NaN is *not* matched by `is_null` — the
+        SQL `IS NULL` predicate only matches NULL. A pandas-style
+        NaN-aware helper is planned on the future `Series` type.
+        """
         return Expr(self._impl.is_null())
 
     def is_not_null(self) -> "Expr":

--- a/python/sedonadb/python/sedonadb/expr/expression.py
+++ b/python/sedonadb/python/sedonadb/expr/expression.py
@@ -1,0 +1,111 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Any, Iterable
+
+from sedonadb._lib import expr_col as _expr_col
+from sedonadb._lib import expr_lit as _expr_lit
+from sedonadb.expr.literal import Literal
+
+
+class Expr:
+    """A column expression.
+
+    `Expr` represents a logical expression that will be evaluated against a
+    `DataFrame` when the frame is executed. Expressions are pure syntax — they
+    do not carry data and are not bound to a particular frame at construction
+    time. Errors such as referring to a column that does not exist surface only
+    when the expression is consumed (for example, by `DataFrame.select()` or
+    `DataFrame.filter()`).
+
+    Construct an `Expr` with `col(name)` or `lit(value)`.
+    """
+
+    __slots__ = ("_impl",)
+
+    def __init__(self, impl):
+        # impl is the underlying _lib.InternalExpr handle. Users normally
+        # do not construct Expr directly; use col() / lit() instead.
+        self._impl = impl
+
+    def __repr__(self) -> str:
+        return f"Expr({self._impl!r})"
+
+    def alias(self, name: str) -> "Expr":
+        """Return a copy of the expression with a new output name."""
+        return Expr(self._impl.alias(name))
+
+    def cast(self, target) -> "Expr":
+        """Cast the expression to the given Arrow type.
+
+        `target` must be an object exposing the Arrow C schema interface
+        (e.g. `pyarrow.int64()`, `pyarrow.string()`, a `pyarrow.Field`, or any
+        object with `__arrow_c_schema__`). Casting to Arrow extension types is
+        not supported.
+        """
+        return Expr(self._impl.cast(target))
+
+    def is_null(self) -> "Expr":
+        """Return a boolean expression that is true where this expression is
+        null (matches both SQL NULL and floating-point NaN)."""
+        return Expr(self._impl.is_null())
+
+    def is_not_null(self) -> "Expr":
+        """Return a boolean expression that is true where this expression is
+        not null."""
+        return Expr(self._impl.is_not_null())
+
+    def isin(self, values: Iterable[Any]) -> "Expr":
+        """Return a boolean expression that is true where this expression
+        equals any of the given values."""
+        coerced = [_to_expr(v) for v in values]
+        return Expr(self._impl.isin([e._impl for e in coerced], False))
+
+    def negate(self) -> "Expr":
+        """Return the arithmetic negation of this expression."""
+        return Expr(self._impl.negate())
+
+
+def col(name: str) -> Expr:
+    """Reference a column by name.
+
+    Examples:
+        >>> from sedonadb.expr import col
+        >>> col("x").alias("y")
+        Expr(...)
+    """
+    return Expr(_expr_col(name))
+
+
+def lit(value: Any) -> Expr:
+    """Wrap a Python value as a literal expression.
+
+    Accepts the same value types as `sedonadb.expr.literal.lit`, including
+    Python scalars, pyarrow arrays/scalars, and Shapely geometries. Returns an
+    `Expr` suitable for composition with column expressions.
+    """
+    if isinstance(value, Expr):
+        return value
+    arrow_obj = value if isinstance(value, Literal) else Literal(value)
+    return Expr(_expr_lit(arrow_obj))
+
+
+def _to_expr(value: Any) -> Expr:
+    """Coerce a Python value to an `Expr`. Returns `Expr` unchanged."""
+    if isinstance(value, Expr):
+        return value
+    return lit(value)

--- a/python/sedonadb/python/sedonadb/expr/expression.py
+++ b/python/sedonadb/python/sedonadb/expr/expression.py
@@ -33,8 +33,12 @@ class Expr:
     when the expression is consumed (for example, by `DataFrame.select()` or
     `DataFrame.filter()`).
 
-    Construct an `Expr` with `col(name)`. Plain Python values composed with an
-    `Expr` via operators are coerced to literal expressions automatically.
+    Construct an `Expr` with `col(name)`. Methods that accept values
+    alongside `Expr` arguments (e.g. `isin`) coerce plain Python values to
+    literal expressions automatically. Operator overloading
+    (`col("x") + 1`, `col("x") > 0`, etc.) is not part of this PR; it
+    arrives in a follow-up that will extend the same coercion path to
+    arithmetic, comparison, and boolean operators.
     """
 
     __slots__ = ("_impl",)

--- a/python/sedonadb/python/sedonadb/expr/expression.py
+++ b/python/sedonadb/python/sedonadb/expr/expression.py
@@ -15,8 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Any, Iterable
+from typing import Any, Iterable, Optional
 
+from sedonadb._lib import InternalExpr as _InternalExpr
 from sedonadb._lib import expr_col as _expr_col
 from sedonadb._lib import expr_lit as _expr_lit
 from sedonadb.expr.literal import Literal
@@ -32,85 +33,154 @@ class Expr:
     when the expression is consumed (for example, by `DataFrame.select()` or
     `DataFrame.filter()`).
 
-    Construct an `Expr` with `col(name)` or `lit(value)`.
+    Construct an `Expr` with `col(name)`. Plain Python values composed with an
+    `Expr` via operators are coerced to literal expressions automatically.
     """
 
     __slots__ = ("_impl",)
 
     def __init__(self, impl):
-        # impl is the underlying _lib.InternalExpr handle. Users normally
-        # do not construct Expr directly; use col() / lit() instead.
+        # `impl` is the underlying _lib.InternalExpr handle. Users normally do
+        # not construct `Expr` directly; use `col()` (or operator composition)
+        # instead. Validate the type so a misuse fails clearly here rather
+        # than later, deep inside a method call.
+        if not isinstance(impl, _InternalExpr):
+            raise TypeError(
+                f"Expr() expects an internal Expr handle "
+                f"(sedonadb._lib.InternalExpr); got {type(impl).__name__}. "
+                f"Use sedonadb.expr.col() to construct a column expression."
+            )
         self._impl = impl
 
     def __repr__(self) -> str:
         return f"Expr({self._impl!r})"
 
     def alias(self, name: str) -> "Expr":
-        """Return a copy of the expression with a new output name."""
+        """Return a copy of the expression with a new output name.
+
+        Args:
+            name: The new name for the column produced by this expression.
+
+        Examples:
+
+            >>> from sedonadb.expr import col
+            >>> col("x").alias("y")
+            Expr(x AS y)
+        """
         return Expr(self._impl.alias(name))
 
     def cast(self, target) -> "Expr":
         """Cast the expression to the given Arrow type.
 
-        `target` must be an object exposing the Arrow C schema interface
-        (e.g. `pyarrow.int64()`, `pyarrow.string()`, a `pyarrow.Field`, or any
-        object with `__arrow_c_schema__`). Casting to Arrow extension types is
-        not supported.
+        Casting to Arrow extension types is not supported and raises an
+        error.
+
+        Args:
+            target: An object exposing the Arrow C schema interface — for
+                example `pyarrow.int64()`, `pyarrow.string()`, or any object
+                with `__arrow_c_schema__`.
+
+        Examples:
+
+            >>> import pyarrow as pa
+            >>> from sedonadb.expr import col
+            >>> col("x").cast(pa.int32())
+            Expr(CAST(x AS Int32))
         """
         return Expr(self._impl.cast(target))
 
     def is_null(self) -> "Expr":
-        """Return a boolean expression that is true where this expression
-        is SQL NULL.
+        """Return a boolean expression that is true where this expression is
+        SQL NULL.
 
-        Note that floating-point NaN is *not* matched by `is_null` — the
-        SQL `IS NULL` predicate only matches NULL. A pandas-style
-        NaN-aware helper is planned on the future `Series` type.
+        Note that floating-point NaN is *not* matched by `is_null` — the SQL
+        `IS NULL` predicate only matches NULL. A pandas-style NaN-aware
+        helper is planned on the future `Series` type.
+
+        Examples:
+
+            >>> from sedonadb.expr import col
+            >>> col("x").is_null()
+            Expr(x IS NULL)
         """
         return Expr(self._impl.is_null())
 
     def is_not_null(self) -> "Expr":
         """Return a boolean expression that is true where this expression is
-        not null."""
+        not SQL NULL.
+
+        Examples:
+
+            >>> from sedonadb.expr import col
+            >>> col("x").is_not_null()
+            Expr(x IS NOT NULL)
+        """
         return Expr(self._impl.is_not_null())
 
     def isin(self, values: Iterable[Any]) -> "Expr":
         """Return a boolean expression that is true where this expression
-        equals any of the given values."""
+        equals any of the given values.
+
+        Plain Python values in `values` are coerced to literal expressions
+        automatically; `Expr` values are passed through unchanged.
+
+        Args:
+            values: An iterable of Python values and/or `Expr` instances to
+                test membership against.
+
+        Examples:
+
+            >>> from sedonadb.expr import col
+            >>> col("x").isin([1, 2, 3])
+            Expr(x IN ([Int64(1), Int64(2), Int64(3)]))
+        """
         coerced = [_to_expr(v) for v in values]
         return Expr(self._impl.isin([e._impl for e in coerced], False))
 
     def negate(self) -> "Expr":
-        """Return the arithmetic negation of this expression."""
+        """Return the arithmetic negation of this expression.
+
+        Examples:
+
+            >>> from sedonadb.expr import col
+            >>> col("x").negate()
+            Expr((- x))
+        """
         return Expr(self._impl.negate())
 
 
-def col(name: str) -> Expr:
+def col(name: str, qualifier: Optional[str] = None) -> Expr:
     """Reference a column by name.
 
+    Args:
+        name: The column name to reference.
+        qualifier: An optional table qualifier (e.g. `"t"` for `t.x`). Useful
+            when the same column name appears in multiple input tables of a
+            join. Defaults to `None`, which leaves the column unqualified and
+            lets the planner resolve against the surrounding schema.
+
     Examples:
+
         >>> from sedonadb.expr import col
-        >>> col("x").alias("y")
-        Expr(...)
+        >>> col("x")
+        Expr(x)
+        >>> col("x", "t")
+        Expr(t.x)
     """
-    return Expr(_expr_col(name))
+    return Expr(_expr_col(name, qualifier))
 
 
-def lit(value: Any) -> Expr:
-    """Wrap a Python value as a literal expression.
+def _to_expr(value: Any) -> Expr:
+    """Coerce a Python value to an `Expr`.
 
-    Accepts the same value types as `sedonadb.expr.literal.lit`, including
-    Python scalars, pyarrow arrays/scalars, and Shapely geometries. Returns an
-    `Expr` suitable for composition with column expressions.
+    `Expr` values pass through unchanged. Anything else is wrapped as a
+    literal expression by routing through the existing `Literal` Arrow-array
+    coercion path. This is the only entry point that turns Python scalars
+    into `Expr` literals — there is intentionally no public `lit() -> Expr`
+    constructor, so that operator-driven coercion stays the single source of
+    literal-handling logic.
     """
     if isinstance(value, Expr):
         return value
     arrow_obj = value if isinstance(value, Literal) else Literal(value)
     return Expr(_expr_lit(arrow_obj))
-
-
-def _to_expr(value: Any) -> Expr:
-    """Coerce a Python value to an `Expr`. Returns `Expr` unchanged."""
-    if isinstance(value, Expr):
-        return value
-    return lit(value)

--- a/python/sedonadb/src/expr.rs
+++ b/python/sedonadb/src/expr.rs
@@ -15,16 +15,46 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use datafusion_common::{Column, ScalarValue};
-use datafusion_expr::{
-    expr::{FieldMetadata, InList},
-    Cast, Expr,
-};
+//! Python-facing expression wrapper.
+//!
+//! This module is the Rust half of `sedonadb.expr.Expr`. It exposes a thin
+//! PyO3 class (`PyExpr`, exported to Python as `_lib.InternalExpr`) that owns
+//! a single `datafusion_expr::Expr` and a small set of factory `#[pyfunction]`s
+//! used by the Python wrapper to construct columns and literals.
+//!
+//! The high-level shape:
+//!
+//! - The Python side (`sedonadb.expr.Expr`) holds a handle to a `PyExpr` and
+//!   provides operator overloading, docstrings, and Pythonic ergonomics.
+//! - This Rust side stays minimal: build the right `Expr` variant, do the
+//!   minimum amount of validation that benefits from native types (e.g.
+//!   inspecting Arrow extension metadata for `cast`), and bubble up errors
+//!   via `PySedonaError`.
+//!
+//! The design mirrors the equivalent layer in the R bindings
+//! (`r/sedonadb/src/rust/src/expression.rs`), where the Python `Expr` plays the
+//! role of `SedonaDBExpr` and `expr_col` / `expr_lit` mirror
+//! `SedonaDBExprFactory::column` / `::literal`.
+
+use datafusion_common::Column;
+use datafusion_expr::{expr::InList, Cast, Expr};
 use pyo3::prelude::*;
 
 use crate::error::PySedonaError;
-use crate::import_from::{import_arrow_array, import_arrow_field};
+use crate::import_from::{import_arrow_field, import_arrow_scalar};
 
+/// PyO3 wrapper around a single DataFusion logical expression.
+///
+/// `PyExpr` is exposed to Python as `_lib.InternalExpr` and is the value
+/// type behind the user-facing `sedonadb.expr.Expr` Python class. It is
+/// `Clone` so that PyO3 method signatures can take `Vec<PyExpr>` by value;
+/// each clone is cheap because `Expr` itself owns its children behind `Box`,
+/// and cloning copies only the small wrapper plus a few `Arc`s in the
+/// underlying tree.
+///
+/// The `inner` field is intentionally `pub` so that other PyO3 modules in
+/// this crate (e.g. `dataframe.rs`) can take `Vec<PyExpr>` arguments and
+/// move the inner `Expr` out without going through accessor methods.
 #[pyclass(name = "InternalExpr")]
 #[derive(Clone)]
 pub struct PyExpr {
@@ -39,23 +69,51 @@ impl PyExpr {
 
 #[pymethods]
 impl PyExpr {
+    /// Pretty-print using DataFusion's `Display` impl (e.g. `"x AS y"`).
+    /// Used by Python's `repr()` / `str()` paths.
     fn __repr__(&self) -> String {
         format!("{}", self.inner)
     }
 
+    /// Debug-print the full Rust `Expr` tree. Useful for tests and
+    /// troubleshooting; not part of the user-facing surface.
     fn debug_string(&self) -> String {
         format!("{:?}", self.inner)
     }
 
+    /// Return the name of the `Expr` enum variant (e.g. `"Column"`,
+    /// `"Literal"`, `"BinaryExpr"`). This is a stable structural property
+    /// that tests can assert on without depending on Display formatting.
     fn variant_name(&self) -> String {
         self.inner.variant_name().to_string()
     }
 
+    /// Wrap this expression in `Expr::Alias { name }`.
+    ///
+    /// We use DataFusion's `alias_if_changed` helper so that aliasing an
+    /// expression to its existing name is a no-op. This avoids producing
+    /// e.g. `Expr::Alias("x", Expr::Column("x"))` which is redundant but
+    /// otherwise legal.
     fn alias(&self, name: &str) -> Result<Self, PySedonaError> {
         let inner = self.inner.clone().alias_if_changed(name.to_string())?;
         Ok(Self { inner })
     }
 
+    /// Wrap this expression in `Expr::Cast` to the storage type of the
+    /// provided Arrow field-like object.
+    ///
+    /// Steps:
+    ///
+    /// 1. Pull an `arrow_schema::Field` out of `target` via the Arrow
+    ///    PyCapsule schema interface (any object exposing
+    ///    `__arrow_c_schema__` works — `pyarrow.DataType`,
+    ///    `pyarrow.Field`, etc.).
+    /// 2. Reject Arrow extension types up front. SedonaDB's spatial types
+    ///    are extension types over WKB; users who reach for `cast` on
+    ///    those almost certainly want a different operation, so we surface
+    ///    a clear error rather than silently dropping the extension.
+    /// 3. Build `Expr::Cast { expr, data_type }` using only the storage
+    ///    type. We don't carry field metadata through the cast.
     fn cast(&self, target: Bound<'_, PyAny>) -> Result<Self, PySedonaError> {
         let field = import_arrow_field(&target)?;
         if let Some(type_name) = field.extension_type_name() {
@@ -70,18 +128,29 @@ impl PyExpr {
         Ok(Self { inner })
     }
 
+    /// Build `Expr::IsNull(self)`. SQL semantics — matches NULL only,
+    /// not floating-point NaN. The Pythonic NaN-aware accessor will live
+    /// on the future `Series` type.
     fn is_null(&self) -> Self {
         Self {
             inner: Expr::IsNull(Box::new(self.inner.clone())),
         }
     }
 
+    /// Build `Expr::IsNotNull(self)`. SQL semantics, mirror of `is_null`.
     fn is_not_null(&self) -> Self {
         Self {
             inner: Expr::IsNotNull(Box::new(self.inner.clone())),
         }
     }
 
+    /// Build `Expr::InList(self IN (values), negated)`.
+    ///
+    /// The Python side already coerces every element of the user's list
+    /// to a `PyExpr` (using `lit()` for non-Expr scalars), so the Rust
+    /// side just needs to clone each `Expr` out of its handle and hand
+    /// the resulting `Vec<Expr>` to `InList::new`. `negated=true`
+    /// produces `NOT IN`, exposed through the optional kwarg below.
     #[pyo3(signature = (values, negated=false))]
     fn isin(&self, values: Vec<PyRef<'_, PyExpr>>, negated: bool) -> Self {
         let list = values.iter().map(|e| e.inner.clone()).collect();
@@ -90,6 +159,7 @@ impl PyExpr {
         }
     }
 
+    /// Build `Expr::Negative(self)` — arithmetic negation, the unary `-`.
     fn negate(&self) -> Self {
         Self {
             inner: Expr::Negative(Box::new(self.inner.clone())),
@@ -97,6 +167,12 @@ impl PyExpr {
     }
 }
 
+/// Construct an unqualified column reference: `Expr::Column("x")`.
+///
+/// Qualified columns (e.g. `t.x`) are not exposed yet; the Python
+/// `col()` helper takes only a single name. When we add joins and
+/// multi-table references we can grow this to accept an optional
+/// table qualifier, matching the R side's `column(name, qualifier)`.
 #[pyfunction]
 pub fn expr_col(name: &str) -> PyExpr {
     PyExpr {
@@ -104,21 +180,24 @@ pub fn expr_col(name: &str) -> PyExpr {
     }
 }
 
+/// Wrap a Python value (already coerced to an Arrow array on the Python
+/// side) as an `Expr::Literal`.
+///
+/// Steps:
+///
+/// 1. Use `import_arrow_scalar` from `import_from.rs`, which handles the
+///    Arrow C array PyCapsule import, validates that the array has
+///    exactly one element, extracts the `ScalarValue`, and preserves any
+///    field metadata (e.g. extension type info needed for spatial
+///    literals). Centralising this here means the literal path,
+///    `with_params`, and any future scalar consumers all share one set
+///    of validation and error messages.
+/// 2. Decompose the resulting `ScalarAndMetadata` into its `(value,
+///    metadata)` parts via `into_inner` and feed them straight to
+///    `Expr::Literal`.
 #[pyfunction]
 pub fn expr_lit(obj: Bound<'_, PyAny>) -> Result<PyExpr, PySedonaError> {
-    let (field, array) = import_arrow_array(&obj)?;
-    if array.len() != 1 {
-        return Err(PySedonaError::SedonaPython(format!(
-            "Expected literal Arrow array of length 1, got length {}",
-            array.len()
-        )));
-    }
-    let scalar_value = ScalarValue::try_from_array(&array, 0)?;
-    let metadata = if field.metadata().is_empty() {
-        None
-    } else {
-        Some(FieldMetadata::new_from_field(&field))
-    };
+    let (scalar_value, metadata) = import_arrow_scalar(&obj)?.into_inner();
     let inner = Expr::Literal(scalar_value, metadata);
     Ok(PyExpr { inner })
 }

--- a/python/sedonadb/src/expr.rs
+++ b/python/sedonadb/src/expr.rs
@@ -1,0 +1,124 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use datafusion_common::{Column, ScalarValue};
+use datafusion_expr::{
+    expr::{FieldMetadata, InList},
+    Cast, Expr,
+};
+use pyo3::prelude::*;
+
+use crate::error::PySedonaError;
+use crate::import_from::{import_arrow_array, import_arrow_field};
+
+#[pyclass(name = "InternalExpr")]
+#[derive(Clone)]
+pub struct PyExpr {
+    pub inner: Expr,
+}
+
+impl PyExpr {
+    pub fn new(inner: Expr) -> Self {
+        Self { inner }
+    }
+}
+
+#[pymethods]
+impl PyExpr {
+    fn __repr__(&self) -> String {
+        format!("{}", self.inner)
+    }
+
+    fn debug_string(&self) -> String {
+        format!("{:?}", self.inner)
+    }
+
+    fn variant_name(&self) -> String {
+        self.inner.variant_name().to_string()
+    }
+
+    fn alias(&self, name: &str) -> Result<Self, PySedonaError> {
+        let inner = self.inner.clone().alias_if_changed(name.to_string())?;
+        Ok(Self { inner })
+    }
+
+    fn cast(&self, target: Bound<'_, PyAny>) -> Result<Self, PySedonaError> {
+        let field = import_arrow_field(&target)?;
+        if let Some(type_name) = field.extension_type_name() {
+            return Err(PySedonaError::SedonaPython(format!(
+                "Can't cast to Arrow extension type '{type_name}'"
+            )));
+        }
+        let inner = Expr::Cast(Cast::new(
+            Box::new(self.inner.clone()),
+            field.data_type().clone(),
+        ));
+        Ok(Self { inner })
+    }
+
+    fn is_null(&self) -> Self {
+        Self {
+            inner: Expr::IsNull(Box::new(self.inner.clone())),
+        }
+    }
+
+    fn is_not_null(&self) -> Self {
+        Self {
+            inner: Expr::IsNotNull(Box::new(self.inner.clone())),
+        }
+    }
+
+    #[pyo3(signature = (values, negated=false))]
+    fn isin(&self, values: Vec<PyRef<'_, PyExpr>>, negated: bool) -> Self {
+        let list = values.iter().map(|e| e.inner.clone()).collect();
+        Self {
+            inner: Expr::InList(InList::new(Box::new(self.inner.clone()), list, negated)),
+        }
+    }
+
+    fn negate(&self) -> Self {
+        Self {
+            inner: Expr::Negative(Box::new(self.inner.clone())),
+        }
+    }
+}
+
+#[pyfunction]
+pub fn expr_col(name: &str) -> PyExpr {
+    PyExpr {
+        inner: Expr::Column(Column::new_unqualified(name)),
+    }
+}
+
+#[pyfunction]
+pub fn expr_lit(obj: Bound<'_, PyAny>) -> Result<PyExpr, PySedonaError> {
+    let (field, array) = import_arrow_array(&obj)?;
+    if array.len() != 1 {
+        return Err(PySedonaError::SedonaPython(format!(
+            "Expected literal Arrow array of length 1, got length {}",
+            array.len()
+        )));
+    }
+    let scalar_value = ScalarValue::try_from_array(&array, 0)?;
+    let metadata = if field.metadata().is_empty() {
+        None
+    } else {
+        Some(FieldMetadata::new_from_field(&field))
+    };
+    let inner = Expr::Literal(scalar_value, metadata);
+    Ok(PyExpr { inner })
+}

--- a/python/sedonadb/src/expr.rs
+++ b/python/sedonadb/src/expr.rs
@@ -167,16 +167,25 @@ impl PyExpr {
     }
 }
 
-/// Construct an unqualified column reference: `Expr::Column("x")`.
+/// Construct a column reference: `Expr::Column("x")` or `Expr::Column("t.x")`.
 ///
-/// Qualified columns (e.g. `t.x`) are not exposed yet; the Python
-/// `col()` helper takes only a single name. When we add joins and
-/// multi-table references we can grow this to accept an optional
-/// table qualifier, matching the R side's `column(name, qualifier)`.
+/// `qualifier` is the optional table name (e.g. the `t` in `t.x`). It maps to
+/// `Some(table_ref)` on `Column::new` so that disambiguating a column across
+/// multiple input tables in a join is possible without parsing the name as
+/// SQL. When `qualifier` is `None` we use `Column::new_unqualified`, which
+/// behaves like a bare identifier in SQL and resolves against whichever
+/// table's schema introduced the name first.
+///
+/// Mirrors `SedonaDBExprFactory::column(name, qualifier)` in the R bindings.
 #[pyfunction]
-pub fn expr_col(name: &str) -> PyExpr {
+#[pyo3(signature = (name, qualifier=None))]
+pub fn expr_col(name: &str, qualifier: Option<&str>) -> PyExpr {
+    let column = match qualifier {
+        Some(q) => Column::new(Some(q), name),
+        None => Column::new_unqualified(name),
+    };
     PyExpr {
-        inner: Expr::Column(Column::new_unqualified(name)),
+        inner: Expr::Column(column),
     }
 }
 

--- a/python/sedonadb/src/lib.rs
+++ b/python/sedonadb/src/lib.rs
@@ -25,6 +25,7 @@ mod context;
 mod dataframe;
 mod datasource;
 mod error;
+mod expr;
 mod import_from;
 mod reader;
 mod runtime;
@@ -123,9 +124,12 @@ fn _lib(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(sedona_python_version, m)?)?;
     m.add_function(wrap_pyfunction!(sedona_python_features, m)?)?;
     m.add_function(wrap_pyfunction!(sedona_scalar_udf, m)?)?;
+    m.add_function(wrap_pyfunction!(expr::expr_col, m)?)?;
+    m.add_function(wrap_pyfunction!(expr::expr_lit, m)?)?;
 
     m.add_class::<context::InternalContext>()?;
     m.add_class::<dataframe::InternalDataFrame>()?;
+    m.add_class::<expr::PyExpr>()?;
     m.add_class::<datasource::PyExternalFormat>()?;
     m.add_class::<datasource::PyProjectedRecordBatchReader>()?;
     m.add("SedonaError", py.get_type::<error::SedonaError>())?;

--- a/python/sedonadb/tests/expr/test_expression.py
+++ b/python/sedonadb/tests/expr/test_expression.py
@@ -15,6 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# These tests assert structural properties of constructed expressions —
+# primarily `variant_name()`, child variants reachable via `debug_string()`,
+# and the presence of user-supplied identifiers (column names, literal
+# values) inside the rendered representation. Where possible we avoid
+# pinning exact substrings of DataFusion's `Display` formatting so the
+# suite is not coupled to a specific DataFusion version.
+
 import pyarrow as pa
 import pytest
 
@@ -32,7 +39,9 @@ def test_lit_from_python_scalar():
     e = lit(5)
     assert isinstance(e, Expr)
     assert e._impl.variant_name() == "Literal"
-    assert "Int64(5)" in repr(e)
+    # Literal value should be represented somewhere in the repr; don't pin
+    # DataFusion's exact format string.
+    assert "5" in repr(e)
 
 
 def test_lit_passthrough_for_existing_expr():
@@ -43,37 +52,47 @@ def test_lit_passthrough_for_existing_expr():
 def test_lit_from_pyarrow_scalar():
     arr = pa.array([42])
     e = lit(arr[0])
-    assert "Int64(42)" in repr(e)
+    assert e._impl.variant_name() == "Literal"
+    assert "42" in repr(e)
 
 
 def test_lit_from_string():
-    assert "Utf8" in repr(lit("hello"))
+    e = lit("hello")
+    assert e._impl.variant_name() == "Literal"
+    assert "hello" in repr(e)
 
 
 def test_lit_from_none():
     e = lit(None)
-    assert "Null" in repr(e) or "NULL" in repr(e)
+    assert e._impl.variant_name() == "Literal"
 
 
 def test_alias():
     e = col("x").alias("y")
-    assert "x AS y" in repr(e)
+    assert e._impl.variant_name() == "Alias"
+    # The new name must be reachable from the user's perspective; the
+    # underlying column name should also still be visible.
+    rep = repr(e)
+    assert "y" in rep
+    assert "x" in rep
 
 
 def test_alias_chain():
     e = col("x").alias("a").alias("b")
-    # Either nested or last-wins; both encode the user intent.
+    assert e._impl.variant_name() == "Alias"
+    # Either nested or last-wins; in both cases the latest name must show.
     assert "b" in repr(e)
 
 
 def test_cast_to_arrow_type():
     e = col("x").cast(pa.int32())
-    assert "CAST(x AS Int32)" in repr(e)
+    assert e._impl.variant_name() == "Cast"
+    assert "x" in repr(e)
 
 
 def test_cast_to_string():
     e = col("x").cast(pa.string())
-    assert "Utf8" in repr(e)
+    assert e._impl.variant_name() == "Cast"
 
 
 def test_cast_rejects_extension_type():
@@ -84,34 +103,41 @@ def test_cast_rejects_extension_type():
 
 
 def test_is_null():
-    assert "x IS NULL" in repr(col("x").is_null())
+    e = col("x").is_null()
+    assert e._impl.variant_name() == "IsNull"
 
 
 def test_is_not_null():
-    assert "x IS NOT NULL" in repr(col("x").is_not_null())
+    e = col("x").is_not_null()
+    assert e._impl.variant_name() == "IsNotNull"
 
 
 def test_isin_python_scalars():
     e = col("x").isin([1, 2, 3])
+    assert e._impl.variant_name() == "InList"
     rep = repr(e)
-    assert "IN" in rep
-    assert "Int64(1)" in rep and "Int64(3)" in rep
+    assert "x" in rep
+    # Each value should still appear somewhere in the rendered form,
+    # without pinning the exact wrapping that DataFusion uses.
+    assert "1" in rep and "3" in rep
 
 
 def test_isin_with_expr_values():
     e = col("x").isin([lit(1), 2, lit(3)])
+    assert e._impl.variant_name() == "InList"
     rep = repr(e)
-    assert "Int64(1)" in rep and "Int64(2)" in rep and "Int64(3)" in rep
+    assert "1" in rep and "2" in rep and "3" in rep
 
 
 def test_negate():
-    assert "(- x)" in repr(col("x").negate())
+    e = col("x").negate()
+    assert e._impl.variant_name() == "Negative"
 
 
 def test_chain_alias_after_predicate():
     e = col("x").is_null().alias("missing")
+    assert e._impl.variant_name() == "Alias"
     assert "missing" in repr(e)
-    assert "IS NULL" in repr(e)
 
 
 def test_expr_is_not_bound_to_dataframe():

--- a/python/sedonadb/tests/expr/test_expression.py
+++ b/python/sedonadb/tests/expr/test_expression.py
@@ -1,0 +1,121 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pyarrow as pa
+import pytest
+
+from sedonadb.expr import Expr, col, lit
+
+
+def test_col_returns_expr():
+    e = col("x")
+    assert isinstance(e, Expr)
+    assert e._impl.variant_name() == "Column"
+    assert "x" in repr(e)
+
+
+def test_lit_from_python_scalar():
+    e = lit(5)
+    assert isinstance(e, Expr)
+    assert e._impl.variant_name() == "Literal"
+    assert "Int64(5)" in repr(e)
+
+
+def test_lit_passthrough_for_existing_expr():
+    e = col("x")
+    assert lit(e) is e
+
+
+def test_lit_from_pyarrow_scalar():
+    arr = pa.array([42])
+    e = lit(arr[0])
+    assert "Int64(42)" in repr(e)
+
+
+def test_lit_from_string():
+    assert "Utf8" in repr(lit("hello"))
+
+
+def test_lit_from_none():
+    e = lit(None)
+    assert "Null" in repr(e) or "NULL" in repr(e)
+
+
+def test_alias():
+    e = col("x").alias("y")
+    assert "x AS y" in repr(e)
+
+
+def test_alias_chain():
+    e = col("x").alias("a").alias("b")
+    # Either nested or last-wins; both encode the user intent.
+    assert "b" in repr(e)
+
+
+def test_cast_to_arrow_type():
+    e = col("x").cast(pa.int32())
+    assert "CAST(x AS Int32)" in repr(e)
+
+
+def test_cast_to_string():
+    e = col("x").cast(pa.string())
+    assert "Utf8" in repr(e)
+
+
+def test_cast_rejects_extension_type():
+    import geoarrow.pyarrow as ga
+
+    with pytest.raises(Exception, match="extension type"):
+        col("x").cast(ga.wkb())
+
+
+def test_is_null():
+    assert "x IS NULL" in repr(col("x").is_null())
+
+
+def test_is_not_null():
+    assert "x IS NOT NULL" in repr(col("x").is_not_null())
+
+
+def test_isin_python_scalars():
+    e = col("x").isin([1, 2, 3])
+    rep = repr(e)
+    assert "IN" in rep
+    assert "Int64(1)" in rep and "Int64(3)" in rep
+
+
+def test_isin_with_expr_values():
+    e = col("x").isin([lit(1), 2, lit(3)])
+    rep = repr(e)
+    assert "Int64(1)" in rep and "Int64(2)" in rep and "Int64(3)" in rep
+
+
+def test_negate():
+    assert "(- x)" in repr(col("x").negate())
+
+
+def test_chain_alias_after_predicate():
+    e = col("x").is_null().alias("missing")
+    assert "missing" in repr(e)
+    assert "IS NULL" in repr(e)
+
+
+def test_expr_is_not_bound_to_dataframe():
+    # Constructing an Expr referring to a non-existent column does not error.
+    # Errors surface only at DataFrame consumption.
+    e = col("nonexistent_column_xyz")
+    assert "nonexistent_column_xyz" in repr(e)

--- a/python/sedonadb/tests/expr/test_expression.py
+++ b/python/sedonadb/tests/expr/test_expression.py
@@ -89,39 +89,33 @@ def test_isin_python_scalars():
     # Plain Python scalars are coerced to literal expressions automatically.
     e = col("x").isin([1, 2, 3])
     assert e._impl.variant_name() == "InList"
-    rep = repr(e)
-    assert "IN" in rep
-    assert "Int64(1)" in rep
-    assert "Int64(3)" in rep
+    assert repr(e) == "Expr(x IN ([Int64(1), Int64(2), Int64(3)]))"
 
 
 def test_isin_with_expr_values():
     # Mixed Expr + scalar input — Exprs pass through, scalars are coerced.
     e = col("x").isin([col("a"), 2])
     assert e._impl.variant_name() == "InList"
-    rep = repr(e)
-    assert "a" in rep
-    assert "Int64(2)" in rep
+    assert repr(e) == "Expr(x IN ([a, Int64(2)]))"
 
 
 def test_negate():
     e = col("x").negate()
     assert e._impl.variant_name() == "Negative"
-    assert "(- x)" in repr(e)
+    assert repr(e) == "Expr((- x))"
 
 
 def test_chain_alias_after_predicate():
     e = col("x").is_null().alias("missing")
     assert e._impl.variant_name() == "Alias"
-    assert "missing" in repr(e)
-    assert "IS NULL" in repr(e)
+    assert repr(e) == "Expr(x IS NULL AS missing)"
 
 
 def test_expr_is_not_bound_to_dataframe():
     # Constructing an Expr referring to a non-existent column does not error.
     # Errors surface only at DataFrame consumption.
     e = col("nonexistent_column_xyz")
-    assert "nonexistent_column_xyz" in repr(e)
+    assert repr(e) == "Expr(nonexistent_column_xyz)"
 
 
 def test_expr_init_rejects_wrong_type():

--- a/python/sedonadb/tests/expr/test_expression.py
+++ b/python/sedonadb/tests/expr/test_expression.py
@@ -15,71 +15,42 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# These tests assert structural properties of constructed expressions —
-# primarily `variant_name()`, child variants reachable via `debug_string()`,
-# and the presence of user-supplied identifiers (column names, literal
-# values) inside the rendered representation. Where possible we avoid
-# pinning exact substrings of DataFusion's `Display` formatting so the
-# suite is not coupled to a specific DataFusion version.
+# These tests pin the exact rendered form of each expression. Locking the
+# Display output is intentional: it doubles as a regression test on how user
+# expressions appear in error messages and `repr()` output, and any DataFusion
+# upgrade that changes the rendering should be reviewed deliberately rather
+# than auto-passing. If you find yourself loosening these assertions, add a
+# replacement check on `_impl.variant_name()` so the structural meaning is
+# still locked.
 
 import pyarrow as pa
 import pytest
 
-from sedonadb.expr import Expr, col, lit
+from sedonadb.expr import Expr, col
 
 
 def test_col_returns_expr():
     e = col("x")
     assert isinstance(e, Expr)
     assert e._impl.variant_name() == "Column"
-    assert "x" in repr(e)
+    assert repr(e) == "Expr(x)"
 
 
-def test_lit_from_python_scalar():
-    e = lit(5)
+def test_col_with_qualifier():
+    e = col("x", "t")
     assert isinstance(e, Expr)
-    assert e._impl.variant_name() == "Literal"
-    # Literal value should be represented somewhere in the repr; don't pin
-    # DataFusion's exact format string.
-    assert "5" in repr(e)
-
-
-def test_lit_passthrough_for_existing_expr():
-    e = col("x")
-    assert lit(e) is e
-
-
-def test_lit_from_pyarrow_scalar():
-    arr = pa.array([42])
-    e = lit(arr[0])
-    assert e._impl.variant_name() == "Literal"
-    assert "42" in repr(e)
-
-
-def test_lit_from_string():
-    e = lit("hello")
-    assert e._impl.variant_name() == "Literal"
-    assert "hello" in repr(e)
-
-
-def test_lit_from_none():
-    e = lit(None)
-    assert e._impl.variant_name() == "Literal"
+    assert e._impl.variant_name() == "Column"
+    assert repr(e) == "Expr(t.x)"
 
 
 def test_alias():
     e = col("x").alias("y")
     assert e._impl.variant_name() == "Alias"
-    # The new name must be reachable from the user's perspective; the
-    # underlying column name should also still be visible.
-    rep = repr(e)
-    assert "y" in rep
-    assert "x" in rep
+    assert "x AS y" in repr(e)
 
 
 def test_alias_chain():
     e = col("x").alias("a").alias("b")
-    assert e._impl.variant_name() == "Alias"
     # Either nested or last-wins; in both cases the latest name must show.
     assert "b" in repr(e)
 
@@ -87,12 +58,12 @@ def test_alias_chain():
 def test_cast_to_arrow_type():
     e = col("x").cast(pa.int32())
     assert e._impl.variant_name() == "Cast"
-    assert "x" in repr(e)
+    assert "CAST(x AS Int32)" in repr(e)
 
 
 def test_cast_to_string():
     e = col("x").cast(pa.string())
-    assert e._impl.variant_name() == "Cast"
+    assert "Utf8" in repr(e)
 
 
 def test_cast_rejects_extension_type():
@@ -105,39 +76,45 @@ def test_cast_rejects_extension_type():
 def test_is_null():
     e = col("x").is_null()
     assert e._impl.variant_name() == "IsNull"
+    assert "x IS NULL" in repr(e)
 
 
 def test_is_not_null():
     e = col("x").is_not_null()
     assert e._impl.variant_name() == "IsNotNull"
+    assert "x IS NOT NULL" in repr(e)
 
 
 def test_isin_python_scalars():
+    # Plain Python scalars are coerced to literal expressions automatically.
     e = col("x").isin([1, 2, 3])
     assert e._impl.variant_name() == "InList"
     rep = repr(e)
-    assert "x" in rep
-    # Each value should still appear somewhere in the rendered form,
-    # without pinning the exact wrapping that DataFusion uses.
-    assert "1" in rep and "3" in rep
+    assert "IN" in rep
+    assert "Int64(1)" in rep
+    assert "Int64(3)" in rep
 
 
 def test_isin_with_expr_values():
-    e = col("x").isin([lit(1), 2, lit(3)])
+    # Mixed Expr + scalar input — Exprs pass through, scalars are coerced.
+    e = col("x").isin([col("a"), 2])
     assert e._impl.variant_name() == "InList"
     rep = repr(e)
-    assert "1" in rep and "2" in rep and "3" in rep
+    assert "a" in rep
+    assert "Int64(2)" in rep
 
 
 def test_negate():
     e = col("x").negate()
     assert e._impl.variant_name() == "Negative"
+    assert "(- x)" in repr(e)
 
 
 def test_chain_alias_after_predicate():
     e = col("x").is_null().alias("missing")
     assert e._impl.variant_name() == "Alias"
     assert "missing" in repr(e)
+    assert "IS NULL" in repr(e)
 
 
 def test_expr_is_not_bound_to_dataframe():
@@ -145,3 +122,12 @@ def test_expr_is_not_bound_to_dataframe():
     # Errors surface only at DataFrame consumption.
     e = col("nonexistent_column_xyz")
     assert "nonexistent_column_xyz" in repr(e)
+
+
+def test_expr_init_rejects_wrong_type():
+    # The Expr constructor should fail clearly when handed something that is
+    # not an internal Expr handle.
+    with pytest.raises(TypeError, match="InternalExpr"):
+        Expr("not an internal expr")
+    with pytest.raises(TypeError, match="InternalExpr"):
+        Expr(42)


### PR DESCRIPTION
Adds the foundation of a Python expression layer that wraps DataFusion's logical `Expr` through PyO3, mirroring the pattern used in the R bindings (`r/sedonadb/src/rust/src/expression.rs`).

This is the first of four small stacked PRs that together implement Phase P1 of #791. This one ships only the foundation:

- `sedonadb.expr.Expr` — column-expression wrapper with `alias`, `cast`, `is_null`, `is_not_null`, `isin`, `negate`.
- `sedonadb.expr.col(name, qualifier=None)` — reference a column by name (with an optional table qualifier for joins).

Operator overloading and DataFrame integration land in follow-up PRs. `Expr` objects are pure syntax: they are not bound to a DataFrame at construction time, and column-validity errors surface only when an `Expr` is consumed by a DataFrame method.

The pre-existing `sedonadb.expr.literal.lit` (returning `Literal`, the lazy parameterized-query helper) is unchanged by this PR and is intentionally kept off `sedonadb.expr`'s package-level surface.

## Test plan
- [x] Unit tests in `tests/expr/test_expression.py` covering construction, qualified columns, alias, cast, null checks, `isin`, `negate`, chaining, and the `__init__` type guard.
- [x] No regressions in the existing `tests/test_dataframe.py`.
- [x] CI green.
