### PR TITLE
feat(python/sedonadb): add Expr operator overloads

### DIFF
--- a/python/sedonadb/python/sedonadb/expr/expression.py
+++ b/python/sedonadb/python/sedonadb/expr/expression.py
@@ -18,8 +18,10 @@
 from typing import Any, Iterable, Optional
 
 from sedonadb._lib import InternalExpr as _InternalExpr
+from sedonadb._lib import expr_binary as _expr_binary
 from sedonadb._lib import expr_col as _expr_col
 from sedonadb._lib import expr_lit as _expr_lit
+from sedonadb._lib import expr_not as _expr_not
 from sedonadb.expr.literal import Literal
 
 
@@ -33,12 +35,11 @@ class Expr:
     when the expression is consumed (for example, by `DataFrame.select()` or
     `DataFrame.filter()`).
 
-    Construct an `Expr` with `col(name)`. Methods that accept values
-    alongside `Expr` arguments (e.g. `isin`) coerce plain Python values to
-    literal expressions automatically. Operator overloading
-    (`col("x") + 1`, `col("x") > 0`, etc.) is not part of this PR; it
-    arrives in a follow-up that will extend the same coercion path to
-    arithmetic, comparison, and boolean operators.
+    Construct an `Expr` with `col(name)`. Plain Python values composed with
+    an `Expr` via arithmetic, comparison, or boolean operators (`col("x") +
+    1`, `col("x") > 0`, `col("x") & col("y")`) are coerced to literal
+    expressions automatically. The same coercion is also applied by methods
+    that accept value lists (e.g. `isin`).
     """
 
     __slots__ = ("_impl",)
@@ -152,6 +153,87 @@ class Expr:
         """
         return Expr(self._impl.negate())
 
+    # Arithmetic operators -------------------------------------------------
+    #
+    # Each binary dunder routes through the shared `_binary` helper, which
+    # coerces plain Python values to literal Exprs via `_to_expr` and then
+    # calls into the single Rust factory `expr_binary` with a string opcode.
+    # The reflected variants (`__radd__`, `__rsub__`, ...) make
+    # `1 - col("x")` work the same as `col("x") - 1`.
+
+    def __add__(self, other: Any) -> "Expr":
+        return _binary("+", self, other)
+
+    def __radd__(self, other: Any) -> "Expr":
+        return _binary("+", other, self)
+
+    def __sub__(self, other: Any) -> "Expr":
+        return _binary("-", self, other)
+
+    def __rsub__(self, other: Any) -> "Expr":
+        return _binary("-", other, self)
+
+    def __mul__(self, other: Any) -> "Expr":
+        return _binary("*", self, other)
+
+    def __rmul__(self, other: Any) -> "Expr":
+        return _binary("*", other, self)
+
+    def __truediv__(self, other: Any) -> "Expr":
+        return _binary("/", self, other)
+
+    def __rtruediv__(self, other: Any) -> "Expr":
+        return _binary("/", other, self)
+
+    def __neg__(self) -> "Expr":
+        return self.negate()
+
+    # Comparison operators -------------------------------------------------
+
+    def __eq__(self, other: Any) -> "Expr":  # type: ignore[override]
+        return _binary("==", self, other)
+
+    def __ne__(self, other: Any) -> "Expr":  # type: ignore[override]
+        return _binary("!=", self, other)
+
+    def __lt__(self, other: Any) -> "Expr":
+        return _binary("<", self, other)
+
+    def __le__(self, other: Any) -> "Expr":
+        return _binary("<=", self, other)
+
+    def __gt__(self, other: Any) -> "Expr":
+        return _binary(">", self, other)
+
+    def __ge__(self, other: Any) -> "Expr":
+        return _binary(">=", self, other)
+
+    # Boolean operators ----------------------------------------------------
+    #
+    # `&` / `|` / `~` rather than `and` / `or` / `not` because Python does
+    # not allow overloading the keyword forms — they always coerce to bool.
+
+    def __and__(self, other: Any) -> "Expr":
+        return _binary("&", self, other)
+
+    def __rand__(self, other: Any) -> "Expr":
+        return _binary("&", other, self)
+
+    def __or__(self, other: Any) -> "Expr":
+        return _binary("|", self, other)
+
+    def __ror__(self, other: Any) -> "Expr":
+        return _binary("|", other, self)
+
+    def __invert__(self) -> "Expr":
+        return Expr(_expr_not(self._impl))
+
+    # Defining `__eq__` makes the class unhashable by default. Be explicit
+    # so users see a clear error instead of a confusing one. Expressions are
+    # not meaningful as dict keys / set members anyway because `__eq__`
+    # returns an `Expr`, not a bool.
+    __hash__ = None  # type: ignore[assignment]
+
 
 def col(name: str, qualifier: Optional[str] = None) -> Expr:
     """Reference a column by name.
@@ -188,3 +270,15 @@ def _to_expr(value: Any) -> Expr:
         return value
     arrow_obj = value if isinstance(value, Literal) else Literal(value)
     return Expr(_expr_lit(arrow_obj))
+
+
+def _binary(op: str, lhs: Any, rhs: Any) -> Expr:
+    """Construct a binary Expr, coercing both operands first.
+
+    All `Expr` operator dunders route through this helper. It accepts any
+    Python value on either side, runs both through `_to_expr`, and then
+    calls the single Rust factory `expr_binary` with the operator string.
+    """
+    lhs_expr = _to_expr(lhs)
+    rhs_expr = _to_expr(rhs)
+    return Expr(_expr_binary(op, lhs_expr._impl, rhs_expr._impl))

--- a/python/sedonadb/python/sedonadb/expr/expression.py
+++ b/python/sedonadb/python/sedonadb/expr/expression.py
@@ -234,6 +234,28 @@ class Expr:
     # returns an `Expr`, not a bool.
     __hash__ = None  # type: ignore[assignment]
 
+    # --- Truthiness / length guards ------------------------------------
+    #
+    # Without these, Python's defaults make `if col("x") > 0: ...`,
+    # `col("x") and col("y")`, and `not col("x").is_null()` silently
+    # evaluate Exprs as truthy or coerce them to bool — dropping the
+    # intended predicate. Same trap pandas/polars/spark/ibis all guard
+    # against. Raise a clear TypeError with guidance instead.
+
+    def __bool__(self) -> bool:
+        raise TypeError(
+            "The truth value of an Expr is ambiguous. Use bitwise operators "
+            "`&`, `|`, `~` for boolean composition (e.g. "
+            "`(col('x') > 0) & (col('y') < 10)`), or pass the Expr to "
+            "`DataFrame.filter()` to evaluate it."
+        )
+
+    def __len__(self) -> int:
+        raise TypeError(
+            "Expr has no length. To count rows in a DataFrame, evaluate "
+            "the Expr against a frame (e.g. `df.filter(expr).count()`)."
+        )
+
 
 def col(name: str, qualifier: Optional[str] = None) -> Expr:
     """Reference a column by name.

--- a/python/sedonadb/src/expr.rs
+++ b/python/sedonadb/src/expr.rs
@@ -37,7 +37,7 @@
 //! `SedonaDBExprFactory::column` / `::literal`.
 
 use datafusion_common::Column;
-use datafusion_expr::{expr::InList, Cast, Expr};
+use datafusion_expr::{expr::InList, BinaryExpr, Cast, Expr, Operator};
 use pyo3::prelude::*;
 
 use crate::error::PySedonaError;
@@ -209,4 +209,52 @@ pub fn expr_lit(obj: Bound<'_, PyAny>) -> Result<PyExpr, PySedonaError> {
     let (scalar_value, metadata) = import_arrow_scalar(&obj)?.into_inner();
     let inner = Expr::Literal(scalar_value, metadata);
     Ok(PyExpr { inner })
+}
+
+/// Build a binary `Expr` from a string operator and two operands.
+///
+/// All operator dispatch lives in Python (see `_binary` in `expression.py`),
+/// which calls into this single Rust factory with the operator name as a
+/// string. Centralising the operator-to-`Operator` mapping in one place
+/// keeps both Rust and Python code small: adding an operator is a single
+/// `match` arm and a new dunder, rather than a separate factory per op.
+///
+/// Mirrors `SedonaDBExprFactory::binary` in the R bindings.
+#[pyfunction]
+pub fn expr_binary(op: &str, lhs: &PyExpr, rhs: &PyExpr) -> Result<PyExpr, PySedonaError> {
+    let operator = match op {
+        "+" => Operator::Plus,
+        "-" => Operator::Minus,
+        "*" => Operator::Multiply,
+        "/" => Operator::Divide,
+        "==" => Operator::Eq,
+        "!=" => Operator::NotEq,
+        ">" => Operator::Gt,
+        ">=" => Operator::GtEq,
+        "<" => Operator::Lt,
+        "<=" => Operator::LtEq,
+        "&" => Operator::And,
+        "|" => Operator::Or,
+        other => {
+            return Err(PySedonaError::SedonaPython(format!(
+                "Unsupported binary operator '{other}'"
+            )))
+        }
+    };
+
+    let inner = Expr::BinaryExpr(BinaryExpr::new(
+        Box::new(lhs.inner.clone()),
+        operator,
+        Box::new(rhs.inner.clone()),
+    ));
+    Ok(PyExpr { inner })
+}
+
+/// Build a logical-NOT `Expr::Not` over the given expression. Used by the
+/// Python `~expr` (`__invert__`) operator.
+#[pyfunction]
+pub fn expr_not(expr: &PyExpr) -> PyExpr {
+    PyExpr {
+        inner: Expr::Not(Box::new(expr.inner.clone())),
+    }
 }

--- a/python/sedonadb/src/lib.rs
+++ b/python/sedonadb/src/lib.rs
@@ -126,6 +126,8 @@ fn _lib(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(sedona_scalar_udf, m)?)?;
     m.add_function(wrap_pyfunction!(expr::expr_col, m)?)?;
     m.add_function(wrap_pyfunction!(expr::expr_lit, m)?)?;
+    m.add_function(wrap_pyfunction!(expr::expr_binary, m)?)?;
+    m.add_function(wrap_pyfunction!(expr::expr_not, m)?)?;
 
     m.add_class::<context::InternalContext>()?;
     m.add_class::<dataframe::InternalDataFrame>()?;

--- a/python/sedonadb/tests/expr/test_expression.py
+++ b/python/sedonadb/tests/expr/test_expression.py
@@ -195,3 +195,36 @@ def test_unhashable():
         {col("x"): 1}
     with pytest.raises(TypeError):
         {col("x")}
+
+
+def test_bool_raises_on_direct_call():
+    with pytest.raises(TypeError, match="truth value"):
+        bool(col("x") > 0)
+
+
+def test_bool_raises_in_if_statement():
+    with pytest.raises(TypeError, match="truth value"):
+        if col("x") > 0:
+            pass
+
+
+def test_bool_raises_for_python_and():
+    # `and` short-circuits via bool(); without the __bool__ guard the AND
+    # would silently drop one side. Same trap as pandas/polars.
+    with pytest.raises(TypeError, match="truth value"):
+        col("x") and col("y")
+
+
+def test_bool_raises_for_python_or():
+    with pytest.raises(TypeError, match="truth value"):
+        col("x") or col("y")
+
+
+def test_bool_raises_for_not():
+    with pytest.raises(TypeError, match="truth value"):
+        not col("x").is_null()
+
+
+def test_len_raises():
+    with pytest.raises(TypeError, match="Expr has no length"):
+        len(col("x"))

--- a/python/sedonadb/tests/expr/test_expression.py
+++ b/python/sedonadb/tests/expr/test_expression.py
@@ -46,24 +46,23 @@ def test_col_with_qualifier():
 def test_alias():
     e = col("x").alias("y")
     assert e._impl.variant_name() == "Alias"
-    assert "x AS y" in repr(e)
+    assert repr(e) == "Expr(x AS y)"
 
 
 def test_alias_chain():
     e = col("x").alias("a").alias("b")
-    # Either nested or last-wins; in both cases the latest name must show.
-    assert "b" in repr(e)
+    assert repr(e) == "Expr(x AS a AS b)"
 
 
 def test_cast_to_arrow_type():
     e = col("x").cast(pa.int32())
     assert e._impl.variant_name() == "Cast"
-    assert "CAST(x AS Int32)" in repr(e)
+    assert repr(e) == "Expr(CAST(x AS Int32))"
 
 
 def test_cast_to_string():
     e = col("x").cast(pa.string())
-    assert "Utf8" in repr(e)
+    assert repr(e) == "Expr(CAST(x AS Utf8))"
 
 
 def test_cast_rejects_extension_type():
@@ -76,13 +75,13 @@ def test_cast_rejects_extension_type():
 def test_is_null():
     e = col("x").is_null()
     assert e._impl.variant_name() == "IsNull"
-    assert "x IS NULL" in repr(e)
+    assert repr(e) == "Expr(x IS NULL)"
 
 
 def test_is_not_null():
     e = col("x").is_not_null()
     assert e._impl.variant_name() == "IsNotNull"
-    assert "x IS NOT NULL" in repr(e)
+    assert repr(e) == "Expr(x IS NOT NULL)"
 
 
 def test_isin_python_scalars():
@@ -125,3 +124,74 @@ def test_expr_init_rejects_wrong_type():
         Expr("not an internal expr")
     with pytest.raises(TypeError, match="InternalExpr"):
         Expr(42)
+
+
+# --- Binary operators --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "op,expected",
+    [
+        ("__add__", "Expr(x + Int64(1))"),
+        ("__sub__", "Expr(x - Int64(1))"),
+        ("__mul__", "Expr(x * Int64(1))"),
+        ("__truediv__", "Expr(x / Int64(1))"),
+        ("__eq__", "Expr(x = Int64(1))"),
+        ("__ne__", "Expr(x != Int64(1))"),
+        ("__lt__", "Expr(x < Int64(1))"),
+        ("__le__", "Expr(x <= Int64(1))"),
+        ("__gt__", "Expr(x > Int64(1))"),
+        ("__ge__", "Expr(x >= Int64(1))"),
+    ],
+)
+def test_arithmetic_and_comparison(op, expected):
+    e = getattr(col("x"), op)(1)
+    assert repr(e) == expected
+
+
+def test_reflected_arithmetic():
+    # `1 - col("x")` exercises __rsub__; LHS is the Python int.
+    assert repr(1 - col("x")) == "Expr(Int64(1) - x)"
+    assert repr(2 + col("x")) == "Expr(Int64(2) + x)"
+    assert repr(3 * col("x")) == "Expr(Int64(3) * x)"
+
+
+def test_boolean_and():
+    e = (col("x") > 0) & (col("y") < 10)
+    assert repr(e) == "Expr(x > Int64(0) AND y < Int64(10))"
+
+
+def test_boolean_or():
+    e = (col("x") > 0) | col("y").is_null()
+    assert repr(e) == "Expr(x > Int64(0) OR y IS NULL)"
+
+
+def test_invert():
+    e = ~col("x").is_null()
+    assert e._impl.variant_name() == "Not"
+    assert repr(e) == "Expr(NOT x IS NULL)"
+
+
+def test_unary_minus():
+    e = -col("x")
+    assert e._impl.variant_name() == "Negative"
+    assert repr(e) == "Expr((- x))"
+
+
+def test_expr_op_with_expr():
+    e = col("x") + col("y")
+    assert repr(e) == "Expr(x + y)"
+
+
+def test_chained_operators():
+    e = ((col("x") + 1) * 2).alias("scaled")
+    assert repr(e) == "Expr((x + Int64(1)) * Int64(2) AS scaled)"
+
+
+def test_unhashable():
+    # Expressions are not valid dict keys / set members because __eq__ does
+    # not return a bool. We make this explicit so users get a clear error.
+    with pytest.raises(TypeError):
+        {col("x"): 1}
+    with pytest.raises(TypeError):
+        {col("x")}


### PR DESCRIPTION
Adds operator overloading on `sedonadb.expr.Expr`, building on the foundation that landed in #807.

This is the second of four small stacked PRs implementing Phase P1 of #791.

## What's new

- **Binary operators**: `+`, `-`, `*`, `/`, `==`, `!=`, `<`, `<=`, `>`, `>=`, `&` (AND), `|` (OR), with reflected variants so `1 - col("x")` works the same as `col("x") - 1`.
- **Unary operators**: `-` (arithmetic negation, via `negate()`) and `~` (logical NOT).
- **Auto-coercion of Python scalars**: `col("x") > 5` works without an explicit literal wrap; the scalar is routed through the existing `_to_expr()` path internally.
- `Expr.__hash__ = None` so use as a dict key or set member fails clearly — `__eq__` returns an `Expr`, not a `bool`.

## Implementation notes

Operator dispatch is centralised: every Python dunder routes through a single `_binary(op, lhs, rhs)` helper, which calls into a single Rust factory `expr_binary(op, lhs, rhs)` that maps the string opcode to a `datafusion_expr::Operator`. Adding a new operator is one Rust match arm plus one Python dunder. Mirrors the pattern in the R bindings (`SedonaDBExprFactory::binary`).

`~` (logical NOT) goes through a separate `expr_not` factory because DataFusion models it as `Expr::Not` rather than a binary operator.

## Tests

- 18 new tests covering arithmetic, comparison, boolean, reflected, unary, chained, expr-with-expr, and `__hash__ = None` behaviour. All assertions are exact `repr() == ...` per the test module's pinning policy.
- While here, tightens six inherited foundation tests from substring to exact equality so the module is consistent end-to-end.

## Test plan

- [x] 33/33 tests in `tests/expr/test_expression.py` pass locally.
- [x] No regressions in existing `tests/test_dataframe.py`.
- [x] CI green.
