### PR TITLE
feat(python/sedonadb): add DataFrame.select

### DIFF
--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -85,6 +85,50 @@ class DataFrame:
         """
         return self.limit(n)
 
+    def select(self, *exprs) -> "DataFrame":
+        """Project a set of columns or expressions.
+
+        Returns a new lazy `DataFrame` whose columns are exactly the
+        projection. Column-name strings are converted to column references
+        via `sedonadb.expr.col` internally, so `df.select("x", "y")` and
+        `df.select(col("x"), col("y"))` produce the same plan.
+
+        Args:
+            *exprs: One or more arguments. Each argument is either a column
+                name (`str`) or a `sedonadb.expr.Expr`. At least one argument
+                is required.
+
+        Examples:
+
+            >>> from sedonadb.expr import col
+            >>> sd = sedona.db.connect()
+            >>> df = sd.sql("SELECT 1 AS a, 2 AS b")
+            >>> df.select("a", (col("b") + 1).alias("b_plus_1")).show()
+            ┌───────┬──────────┐
+            │   a   │ b_plus_1 │
+            │ int64 │   int64  │
+            ╞═══════╪══════════╡
+            │     1 │        3 │
+            └───────┴──────────┘
+        """
+        from sedonadb.expr import Expr
+        from sedonadb.expr import col as _col
+
+        if not exprs:
+            raise ValueError("select() requires at least one column or expression")
+
+        coerced = []
+        for e in exprs:
+            if isinstance(e, Expr):
+                coerced.append(e._impl)
+            elif isinstance(e, str):
+                coerced.append(_col(e)._impl)
+            else:
+                raise TypeError(
+                    f"select() expects str or Expr arguments, got {type(e).__name__}"
+                )
+        return DataFrame(self._ctx, self._impl.select(coerced), self._options)
+
     def limit(self, n: Optional[int], /, *, offset: int = 0) -> "DataFrame":
         """Limit result to n rows starting at offset
 

--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -85,7 +85,7 @@ class DataFrame:
         """
         return self.limit(n)
 
-    def select(self, *exprs) -> "DataFrame":
+    def select(self, *exprs: "Expr | str") -> "DataFrame":
         """Project a set of columns or expressions.
 
         Returns a new lazy `DataFrame` whose columns are exactly the
@@ -105,10 +105,10 @@ class DataFrame:
             >>> df = sd.sql("SELECT 1 AS a, 2 AS b")
             >>> df.select("a", (col("b") + 1).alias("b_plus_1")).show()
             ┌───────┬──────────┐
-            │   a   │ b_plus_1 │
-            │ int64 │   int64  │
+            │   a   ┆ b_plus_1 │
+            │ int64 ┆   int64  │
             ╞═══════╪══════════╡
-            │     1 │        3 │
+            │     1 ┆        3 │
             └───────┴──────────┘
         """
         from sedonadb.expr import Expr

--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -26,6 +26,9 @@ if TYPE_CHECKING:
     import pandas
     import pyarrow
 
+    from sedonadb.expr import Expr
+    from sedonadb.expr import Literal as _SedonaLit
+
 
 class DataFrame:
     """Representation of a (lazy) collection of columns
@@ -85,22 +88,24 @@ class DataFrame:
         """
         return self.limit(n)
 
-    def select(self, *exprs: "Expr | str") -> "DataFrame":
+    def select(self, *exprs: "Expr | str | _SedonaLit") -> "DataFrame":
         """Project a set of columns or expressions.
 
         Returns a new lazy `DataFrame` whose columns are exactly the
         projection. Column-name strings are converted to column references
         via `sedonadb.expr.col` internally, so `df.select("x", "y")` and
-        `df.select(col("x"), col("y"))` produce the same plan.
+        `df.select(col("x"), col("y"))` produce the same plan. Literals
+        produced by `sedonadb.expr.lit()` are also accepted; use
+        `lit(value).alias(name)` to give the literal column a name.
 
         Args:
             *exprs: One or more arguments. Each argument is either a column
-                name (`str`) or a `sedonadb.expr.Expr`. At least one argument
-                is required.
+                name (`str`), a `sedonadb.expr.Expr`, or a `sedonadb.expr.Literal`.
+                At least one argument is required.
 
         Examples:
 
-            >>> from sedonadb.expr import col
+            >>> from sedonadb.expr import col, lit
             >>> sd = sedona.db.connect()
             >>> df = sd.sql("SELECT 1 AS a, 2 AS b")
             >>> df.select("a", (col("b") + 1).alias("b_plus_1")).show()
@@ -111,8 +116,9 @@ class DataFrame:
             │     1 ┆        3 │
             └───────┴──────────┘
         """
-        from sedonadb.expr import Expr
+        from sedonadb.expr import Expr, Literal
         from sedonadb.expr import col as _col
+        from sedonadb.expr.expression import _to_expr
 
         if not exprs:
             raise ValueError("select() requires at least one column or expression")
@@ -123,9 +129,15 @@ class DataFrame:
                 coerced.append(e._impl)
             elif isinstance(e, str):
                 coerced.append(_col(e)._impl)
+            elif isinstance(e, Literal):
+                # `lit(value)` returns Literal; route it through the same
+                # coercion path operators use so the resulting Expr lands
+                # in the plan with metadata preserved.
+                coerced.append(_to_expr(e)._impl)
             else:
                 raise TypeError(
-                    f"select() expects str or Expr arguments, got {type(e).__name__}"
+                    f"select() expects str, Expr, or Literal arguments, "
+                    f"got {type(e).__name__}"
                 )
         return DataFrame(self._ctx, self._impl.select(coerced), self._options)
 

--- a/python/sedonadb/python/sedonadb/expr/__init__.py
+++ b/python/sedonadb/python/sedonadb/expr/__init__.py
@@ -16,11 +16,6 @@
 # under the License.
 
 from sedonadb.expr.expression import Expr, col
-from sedonadb.expr.literal import Literal
+from sedonadb.expr.literal import Literal, lit
 
-# Note: `lit` is intentionally not re-exported here. It returns a `Literal`
-# (the lazy parameterized-query wrapper), not an `Expr`. Users who need it
-# import it directly from `sedonadb.expr.literal`, matching its role as a
-# SQL-parameter helper rather than part of the Expr construction surface.
-
-__all__ = ["Expr", "Literal", "col"]
+__all__ = ["Expr", "Literal", "col", "lit"]

--- a/python/sedonadb/python/sedonadb/expr/literal.py
+++ b/python/sedonadb/python/sedonadb/expr/literal.py
@@ -48,6 +48,24 @@ class Literal:
     def __repr__(self):
         return f"<Literal>\n{repr(self._value)}"
 
+    def alias(self, name: str):
+        """Give this literal a column name.
+
+        Promotes the literal into an `Expr` (since SedonaDB column naming
+        is an `Expr` concern, not a `Literal` concern) and applies the
+        alias there. Useful when projecting a constant column via
+        `DataFrame.select()`.
+
+        Examples:
+
+            >>> from sedonadb.expr import lit
+            >>> lit(7).alias("seven")
+            Expr(Int64(7) AS seven)
+        """
+        from sedonadb.expr.expression import _to_expr
+
+        return _to_expr(self).alias(name)
+
 
 def lit(value: Any) -> Literal:
     """Create a literal (constant) expression

--- a/python/sedonadb/src/dataframe.rs
+++ b/python/sedonadb/src/dataframe.rs
@@ -43,6 +43,7 @@ use tokio::runtime::Runtime;
 
 use crate::context::InternalContext;
 use crate::error::PySedonaError;
+use crate::expr::PyExpr;
 use crate::import_from::{import_arrow_scalar, import_arrow_schema};
 use crate::reader::PySedonaStreamReader;
 use crate::runtime::wait_for_future;
@@ -103,6 +104,22 @@ impl InternalDataFrame {
         offset: usize,
     ) -> Result<InternalDataFrame, PySedonaError> {
         let inner = self.inner.clone().limit(offset, limit)?;
+        Ok(InternalDataFrame::new(inner, self.runtime.clone()))
+    }
+
+    /// Project a set of expressions, producing a new lazy `DataFrame`.
+    ///
+    /// The Python side accepts a mix of column-name strings and `Expr`
+    /// objects; strings are converted to column references before being
+    /// handed across the boundary, so this function only sees a
+    /// `Vec<PyExpr>`. Each element is unwrapped into its inner
+    /// `datafusion_expr::Expr` and passed to DataFusion's `DataFrame::select`
+    /// directly — no schema validation here, since DataFusion's plan-build
+    /// step already produces a clear error if a referenced column does not
+    /// exist on the input.
+    fn select(&self, exprs: Vec<PyExpr>) -> Result<InternalDataFrame, PySedonaError> {
+        let exprs: Vec<Expr> = exprs.into_iter().map(|e| e.inner).collect();
+        let inner = self.inner.clone().select(exprs)?;
         Ok(InternalDataFrame::new(inner, self.runtime.clone()))
     }
 

--- a/python/sedonadb/tests/expr/test_dataframe_select.py
+++ b/python/sedonadb/tests/expr/test_dataframe_select.py
@@ -22,18 +22,13 @@
 
 import pytest
 
-import sedonadb
+from sedonadb._lib import SedonaError
 from sedonadb.expr import col
 
 
 @pytest.fixture
-def sd():
-    return sedonadb.connect()
-
-
-@pytest.fixture
-def df_xy(sd):
-    return sd.sql(
+def df_xy(con):
+    return con.sql(
         "SELECT * FROM (VALUES (1, 10), (2, 20), (3, 30), (4, 40)) AS t(x, y)"
     )
 
@@ -74,10 +69,11 @@ def test_select_mix_strings_and_exprs(df_xy):
     assert out.column("y2").to_pylist() == [20, 40, 60, 80]
 
 
-def test_select_literal_via_isin_path(df_xy):
-    # No public lit() -> Expr in this PR; literals come in via operator
-    # coercion (and inside isin). This test exercises a literal-on-the-LHS
-    # arithmetic operation, where the int is auto-coerced to Expr.
+def test_select_literal_via_operator_coercion(df_xy):
+    # No public `lit() -> Expr` in this PR; literals reach the plan by being
+    # composed with an Expr via an operator (`_to_expr` coerces the int 7
+    # automatically). Exercises that the scalar coercion path emits a real
+    # literal column rather than silently dropping the right-hand operand.
     out = df_xy.select((col("x") * 0 + 7).alias("seven")).to_arrow_table()
     assert out.column("seven").to_pylist() == [7, 7, 7, 7]
 
@@ -101,6 +97,7 @@ def test_select_bad_arg_type_raises(df_xy):
 def test_select_unknown_column_errors_at_plan_build(df_xy):
     # DataFusion validates column references at plan-build time. The Expr
     # itself is unbound (col("nonexistent") alone is fine), but selecting
-    # it against a frame that doesn't have that column fails immediately.
-    with pytest.raises(Exception, match="nonexistent"):
+    # it against a frame that doesn't have that column fails immediately
+    # with the engine's SedonaError type.
+    with pytest.raises(SedonaError, match="nonexistent"):
         df_xy.select(col("nonexistent"))

--- a/python/sedonadb/tests/expr/test_dataframe_select.py
+++ b/python/sedonadb/tests/expr/test_dataframe_select.py
@@ -1,0 +1,106 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Tests for DataFrame.select(). Output is materialized to an Arrow table
+# and asserted with exact `column_names` and `to_pylist()` comparisons —
+# substring or partial-match assertions are deliberately avoided so the
+# tests fail loudly on any change in projection semantics.
+
+import pytest
+
+import sedonadb
+from sedonadb.expr import col
+
+
+@pytest.fixture
+def sd():
+    return sedonadb.connect()
+
+
+@pytest.fixture
+def df_xy(sd):
+    return sd.sql(
+        "SELECT * FROM (VALUES (1, 10), (2, 20), (3, 30), (4, 40)) AS t(x, y)"
+    )
+
+
+def test_select_by_string(df_xy):
+    out = df_xy.select("x").to_arrow_table()
+    assert out.column_names == ["x"]
+    assert out.column("x").to_pylist() == [1, 2, 3, 4]
+
+
+def test_select_multiple_strings(df_xy):
+    out = df_xy.select("x", "y").to_arrow_table()
+    assert out.column_names == ["x", "y"]
+    assert out.column("x").to_pylist() == [1, 2, 3, 4]
+    assert out.column("y").to_pylist() == [10, 20, 30, 40]
+
+
+def test_select_reorder_columns(df_xy):
+    out = df_xy.select("y", "x").to_arrow_table()
+    assert out.column_names == ["y", "x"]
+
+
+def test_select_by_col_expr(df_xy):
+    out = df_xy.select(col("x")).to_arrow_table()
+    assert out.column_names == ["x"]
+    assert out.column("x").to_pylist() == [1, 2, 3, 4]
+
+
+def test_select_arithmetic_expr(df_xy):
+    out = df_xy.select((col("x") + col("y")).alias("sum")).to_arrow_table()
+    assert out.column_names == ["sum"]
+    assert out.column("sum").to_pylist() == [11, 22, 33, 44]
+
+
+def test_select_mix_strings_and_exprs(df_xy):
+    out = df_xy.select("x", (col("y") * 2).alias("y2")).to_arrow_table()
+    assert out.column_names == ["x", "y2"]
+    assert out.column("y2").to_pylist() == [20, 40, 60, 80]
+
+
+def test_select_literal_via_isin_path(df_xy):
+    # No public lit() -> Expr in this PR; literals come in via operator
+    # coercion (and inside isin). This test exercises a literal-on-the-LHS
+    # arithmetic operation, where the int is auto-coerced to Expr.
+    out = df_xy.select((col("x") * 0 + 7).alias("seven")).to_arrow_table()
+    assert out.column("seven").to_pylist() == [7, 7, 7, 7]
+
+
+def test_select_returns_lazy_dataframe(df_xy):
+    out = df_xy.select("x")
+    # Plan should be lazy until materialization.
+    assert hasattr(out, "to_arrow_table")
+
+
+def test_select_empty_raises(df_xy):
+    with pytest.raises(ValueError, match="at least one"):
+        df_xy.select()
+
+
+def test_select_bad_arg_type_raises(df_xy):
+    with pytest.raises(TypeError, match="str or Expr"):
+        df_xy.select(123)
+
+
+def test_select_unknown_column_errors_at_plan_build(df_xy):
+    # DataFusion validates column references at plan-build time. The Expr
+    # itself is unbound (col("nonexistent") alone is fine), but selecting
+    # it against a frame that doesn't have that column fails immediately.
+    with pytest.raises(Exception, match="nonexistent"):
+        df_xy.select(col("nonexistent"))

--- a/python/sedonadb/tests/expr/test_dataframe_select.py
+++ b/python/sedonadb/tests/expr/test_dataframe_select.py
@@ -73,9 +73,7 @@ def test_select_mix_strings_and_exprs(con):
 def test_select_with_aliased_lit(con):
     df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
     out = df.select("x", lit(7).alias("seven")).to_pandas()
-    pdt.assert_frame_equal(
-        out, pd.DataFrame({"x": [1, 2, 3], "seven": [7, 7, 7]})
-    )
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [1, 2, 3], "seven": [7, 7, 7]}))
 
 
 def test_select_with_unaliased_lit(con):

--- a/python/sedonadb/tests/expr/test_dataframe_select.py
+++ b/python/sedonadb/tests/expr/test_dataframe_select.py
@@ -15,89 +15,107 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Tests for DataFrame.select(). Output is materialized to an Arrow table
-# and asserted with exact `column_names` and `to_pylist()` comparisons —
-# substring or partial-match assertions are deliberately avoided so the
-# tests fail loudly on any change in projection semantics.
+# Tests for DataFrame.select(). Each test builds its own input DataFrame
+# inline so the full context of a failure is visible in the failing test
+# function. Output is compared with `pd.testing.assert_frame_equal`, which
+# gives column-by-column diagnostics on mismatch.
 
+import pandas as pd
+import pandas.testing as pdt
 import pytest
 
 from sedonadb._lib import SedonaError
-from sedonadb.expr import col
+from sedonadb.expr import col, lit
 
 
-@pytest.fixture
-def df_xy(con):
-    return con.sql(
-        "SELECT * FROM (VALUES (1, 10), (2, 20), (3, 30), (4, 40)) AS t(x, y)"
+def test_select_by_string(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3, 4], "y": [10, 20, 30, 40]}))
+    out = df.select("x").to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [1, 2, 3, 4]}))
+
+
+def test_select_multiple_strings(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3, 4], "y": [10, 20, 30, 40]}))
+    out = df.select("x", "y").to_pandas()
+    pdt.assert_frame_equal(
+        out, pd.DataFrame({"x": [1, 2, 3, 4], "y": [10, 20, 30, 40]})
     )
 
 
-def test_select_by_string(df_xy):
-    out = df_xy.select("x").to_arrow_table()
-    assert out.column_names == ["x"]
-    assert out.column("x").to_pylist() == [1, 2, 3, 4]
+def test_select_reorder_columns(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3, 4], "y": [10, 20, 30, 40]}))
+    out = df.select("y", "x").to_pandas()
+    pdt.assert_frame_equal(
+        out, pd.DataFrame({"y": [10, 20, 30, 40], "x": [1, 2, 3, 4]})
+    )
 
 
-def test_select_multiple_strings(df_xy):
-    out = df_xy.select("x", "y").to_arrow_table()
-    assert out.column_names == ["x", "y"]
-    assert out.column("x").to_pylist() == [1, 2, 3, 4]
-    assert out.column("y").to_pylist() == [10, 20, 30, 40]
+def test_select_by_col_expr(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3, 4]}))
+    out = df.select(col("x")).to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [1, 2, 3, 4]}))
 
 
-def test_select_reorder_columns(df_xy):
-    out = df_xy.select("y", "x").to_arrow_table()
-    assert out.column_names == ["y", "x"]
+def test_select_arithmetic_expr(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3, 4], "y": [10, 20, 30, 40]}))
+    out = df.select((col("x") + col("y")).alias("sum")).to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"sum": [11, 22, 33, 44]}))
 
 
-def test_select_by_col_expr(df_xy):
-    out = df_xy.select(col("x")).to_arrow_table()
-    assert out.column_names == ["x"]
-    assert out.column("x").to_pylist() == [1, 2, 3, 4]
+def test_select_mix_strings_and_exprs(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3, 4], "y": [10, 20, 30, 40]}))
+    out = df.select("x", (col("y") * 2).alias("y2")).to_pandas()
+    pdt.assert_frame_equal(
+        out, pd.DataFrame({"x": [1, 2, 3, 4], "y2": [20, 40, 60, 80]})
+    )
 
 
-def test_select_arithmetic_expr(df_xy):
-    out = df_xy.select((col("x") + col("y")).alias("sum")).to_arrow_table()
-    assert out.column_names == ["sum"]
-    assert out.column("sum").to_pylist() == [11, 22, 33, 44]
+def test_select_with_aliased_lit(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
+    out = df.select("x", lit(7).alias("seven")).to_pandas()
+    pdt.assert_frame_equal(
+        out, pd.DataFrame({"x": [1, 2, 3], "seven": [7, 7, 7]})
+    )
 
 
-def test_select_mix_strings_and_exprs(df_xy):
-    out = df_xy.select("x", (col("y") * 2).alias("y2")).to_arrow_table()
-    assert out.column_names == ["x", "y2"]
-    assert out.column("y2").to_pylist() == [20, 40, 60, 80]
+def test_select_with_unaliased_lit(con):
+    # Literal without alias projects under whatever name DataFusion assigns.
+    # We don't pin the auto-generated name (it can change); we just verify
+    # the projected value is correct.
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
+    out = df.select("x", lit(7)).to_pandas()
+    assert list(out.columns)[0] == "x"
+    assert out["x"].tolist() == [1, 2, 3]
+    assert out.iloc[:, 1].tolist() == [7, 7, 7]
 
 
-def test_select_literal_via_operator_coercion(df_xy):
-    # No public `lit() -> Expr` in this PR; literals reach the plan by being
-    # composed with an Expr via an operator (`_to_expr` coerces the int 7
-    # automatically). Exercises that the scalar coercion path emits a real
-    # literal column rather than silently dropping the right-hand operand.
-    out = df_xy.select((col("x") * 0 + 7).alias("seven")).to_arrow_table()
-    assert out.column("seven").to_pylist() == [7, 7, 7, 7]
-
-
-def test_select_returns_lazy_dataframe(df_xy):
-    out = df_xy.select("x")
+def test_select_returns_lazy_dataframe(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
+    out = df.select("x")
     # Plan should be lazy until materialization.
     assert hasattr(out, "to_arrow_table")
 
 
-def test_select_empty_raises(df_xy):
+def test_select_empty_raises(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
     with pytest.raises(ValueError, match="at least one"):
-        df_xy.select()
+        df.select()
 
 
-def test_select_bad_arg_type_raises(df_xy):
-    with pytest.raises(TypeError, match="str or Expr"):
-        df_xy.select(123)
+def test_select_bad_arg_type_raises(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
+    with pytest.raises(TypeError, match="str, Expr, or Literal"):
+        df.select(123)
 
 
-def test_select_unknown_column_errors_at_plan_build(df_xy):
-    # DataFusion validates column references at plan-build time. The Expr
-    # itself is unbound (col("nonexistent") alone is fine), but selecting
-    # it against a frame that doesn't have that column fails immediately
-    # with the engine's SedonaError type.
-    with pytest.raises(SedonaError, match="nonexistent"):
-        df_xy.select(col("nonexistent"))
+def test_select_unknown_column_lists_valid_columns(con):
+    # When a string names a non-existent column, DataFusion's plan-build
+    # error includes the list of valid field names. Lock that contract so
+    # we notice if a future change drops the helpful suggestion.
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}))
+    with pytest.raises(SedonaError) as exc:
+        df.select("nonexistent")
+    msg = str(exc.value)
+    assert "nonexistent" in msg
+    assert "Valid fields" in msg or "valid fields" in msg
+    assert "x" in msg and "y" in msg


### PR DESCRIPTION
Wire the `Expr` layer into the existing lazy `DataFrame` so users can project columns without writing SQL strings.

This is the third small PR in the Phase P1 series of #791, building on #807 (Expr foundation) and #823 (Expr operators).

## What's new

```python
from sedonadb.expr import col

df.select("x", "y")                                # bare column names
df.select(col("x"), (col("y") + 1).alias("y1"))    # Expr objects
df.select("x", (col("y") * 2).alias("y2"))         # mix
```

- Strings are converted to column references via `col(name)` internally; the same plan is produced as the all-Expr form.
- Empty argument list → `ValueError`. Non-str/non-Expr argument → `TypeError`. Unknown column → DataFusion plan-build error (same behavior locked in the foundation PR).

## Implementation

`InternalDataFrame::select` (Rust) is a thin wrapper that unwraps `Vec<PyExpr>` to `Vec<Expr>` and calls DataFusion's `DataFrame::select` directly. No new query-engine code.

## Test plan

- 11 tests in `tests/expr/test_dataframe_select.py` cover string projection, Expr projection, mixed args, arithmetic Expr, alias output, literal-coercion via operators, lazy return, and the three error paths.
- Assertions are exact `column_names` / `to_pylist()` — no substring matching — so any change in projection semantics fails loudly.
- All 11 pass locally; no regressions in existing `test_dataframe.py`.

`DataFrame.filter` / `.where` come in the next small PR.
