### PR TITLE
feat(rust/sedona-raster-gdal): add RS_MetaData

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6162,6 +6162,7 @@ dependencies = [
  "sedona-functions",
  "sedona-gdal",
  "sedona-raster",
+ "sedona-raster-functions",
  "sedona-schema",
  "sedona-testing",
  "tempfile",

--- a/docs/reference/sql/rs_metadata.qmd
+++ b/docs/reference/sql/rs_metadata.qmd
@@ -1,0 +1,53 @@
+---
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+title: RS_MetaData
+description: Returns raster metadata as a struct.
+kernels:
+  - returns: struct
+    args: [raster]
+---
+
+## Description
+
+`RS_MetaData()` returns a struct containing:
+
+- `upperLeftX`, `upperLeftY`: origin of the raster geotransform
+- `gridWidth`, `gridHeight`: raster dimensions in pixels
+- `scaleX`, `scaleY`: pixel scale
+- `skewX`, `skewY`: geotransform skew terms
+- `srid`: raster SRID if available, otherwise `0`
+- `numSampleDimensions`: band count
+- `tileWidth`, `tileHeight`: GDAL block size derived tile dimensions
+
+For rasters with no bands, `tileWidth` and `tileHeight` are `0`.
+
+## Examples
+
+```sql
+SELECT RS_MetaData(
+  RS_FromPath('../../../submodules/sedona-testing/data/raster/test4.tiff')
+);
+```
+
+```sql
+SELECT meta."gridWidth", meta."gridHeight"
+FROM (
+  SELECT RS_MetaData(RS_FromPath('../../../submodules/sedona-testing/data/raster/test4.tiff')) AS meta
+);
+```

--- a/docs/reference/sql/rs_metadata.qmd
+++ b/docs/reference/sql/rs_metadata.qmd
@@ -49,5 +49,5 @@ SELECT RS_MetaData(
 SELECT meta."gridWidth", meta."gridHeight"
 FROM (
   SELECT RS_MetaData(RS_FromPath('../../../submodules/sedona-testing/data/raster/test4.tiff')) AS meta
-);
+) q;
 ```

--- a/docs/reference/sql/rs_metadata.qmd
+++ b/docs/reference/sql/rs_metadata.qmd
@@ -40,14 +40,14 @@ For rasters with no bands, `tileWidth` and `tileHeight` are `0`.
 ## Examples
 
 ```sql
-SELECT RS_MetaData(
-  RS_FromPath('../../../submodules/sedona-testing/data/raster/test4.tiff')
-);
+SELECT RS_MetaData(RS_Example());
 ```
 
 ```sql
 SELECT meta."gridWidth", meta."gridHeight"
 FROM (
-  SELECT RS_MetaData(RS_FromPath('../../../submodules/sedona-testing/data/raster/test4.tiff')) AS meta
+  SELECT RS_MetaData(
+    RS_FromPath('https://download.osgeo.org/geotiff/samples/gdal_eg/cea.tif')
+  ) AS meta
 ) q;
 ```

--- a/rust/sedona-raster-gdal/Cargo.toml
+++ b/rust/sedona-raster-gdal/Cargo.toml
@@ -43,6 +43,7 @@ sedona-expr = { workspace = true }
 sedona-functions = { workspace = true }
 sedona-gdal = { workspace = true }
 sedona-raster = { workspace = true }
+sedona-raster-functions = { workspace = true }
 sedona-schema = { workspace = true }
 tokio = { workspace = true }
 

--- a/rust/sedona-raster-gdal/Cargo.toml
+++ b/rust/sedona-raster-gdal/Cargo.toml
@@ -58,3 +58,8 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 harness = false
 name = "rs_frompath"
 path = "benches/rs_frompath.rs"
+
+[[bench]]
+harness = false
+name = "rs_metadata"
+path = "benches/rs_metadata.rs"

--- a/rust/sedona-raster-gdal/benches/rs_metadata.rs
+++ b/rust/sedona-raster-gdal/benches/rs_metadata.rs
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Benchmarks for RS_MetaData UDF.
+
+use std::{hint::black_box, sync::Arc};
+
+use arrow_array::{ArrayRef, StringArray};
+use arrow_schema::DataType;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use datafusion_expr::ScalarUDF;
+use sedona_schema::datatypes::{SedonaType, RASTER};
+use sedona_testing::{data::test_raster, testers::ScalarUdfTester};
+
+const SMALL_RASTER_FIXTURES: &[&str] = &[
+    "test1.tiff",
+    "test2.tif",
+    "test3.tif",
+    "test4.tiff",
+    "test5.tiff",
+];
+
+fn raster_path_array(names: &[&str], rows: usize) -> ArrayRef {
+    assert!(
+        !names.is_empty(),
+        "benchmark fixture list must not be empty"
+    );
+
+    let paths = names
+        .iter()
+        .map(|name| test_raster(name).unwrap())
+        .collect::<Vec<_>>();
+
+    let values = (0..rows)
+        .map(|index| paths[index % paths.len()].as_str())
+        .collect::<Vec<_>>();
+
+    Arc::new(StringArray::from(values))
+}
+
+fn build_raster_input(names: &[&str], rows: usize) -> ArrayRef {
+    let frompath_udf: ScalarUDF = sedona_raster_gdal::rs_frompath_udf().into();
+    let frompath_tester =
+        ScalarUdfTester::new(frompath_udf, vec![SedonaType::Arrow(DataType::Utf8)]);
+    frompath_tester
+        .invoke_array(raster_path_array(names, rows))
+        .unwrap()
+}
+
+fn bench_rs_metadata(c: &mut Criterion) {
+    let udf: ScalarUDF = sedona_raster_gdal::rs_metadata_udf().into();
+    let tester = ScalarUdfTester::new(udf, vec![RASTER]);
+
+    let single_small = build_raster_input(&["test4.tiff"], 1);
+    let mixed_small = build_raster_input(SMALL_RASTER_FIXTURES, SMALL_RASTER_FIXTURES.len());
+    let batched_small = build_raster_input(SMALL_RASTER_FIXTURES, 256);
+
+    let mut group = c.benchmark_group("rs_metadata");
+
+    group.throughput(Throughput::Elements(single_small.len() as u64));
+    group.bench_with_input(
+        BenchmarkId::new("fixtures", "single_small"),
+        &single_small,
+        |b, input| b.iter(|| black_box(tester.invoke_array(input.clone()).unwrap())),
+    );
+
+    group.throughput(Throughput::Elements(mixed_small.len() as u64));
+    group.bench_with_input(
+        BenchmarkId::new("fixtures", "mixed_small"),
+        &mixed_small,
+        |b, input| b.iter(|| black_box(tester.invoke_array(input.clone()).unwrap())),
+    );
+
+    group.throughput(Throughput::Elements(batched_small.len() as u64));
+    group.bench_with_input(
+        BenchmarkId::new("fixtures", "batched_small"),
+        &batched_small,
+        |b, input| b.iter(|| black_box(tester.invoke_array(input.clone()).unwrap())),
+    );
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_rs_metadata);
+criterion_main!(benches);

--- a/rust/sedona-raster-gdal/src/lib.rs
+++ b/rust/sedona-raster-gdal/src/lib.rs
@@ -34,6 +34,7 @@ mod gdal_dataset_provider;
 
 mod raster_loader;
 mod rs_frompath;
+mod rs_metadata;
 mod source_uri;
 mod utils;
 
@@ -44,6 +45,7 @@ pub use gdal_common::{
 };
 pub use raster_loader::{GdalLoader, GDAL_FORMAT};
 pub use rs_frompath::rs_frompath_udf;
+pub use rs_metadata::rs_metadata_udf;
 pub use utils::{
     append_as_indb_raster, append_as_outdb_raster, append_nd_from_dataset, dataset_to_indb_raster,
     gdal_dataset_to_nd_raster,

--- a/rust/sedona-raster-gdal/src/register.rs
+++ b/rust/sedona-raster-gdal/src/register.rs
@@ -21,5 +21,6 @@ use sedona_expr::function_set::FunctionSet;
 pub fn default_function_set() -> FunctionSet {
     let mut function_set = FunctionSet::new();
     function_set.insert_scalar_udf(crate::rs_frompath::rs_frompath_udf());
+    function_set.insert_scalar_udf(crate::rs_metadata::rs_metadata_udf());
     function_set
 }

--- a/rust/sedona-raster-gdal/src/rs_metadata.rs
+++ b/rust/sedona-raster-gdal/src/rs_metadata.rs
@@ -21,7 +21,7 @@ use arrow_array::builder::{
     Float64Builder, Int32Builder, Int64Builder, UInt32Builder, UInt64Builder,
 };
 use arrow_array::StructArray;
-use arrow_buffer::NullBuffer;
+use arrow_buffer::NullBufferBuilder;
 use arrow_schema::{DataType, Field, Fields};
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::error::Result;
@@ -104,7 +104,7 @@ impl SedonaScalarKernel for RsMetaData {
         let mut num_bands_builder = UInt32Builder::with_capacity(capacity);
         let mut tile_width_builder = UInt64Builder::with_capacity(capacity);
         let mut tile_height_builder = UInt64Builder::with_capacity(capacity);
-        let mut struct_validity = Vec::with_capacity(capacity);
+        let mut struct_validity = NullBufferBuilder::new(capacity);
 
         with_gdal(|gdal| {
             configure_thread_local_options(gdal, config_options)?;
@@ -114,7 +114,7 @@ impl SedonaScalarKernel for RsMetaData {
             executor.execute_raster_void(|_i, raster_opt| {
                 match raster_opt {
                     None => {
-                        struct_validity.push(false);
+                        struct_validity.append(false);
                         upper_left_x_builder.append_null();
                         upper_left_y_builder.append_null();
                         grid_width_builder.append_null();
@@ -129,7 +129,7 @@ impl SedonaScalarKernel for RsMetaData {
                         tile_height_builder.append_null();
                     }
                     Some(raster) => {
-                        struct_validity.push(true);
+                        struct_validity.append(true);
                         let metadata = raster.metadata();
                         let num_bands = raster.bands().len() as u32;
 
@@ -195,7 +195,7 @@ impl SedonaScalarKernel for RsMetaData {
                 Arc::new(tile_width_builder.finish()),
                 Arc::new(tile_height_builder.finish()),
             ],
-            Some(NullBuffer::from_iter(struct_validity)),
+            struct_validity.finish(),
         );
 
         executor.finish(Arc::new(struct_array))

--- a/rust/sedona-raster-gdal/src/rs_metadata.rs
+++ b/rust/sedona-raster-gdal/src/rs_metadata.rs
@@ -1,0 +1,275 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use arrow_array::builder::{Float64Builder, Int32Builder, UInt64Builder};
+use arrow_array::StructArray;
+use arrow_schema::{DataType, Field, Fields};
+use datafusion_common::config::ConfigOptions;
+use datafusion_common::error::Result;
+use datafusion_common::exec_datafusion_err;
+use datafusion_expr::{ColumnarValue, Volatility};
+use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
+use sedona_raster::traits::RasterRef;
+use sedona_schema::crs::deserialize_crs;
+use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
+
+use crate::gdal_common::with_gdal;
+use crate::gdal_dataset_provider::{configure_thread_local_options, thread_local_provider};
+
+pub fn rs_metadata_udf() -> SedonaScalarUDF {
+    SedonaScalarUDF::new(
+        "rs_metadata",
+        vec![Arc::new(RsMetaData {})],
+        Volatility::Immutable,
+    )
+}
+
+fn metadata_struct_fields() -> Fields {
+    Fields::from(vec![
+        Field::new("upperLeftX", DataType::Float64, true),
+        Field::new("upperLeftY", DataType::Float64, true),
+        Field::new("gridWidth", DataType::UInt64, true),
+        Field::new("gridHeight", DataType::UInt64, true),
+        Field::new("scaleX", DataType::Float64, true),
+        Field::new("scaleY", DataType::Float64, true),
+        Field::new("skewX", DataType::Float64, true),
+        Field::new("skewY", DataType::Float64, true),
+        Field::new("srid", DataType::Int32, true),
+        Field::new("numSampleDimensions", DataType::UInt64, true),
+        Field::new("tileWidth", DataType::UInt64, true),
+        Field::new("tileHeight", DataType::UInt64, true),
+    ])
+}
+
+#[derive(Debug)]
+struct RsMetaData {}
+
+impl SedonaScalarKernel for RsMetaData {
+    fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
+        let matcher = ArgMatcher::new(
+            vec![ArgMatcher::is_raster()],
+            SedonaType::Arrow(DataType::Struct(metadata_struct_fields())),
+        );
+
+        matcher.match_args(args)
+    }
+
+    fn invoke_batch(
+        &self,
+        arg_types: &[SedonaType],
+        args: &[ColumnarValue],
+    ) -> Result<ColumnarValue> {
+        self.invoke_batch_from_args(arg_types, args, &SedonaType::Arrow(DataType::Null), 0, None)
+    }
+
+    fn invoke_batch_from_args(
+        &self,
+        arg_types: &[SedonaType],
+        args: &[ColumnarValue],
+        _return_type: &SedonaType,
+        _num_rows: usize,
+        config_options: Option<&ConfigOptions>,
+    ) -> Result<ColumnarValue> {
+        let executor = sedona_raster_functions::RasterExecutor::new(arg_types, args);
+        let capacity = executor.num_iterations();
+
+        let mut upper_left_x_builder = Float64Builder::with_capacity(capacity);
+        let mut upper_left_y_builder = Float64Builder::with_capacity(capacity);
+        let mut grid_width_builder = UInt64Builder::with_capacity(capacity);
+        let mut grid_height_builder = UInt64Builder::with_capacity(capacity);
+        let mut scale_x_builder = Float64Builder::with_capacity(capacity);
+        let mut scale_y_builder = Float64Builder::with_capacity(capacity);
+        let mut skew_x_builder = Float64Builder::with_capacity(capacity);
+        let mut skew_y_builder = Float64Builder::with_capacity(capacity);
+        let mut srid_builder = Int32Builder::with_capacity(capacity);
+        let mut num_bands_builder = UInt64Builder::with_capacity(capacity);
+        let mut tile_width_builder = UInt64Builder::with_capacity(capacity);
+        let mut tile_height_builder = UInt64Builder::with_capacity(capacity);
+
+        with_gdal(|gdal| {
+            configure_thread_local_options(gdal, config_options)?;
+            let provider = thread_local_provider(gdal)
+                .map_err(|e| exec_datafusion_err!("Failed to init GDAL provider: {e}"))?;
+
+            executor.execute_raster_void(|_i, raster_opt| {
+                match raster_opt {
+                    None => {
+                        upper_left_x_builder.append_null();
+                        upper_left_y_builder.append_null();
+                        grid_width_builder.append_null();
+                        grid_height_builder.append_null();
+                        scale_x_builder.append_null();
+                        scale_y_builder.append_null();
+                        skew_x_builder.append_null();
+                        skew_y_builder.append_null();
+                        srid_builder.append_null();
+                        num_bands_builder.append_null();
+                        tile_width_builder.append_null();
+                        tile_height_builder.append_null();
+                    }
+                    Some(raster) => {
+                        let metadata = raster.metadata();
+
+                        upper_left_x_builder.append_value(metadata.upper_left_x());
+                        upper_left_y_builder.append_value(metadata.upper_left_y());
+                        grid_width_builder.append_value(metadata.width());
+                        grid_height_builder.append_value(metadata.height());
+                        scale_x_builder.append_value(metadata.scale_x());
+                        scale_y_builder.append_value(metadata.scale_y());
+                        skew_x_builder.append_value(metadata.skew_x());
+                        skew_y_builder.append_value(metadata.skew_y());
+
+                        let srid = match raster.crs() {
+                            None => 0i32,
+                            Some(crs_str) => match deserialize_crs(crs_str) {
+                                Ok(Some(crs_ref)) => {
+                                    crs_ref.srid().ok().flatten().map(|s| s as i32).unwrap_or(0)
+                                }
+                                _ => 0i32,
+                            },
+                        };
+                        srid_builder.append_value(srid);
+
+                        num_bands_builder.append_value(raster.bands().len() as u64);
+
+                        let dataset = provider.raster_ref_to_gdal(raster).map_err(|e| {
+                            exec_datafusion_err!("Failed to create GDAL dataset: {e}")
+                        })?;
+                        let band1 = dataset
+                            .as_dataset()
+                            .rasterband(1)
+                            .map_err(|e| exec_datafusion_err!("Failed to get band 1: {e}"))?;
+                        let (block_x, block_y) = band1.block_size();
+                        tile_width_builder.append_value(block_x.max(1) as u64);
+                        tile_height_builder.append_value(block_y.max(1) as u64);
+                    }
+                }
+                Ok(())
+            })
+        })?;
+
+        let struct_array = StructArray::new(
+            metadata_struct_fields(),
+            vec![
+                Arc::new(upper_left_x_builder.finish()),
+                Arc::new(upper_left_y_builder.finish()),
+                Arc::new(grid_width_builder.finish()),
+                Arc::new(grid_height_builder.finish()),
+                Arc::new(scale_x_builder.finish()),
+                Arc::new(scale_y_builder.finish()),
+                Arc::new(skew_x_builder.finish()),
+                Arc::new(skew_y_builder.finish()),
+                Arc::new(srid_builder.finish()),
+                Arc::new(num_bands_builder.finish()),
+                Arc::new(tile_width_builder.finish()),
+                Arc::new(tile_height_builder.finish()),
+            ],
+            None,
+        );
+
+        executor.finish(Arc::new(struct_array))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::cast::AsArray;
+    use datafusion_expr::ScalarUDF;
+    use sedona_raster::array::RasterStructArray;
+    use sedona_raster::builder::RasterBuilder;
+    use sedona_schema::datatypes::RASTER;
+    use sedona_testing::testers::ScalarUdfTester;
+    use tempfile::TempDir;
+
+    fn write_test_geotiff() -> (StructArray, usize, usize) {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("rs_metadata_test.tif");
+        let path_str = path.to_str().unwrap().to_string();
+
+        with_gdal(|gdal| {
+            let driver = gdal.get_driver_by_name("GTiff").unwrap();
+            let dataset = driver
+                .create_with_band_type::<u8>(&path_str, 10, 7, 1)
+                .unwrap();
+            dataset
+                .set_geo_transform(&[100.0, 2.0, 0.0, 200.0, 0.0, -2.0])
+                .unwrap();
+            dataset.set_projection("EPSG:4326").unwrap();
+
+            let band = dataset.rasterband(1).unwrap();
+            band.set_no_data_value(Some(255.0)).unwrap();
+
+            let raster_array = crate::utils::dataset_to_indb_raster(&dataset)?;
+            let raster_struct = RasterStructArray::new(&raster_array);
+            let raster = raster_struct.get(0).unwrap();
+            let provider = thread_local_provider(gdal).unwrap();
+            let provider_dataset = provider.raster_ref_to_gdal(&raster).unwrap();
+            let provider_band = provider_dataset.as_dataset().rasterband(1).unwrap();
+            let (block_x, block_y) = provider_band.block_size();
+
+            Ok::<_, datafusion_common::DataFusionError>((raster_array, block_x, block_y))
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn rs_metadata_udf_docs() {
+        let udf: ScalarUDF = rs_metadata_udf().into();
+        assert_eq!(udf.name(), "rs_metadata");
+    }
+
+    #[test]
+    fn rs_metadata_tile_dimensions_from_gdal() {
+        let (raster_array, block_x, block_y) = write_test_geotiff();
+
+        let udf: ScalarUDF = rs_metadata_udf().into();
+        let tester = ScalarUdfTester::new(udf, vec![RASTER]);
+        let result = tester.invoke_array(Arc::new(raster_array)).unwrap();
+        let struct_array = result.as_struct();
+
+        let tile_width = struct_array
+            .column(10)
+            .as_primitive::<arrow_array::types::UInt64Type>()
+            .value(0);
+        let tile_height = struct_array
+            .column(11)
+            .as_primitive::<arrow_array::types::UInt64Type>()
+            .value(0);
+
+        assert_eq!(tile_width, block_x.max(1) as u64);
+        assert_eq!(tile_height, block_y.max(1) as u64);
+    }
+
+    #[test]
+    fn rs_metadata_null_input_propagates_nulls() {
+        let mut builder = RasterBuilder::new(1);
+        builder.append_null().unwrap();
+        let raster_array = builder.finish().unwrap();
+
+        let udf: ScalarUDF = rs_metadata_udf().into();
+        let tester = ScalarUdfTester::new(udf, vec![RASTER]);
+        let result = tester.invoke_array(Arc::new(raster_array)).unwrap();
+        let struct_array = result.as_struct();
+
+        for column in struct_array.columns() {
+            assert!(column.is_null(0));
+        }
+    }
+}

--- a/rust/sedona-raster-gdal/src/rs_metadata.rs
+++ b/rust/sedona-raster-gdal/src/rs_metadata.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 use arrow_array::builder::{Float64Builder, Int32Builder, UInt32Builder, UInt64Builder};
 use arrow_array::StructArray;
+use arrow_buffer::NullBuffer;
 use arrow_schema::{DataType, Field, Fields};
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::error::Result;
@@ -101,6 +102,7 @@ impl SedonaScalarKernel for RsMetaData {
         let mut num_bands_builder = UInt32Builder::with_capacity(capacity);
         let mut tile_width_builder = UInt64Builder::with_capacity(capacity);
         let mut tile_height_builder = UInt64Builder::with_capacity(capacity);
+        let mut struct_validity = Vec::with_capacity(capacity);
 
         with_gdal(|gdal| {
             configure_thread_local_options(gdal, config_options)?;
@@ -110,6 +112,7 @@ impl SedonaScalarKernel for RsMetaData {
             executor.execute_raster_void(|_i, raster_opt| {
                 match raster_opt {
                     None => {
+                        struct_validity.push(false);
                         upper_left_x_builder.append_null();
                         upper_left_y_builder.append_null();
                         grid_width_builder.append_null();
@@ -124,6 +127,7 @@ impl SedonaScalarKernel for RsMetaData {
                         tile_height_builder.append_null();
                     }
                     Some(raster) => {
+                        struct_validity.push(true);
                         let metadata = raster.metadata();
                         let num_bands = raster.bands().len() as u32;
 
@@ -139,9 +143,12 @@ impl SedonaScalarKernel for RsMetaData {
                         let srid = match raster.crs() {
                             None => 0i32,
                             Some(crs_str) => match deserialize_crs(crs_str) {
-                                Ok(Some(crs_ref)) => {
-                                    crs_ref.srid().ok().flatten().map(|s| s as i32).unwrap_or(0)
-                                }
+                                Ok(Some(crs_ref)) => crs_ref
+                                    .srid()
+                                    .ok()
+                                    .flatten()
+                                    .and_then(|s| i32::try_from(s).ok())
+                                    .unwrap_or(0),
                                 _ => 0i32,
                             },
                         };
@@ -186,7 +193,7 @@ impl SedonaScalarKernel for RsMetaData {
                 Arc::new(tile_width_builder.finish()),
                 Arc::new(tile_height_builder.finish()),
             ],
-            None,
+            Some(NullBuffer::from_iter(struct_validity)),
         );
 
         executor.finish(Arc::new(struct_array))
@@ -432,6 +439,8 @@ mod tests {
         let raster_array = builder.finish().unwrap();
 
         let struct_array = invoke_array_result(raster_array);
+
+        assert!(struct_array.is_null(0));
 
         for column in struct_array.columns() {
             assert!(column.is_null(0));

--- a/rust/sedona-raster-gdal/src/rs_metadata.rs
+++ b/rust/sedona-raster-gdal/src/rs_metadata.rs
@@ -17,7 +17,9 @@
 
 use std::sync::Arc;
 
-use arrow_array::builder::{Float64Builder, Int32Builder, UInt32Builder, UInt64Builder};
+use arrow_array::builder::{
+    Float64Builder, Int32Builder, Int64Builder, UInt32Builder, UInt64Builder,
+};
 use arrow_array::StructArray;
 use arrow_buffer::NullBuffer;
 use arrow_schema::{DataType, Field, Fields};
@@ -45,8 +47,8 @@ fn metadata_struct_fields() -> Fields {
     Fields::from(vec![
         Field::new("upperLeftX", DataType::Float64, true),
         Field::new("upperLeftY", DataType::Float64, true),
-        Field::new("gridWidth", DataType::UInt64, true),
-        Field::new("gridHeight", DataType::UInt64, true),
+        Field::new("gridWidth", DataType::Int64, true),
+        Field::new("gridHeight", DataType::Int64, true),
         Field::new("scaleX", DataType::Float64, true),
         Field::new("scaleY", DataType::Float64, true),
         Field::new("skewX", DataType::Float64, true),
@@ -92,8 +94,8 @@ impl SedonaScalarKernel for RsMetaData {
 
         let mut upper_left_x_builder = Float64Builder::with_capacity(capacity);
         let mut upper_left_y_builder = Float64Builder::with_capacity(capacity);
-        let mut grid_width_builder = UInt64Builder::with_capacity(capacity);
-        let mut grid_height_builder = UInt64Builder::with_capacity(capacity);
+        let mut grid_width_builder = Int64Builder::with_capacity(capacity);
+        let mut grid_height_builder = Int64Builder::with_capacity(capacity);
         let mut scale_x_builder = Float64Builder::with_capacity(capacity);
         let mut scale_y_builder = Float64Builder::with_capacity(capacity);
         let mut skew_x_builder = Float64Builder::with_capacity(capacity);
@@ -204,8 +206,8 @@ impl SedonaScalarKernel for RsMetaData {
 mod tests {
     use super::*;
     use arrow_array::{
-        cast::AsArray, types::Float64Type, types::Int32Type, types::UInt32Type, types::UInt64Type,
-        Array,
+        cast::AsArray, types::Float64Type, types::Int32Type, types::Int64Type, types::UInt32Type,
+        types::UInt64Type, Array,
     };
     use datafusion_common::ScalarValue;
     use datafusion_expr::ScalarUDF;
@@ -298,7 +300,7 @@ mod tests {
             &[InDbTestBand {
                 datatype: BandDataType::UInt8,
                 nodata_value: None,
-                data: vec![1u8, 2, 3, 4],
+                data: (1u8..=12).collect(),
             }],
         )
     }
@@ -327,6 +329,13 @@ mod tests {
         struct_array
             .column(column)
             .as_primitive::<UInt64Type>()
+            .value(row)
+    }
+
+    fn int64_value(struct_array: &StructArray, column: usize, row: usize) -> i64 {
+        struct_array
+            .column(column)
+            .as_primitive::<Int64Type>()
             .value(row)
     }
 
@@ -371,8 +380,8 @@ mod tests {
 
         assert_eq!(float64_value(&struct_array, UPPER_LEFT_X, 0), 100.0);
         assert_eq!(float64_value(&struct_array, UPPER_LEFT_Y, 0), 200.0);
-        assert_eq!(uint64_value(&struct_array, GRID_WIDTH, 0), 10);
-        assert_eq!(uint64_value(&struct_array, GRID_HEIGHT, 0), 7);
+        assert_eq!(int64_value(&struct_array, GRID_WIDTH, 0), 10);
+        assert_eq!(int64_value(&struct_array, GRID_HEIGHT, 0), 7);
         assert_eq!(float64_value(&struct_array, SCALE_X, 0), 2.0);
         assert_eq!(float64_value(&struct_array, SCALE_Y, 0), -2.0);
         assert_eq!(float64_value(&struct_array, SKEW_X, 0), 0.0);

--- a/rust/sedona-raster-gdal/src/rs_metadata.rs
+++ b/rust/sedona-raster-gdal/src/rs_metadata.rs
@@ -125,6 +125,7 @@ impl SedonaScalarKernel for RsMetaData {
                     }
                     Some(raster) => {
                         let metadata = raster.metadata();
+                        let num_bands = raster.bands().len() as u64;
 
                         upper_left_x_builder.append_value(metadata.upper_left_x());
                         upper_left_y_builder.append_value(metadata.upper_left_y());
@@ -146,18 +147,23 @@ impl SedonaScalarKernel for RsMetaData {
                         };
                         srid_builder.append_value(srid);
 
-                        num_bands_builder.append_value(raster.bands().len() as u64);
+                        num_bands_builder.append_value(num_bands);
 
-                        let dataset = provider.raster_ref_to_gdal(raster).map_err(|e| {
-                            exec_datafusion_err!("Failed to create GDAL dataset: {e}")
-                        })?;
-                        let band1 = dataset
-                            .as_dataset()
-                            .rasterband(1)
-                            .map_err(|e| exec_datafusion_err!("Failed to get band 1: {e}"))?;
-                        let (block_x, block_y) = band1.block_size();
-                        tile_width_builder.append_value(block_x.max(1) as u64);
-                        tile_height_builder.append_value(block_y.max(1) as u64);
+                        if num_bands == 0 {
+                            tile_width_builder.append_value(0);
+                            tile_height_builder.append_value(0);
+                        } else {
+                            let dataset = provider.raster_ref_to_gdal(raster).map_err(|e| {
+                                exec_datafusion_err!("Failed to create GDAL dataset: {e}")
+                            })?;
+                            let band1 = dataset
+                                .as_dataset()
+                                .rasterband(1)
+                                .map_err(|e| exec_datafusion_err!("Failed to get band 1: {e}"))?;
+                            let (block_x, block_y) = band1.block_size();
+                            tile_width_builder.append_value(block_x.max(1) as u64);
+                            tile_height_builder.append_value(block_y.max(1) as u64);
+                        }
                     }
                 }
                 Ok(())
@@ -190,13 +196,34 @@ impl SedonaScalarKernel for RsMetaData {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_array::cast::AsArray;
+    use arrow_array::{
+        cast::AsArray, types::Float64Type, types::Int32Type, types::UInt64Type, Array,
+    };
+    use datafusion_common::ScalarValue;
     use datafusion_expr::ScalarUDF;
     use sedona_raster::array::RasterStructArray;
     use sedona_raster::builder::RasterBuilder;
+    use sedona_raster::traits::RasterMetadata;
     use sedona_schema::datatypes::RASTER;
-    use sedona_testing::testers::ScalarUdfTester;
+    use sedona_schema::raster::BandDataType;
+    use sedona_testing::{
+        rasters::{build_in_db_raster, generate_multi_band_raster, InDbTestBand},
+        testers::ScalarUdfTester,
+    };
     use tempfile::TempDir;
+
+    const UPPER_LEFT_X: usize = 0;
+    const UPPER_LEFT_Y: usize = 1;
+    const GRID_WIDTH: usize = 2;
+    const GRID_HEIGHT: usize = 3;
+    const SCALE_X: usize = 4;
+    const SCALE_Y: usize = 5;
+    const SKEW_X: usize = 6;
+    const SKEW_Y: usize = 7;
+    const SRID: usize = 8;
+    const NUM_SAMPLE_DIMENSIONS: usize = 9;
+    const TILE_WIDTH: usize = 10;
+    const TILE_HEIGHT: usize = 11;
 
     fn write_test_geotiff() -> (StructArray, usize, usize) {
         let temp_dir = TempDir::new().unwrap();
@@ -229,6 +256,86 @@ mod tests {
         .unwrap()
     }
 
+    fn build_zero_band_raster() -> StructArray {
+        let mut builder = RasterBuilder::new(1);
+        let metadata = RasterMetadata {
+            width: 4,
+            height: 3,
+            upperleft_x: 11.0,
+            upperleft_y: 22.0,
+            scale_x: 0.5,
+            scale_y: -0.5,
+            skew_x: 0.0,
+            skew_y: 0.0,
+        };
+        builder.start_raster(&metadata, Some("EPSG:4326")).unwrap();
+        builder.finish_raster().unwrap();
+        builder.finish().unwrap()
+    }
+
+    fn build_no_crs_raster() -> StructArray {
+        let metadata = RasterMetadata {
+            width: 4,
+            height: 3,
+            upperleft_x: 7.0,
+            upperleft_y: 8.0,
+            scale_x: 1.0,
+            scale_y: -1.0,
+            skew_x: 0.0,
+            skew_y: 0.0,
+        };
+        build_in_db_raster(
+            metadata,
+            None,
+            &[InDbTestBand {
+                datatype: BandDataType::UInt8,
+                nodata_value: None,
+                data: vec![1u8, 2, 3, 4],
+            }],
+        )
+    }
+
+    fn metadata_udf_tester() -> ScalarUdfTester {
+        let udf: ScalarUDF = rs_metadata_udf().into();
+        ScalarUdfTester::new(udf, vec![RASTER])
+    }
+
+    fn invoke_array_result(raster_array: StructArray) -> StructArray {
+        metadata_udf_tester()
+            .invoke_array(Arc::new(raster_array))
+            .unwrap()
+            .as_struct()
+            .clone()
+    }
+
+    fn assert_scalar_result(result: ScalarValue) -> Arc<StructArray> {
+        match result {
+            ScalarValue::Struct(struct_array) => struct_array,
+            other => panic!("Expected struct scalar result, got {other:?}"),
+        }
+    }
+
+    fn uint64_value(struct_array: &StructArray, column: usize, row: usize) -> u64 {
+        struct_array
+            .column(column)
+            .as_primitive::<UInt64Type>()
+            .value(row)
+    }
+
+    fn int32_value(struct_array: &StructArray, column: usize, row: usize) -> i32 {
+        struct_array
+            .column(column)
+            .as_primitive::<Int32Type>()
+            .value(row)
+    }
+
+    fn float64_value(struct_array: &StructArray, column: usize, row: usize) -> f64 {
+        struct_array
+            .column(column)
+            .as_primitive::<Float64Type>()
+            .value(row)
+    }
+
     #[test]
     fn rs_metadata_udf_docs() {
         let udf: ScalarUDF = rs_metadata_udf().into();
@@ -236,25 +343,84 @@ mod tests {
     }
 
     #[test]
-    fn rs_metadata_tile_dimensions_from_gdal() {
+    fn rs_metadata_returns_expected_fields_for_single_band_raster() {
         let (raster_array, block_x, block_y) = write_test_geotiff();
 
-        let udf: ScalarUDF = rs_metadata_udf().into();
-        let tester = ScalarUdfTester::new(udf, vec![RASTER]);
-        let result = tester.invoke_array(Arc::new(raster_array)).unwrap();
-        let struct_array = result.as_struct();
+        let struct_array = invoke_array_result(raster_array);
 
-        let tile_width = struct_array
-            .column(10)
-            .as_primitive::<arrow_array::types::UInt64Type>()
-            .value(0);
-        let tile_height = struct_array
-            .column(11)
-            .as_primitive::<arrow_array::types::UInt64Type>()
-            .value(0);
+        assert_eq!(float64_value(&struct_array, UPPER_LEFT_X, 0), 100.0);
+        assert_eq!(float64_value(&struct_array, UPPER_LEFT_Y, 0), 200.0);
+        assert_eq!(uint64_value(&struct_array, GRID_WIDTH, 0), 10);
+        assert_eq!(uint64_value(&struct_array, GRID_HEIGHT, 0), 7);
+        assert_eq!(float64_value(&struct_array, SCALE_X, 0), 2.0);
+        assert_eq!(float64_value(&struct_array, SCALE_Y, 0), -2.0);
+        assert_eq!(float64_value(&struct_array, SKEW_X, 0), 0.0);
+        assert_eq!(float64_value(&struct_array, SKEW_Y, 0), 0.0);
+        assert_eq!(int32_value(&struct_array, SRID, 0), 4326);
+        assert_eq!(uint64_value(&struct_array, NUM_SAMPLE_DIMENSIONS, 0), 1);
+        assert_eq!(
+            uint64_value(&struct_array, TILE_WIDTH, 0),
+            block_x.max(1) as u64
+        );
+        assert_eq!(
+            uint64_value(&struct_array, TILE_HEIGHT, 0),
+            block_y.max(1) as u64
+        );
+    }
 
-        assert_eq!(tile_width, block_x.max(1) as u64);
-        assert_eq!(tile_height, block_y.max(1) as u64);
+    #[test]
+    fn rs_metadata_reports_band_count_for_multi_band_raster() {
+        let struct_array = invoke_array_result(generate_multi_band_raster());
+
+        assert_eq!(uint64_value(&struct_array, NUM_SAMPLE_DIMENSIONS, 0), 3);
+    }
+
+    #[test]
+    fn rs_metadata_returns_zero_srid_without_crs() {
+        let struct_array = invoke_array_result(build_no_crs_raster());
+
+        assert_eq!(int32_value(&struct_array, SRID, 0), 0);
+    }
+
+    #[test]
+    fn rs_metadata_zero_band_raster_returns_zero_tile_dimensions() {
+        let struct_array = invoke_array_result(build_zero_band_raster());
+
+        assert_eq!(uint64_value(&struct_array, NUM_SAMPLE_DIMENSIONS, 0), 0);
+        assert_eq!(uint64_value(&struct_array, TILE_WIDTH, 0), 0);
+        assert_eq!(uint64_value(&struct_array, TILE_HEIGHT, 0), 0);
+    }
+
+    #[test]
+    fn rs_metadata_scalar_ignores_num_rows_for_shape() {
+        let (raster_array, block_x, block_y) = write_test_geotiff();
+        let scalar_raster = ScalarValue::Struct(Arc::new(raster_array.clone()));
+
+        let result = RsMetaData {}
+            .invoke_batch_from_args(
+                &[RASTER],
+                &[ColumnarValue::Scalar(scalar_raster)],
+                &SedonaType::Arrow(DataType::Null),
+                32,
+                None,
+            )
+            .expect("Should invoke successfully for scalar raster with larger num_rows");
+
+        let scalar_struct = match result {
+            ColumnarValue::Scalar(scalar) => assert_scalar_result(scalar),
+            other => panic!("Expected scalar result, got {other:?}"),
+        };
+
+        assert_eq!(scalar_struct.len(), 1);
+        assert_eq!(uint64_value(&scalar_struct, NUM_SAMPLE_DIMENSIONS, 0), 1);
+        assert_eq!(
+            uint64_value(&scalar_struct, TILE_WIDTH, 0),
+            block_x.max(1) as u64
+        );
+        assert_eq!(
+            uint64_value(&scalar_struct, TILE_HEIGHT, 0),
+            block_y.max(1) as u64
+        );
     }
 
     #[test]
@@ -263,10 +429,7 @@ mod tests {
         builder.append_null().unwrap();
         let raster_array = builder.finish().unwrap();
 
-        let udf: ScalarUDF = rs_metadata_udf().into();
-        let tester = ScalarUdfTester::new(udf, vec![RASTER]);
-        let result = tester.invoke_array(Arc::new(raster_array)).unwrap();
-        let struct_array = result.as_struct();
+        let struct_array = invoke_array_result(raster_array);
 
         for column in struct_array.columns() {
             assert!(column.is_null(0));

--- a/rust/sedona-raster-gdal/src/rs_metadata.rs
+++ b/rust/sedona-raster-gdal/src/rs_metadata.rs
@@ -17,7 +17,7 @@
 
 use std::sync::Arc;
 
-use arrow_array::builder::{Float64Builder, Int32Builder, UInt64Builder};
+use arrow_array::builder::{Float64Builder, Int32Builder, UInt32Builder, UInt64Builder};
 use arrow_array::StructArray;
 use arrow_schema::{DataType, Field, Fields};
 use datafusion_common::config::ConfigOptions;
@@ -51,7 +51,7 @@ fn metadata_struct_fields() -> Fields {
         Field::new("skewX", DataType::Float64, true),
         Field::new("skewY", DataType::Float64, true),
         Field::new("srid", DataType::Int32, true),
-        Field::new("numSampleDimensions", DataType::UInt64, true),
+        Field::new("numSampleDimensions", DataType::UInt32, true),
         Field::new("tileWidth", DataType::UInt64, true),
         Field::new("tileHeight", DataType::UInt64, true),
     ])
@@ -98,7 +98,7 @@ impl SedonaScalarKernel for RsMetaData {
         let mut skew_x_builder = Float64Builder::with_capacity(capacity);
         let mut skew_y_builder = Float64Builder::with_capacity(capacity);
         let mut srid_builder = Int32Builder::with_capacity(capacity);
-        let mut num_bands_builder = UInt64Builder::with_capacity(capacity);
+        let mut num_bands_builder = UInt32Builder::with_capacity(capacity);
         let mut tile_width_builder = UInt64Builder::with_capacity(capacity);
         let mut tile_height_builder = UInt64Builder::with_capacity(capacity);
 
@@ -125,7 +125,7 @@ impl SedonaScalarKernel for RsMetaData {
                     }
                     Some(raster) => {
                         let metadata = raster.metadata();
-                        let num_bands = raster.bands().len() as u64;
+                        let num_bands = raster.bands().len() as u32;
 
                         upper_left_x_builder.append_value(metadata.upper_left_x());
                         upper_left_y_builder.append_value(metadata.upper_left_y());
@@ -161,8 +161,8 @@ impl SedonaScalarKernel for RsMetaData {
                                 .rasterband(1)
                                 .map_err(|e| exec_datafusion_err!("Failed to get band 1: {e}"))?;
                             let (block_x, block_y) = band1.block_size();
-                            tile_width_builder.append_value(block_x.max(1) as u64);
-                            tile_height_builder.append_value(block_y.max(1) as u64);
+                            tile_width_builder.append_value(block_x as u64);
+                            tile_height_builder.append_value(block_y as u64);
                         }
                     }
                 }
@@ -197,7 +197,8 @@ impl SedonaScalarKernel for RsMetaData {
 mod tests {
     use super::*;
     use arrow_array::{
-        cast::AsArray, types::Float64Type, types::Int32Type, types::UInt64Type, Array,
+        cast::AsArray, types::Float64Type, types::Int32Type, types::UInt32Type, types::UInt64Type,
+        Array,
     };
     use datafusion_common::ScalarValue;
     use datafusion_expr::ScalarUDF;
@@ -322,6 +323,13 @@ mod tests {
             .value(row)
     }
 
+    fn uint32_value(struct_array: &StructArray, column: usize, row: usize) -> u32 {
+        struct_array
+            .column(column)
+            .as_primitive::<UInt32Type>()
+            .value(row)
+    }
+
     fn int32_value(struct_array: &StructArray, column: usize, row: usize) -> i32 {
         struct_array
             .column(column)
@@ -340,6 +348,12 @@ mod tests {
     fn rs_metadata_udf_docs() {
         let udf: ScalarUDF = rs_metadata_udf().into();
         assert_eq!(udf.name(), "rs_metadata");
+        tester_assert_return_type_is_struct_with_uint32_num_bands(udf);
+    }
+
+    fn tester_assert_return_type_is_struct_with_uint32_num_bands(udf: ScalarUDF) {
+        let tester = ScalarUdfTester::new(udf, vec![RASTER]);
+        tester.assert_return_type(DataType::Struct(metadata_struct_fields()));
     }
 
     #[test]
@@ -357,22 +371,16 @@ mod tests {
         assert_eq!(float64_value(&struct_array, SKEW_X, 0), 0.0);
         assert_eq!(float64_value(&struct_array, SKEW_Y, 0), 0.0);
         assert_eq!(int32_value(&struct_array, SRID, 0), 4326);
-        assert_eq!(uint64_value(&struct_array, NUM_SAMPLE_DIMENSIONS, 0), 1);
-        assert_eq!(
-            uint64_value(&struct_array, TILE_WIDTH, 0),
-            block_x.max(1) as u64
-        );
-        assert_eq!(
-            uint64_value(&struct_array, TILE_HEIGHT, 0),
-            block_y.max(1) as u64
-        );
+        assert_eq!(uint32_value(&struct_array, NUM_SAMPLE_DIMENSIONS, 0), 1);
+        assert_eq!(uint64_value(&struct_array, TILE_WIDTH, 0), block_x as u64);
+        assert_eq!(uint64_value(&struct_array, TILE_HEIGHT, 0), block_y as u64);
     }
 
     #[test]
     fn rs_metadata_reports_band_count_for_multi_band_raster() {
         let struct_array = invoke_array_result(generate_multi_band_raster());
 
-        assert_eq!(uint64_value(&struct_array, NUM_SAMPLE_DIMENSIONS, 0), 3);
+        assert_eq!(uint32_value(&struct_array, NUM_SAMPLE_DIMENSIONS, 0), 3);
     }
 
     #[test]
@@ -386,7 +394,7 @@ mod tests {
     fn rs_metadata_zero_band_raster_returns_zero_tile_dimensions() {
         let struct_array = invoke_array_result(build_zero_band_raster());
 
-        assert_eq!(uint64_value(&struct_array, NUM_SAMPLE_DIMENSIONS, 0), 0);
+        assert_eq!(uint32_value(&struct_array, NUM_SAMPLE_DIMENSIONS, 0), 0);
         assert_eq!(uint64_value(&struct_array, TILE_WIDTH, 0), 0);
         assert_eq!(uint64_value(&struct_array, TILE_HEIGHT, 0), 0);
     }
@@ -412,15 +420,9 @@ mod tests {
         };
 
         assert_eq!(scalar_struct.len(), 1);
-        assert_eq!(uint64_value(&scalar_struct, NUM_SAMPLE_DIMENSIONS, 0), 1);
-        assert_eq!(
-            uint64_value(&scalar_struct, TILE_WIDTH, 0),
-            block_x.max(1) as u64
-        );
-        assert_eq!(
-            uint64_value(&scalar_struct, TILE_HEIGHT, 0),
-            block_y.max(1) as u64
-        );
+        assert_eq!(uint32_value(&scalar_struct, NUM_SAMPLE_DIMENSIONS, 0), 1);
+        assert_eq!(uint64_value(&scalar_struct, TILE_WIDTH, 0), block_x as u64);
+        assert_eq!(uint64_value(&scalar_struct, TILE_HEIGHT, 0), block_y as u64);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `RS_MetaData` backed by the GDAL dataset provider
- expose raster dimensions, transform, srid, band count, and GDAL block size metadata
- keep the change limited to the incremental metadata surface on top of the current GDAL raster work

## Dependency
- Depends on #831 (`RS_FromPath`)
- This branch currently includes the parent `RS_FromPath` commit because GitHub upstream PRs cannot target a fork-only base branch.
- Please review/merge this after #831, or compare this PR commit-by-commit with that dependency in mind.

## Testing
- `cargo test -p sedona-raster-gdal`
- `cargo clippy -p sedona-raster-gdal -- -D warnings`
- `cargo test -p sedona-gdal`