### PR TITLE
feat(python/sedonadb): add DataFrame.filter / DataFrame.where

### DIFF
--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -198,8 +198,6 @@ class DataFrame:
             self._options,
         )
 
-    where = filter
-
     def limit(self, n: Optional[int], /, *, offset: int = 0) -> "DataFrame":
         """Limit result to n rows starting at offset
 

--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -141,6 +141,65 @@ class DataFrame:
                 )
         return DataFrame(self._ctx, self._impl.select(coerced), self._options)
 
+    def filter(self, *exprs: "Expr") -> "DataFrame":
+        """Filter rows by one or more boolean expressions.
+
+        Multiple expressions are combined with logical AND, so
+        `df.filter(a, b)` is equivalent to `df.filter(a & b)` and to
+        `df.filter(a).filter(b)` (the planner sees one conjunction in
+        the first two forms and two filter nodes in the third).
+
+        Only `Expr` arguments are accepted. Strings are not interpreted
+        as SQL predicates (that is a separate feature). Bare `Literal`
+        values are also rejected — `filter(lit(True))` is almost
+        certainly a typo; if you really mean a constant predicate, wrap
+        a column expression like `col("flag") == lit(True)`.
+
+        Args:
+            *exprs: One or more boolean `sedonadb.expr.Expr` predicates.
+                At least one argument is required.
+
+        Examples:
+
+            >>> from sedonadb.expr import col
+            >>> sd = sedona.db.connect()
+            >>> df = sd.sql("SELECT * FROM (VALUES (1), (2), (3), (4)) AS t(x)")
+            >>> df.filter(col("x") > 2).show()
+            ┌───────┐
+            │   x   │
+            │ int64 │
+            ╞═══════╡
+            │     3 │
+            ├╌╌╌╌╌╌╌┤
+            │     4 │
+            └───────┘
+        """
+        from sedonadb.expr import Expr, Literal
+
+        if not exprs:
+            raise ValueError("filter() requires at least one predicate")
+
+        for e in exprs:
+            if isinstance(e, Literal):
+                raise TypeError(
+                    "filter() does not accept Literal arguments. "
+                    "filter(lit(value)) is almost always a typo; if you really "
+                    "want a constant predicate, wrap a column expression like "
+                    "col('flag') == lit(value)."
+                )
+            if not isinstance(e, Expr):
+                raise TypeError(
+                    f"filter() expects Expr arguments, got {type(e).__name__}"
+                )
+
+        return DataFrame(
+            self._ctx,
+            self._impl.filter([e._impl for e in exprs]),
+            self._options,
+        )
+
+    where = filter
+
     def limit(self, n: Optional[int], /, *, offset: int = 0) -> "DataFrame":
         """Limit result to n rows starting at offset
 

--- a/python/sedonadb/src/dataframe.rs
+++ b/python/sedonadb/src/dataframe.rs
@@ -123,6 +123,34 @@ impl InternalDataFrame {
         Ok(InternalDataFrame::new(inner, self.runtime.clone()))
     }
 
+    /// Filter rows by one or more boolean expressions, producing a new
+    /// lazy `DataFrame`.
+    ///
+    /// The Python side guarantees `exprs` is non-empty and that every
+    /// element is an `Expr` (no strings, no Literals — those rejections
+    /// happen at the Python boundary so the error message can point at
+    /// the right alternative). Multiple predicates are combined with
+    /// logical AND using `Expr::and`, which yields a single composed
+    /// `Expr` to hand to DataFusion's `DataFrame::filter`. This avoids
+    /// stacking N filter nodes for a `filter(p1, p2, ...)` call and
+    /// lets the optimizer reason about the conjunction as one unit.
+    /// Column-validity errors surface at plan-build time from
+    /// DataFusion, matching the behavior of `select`.
+    fn filter(&self, exprs: Vec<PyExpr>) -> Result<InternalDataFrame, PySedonaError> {
+        if exprs.is_empty() {
+            return Err(PySedonaError::SedonaPython(
+                "filter() requires at least one predicate".to_string(),
+            ));
+        }
+        let mut iter = exprs.into_iter().map(|e| e.inner);
+        let mut combined = iter.next().unwrap();
+        for next in iter {
+            combined = combined.and(next);
+        }
+        let inner = self.inner.clone().filter(combined)?;
+        Ok(InternalDataFrame::new(inner, self.runtime.clone()))
+    }
+
     fn execute<'py>(&self, py: Python<'py>) -> Result<usize, PySedonaError> {
         let df = self.inner.clone();
         let count = wait_for_future(py, &self.runtime, async move {

--- a/python/sedonadb/src/dataframe.rs
+++ b/python/sedonadb/src/dataframe.rs
@@ -129,24 +129,22 @@ impl InternalDataFrame {
     /// The Python side guarantees `exprs` is non-empty and that every
     /// element is an `Expr` (no strings, no Literals — those rejections
     /// happen at the Python boundary so the error message can point at
-    /// the right alternative). Multiple predicates are combined with
-    /// logical AND using `Expr::and`, which yields a single composed
-    /// `Expr` to hand to DataFusion's `DataFrame::filter`. This avoids
-    /// stacking N filter nodes for a `filter(p1, p2, ...)` call and
-    /// lets the optimizer reason about the conjunction as one unit.
-    /// Column-validity errors surface at plan-build time from
-    /// DataFusion, matching the behavior of `select`.
+    /// the right alternative). Multiple predicates are combined into a
+    /// single composed `Expr` using DataFusion's `conjunction` helper,
+    /// which yields one conjunction node for the optimizer to reason
+    /// about rather than stacked filter nodes. Column-validity errors
+    /// surface at plan-build time from DataFusion, matching the
+    /// behavior of `select`.
     fn filter(&self, exprs: Vec<PyExpr>) -> Result<InternalDataFrame, PySedonaError> {
         if exprs.is_empty() {
             return Err(PySedonaError::SedonaPython(
                 "filter() requires at least one predicate".to_string(),
             ));
         }
-        let mut iter = exprs.into_iter().map(|e| e.inner);
-        let mut combined = iter.next().unwrap();
-        for next in iter {
-            combined = combined.and(next);
-        }
+        // `conjunction` returns None only for an empty iterator, which we
+        // already rejected above; unwrap is safe.
+        let combined = datafusion_expr::utils::conjunction(exprs.into_iter().map(|e| e.inner))
+            .expect("non-empty predicates checked above");
         let inner = self.inner.clone().filter(combined)?;
         Ok(InternalDataFrame::new(inner, self.runtime.clone()))
     }

--- a/python/sedonadb/src/dataframe.rs
+++ b/python/sedonadb/src/dataframe.rs
@@ -136,17 +136,19 @@ impl InternalDataFrame {
     /// surface at plan-build time from DataFusion, matching the
     /// behavior of `select`.
     fn filter(&self, exprs: Vec<PyExpr>) -> Result<InternalDataFrame, PySedonaError> {
-        if exprs.is_empty() {
-            return Err(PySedonaError::SedonaPython(
+        // `conjunction` returns None only for an empty iterator; the
+        // `else` arm doubles as defense-in-depth against an empty
+        // predicate list slipping past the Python-side guard.
+        if let Some(combined) =
+            datafusion_expr::utils::conjunction(exprs.into_iter().map(|e| e.inner))
+        {
+            let inner = self.inner.clone().filter(combined)?;
+            Ok(InternalDataFrame::new(inner, self.runtime.clone()))
+        } else {
+            Err(PySedonaError::SedonaPython(
                 "filter() requires at least one predicate".to_string(),
-            ));
+            ))
         }
-        // `conjunction` returns None only for an empty iterator, which we
-        // already rejected above; unwrap is safe.
-        let combined = datafusion_expr::utils::conjunction(exprs.into_iter().map(|e| e.inner))
-            .expect("non-empty predicates checked above");
-        let inner = self.inner.clone().filter(combined)?;
-        Ok(InternalDataFrame::new(inner, self.runtime.clone()))
     }
 
     fn execute<'py>(&self, py: Python<'py>) -> Result<usize, PySedonaError> {

--- a/python/sedonadb/tests/expr/test_dataframe_filter.py
+++ b/python/sedonadb/tests/expr/test_dataframe_filter.py
@@ -1,0 +1,138 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Tests for DataFrame.filter() / .where(). Each test builds its own input
+# DataFrame inline so the full context of a failure is visible in the
+# failing test function. Output is compared with
+# `pd.testing.assert_frame_equal`, which gives row/column diagnostics on
+# mismatch. Index is reset on the materialized output because pandas
+# preserves the original positions after a filter and we want to compare
+# logical contents.
+
+import pandas as pd
+import pandas.testing as pdt
+import pytest
+
+from sedonadb._lib import SedonaError
+from sedonadb.expr import col, lit
+
+
+def _xy_df(con):
+    return con.create_data_frame(
+        pd.DataFrame({"x": [1, 2, 3, 4], "y": [10, 20, 30, 40]})
+    )
+
+
+def test_filter_simple_predicate(con):
+    out = _xy_df(con).filter(col("x") > 2).to_pandas().reset_index(drop=True)
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [3, 4], "y": [30, 40]}))
+
+
+def test_filter_multiple_predicates_anded(con):
+    out = (
+        _xy_df(con)
+        .filter(col("x") > 1, col("x") < 4)
+        .to_pandas()
+        .reset_index(drop=True)
+    )
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [2, 3], "y": [20, 30]}))
+
+
+def test_filter_with_explicit_and(con):
+    out = (
+        _xy_df(con)
+        .filter((col("x") > 1) & (col("y") < 40))
+        .to_pandas()
+        .reset_index(drop=True)
+    )
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [2, 3], "y": [20, 30]}))
+
+
+def test_filter_with_or(con):
+    out = (
+        _xy_df(con)
+        .filter((col("x") == 1) | (col("x") == 4))
+        .to_pandas()
+        .reset_index(drop=True)
+    )
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [1, 4], "y": [10, 40]}))
+
+
+def test_filter_with_not(con):
+    out = _xy_df(con).filter(~(col("x") == 2)).to_pandas().reset_index(drop=True)
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [1, 3, 4], "y": [10, 30, 40]}))
+
+
+def test_filter_isin(con):
+    out = _xy_df(con).filter(col("x").isin([2, 4])).to_pandas().reset_index(drop=True)
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [2, 4], "y": [20, 40]}))
+
+
+def test_where_alias_produces_same_output(con):
+    df = _xy_df(con)
+    out_filter = df.filter(col("x") > 2).to_pandas().reset_index(drop=True)
+    out_where = df.where(col("x") > 2).to_pandas().reset_index(drop=True)
+    pdt.assert_frame_equal(out_filter, out_where)
+
+
+def test_chained_filter_calls(con):
+    # `filter(a).filter(b)` builds two filter nodes in the plan, equivalent
+    # in result to `filter(a, b)` (which builds one). Both should pass and
+    # produce the same output.
+    df = _xy_df(con)
+    chained = (
+        df.filter(col("x") > 1).filter(col("x") < 4).to_pandas().reset_index(drop=True)
+    )
+    combined = df.filter(col("x") > 1, col("x") < 4).to_pandas().reset_index(drop=True)
+    pdt.assert_frame_equal(chained, combined)
+    pdt.assert_frame_equal(chained, pd.DataFrame({"x": [2, 3], "y": [20, 30]}))
+
+
+def test_filter_returns_lazy_dataframe(con):
+    out = _xy_df(con).filter(col("x") > 0)
+    assert hasattr(out, "to_arrow_table")
+
+
+def test_filter_empty_raises(con):
+    with pytest.raises(ValueError, match="at least one predicate"):
+        _xy_df(con).filter()
+
+
+def test_filter_string_arg_raises(con):
+    # Strings are not interpreted as SQL predicates (that's a separate
+    # feature). Should fail at the Python boundary with a clear message.
+    with pytest.raises(TypeError, match="Expr"):
+        _xy_df(con).filter("x > 0")
+
+
+def test_filter_literal_arg_raises(con):
+    # filter(lit(value)) is almost always a typo. We reject at the Python
+    # boundary so the user sees an actionable suggestion rather than a
+    # silent no-op (DataFusion would accept `WHERE 7` as truthy).
+    with pytest.raises(TypeError, match="Literal"):
+        _xy_df(con).filter(lit(True))
+
+
+def test_filter_unknown_column_lists_valid_columns(con):
+    # DataFusion's plan-build error includes the list of valid field names.
+    # Lock that contract so a future change doesn't drop the suggestion.
+    with pytest.raises(SedonaError) as exc:
+        _xy_df(con).filter(col("nonexistent") > 0)
+    msg = str(exc.value)
+    assert "nonexistent" in msg
+    assert "Valid fields" in msg or "valid fields" in msg
+    assert "x" in msg and "y" in msg

--- a/python/sedonadb/tests/expr/test_dataframe_filter.py
+++ b/python/sedonadb/tests/expr/test_dataframe_filter.py
@@ -15,13 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Tests for DataFrame.filter() / .where(). Each test builds its own input
-# DataFrame inline so the full context of a failure is visible in the
-# failing test function. Output is compared with
-# `pd.testing.assert_frame_equal`, which gives row/column diagnostics on
-# mismatch. Index is reset on the materialized output because pandas
-# preserves the original positions after a filter and we want to compare
-# logical contents.
+# Tests for DataFrame.filter(). Each test builds its own input DataFrame
+# inline so the full context of a failure is visible in the failing test
+# function. Output is compared with `pd.testing.assert_frame_equal`, which
+# gives row/column diagnostics on mismatch. Index is reset on materialized
+# output because pandas preserves the original positions after a filter
+# and we want to compare logical contents.
 
 import pandas as pd
 import pandas.testing as pdt
@@ -31,107 +30,92 @@ from sedonadb._lib import SedonaError
 from sedonadb.expr import col, lit
 
 
-def _xy_df(con):
-    return con.create_data_frame(
-        pd.DataFrame({"x": [1, 2, 3, 4], "y": [10, 20, 30, 40]})
-    )
-
-
 def test_filter_simple_predicate(con):
-    out = _xy_df(con).filter(col("x") > 2).to_pandas().reset_index(drop=True)
-    pdt.assert_frame_equal(out, pd.DataFrame({"x": [3, 4], "y": [30, 40]}))
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
+    out = df.filter(col("x") > 1).to_pandas().reset_index(drop=True)
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [2, 3]}))
 
 
 def test_filter_multiple_predicates_anded(con):
-    out = (
-        _xy_df(con)
-        .filter(col("x") > 1, col("x") < 4)
-        .to_pandas()
-        .reset_index(drop=True)
-    )
-    pdt.assert_frame_equal(out, pd.DataFrame({"x": [2, 3], "y": [20, 30]}))
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3, 4]}))
+    out = df.filter(col("x") > 1, col("x") < 4).to_pandas().reset_index(drop=True)
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [2, 3]}))
 
 
 def test_filter_with_explicit_and(con):
-    out = (
-        _xy_df(con)
-        .filter((col("x") > 1) & (col("y") < 40))
-        .to_pandas()
-        .reset_index(drop=True)
-    )
-    pdt.assert_frame_equal(out, pd.DataFrame({"x": [2, 3], "y": [20, 30]}))
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3], "y": [10, 20, 30]}))
+    out = df.filter((col("x") > 1) & (col("y") < 30)).to_pandas().reset_index(drop=True)
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [2], "y": [20]}))
 
 
 def test_filter_with_or(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
     out = (
-        _xy_df(con)
-        .filter((col("x") == 1) | (col("x") == 4))
-        .to_pandas()
-        .reset_index(drop=True)
+        df.filter((col("x") == 1) | (col("x") == 3)).to_pandas().reset_index(drop=True)
     )
-    pdt.assert_frame_equal(out, pd.DataFrame({"x": [1, 4], "y": [10, 40]}))
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [1, 3]}))
 
 
 def test_filter_with_not(con):
-    out = _xy_df(con).filter(~(col("x") == 2)).to_pandas().reset_index(drop=True)
-    pdt.assert_frame_equal(out, pd.DataFrame({"x": [1, 3, 4], "y": [10, 30, 40]}))
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
+    out = df.filter(~(col("x") == 2)).to_pandas().reset_index(drop=True)
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [1, 3]}))
 
 
 def test_filter_isin(con):
-    out = _xy_df(con).filter(col("x").isin([2, 4])).to_pandas().reset_index(drop=True)
-    pdt.assert_frame_equal(out, pd.DataFrame({"x": [2, 4], "y": [20, 40]}))
-
-
-def test_where_alias_produces_same_output(con):
-    df = _xy_df(con)
-    out_filter = df.filter(col("x") > 2).to_pandas().reset_index(drop=True)
-    out_where = df.where(col("x") > 2).to_pandas().reset_index(drop=True)
-    pdt.assert_frame_equal(out_filter, out_where)
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
+    out = df.filter(col("x").isin([1, 3])).to_pandas().reset_index(drop=True)
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [1, 3]}))
 
 
 def test_chained_filter_calls(con):
     # `filter(a).filter(b)` builds two filter nodes in the plan, equivalent
     # in result to `filter(a, b)` (which builds one). Both should pass and
     # produce the same output.
-    df = _xy_df(con)
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3, 4]}))
     chained = (
         df.filter(col("x") > 1).filter(col("x") < 4).to_pandas().reset_index(drop=True)
     )
     combined = df.filter(col("x") > 1, col("x") < 4).to_pandas().reset_index(drop=True)
     pdt.assert_frame_equal(chained, combined)
-    pdt.assert_frame_equal(chained, pd.DataFrame({"x": [2, 3], "y": [20, 30]}))
+    pdt.assert_frame_equal(chained, pd.DataFrame({"x": [2, 3]}))
 
 
 def test_filter_returns_lazy_dataframe(con):
-    out = _xy_df(con).filter(col("x") > 0)
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
+    out = df.filter(col("x") > 0)
     assert hasattr(out, "to_arrow_table")
 
 
 def test_filter_empty_raises(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
     with pytest.raises(ValueError, match="at least one predicate"):
-        _xy_df(con).filter()
+        df.filter()
 
 
 def test_filter_string_arg_raises(con):
     # Strings are not interpreted as SQL predicates (that's a separate
     # feature). Should fail at the Python boundary with a clear message.
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
     with pytest.raises(TypeError, match="Expr"):
-        _xy_df(con).filter("x > 0")
+        df.filter("x > 0")
 
 
 def test_filter_literal_arg_raises(con):
     # filter(lit(value)) is almost always a typo. We reject at the Python
     # boundary so the user sees an actionable suggestion rather than a
     # silent no-op (DataFusion would accept `WHERE 7` as truthy).
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
     with pytest.raises(TypeError, match="Literal"):
-        _xy_df(con).filter(lit(True))
+        df.filter(lit(True))
 
 
 def test_filter_unknown_column_lists_valid_columns(con):
     # DataFusion's plan-build error includes the list of valid field names.
     # Lock that contract so a future change doesn't drop the suggestion.
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}))
     with pytest.raises(SedonaError) as exc:
-        _xy_df(con).filter(col("nonexistent") > 0)
+        df.filter(col("nonexistent") > 0)
     msg = str(exc.value)
     assert "nonexistent" in msg
     assert "Valid fields" in msg or "valid fields" in msg


### PR DESCRIPTION
Wire the `Expr` layer into the existing lazy `DataFrame` so users can filter rows without writing SQL predicates.

This is the fourth and final small PR completing Phase P1 of #791, building on #807 (Expr foundation), #823 (operators), and #832 (`DataFrame.select`).

## What's new

```python
from sedonadb.expr import col

df.filter(col("x") > 0)
df.filter(col("x") > 0, col("y") < 10)              # multiple preds → AND
df.filter((col("x") > 0) & col("y").is_not_null())  # explicit & also fine
df.filter(col("x") > 1).filter(col("x") < 4)        # chained: two filter nodes
```

Multiple predicates are AND-combined into a single composed `Expr` via DataFusion's `conjunction` helper, giving the optimizer one conjunction to reason about rather than N stacked filter nodes. Chained `.filter().filter()` calls produce two filter nodes in the plan but the same result.

## Decision worth flagging — rejecting `Literal` 🛎️ cc @paleolimbot

`filter()` rejects both `str` and `Literal` arguments at the Python boundary.

- **Strings** are not interpreted as SQL predicates — that's a separate `query()`-style feature, not this PR's surface.
- **`Literal`** is rejected because `filter(lit(True))` (or any `filter(lit(value))`) is almost always a typo: DataFusion would silently accept `WHERE 7` as truthy, producing a filter that looks present in the source but is actually a no-op. If a user genuinely wants a constant predicate they can write `col("flag") == lit(True)`, which forces the intent.

This is more restrictive than `select`, which does accept `Literal`. The asymmetry is intentional: a literal as a projection is meaningful (a constant column), but a literal as a filter is almost never what you want. Happy to revisit if you'd rather have `filter(lit(...))` accepted and the resulting no-op surface as an optimizer-time warning instead.

## Implementation

Rust: `InternalDataFrame::filter(Vec<PyExpr>)` — empty list errors at the Python boundary; multi-element lists are folded via `datafusion_expr::utils::conjunction`, matching the pattern used elsewhere in the workspace (`sedona-pointcloud`, `sedona-query-planner`). Step-by-step comments explain the conjunction choice.

Python: `DataFrame.filter(*exprs: "Expr") -> DataFrame` with explicit `isinstance` checks rejecting `str`, `Literal`, and other types.

## Test plan

12 tests in `tests/expr/test_dataframe_filter.py`:

- **Positive**: simple predicate, multi-AND, explicit `&`, `|`, `~`, `isin`, chained `filter().filter()` matches multi-AND.
- **Lazy**: filter returns a `DataFrame` without materializing.
- **Errors**: empty filter → `ValueError`; string arg → `TypeError`; `Literal` arg → `TypeError` with the actionable suggestion; unknown column → `SedonaError` whose message includes the valid field names.

Each test builds its own input `df` inline from the smallest `pd.DataFrame({...})` that exercises the predicate. Existing select/expression/literal tests all still pass. `ruff format` and doctests both clean.

## What's next

This completes the issue-tracker Phase P1 (Expr layer + select/filter on DataFrame). Phase P2 in the [design doc](https://github.com/apache/sedona-db/issues/791) covers `Series` / `Scalar`, `groupby`, `merge`, the curated `sd.st` module, and the cookbook track.
