### PR TITLE
ci(r): pre-install nightly Rust + rust-src on macos to defuse #837

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -74,6 +74,17 @@ jobs:
           rustup toolchain install stable --no-self-update
           rustup default stable
 
+      # The `cargo +nightly build … -Zbuild-std=panic_abort,std` path in
+      # r/sedonadb/src/Makevars.in is only meant to fire for the
+      # wasm32-unknown-emscripten target, but it has been observed firing
+      # intermittently on macos-latest (see #837). Pre-install nightly +
+      # rust-src so a stray invocation doesn't hand `cargo build` to
+      # rustup-init.
+      - name: Pre-install nightly Rust + rust-src (workaround for #837)
+        if: matrix.config.os == 'macos-latest'
+        run: |
+          rustup toolchain install nightly --component rust-src --no-self-update
+
       # Set the default toolchain here so that rust-cache saves/restores
       # the correct target. (The R package will use this target regardless,
       # this just in theory helps the cache)


### PR DESCRIPTION
## Summary

- Pre-install nightly Rust + `rust-src` on `macos-latest` in the R workflow.
- Workaround for the intermittent `r / macos-latest (release)` failure tracked in #837 — the wasm-only `cargo +nightly build … -Zbuild-std=panic_abort,std` recipe in `r/sedonadb/src/Makevars.in` has been observed firing on macos despite `TARGET` being empty, and when no nightly toolchain is installed the rustup proxy hands the args to `rustup-init` and the job dies on `error: unexpected argument 'build' found`.

This change does **not** fix the underlying reason the wasm branch fires on non-wasm runs — that's the follow-up in #837. It just makes the stray invocation succeed so the build doesn't crash on a missing toolchain.

## Test plan

- [ ] CI `r / macos-latest (release)` passes on this branch.
- [ ] Linux and Windows R jobs unaffected (the new step is gated on `matrix.config.os == 'macos-latest'`).
- [ ] No measurable slowdown beyond one extra `rustup toolchain install` (~30s).