### PR TITLE
ci: disable rust-cache cache-bin on macOS, add rustup-init guard (#837)

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -117,6 +117,10 @@ jobs:
         with:
           # Update this key to force a new cache
           prefix-key: "python-wheel-macOS-latest-v2"
+          # Don't cache ~/.cargo/bin -- caching it across runner-image
+          # generations leaves cargo on PATH as a stale rustup-init that
+          # rejects normal subcommands. See sedona-db#837.
+          cache-bin: false
 
       - name: Clone vcpkg
         uses: actions/checkout@v6
@@ -170,6 +174,10 @@ jobs:
         with:
           # Update this key to force a new cache
           prefix-key: "python-wheel-macOS-latest-v2"
+          # Don't cache ~/.cargo/bin -- caching it across runner-image
+          # generations leaves cargo on PATH as a stale rustup-init that
+          # rejects normal subcommands. See sedona-db#837.
+          cache-bin: false
 
       - name: Clone vcpkg
         uses: actions/checkout@v6

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -74,17 +74,6 @@ jobs:
           rustup toolchain install stable --no-self-update
           rustup default stable
 
-      # The `cargo +nightly build … -Zbuild-std=panic_abort,std` path in
-      # r/sedonadb/src/Makevars.in is only meant to fire for the
-      # wasm32-unknown-emscripten target, but it has been observed firing
-      # intermittently on macos-latest (see #837). Pre-install nightly +
-      # rust-src so a stray invocation doesn't hand `cargo build` to
-      # rustup-init.
-      - name: Pre-install nightly Rust + rust-src (workaround for #837)
-        if: matrix.config.os == 'macos-latest'
-        run: |
-          rustup toolchain install nightly --component rust-src --no-self-update
-
       # Set the default toolchain here so that rust-cache saves/restores
       # the correct target. (The R package will use this target regardless,
       # this just in theory helps the cache)
@@ -119,6 +108,7 @@ jobs:
         with:
           prefix-key: "r-v4"
           workspaces: ${{ env.CACHE_WORKSPACE }}
+          cache-bin: false
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/r/sedonadb/configure
+++ b/r/sedonadb/configure
@@ -56,6 +56,29 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
+# Guard against `cargo` resolving to the rustup-init installer. When the
+# rustup proxy can't find its install state it identifies as "rustup-init"
+# and rejects normal cargo subcommands like `build` and `metadata`, which
+# surfaces as a misleading "unexpected argument 'build'" failure deep in
+# the Make recipe. Fail fast with the real diagnosis. See sedona-db#837.
+case "$CARGO_VERSION" in
+  rustup-init*)
+    echo "-------------- ERROR: CONFIGURATION FAILED --------------------"
+    echo ""
+    echo "'cargo' on PATH is the rustup-init installer, not the rustup"
+    echo "proxy. cargo --version reports:"
+    echo "    $CARGO_VERSION"
+    echo ""
+    echo "Ensure \$HOME/.cargo/bin is ahead of any other Rust installer"
+    echo "on PATH (e.g. Homebrew rustup), or reinstall the stable toolchain"
+    echo "with: rustup toolchain install stable && rustup default stable"
+    echo ""
+    echo "---------------------------------------------------------------"
+
+    exit 1
+    ;;
+esac
+
 # There's a little chance that rustc is not available on PATH while cargo is.
 # So, just ignore the error case.
 RUSTC_VERSION="$(rustc --version || true)"

--- a/r/sedonadb/configure.win
+++ b/r/sedonadb/configure.win
@@ -48,6 +48,28 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
+# Guard against `cargo` resolving to the rustup-init installer. When the
+# rustup proxy can't find its install state it identifies as "rustup-init"
+# and rejects normal cargo subcommands like `build` and `metadata`, which
+# surfaces as a misleading "unexpected argument 'build'" failure deep in
+# the Make recipe. Fail fast with the real diagnosis. See sedona-db#837.
+case "$CARGO_VERSION" in
+  rustup-init*)
+    echo "-------------- ERROR: CONFIGURATION FAILED --------------------"
+    echo ""
+    echo "'cargo' on PATH is the rustup-init installer, not the rustup"
+    echo "proxy. cargo --version reports:"
+    echo "    $CARGO_VERSION"
+    echo ""
+    echo "Reinstall the stable toolchain with:"
+    echo "    rustup toolchain install stable && rustup default stable"
+    echo ""
+    echo "---------------------------------------------------------------"
+
+    exit 1
+    ;;
+esac
+
 # There's a little chance that rustc is not available on PATH while cargo is.
 # So, just ignore the error case.
 RUSTC_VERSION="$(rustc --version || true)"


### PR DESCRIPTION
Replaces the nightly+rust-src workaround from #838 with the actual fix, extends the fix to `python-wheels.yml` (which hit the same root cause in cibuildwheel), and adds a fast-fail guard in `r/sedonadb/configure` so the real diagnosis surfaces immediately if this regresses.

## What

- `.github/workflows/r.yml`: drop the `Pre-install nightly Rust + rust-src` step; set `cache-bin: false` on the rust-cache step.
- `.github/workflows/python-wheels.yml`: set `cache-bin: false` on the two macOS jobs (`macOS-arm64`, `macOS-amd64`) where the same failure mode hit cibuildwheel (`cargo metadata` reported as `rustup-init`).
- `r/sedonadb/configure` and `r/sedonadb/configure.win`: when `cargo --version` reports a `rustup-init` banner, exit with a clear message rather than letting Make fall over on a misleading "unexpected argument" error later.

## Why

The macos-latest R job intermittently failed with `error: unexpected argument 'build' found / Usage: rustup-init[EXE] [OPTIONS]`. The error implicates the `cargo +nightly` branch in `r/sedonadb/src/Makevars.in`, but that branch is gated to `wasm32-unknown-emscripten` and doesn't fire on macOS. Make echoes the whole `if/then/else` recipe as a single line, so both cargo invocations appear in the log even though only the stable `cargo build` runs.

The real signal is the configure step's `using Rust package manager: 'rustup-init 1.29.0'`: `cargo` on PATH was acting as the rustup-init installer instead of the toolchain proxy. cibuildwheel hit the same thing on `cargo metadata`.

`Swatinem/rust-cache@v2` defaults to `cache-bin: true`, which caches `~/.cargo/bin`. The cached bin directory was saved on an older macos-latest runner image and conflicts with the current image on restore — the rustup proxy ends up unable to find its install state and falls back to installer mode, where `build`/`metadata` are unrecognized arguments.

#838 worked by accident: adding a nightly toolchain bumped the rust-cache environment hash (`a124ad58` → `06097aa2`), which evicted the bad cache. The nightly toolchain itself is never invoked.

## Verification

Two CI runs on this branch with `cache-bin: false` on `r.yml`:

1. **Run 1** (cache miss, https://github.com/apache/sedona-db/actions/runs/25875234541): macos-latest passes; `cargo --version` reports `cargo 1.95.0`; new cache saved under `r-v4-test-Darwin-arm64-a124ad58` (the same env-hash bucket that originally failed).
2. **Run 2** (cache hit on `a124ad58`, https://github.com/apache/sedona-db/actions/runs/25876768279): `Cache restored successfully`; macos-latest passes; `cargo --version` still reports `cargo 1.95.0`. This is the controlled test — reproduces the failing trigger and doesn't fail.

Closes #837. Supersedes #838.