### PR TITLE
feat(rust/sedona-functions,c/sedona-geos): Implement geography kernels for structural transformations and accessors

### DIFF
--- a/c/sedona-geos/src/st_boundary.rs
+++ b/c/sedona-geos/src/st_boundary.rs
@@ -27,7 +27,7 @@ use sedona_expr::{
 };
 use sedona_geometry::wkb_factory::WKB_MIN_PROBABLE_BYTES;
 use sedona_schema::{
-    datatypes::{SedonaType, WKB_GEOMETRY},
+    datatypes::{SedonaType, WKB_GEOGRAPHY, WKB_GEOMETRY},
     matchers::ArgMatcher,
 };
 
@@ -36,17 +36,24 @@ use crate::geos_to_wkb::write_geos_geometry;
 
 /// ST_Boundary() implementation using the geos crate
 pub fn st_boundary_impl() -> Vec<ScalarKernelRef> {
-    ItemCrsKernel::wrap_impl(STBoundary {})
+    ItemCrsKernel::wrap_impl(vec![
+        Arc::new(STBoundary {
+            matcher: ArgMatcher::new(vec![ArgMatcher::is_geometry()], WKB_GEOMETRY),
+        }),
+        Arc::new(STBoundary {
+            matcher: ArgMatcher::new(vec![ArgMatcher::is_geography()], WKB_GEOGRAPHY),
+        }),
+    ])
 }
 
 #[derive(Debug)]
-struct STBoundary {}
+struct STBoundary {
+    matcher: ArgMatcher,
+}
 
 impl SedonaScalarKernel for STBoundary {
     fn return_type(&self, args: &[SedonaType]) -> datafusion_common::Result<Option<SedonaType>> {
-        let matcher = ArgMatcher::new(vec![ArgMatcher::is_geometry()], WKB_GEOMETRY);
-
-        matcher.match_args(args)
+        self.matcher.match_args(args)
     }
 
     fn invoke_batch(
@@ -287,16 +294,16 @@ fn collect_boundary_components(
 mod tests {
     use rstest::rstest;
     use sedona_expr::scalar_udf::SedonaScalarUDF;
-    use sedona_schema::datatypes::{WKB_GEOMETRY, WKB_GEOMETRY_ITEM_CRS, WKB_VIEW_GEOMETRY};
+    use sedona_schema::datatypes::{WKB_GEOGRAPHY_ITEM_CRS, WKB_GEOMETRY_ITEM_CRS};
     use sedona_testing::testers::ScalarUdfTester;
 
     use super::*;
 
     #[rstest]
-    fn udf(#[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType) {
+    fn udf(#[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType) {
         let udf = SedonaScalarUDF::from_impl("st_boundary", st_boundary_impl());
-        let tester = ScalarUdfTester::new(udf.into(), vec![sedona_type]);
-        tester.assert_return_type(WKB_GEOMETRY);
+        let tester = ScalarUdfTester::new(udf.into(), vec![sedona_type.clone()]);
+        tester.assert_return_type(sedona_type.clone());
 
         let result = tester
             .invoke_scalar(
@@ -372,7 +379,10 @@ mod tests {
     }
 
     #[rstest]
-    fn udf_invoke_item_crs(#[values(WKB_GEOMETRY_ITEM_CRS.clone())] sedona_type: SedonaType) {
+    fn udf_invoke_item_crs(
+        #[values(WKB_GEOMETRY_ITEM_CRS.clone(), WKB_GEOGRAPHY_ITEM_CRS.clone())]
+        sedona_type: SedonaType,
+    ) {
         let udf = SedonaScalarUDF::from_impl("st_boundary", st_boundary_impl());
         let tester = ScalarUdfTester::new(udf.into(), vec![sedona_type.clone()]);
         tester.assert_return_type(sedona_type);

--- a/c/sedona-geos/src/st_line_merge.rs
+++ b/c/sedona-geos/src/st_line_merge.rs
@@ -26,31 +26,48 @@ use sedona_expr::{
     scalar_udf::{ScalarKernelRef, SedonaScalarKernel},
 };
 use sedona_geometry::wkb_factory::WKB_MIN_PROBABLE_BYTES;
-use sedona_schema::{datatypes::WKB_GEOMETRY, matchers::ArgMatcher};
+use sedona_schema::{
+    datatypes::{WKB_GEOGRAPHY, WKB_GEOMETRY},
+    matchers::ArgMatcher,
+};
 
 use crate::executor::GeosExecutor;
 use crate::geos_to_wkb::write_geos_geometry;
 
 pub fn st_line_merge_impl() -> Vec<ScalarKernelRef> {
-    ItemCrsKernel::wrap_impl(STLineMerge {})
+    ItemCrsKernel::wrap_impl(vec![
+        Arc::new(STLineMerge {
+            matcher: ArgMatcher::new(
+                vec![
+                    ArgMatcher::is_geometry(),
+                    ArgMatcher::optional(ArgMatcher::is_boolean()),
+                ],
+                WKB_GEOMETRY,
+            ),
+        }),
+        Arc::new(STLineMerge {
+            matcher: ArgMatcher::new(
+                vec![
+                    ArgMatcher::is_geography(),
+                    ArgMatcher::optional(ArgMatcher::is_boolean()),
+                ],
+                WKB_GEOGRAPHY,
+            ),
+        }),
+    ])
 }
 
 #[derive(Debug)]
-struct STLineMerge {}
+struct STLineMerge {
+    matcher: ArgMatcher,
+}
 
 impl SedonaScalarKernel for STLineMerge {
     fn return_type(
         &self,
         args: &[sedona_schema::datatypes::SedonaType],
     ) -> datafusion_common::Result<Option<sedona_schema::datatypes::SedonaType>> {
-        let matcher = ArgMatcher::new(
-            vec![
-                ArgMatcher::is_geometry(),
-                ArgMatcher::optional(ArgMatcher::is_boolean()),
-            ],
-            WKB_GEOMETRY,
-        );
-        matcher.match_args(args)
+        self.matcher.match_args(args)
     }
 
     fn invoke_batch(
@@ -120,7 +137,7 @@ mod tests {
     use rstest::rstest;
     use sedona_expr::scalar_udf::SedonaScalarUDF;
     use sedona_schema::datatypes::{
-        SedonaType, WKB_GEOMETRY, WKB_GEOMETRY_ITEM_CRS, WKB_VIEW_GEOMETRY,
+        SedonaType, WKB_GEOGRAPHY, WKB_GEOGRAPHY_ITEM_CRS, WKB_GEOMETRY, WKB_GEOMETRY_ITEM_CRS,
     };
     use sedona_testing::create::create_array;
     use sedona_testing::testers::ScalarUdfTester;
@@ -128,15 +145,15 @@ mod tests {
     use super::*;
 
     #[rstest]
-    fn udf(#[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType) {
+    fn udf(#[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType) {
         use arrow_schema::DataType;
 
         let udf = SedonaScalarUDF::from_impl("st_linemerge", st_line_merge_impl());
         let tester = ScalarUdfTester::new(
             udf.into(),
-            vec![sedona_type, SedonaType::Arrow(DataType::Boolean)],
+            vec![sedona_type.clone(), SedonaType::Arrow(DataType::Boolean)],
         );
-        tester.assert_return_type(WKB_GEOMETRY);
+        tester.assert_return_type(sedona_type.clone());
 
         let input = vec![
             Some("MULTILINESTRING ((0 0, 1 0), (1 0, 1 1))"),
@@ -185,7 +202,10 @@ mod tests {
     }
 
     #[rstest]
-    fn udf_invoke_item_crs(#[values(WKB_GEOMETRY_ITEM_CRS.clone())] sedona_type: SedonaType) {
+    fn udf_invoke_item_crs(
+        #[values(WKB_GEOMETRY_ITEM_CRS.clone(), WKB_GEOGRAPHY_ITEM_CRS.clone())]
+        sedona_type: SedonaType,
+    ) {
         use arrow_schema::DataType;
 
         let udf = SedonaScalarUDF::from_impl("st_linemerge", st_line_merge_impl());

--- a/c/sedona-geos/src/st_normalize.rs
+++ b/c/sedona-geos/src/st_normalize.rs
@@ -96,9 +96,7 @@ mod tests {
     use geos::{Geom, Geometry};
     use rstest::rstest;
     use sedona_expr::scalar_udf::SedonaScalarUDF;
-    use sedona_schema::datatypes::{
-        WKB_GEOGRAPHY, WKB_GEOGRAPHY_ITEM_CRS, WKB_GEOMETRY, WKB_GEOMETRY_ITEM_CRS,
-    };
+    use sedona_schema::datatypes::{WKB_GEOGRAPHY_ITEM_CRS, WKB_GEOMETRY_ITEM_CRS};
     use sedona_testing::testers::ScalarUdfTester;
 
     use super::*;
@@ -143,7 +141,7 @@ mod tests {
                 Some("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))"),
                 Some("MULTILINESTRING ((3 3, 4 4), (1 1, 2 2))"),
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
         sedona_testing::compare::assert_array_equal(&batch_result, &expected);
     }

--- a/c/sedona-geos/src/st_normalize.rs
+++ b/c/sedona-geos/src/st_normalize.rs
@@ -96,7 +96,9 @@ mod tests {
     use geos::{Geom, Geometry};
     use rstest::rstest;
     use sedona_expr::scalar_udf::SedonaScalarUDF;
-    use sedona_schema::datatypes::{WKB_GEOGRAPHY, WKB_GEOGRAPHY_ITEM_CRS, WKB_GEOMETRY, WKB_GEOMETRY_ITEM_CRS};
+    use sedona_schema::datatypes::{
+        WKB_GEOGRAPHY, WKB_GEOGRAPHY_ITEM_CRS, WKB_GEOMETRY, WKB_GEOMETRY_ITEM_CRS,
+    };
     use sedona_testing::testers::ScalarUdfTester;
 
     use super::*;

--- a/c/sedona-geos/src/st_normalize.rs
+++ b/c/sedona-geos/src/st_normalize.rs
@@ -25,7 +25,7 @@ use sedona_expr::{
 };
 use sedona_geometry::wkb_factory::WKB_MIN_PROBABLE_BYTES;
 use sedona_schema::{
-    datatypes::{SedonaType, WKB_GEOMETRY},
+    datatypes::{SedonaType, WKB_GEOGRAPHY, WKB_GEOMETRY},
     matchers::ArgMatcher,
 };
 
@@ -34,17 +34,24 @@ use crate::geos_to_wkb::write_geos_geometry;
 
 /// ST_Normalize() implementation using the geos crate
 pub fn st_normalize_impl() -> Vec<ScalarKernelRef> {
-    ItemCrsKernel::wrap_impl(STNormalize {})
+    ItemCrsKernel::wrap_impl(vec![
+        Arc::new(STNormalize {
+            matcher: ArgMatcher::new(vec![ArgMatcher::is_geometry()], WKB_GEOMETRY),
+        }),
+        Arc::new(STNormalize {
+            matcher: ArgMatcher::new(vec![ArgMatcher::is_geography()], WKB_GEOGRAPHY),
+        }),
+    ])
 }
 
 #[derive(Debug)]
-struct STNormalize {}
+struct STNormalize {
+    matcher: ArgMatcher,
+}
 
 impl SedonaScalarKernel for STNormalize {
     fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
-        let matcher = ArgMatcher::new(vec![ArgMatcher::is_geometry()], WKB_GEOMETRY);
-
-        matcher.match_args(args)
+        self.matcher.match_args(args)
     }
 
     fn invoke_batch(
@@ -89,17 +96,17 @@ mod tests {
     use geos::{Geom, Geometry};
     use rstest::rstest;
     use sedona_expr::scalar_udf::SedonaScalarUDF;
-    use sedona_schema::datatypes::{WKB_GEOMETRY, WKB_GEOMETRY_ITEM_CRS, WKB_VIEW_GEOMETRY};
+    use sedona_schema::datatypes::{WKB_GEOGRAPHY, WKB_GEOGRAPHY_ITEM_CRS, WKB_GEOMETRY, WKB_GEOMETRY_ITEM_CRS};
     use sedona_testing::testers::ScalarUdfTester;
 
     use super::*;
 
     #[rstest]
-    fn udf(#[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType) {
+    fn udf(#[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType) {
         let udf = SedonaScalarUDF::from_impl("st_normalize", st_normalize_impl());
         let tester = ScalarUdfTester::new(udf.into(), vec![sedona_type.clone()]);
 
-        tester.assert_return_type(WKB_GEOMETRY);
+        tester.assert_return_type(sedona_type.clone());
 
         let input_wkt = "POLYGON((1 1, 1 0, 0 0, 0 1, 1 1))";
         let expected_wkt = "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))";
@@ -140,7 +147,10 @@ mod tests {
     }
 
     #[rstest]
-    fn udf_invoke_item_crs(#[values(WKB_GEOMETRY_ITEM_CRS.clone())] sedona_type: SedonaType) {
+    fn udf_invoke_item_crs(
+        #[values(WKB_GEOMETRY_ITEM_CRS.clone(), WKB_GEOGRAPHY_ITEM_CRS.clone())]
+        sedona_type: SedonaType,
+    ) {
         let udf = SedonaScalarUDF::from_impl("st_normalize", st_normalize_impl());
         let tester = ScalarUdfTester::new(udf.into(), vec![sedona_type.clone()]);
 
@@ -153,7 +163,7 @@ mod tests {
     }
 
     #[rstest]
-    fn udf_already_normalized(#[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType) {
+    fn udf_already_normalized(#[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType) {
         let udf = SedonaScalarUDF::from_impl("st_normalize", st_normalize_impl());
         let tester = ScalarUdfTester::new(udf.into(), vec![sedona_type]);
         let already_normal = "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))";

--- a/c/sedona-geos/src/st_nrings.rs
+++ b/c/sedona-geos/src/st_nrings.rs
@@ -39,7 +39,7 @@ struct STNRings {}
 impl SedonaScalarKernel for STNRings {
     fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
         let matcher = ArgMatcher::new(
-            vec![ArgMatcher::is_geometry()],
+            vec![ArgMatcher::is_geometry_or_geography()],
             SedonaType::Arrow(DataType::Int32),
         );
         matcher.match_args(args)
@@ -116,7 +116,8 @@ mod tests {
     use rstest::rstest;
     use sedona_expr::scalar_udf::SedonaScalarUDF;
     use sedona_schema::datatypes::{
-        SedonaType, WKB_GEOMETRY, WKB_GEOMETRY_ITEM_CRS, WKB_VIEW_GEOMETRY,
+        SedonaType, WKB_GEOGRAPHY, WKB_GEOGRAPHY_ITEM_CRS, WKB_GEOMETRY, WKB_GEOMETRY_ITEM_CRS,
+        WKB_VIEW_GEOGRAPHY, WKB_VIEW_GEOMETRY,
     };
     use sedona_testing::compare::assert_array_equal;
     use sedona_testing::testers::ScalarUdfTester;
@@ -125,7 +126,7 @@ mod tests {
 
     #[rstest]
     fn udf(
-        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY, WKB_GEOMETRY_ITEM_CRS.clone())]
+        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY, WKB_GEOGRAPHY, WKB_VIEW_GEOGRAPHY, WKB_GEOMETRY_ITEM_CRS.clone(), WKB_GEOGRAPHY_ITEM_CRS.clone())]
         sedona_type: SedonaType,
     ) {
         let udf = SedonaScalarUDF::from_impl("st_nrings", st_nrings_impl());

--- a/c/sedona-geos/src/st_numinteriorrings.rs
+++ b/c/sedona-geos/src/st_numinteriorrings.rs
@@ -39,7 +39,7 @@ struct STNumInteriorRings {}
 impl SedonaScalarKernel for STNumInteriorRings {
     fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
         let matcher = ArgMatcher::new(
-            vec![ArgMatcher::is_geometry()],
+            vec![ArgMatcher::is_geometry_or_geography()],
             SedonaType::Arrow(DataType::Int32),
         );
 

--- a/c/sedona-geos/src/st_numinteriorrings.rs
+++ b/c/sedona-geos/src/st_numinteriorrings.rs
@@ -103,7 +103,8 @@ mod tests {
     use rstest::rstest;
     use sedona_expr::scalar_udf::SedonaScalarUDF;
     use sedona_schema::datatypes::{
-        SedonaType, WKB_GEOMETRY, WKB_GEOMETRY_ITEM_CRS, WKB_VIEW_GEOMETRY,
+        SedonaType, WKB_GEOGRAPHY, WKB_GEOGRAPHY_ITEM_CRS, WKB_GEOMETRY, WKB_GEOMETRY_ITEM_CRS,
+        WKB_VIEW_GEOGRAPHY, WKB_VIEW_GEOMETRY,
     };
     use sedona_testing::compare::assert_array_equal;
     use sedona_testing::testers::ScalarUdfTester;
@@ -112,7 +113,7 @@ mod tests {
 
     #[rstest]
     fn udf(
-        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY, WKB_GEOMETRY_ITEM_CRS.clone())]
+        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY, WKB_GEOGRAPHY, WKB_VIEW_GEOGRAPHY, WKB_GEOMETRY_ITEM_CRS.clone(), WKB_GEOGRAPHY_ITEM_CRS.clone())]
         sedona_type: SedonaType,
     ) {
         let udf = SedonaScalarUDF::from_impl("st_numinteriorrings", st_num_interior_rings_impl());

--- a/c/sedona-geos/src/st_numpoints.rs
+++ b/c/sedona-geos/src/st_numpoints.rs
@@ -39,7 +39,7 @@ struct STNumPoints {}
 impl SedonaScalarKernel for STNumPoints {
     fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
         let matcher = ArgMatcher::new(
-            vec![ArgMatcher::is_geometry()],
+            vec![ArgMatcher::is_geometry_or_geography()],
             SedonaType::Arrow(DataType::Int32),
         );
 
@@ -96,7 +96,8 @@ mod tests {
     use rstest::rstest;
     use sedona_expr::scalar_udf::SedonaScalarUDF;
     use sedona_schema::datatypes::{
-        SedonaType, WKB_GEOMETRY, WKB_GEOMETRY_ITEM_CRS, WKB_VIEW_GEOMETRY,
+        SedonaType, WKB_GEOGRAPHY, WKB_GEOGRAPHY_ITEM_CRS, WKB_GEOMETRY, WKB_GEOMETRY_ITEM_CRS,
+        WKB_VIEW_GEOGRAPHY, WKB_VIEW_GEOMETRY,
     };
     use sedona_testing::compare::assert_array_equal;
     use sedona_testing::testers::ScalarUdfTester;
@@ -105,7 +106,7 @@ mod tests {
 
     #[rstest]
     fn udf(
-        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY, WKB_GEOMETRY_ITEM_CRS.clone())]
+        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY, WKB_GEOGRAPHY, WKB_VIEW_GEOGRAPHY, WKB_GEOMETRY_ITEM_CRS.clone(), WKB_GEOGRAPHY_ITEM_CRS.clone())]
         sedona_type: SedonaType,
     ) {
         let udf = SedonaScalarUDF::from_impl("st_numpoints", st_num_points_impl());

--- a/python/sedonadb/tests/geography/test_geog_mechanical_transforms.py
+++ b/python/sedonadb/tests/geography/test_geog_mechanical_transforms.py
@@ -643,3 +643,53 @@ def test_st_numinteriorrings(eng, geog, expected):
 def test_st_numpoints(eng, geog, expected):
     eng = eng.create_or_skip()
     eng.assert_query_result(f"SELECT ST_NumPoints({geog_or_null(geog)})", expected)
+
+
+@pytest.mark.parametrize("eng", [SedonaDB])
+@pytest.mark.parametrize(
+    ("geog", "expected"),
+    [
+        pytest.param(None, None, id="null"),
+        pytest.param("POINT EMPTY", "MULTIPOINT EMPTY", id="point_empty"),
+        pytest.param("LINESTRING EMPTY", "MULTIPOINT EMPTY", id="linestring_empty"),
+        pytest.param("POLYGON EMPTY", "MULTIPOINT EMPTY", id="polygon_empty"),
+        pytest.param("MULTIPOINT EMPTY", "MULTIPOINT EMPTY", id="multipoint_empty"),
+        pytest.param(
+            "GEOMETRYCOLLECTION EMPTY",
+            "MULTIPOINT EMPTY",
+            id="geometrycollection_empty",
+        ),
+        pytest.param("POINT (1 2)", "MULTIPOINT (1 2)", id="point"),
+        pytest.param(
+            "LINESTRING (1 2, 3 4, 5 6)", "MULTIPOINT (1 2, 3 4, 5 6)", id="linestring"
+        ),
+        pytest.param(
+            "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))",
+            "MULTIPOINT (0 0, 10 0, 10 10, 0 10, 0 0)",
+            id="polygon",
+        ),
+        pytest.param(
+            "MULTIPOINT (1 2, 3 4, 5 6, 7 8)",
+            "MULTIPOINT (1 2, 3 4, 5 6, 7 8)",
+            id="multipoint",
+        ),
+        pytest.param(
+            "LINESTRING Z (1 2 3, 4 5 6, 7 8 9)",
+            "MULTIPOINT Z (1 2 3, 4 5 6, 7 8 9)",
+            id="linestring_z",
+        ),
+        pytest.param(
+            "LINESTRING M (1 2 3, 4 5 6, 7 8 9)",
+            "MULTIPOINT M (1 2 3, 4 5 6, 7 8 9)",
+            id="linestring_m",
+        ),
+        pytest.param(
+            "LINESTRING ZM (1 2 3 4, 5 6 7 8, 9 0 1 2)",
+            "MULTIPOINT ZM (1 2 3 4, 5 6 7 8, 9 0 1 2)",
+            id="linestring_zm",
+        ),
+    ],
+)
+def test_st_points(eng, geog, expected):
+    eng = eng.create_or_skip()
+    eng.assert_query_result(f"SELECT ST_Points({geog_or_null(geog)})", expected)

--- a/python/sedonadb/tests/geography/test_geog_mechanical_transforms.py
+++ b/python/sedonadb/tests/geography/test_geog_mechanical_transforms.py
@@ -1,0 +1,572 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Tests for mechanical geography transformations that output the same type as input.
+
+These functions were recently updated to support geography types in addition to
+geometry types. Tests cover essential cases: null, empty, valid, Z, M, and ZM.
+"""
+
+import pytest
+import sedonadb
+from sedonadb.testing import SedonaDB, geog_or_null, val_or_null
+
+if "s2geography" not in sedonadb.__features__:
+    pytest.skip("Python package built without s2geography", allow_module_level=True)
+
+
+# =============================================================================
+# ST_FlipCoordinates
+# =============================================================================
+
+
+@pytest.mark.parametrize("eng", [SedonaDB])
+@pytest.mark.parametrize(
+    ("geog", "expected"),
+    [
+        pytest.param(None, None, id="null"),
+        pytest.param("POINT EMPTY", "POINT (nan nan)", id="point_empty"),
+        pytest.param("LINESTRING EMPTY", "LINESTRING EMPTY", id="linestring_empty"),
+        pytest.param("POLYGON EMPTY", "POLYGON EMPTY", id="polygon_empty"),
+        pytest.param("POINT (0 1)", "POINT (1 0)", id="point"),
+        pytest.param(
+            "LINESTRING (0 1, 2 3)", "LINESTRING (1 0, 3 2)", id="linestring"
+        ),
+        pytest.param(
+            "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))",
+            "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))",
+            id="polygon",
+        ),
+        pytest.param("POINT Z (0 1 5)", "POINT Z (1 0 5)", id="point_z"),
+        pytest.param("POINT M (0 1 5)", "POINT M (1 0 5)", id="point_m"),
+        pytest.param("POINT ZM (0 1 5 7)", "POINT ZM (1 0 5 7)", id="point_zm"),
+    ],
+)
+def test_st_flipcoordinates(eng, geog, expected):
+    eng = eng.create_or_skip()
+    eng.assert_query_result(
+        f"SELECT ST_FlipCoordinates({geog_or_null(geog)})", expected
+    )
+
+
+# =============================================================================
+# ST_Force2D / ST_Force3D
+# =============================================================================
+
+
+@pytest.mark.parametrize("eng", [SedonaDB])
+@pytest.mark.parametrize(
+    ("geog", "expected_2d", "expected_3d"),
+    [
+        pytest.param(None, None, None, id="null"),
+        pytest.param(
+            "POINT EMPTY",
+            "POINT (nan nan)",
+            "POINT Z (nan nan nan)",
+            id="point_empty",
+        ),
+        pytest.param(
+            "LINESTRING EMPTY",
+            "LINESTRING EMPTY",
+            "LINESTRING Z EMPTY",
+            id="linestring_empty",
+        ),
+        pytest.param("POINT (0 1)", "POINT (0 1)", "POINT Z (0 1 5)", id="point"),
+        pytest.param(
+            "POINT Z (0 1 9)", "POINT (0 1)", "POINT Z (0 1 9)", id="point_z"
+        ),
+        pytest.param(
+            "POINT M (0 1 9)", "POINT (0 1)", "POINT Z (0 1 5)", id="point_m"
+        ),
+        pytest.param(
+            "POINT ZM (0 1 9 8)", "POINT (0 1)", "POINT Z (0 1 9)", id="point_zm"
+        ),
+    ],
+)
+def test_st_force_dim(eng, geog, expected_2d, expected_3d):
+    eng = eng.create_or_skip()
+    eng.assert_query_result(f"SELECT ST_Force2D({geog_or_null(geog)})", expected_2d)
+    eng.assert_query_result(f"SELECT ST_Force3D({geog_or_null(geog)}, 5)", expected_3d)
+
+
+# =============================================================================
+# ST_Force3DM
+# =============================================================================
+
+
+@pytest.mark.parametrize("eng", [SedonaDB])
+@pytest.mark.parametrize(
+    ("geog", "m", "expected_without_m", "expected_with_m"),
+    [
+        pytest.param(None, 5, None, None, id="null"),
+        pytest.param(
+            "POINT EMPTY",
+            5,
+            "POINT M (nan nan nan)",
+            "POINT M (nan nan nan)",
+            id="point_empty",
+        ),
+        pytest.param(
+            "POINT (0 1)", 5, "POINT M (0 1 0)", "POINT M (0 1 5)", id="point"
+        ),
+        pytest.param(
+            "POINT Z (0 1 2)", 5, "POINT M (0 1 0)", "POINT M (0 1 5)", id="point_z"
+        ),
+        pytest.param(
+            "POINT M (0 1 3)", 5, "POINT M (0 1 3)", "POINT M (0 1 3)", id="point_m"
+        ),
+        pytest.param(
+            "POINT ZM (0 1 2 3)",
+            5,
+            "POINT M (0 1 3)",
+            "POINT M (0 1 3)",
+            id="point_zm",
+        ),
+    ],
+)
+def test_st_force3dm(eng, geog, m, expected_without_m, expected_with_m):
+    eng = eng.create_or_skip()
+    eng.assert_query_result(
+        f"SELECT ST_Force3DM({geog_or_null(geog)})", expected_without_m
+    )
+    eng.assert_query_result(
+        f"SELECT ST_Force3DM({geog_or_null(geog)}, {val_or_null(m)})", expected_with_m
+    )
+
+
+# =============================================================================
+# ST_Force4D
+# =============================================================================
+
+
+@pytest.mark.parametrize("eng", [SedonaDB])
+@pytest.mark.parametrize(
+    ("geog", "z", "m", "expected_without_defaults", "expected_with_defaults"),
+    [
+        pytest.param(None, 5, 7, None, None, id="null"),
+        pytest.param(
+            "POINT EMPTY",
+            5,
+            7,
+            "POINT ZM (nan nan nan nan)",
+            "POINT ZM (nan nan nan nan)",
+            id="point_empty",
+        ),
+        pytest.param(
+            "POINT (0 1)",
+            5,
+            7,
+            "POINT ZM (0 1 0 0)",
+            "POINT ZM (0 1 5 7)",
+            id="point",
+        ),
+        pytest.param(
+            "POINT Z (0 1 2)",
+            5,
+            7,
+            "POINT ZM (0 1 2 0)",
+            "POINT ZM (0 1 2 7)",
+            id="point_z",
+        ),
+        pytest.param(
+            "POINT M (0 1 3)",
+            5,
+            7,
+            "POINT ZM (0 1 0 3)",
+            "POINT ZM (0 1 5 3)",
+            id="point_m",
+        ),
+        pytest.param(
+            "POINT ZM (0 1 2 3)",
+            5,
+            7,
+            "POINT ZM (0 1 2 3)",
+            "POINT ZM (0 1 2 3)",
+            id="point_zm",
+        ),
+    ],
+)
+def test_st_force4d(eng, geog, z, m, expected_without_defaults, expected_with_defaults):
+    eng = eng.create_or_skip()
+    eng.assert_query_result(
+        f"SELECT ST_Force4D({geog_or_null(geog)})", expected_without_defaults
+    )
+    eng.assert_query_result(
+        f"SELECT ST_Force4D({geog_or_null(geog)}, {val_or_null(z)}, {val_or_null(m)})",
+        expected_with_defaults,
+    )
+
+
+# =============================================================================
+# ST_GeometryN
+# =============================================================================
+
+
+@pytest.mark.parametrize("eng", [SedonaDB])
+@pytest.mark.parametrize(
+    ("geog", "index", "expected"),
+    [
+        pytest.param(None, 1, None, id="null"),
+        pytest.param("POINT EMPTY", 1, "POINT (nan nan)", id="point_empty"),
+        pytest.param("MULTIPOINT EMPTY", 1, None, id="multipoint_empty"),
+        pytest.param("POINT (1 1)", 1, "POINT (1 1)", id="point_n1"),
+        pytest.param("POINT (1 1)", 2, None, id="point_n2_oob"),
+        pytest.param(
+            "MULTIPOINT ((1 1), (2 2), (3 3))", 2, "POINT (2 2)", id="multipoint_n2"
+        ),
+        pytest.param(
+            "MULTILINESTRING ((1 1, 2 2), (3 3, 4 4))",
+            1,
+            "LINESTRING (1 1, 2 2)",
+            id="multilinestring_n1",
+        ),
+        pytest.param(
+            "GEOMETRYCOLLECTION (POINT (1 2), LINESTRING (3 4, 5 6))",
+            2,
+            "LINESTRING (3 4, 5 6)",
+            id="gc_n2",
+        ),
+        pytest.param(
+            "MULTIPOINT Z ((1 1 5), (2 2 6))",
+            1,
+            "POINT Z (1 1 5)",
+            id="multipoint_z",
+        ),
+        pytest.param(
+            "MULTIPOINT M ((1 1 5), (2 2 6))",
+            1,
+            "POINT M (1 1 5)",
+            id="multipoint_m",
+        ),
+        pytest.param(
+            "MULTIPOINT ZM ((1 1 5 7), (2 2 6 8))",
+            1,
+            "POINT ZM (1 1 5 7)",
+            id="multipoint_zm",
+        ),
+    ],
+)
+def test_st_geometryn(eng, geog, index, expected):
+    eng = eng.create_or_skip()
+    eng.assert_query_result(
+        f"SELECT ST_GeometryN({geog_or_null(geog)}, {val_or_null(index)})", expected
+    )
+
+
+# =============================================================================
+# ST_InteriorRingN
+# =============================================================================
+
+
+@pytest.mark.parametrize("eng", [SedonaDB])
+@pytest.mark.parametrize(
+    ("geog", "index", "expected"),
+    [
+        pytest.param(None, 1, None, id="null"),
+        pytest.param("POINT (0 0)", 1, None, id="point"),
+        pytest.param("LINESTRING (0 0, 1 1)", 1, None, id="linestring"),
+        pytest.param("POLYGON EMPTY", 1, None, id="polygon_empty"),
+        pytest.param(
+            "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))", 1, None, id="polygon_no_holes"
+        ),
+        pytest.param(
+            "POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))",
+            1,
+            "LINESTRING (1 1, 1 2, 2 2, 2 1, 1 1)",
+            id="polygon_with_hole",
+        ),
+        pytest.param(
+            "POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))",
+            2,
+            None,
+            id="polygon_oob",
+        ),
+        pytest.param(
+            "POLYGON Z ((0 0 10, 4 0 10, 4 4 10, 0 4 10, 0 0 10), (1 1 5, 1 2 5, 2 2 5, 2 1 5, 1 1 5))",
+            1,
+            "LINESTRING Z (1 1 5, 1 2 5, 2 2 5, 2 1 5, 1 1 5)",
+            id="polygon_z",
+        ),
+        pytest.param(
+            "POLYGON M ((0 0 1, 4 0 2, 4 4 3, 0 4 4, 0 0 5), (1 1 6, 1 2 7, 2 2 8, 2 1 9, 1 1 10))",
+            1,
+            "LINESTRING M (1 1 6, 1 2 7, 2 2 8, 2 1 9, 1 1 10)",
+            id="polygon_m",
+        ),
+        pytest.param(
+            "POLYGON ZM ((0 0 10 1, 4 0 10 2, 4 4 10 3, 0 4 10 4, 0 0 10 5), (1 1 5 6, 1 2 5 7, 2 2 5 8, 2 1 5 9, 1 1 5 10))",
+            1,
+            "LINESTRING ZM (1 1 5 6, 1 2 5 7, 2 2 5 8, 2 1 5 9, 1 1 5 10)",
+            id="polygon_zm",
+        ),
+    ],
+)
+def test_st_interiorringn(eng, geog, index, expected):
+    eng = eng.create_or_skip()
+    eng.assert_query_result(
+        f"SELECT ST_InteriorRingN({geog_or_null(geog)}, {val_or_null(index)})", expected
+    )
+
+
+# =============================================================================
+# ST_Reverse
+# =============================================================================
+
+
+@pytest.mark.parametrize("eng", [SedonaDB])
+@pytest.mark.parametrize(
+    ("geog", "expected"),
+    [
+        pytest.param(None, None, id="null"),
+        pytest.param("POINT EMPTY", "POINT (nan nan)", id="point_empty"),
+        pytest.param("LINESTRING EMPTY", "LINESTRING EMPTY", id="linestring_empty"),
+        pytest.param("POINT (1 2)", "POINT (1 2)", id="point"),
+        pytest.param(
+            "LINESTRING (0 0, 1 1, 2 2)",
+            "LINESTRING (2 2, 1 1, 0 0)",
+            id="linestring",
+        ),
+        pytest.param(
+            "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))",
+            "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))",
+            id="polygon",
+        ),
+        pytest.param(
+            "MULTIPOINT (1 2, 3 4)", "MULTIPOINT (1 2, 3 4)", id="multipoint"
+        ),
+        pytest.param(
+            "LINESTRING Z (0 0 1, 1 1 2, 2 2 3)",
+            "LINESTRING Z (2 2 3, 1 1 2, 0 0 1)",
+            id="linestring_z",
+        ),
+        pytest.param(
+            "LINESTRING M (0 0 1, 1 1 2, 2 2 3)",
+            "LINESTRING M (2 2 3, 1 1 2, 0 0 1)",
+            id="linestring_m",
+        ),
+        pytest.param(
+            "LINESTRING ZM (0 0 1 4, 1 1 2 5, 2 2 3 6)",
+            "LINESTRING ZM (2 2 3 6, 1 1 2 5, 0 0 1 4)",
+            id="linestring_zm",
+        ),
+    ],
+)
+def test_st_reverse(eng, geog, expected):
+    eng = eng.create_or_skip()
+    eng.assert_query_result(f"SELECT ST_Reverse({geog_or_null(geog)})", expected)
+
+
+# =============================================================================
+# ST_PointN
+# =============================================================================
+
+
+@pytest.mark.parametrize("eng", [SedonaDB])
+@pytest.mark.parametrize(
+    ("geog", "n", "expected"),
+    [
+        pytest.param(None, 1, None, id="null"),
+        pytest.param("LINESTRING EMPTY", 1, None, id="linestring_empty"),
+        pytest.param("POINT (1 2)", 1, None, id="point"),
+        pytest.param(
+            "LINESTRING (1 2, 3 4, 5 6)", 1, "POINT (1 2)", id="linestring_n1"
+        ),
+        pytest.param(
+            "LINESTRING (1 2, 3 4, 5 6)", 2, "POINT (3 4)", id="linestring_n2"
+        ),
+        pytest.param(
+            "LINESTRING (1 2, 3 4, 5 6)", 3, "POINT (5 6)", id="linestring_n3"
+        ),
+        pytest.param("LINESTRING (1 2, 3 4, 5 6)", 4, None, id="linestring_oob"),
+        pytest.param(
+            "LINESTRING (1 2, 3 4, 5 6)", -1, "POINT (5 6)", id="linestring_neg1"
+        ),
+        pytest.param(
+            "LINESTRING Z (1 2 3, 4 5 6)",
+            1,
+            "POINT Z (1 2 3)",
+            id="linestring_z",
+        ),
+        pytest.param(
+            "LINESTRING M (1 2 3, 4 5 6)",
+            1,
+            "POINT M (1 2 3)",
+            id="linestring_m",
+        ),
+        pytest.param(
+            "LINESTRING ZM (1 2 3 4, 5 6 7 8)",
+            1,
+            "POINT ZM (1 2 3 4)",
+            id="linestring_zm",
+        ),
+    ],
+)
+def test_st_pointn(eng, geog, n, expected):
+    eng = eng.create_or_skip()
+    eng.assert_query_result(
+        f"SELECT ST_PointN({geog_or_null(geog)}, {val_or_null(n)})", expected
+    )
+
+
+# =============================================================================
+# ST_Boundary
+# =============================================================================
+
+
+@pytest.mark.parametrize("eng", [SedonaDB])
+@pytest.mark.parametrize(
+    ("geog", "expected"),
+    [
+        pytest.param(None, None, id="null"),
+        pytest.param("POINT (1 2)", "GEOMETRYCOLLECTION EMPTY", id="point"),
+        pytest.param(
+            "LINESTRING (0 0, 1 1)", "MULTIPOINT (0 0, 1 1)", id="linestring"
+        ),
+        pytest.param(
+            "LINESTRING (0 0, 1 1, 0 0)", "MULTIPOINT EMPTY", id="linestring_closed"
+        ),
+        pytest.param(
+            "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))",
+            "LINESTRING (0 0, 1 0, 1 1, 0 1, 0 0)",
+            id="polygon",
+        ),
+        pytest.param(
+            "POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))",
+            "MULTILINESTRING ((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))",
+            id="polygon_with_hole",
+        ),
+        pytest.param(
+            "MULTIPOINT (0 0, 1 1)", "GEOMETRYCOLLECTION EMPTY", id="multipoint"
+        ),
+    ],
+)
+def test_st_boundary(eng, geog, expected):
+    eng = eng.create_or_skip()
+    eng.assert_query_result(f"SELECT ST_Boundary({geog_or_null(geog)})", expected)
+
+
+# =============================================================================
+# ST_LineMerge
+# =============================================================================
+
+
+@pytest.mark.parametrize("eng", [SedonaDB])
+@pytest.mark.parametrize(
+    ("geog", "expected"),
+    [
+        pytest.param(None, None, id="null"),
+        pytest.param("LINESTRING EMPTY", "LINESTRING EMPTY", id="linestring_empty"),
+        pytest.param(
+            "MULTILINESTRING EMPTY",
+            "MULTILINESTRING EMPTY",
+            id="multilinestring_empty",
+        ),
+        pytest.param(
+            "MULTILINESTRING ((0 0, 1 0), (1 0, 1 1))",
+            "LINESTRING (0 0, 1 0, 1 1)",
+            id="touching",
+        ),
+        pytest.param(
+            "MULTILINESTRING ((0 0, 1 0), (1 1, 1 0))",
+            "LINESTRING (0 0, 1 0, 1 1)",
+            id="opposite_direction",
+        ),
+        pytest.param(
+            "MULTILINESTRING ((0 0, 1 0), (8 8, 9 9))",
+            "MULTILINESTRING ((0 0, 1 0), (8 8, 9 9))",
+            id="non_touching",
+        ),
+        pytest.param(
+            "LINESTRING (0 0, 1 0)", "LINESTRING (0 0, 1 0)", id="single_linestring"
+        ),
+    ],
+)
+def test_st_linemerge(eng, geog, expected):
+    eng = eng.create_or_skip()
+    eng.assert_query_result(f"SELECT ST_LineMerge({geog_or_null(geog)})", expected)
+
+
+@pytest.mark.parametrize("eng", [SedonaDB])
+@pytest.mark.parametrize(
+    ("geog", "expected"),
+    [
+        pytest.param(
+            "MULTILINESTRING ((0 0, 1 0), (1 0, 1 1))",
+            "LINESTRING (0 0, 1 0, 1 1)",
+            id="touching_directed",
+        ),
+        pytest.param(
+            "MULTILINESTRING ((0 0, 1 0), (1 1, 1 0))",
+            "MULTILINESTRING ((0 0, 1 0), (1 1, 1 0))",
+            id="opposite_not_merged",
+        ),
+    ],
+)
+def test_st_linemerge_directed(eng, geog, expected):
+    eng = eng.create_or_skip()
+    eng.assert_query_result(
+        f"SELECT ST_LineMerge({geog_or_null(geog)}, true)", expected
+    )
+
+
+# =============================================================================
+# ST_Normalize
+# =============================================================================
+
+
+@pytest.mark.parametrize("eng", [SedonaDB])
+@pytest.mark.parametrize(
+    ("geog", "expected"),
+    [
+        pytest.param(None, None, id="null"),
+        pytest.param("POINT EMPTY", "POINT EMPTY", id="point_empty"),
+        pytest.param("LINESTRING EMPTY", "LINESTRING EMPTY", id="linestring_empty"),
+        pytest.param("POINT (1 2)", "POINT(1 2)", id="point"),
+        pytest.param(
+            "POLYGON ((1 1, 1 0, 0 0, 0 1, 1 1))",
+            "POLYGON((0 0,0 1,1 1,1 0,0 0))",
+            id="polygon",
+        ),
+        pytest.param(
+            "MULTILINESTRING ((2 2, 1 1), (4 4, 3 3))",
+            "MULTILINESTRING((3 3,4 4),(1 1,2 2))",
+            id="multilinestring",
+        ),
+        pytest.param(
+            "POLYGON Z ((1 1 5, 1 0 5, 0 0 5, 0 1 5, 1 1 5))",
+            "POLYGON Z((0 0 5,0 1 5,1 1 5,1 0 5,0 0 5))",
+            id="polygon_z",
+        ),
+        pytest.param(
+            "POLYGON M ((1 1 7, 1 0 7, 0 0 7, 0 1 7, 1 1 7))",
+            "POLYGON M((0 0 7,0 1 7,1 1 7,1 0 7,0 0 7))",
+            id="polygon_m",
+        ),
+        pytest.param(
+            "POLYGON ZM ((1 1 5 7, 1 0 5 7, 0 0 5 7, 0 1 5 7, 1 1 5 7))",
+            "POLYGON ZM((0 0 5 7,0 1 5 7,1 1 5 7,1 0 5 7,0 0 5 7))",
+            id="polygon_zm",
+        ),
+    ],
+)
+def test_st_normalize(eng, geog, expected):
+    eng = eng.create_or_skip()
+    # Use ST_AsText because SedonaDB normalizes WKT output format
+    eng.assert_query_result(
+        f"SELECT ST_AsText(ST_Normalize({geog_or_null(geog)}))", expected
+    )

--- a/python/sedonadb/tests/geography/test_geog_mechanical_transforms.py
+++ b/python/sedonadb/tests/geography/test_geog_mechanical_transforms.py
@@ -463,42 +463,66 @@ def test_st_linemerge_directed(eng, geog, expected):
     ("geog", "expected"),
     [
         pytest.param(None, None, id="null"),
-        pytest.param("POINT EMPTY", "POINT EMPTY", id="point_empty"),
+        pytest.param("POINT EMPTY", "POINT (nan nan)", id="point_empty"),
         pytest.param("LINESTRING EMPTY", "LINESTRING EMPTY", id="linestring_empty"),
-        pytest.param("POINT (1 2)", "POINT(1 2)", id="point"),
+        pytest.param("POINT (1 2)", "POINT (1 2)", id="point"),
         pytest.param(
             "POLYGON ((1 1, 1 0, 0 0, 0 1, 1 1))",
-            "POLYGON((0 0,0 1,1 1,1 0,0 0))",
+            "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))",
             id="polygon",
         ),
         pytest.param(
             "MULTILINESTRING ((2 2, 1 1), (4 4, 3 3))",
-            "MULTILINESTRING((3 3,4 4),(1 1,2 2))",
+            "MULTILINESTRING ((3 3, 4 4), (1 1, 2 2))",
             id="multilinestring",
         ),
         pytest.param(
             "POLYGON Z ((1 1 5, 1 0 5, 0 0 5, 0 1 5, 1 1 5))",
-            "POLYGON Z((0 0 5,0 1 5,1 1 5,1 0 5,0 0 5))",
+            "POLYGON Z ((0 0 5, 0 1 5, 1 1 5, 1 0 5, 0 0 5))",
             id="polygon_z",
         ),
         pytest.param(
             "POLYGON M ((1 1 7, 1 0 7, 0 0 7, 0 1 7, 1 1 7))",
-            "POLYGON M((0 0 7,0 1 7,1 1 7,1 0 7,0 0 7))",
+            "POLYGON M ((0 0 7, 0 1 7, 1 1 7, 1 0 7, 0 0 7))",
             id="polygon_m",
         ),
         pytest.param(
             "POLYGON ZM ((1 1 5 7, 1 0 5 7, 0 0 5 7, 0 1 5 7, 1 1 5 7))",
-            "POLYGON ZM((0 0 5 7,0 1 5 7,1 1 5 7,1 0 5 7,0 0 5 7))",
+            "POLYGON ZM ((0 0 5 7, 0 1 5 7, 1 1 5 7, 1 0 5 7, 0 0 5 7))",
             id="polygon_zm",
         ),
     ],
 )
 def test_st_normalize(eng, geog, expected):
     eng = eng.create_or_skip()
-    # Use ST_AsText because SedonaDB normalizes WKT output format
-    eng.assert_query_result(
-        f"SELECT ST_AsText(ST_Normalize({geog_or_null(geog)}))", expected
-    )
+    eng.assert_query_result(f"SELECT ST_Normalize({geog_or_null(geog)})", expected)
+
+
+# Verify the behaviour of ST_Normalize() with a polar cap
+@pytest.mark.parametrize("eng", [SedonaDB])
+@pytest.mark.parametrize(
+    ("geog", "expected"),
+    [
+        pytest.param(
+            "POLYGON ((-120 80, 0 80, 120 80, -120 80))",
+            "POLYGON ((-120 80, 0 80, 120 80, -120 80))",
+            id="polygon_polar",
+        ),
+        pytest.param(
+            "POLYGON ((-120 80, 120 80, 0 80, -120 80))",
+            "POLYGON ((-120 80, 120 80, 0 80, -120 80))",
+            id="polygon_polar_rev",
+        ),
+        pytest.param(
+            "POLYGON ((0 80, 120 80, -120 80, 0 80))",
+            "POLYGON ((-120 80, 0 80, 120 80, -120 80))",
+            id="polygon_polar_rot",
+        ),
+    ],
+)
+def test_st_normalize_polar(eng, geog, expected):
+    eng = eng.create_or_skip()
+    eng.assert_query_result(f"SELECT ST_Normalize({geog_or_null(geog)})", expected)
 
 
 @pytest.mark.parametrize("eng", [SedonaDB])

--- a/python/sedonadb/tests/geography/test_geog_mechanical_transforms.py
+++ b/python/sedonadb/tests/geography/test_geog_mechanical_transforms.py
@@ -16,23 +16,12 @@
 # under the License.
 
 """
-Tests for mechanical geography transformations that output the same type as input.
-
-These functions were recently updated to support geography types in addition to
-geometry types. Tests cover essential cases: null, empty, valid, Z, M, and ZM.
+Tests for mechanical geography transformations whose implementations are shared
+with geometry
 """
 
 import pytest
-import sedonadb
 from sedonadb.testing import SedonaDB, geog_or_null, val_or_null
-
-if "s2geography" not in sedonadb.__features__:
-    pytest.skip("Python package built without s2geography", allow_module_level=True)
-
-
-# =============================================================================
-# ST_FlipCoordinates
-# =============================================================================
 
 
 @pytest.mark.parametrize("eng", [SedonaDB])
@@ -44,9 +33,7 @@ if "s2geography" not in sedonadb.__features__:
         pytest.param("LINESTRING EMPTY", "LINESTRING EMPTY", id="linestring_empty"),
         pytest.param("POLYGON EMPTY", "POLYGON EMPTY", id="polygon_empty"),
         pytest.param("POINT (0 1)", "POINT (1 0)", id="point"),
-        pytest.param(
-            "LINESTRING (0 1, 2 3)", "LINESTRING (1 0, 3 2)", id="linestring"
-        ),
+        pytest.param("LINESTRING (0 1, 2 3)", "LINESTRING (1 0, 3 2)", id="linestring"),
         pytest.param(
             "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))",
             "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))",
@@ -62,11 +49,6 @@ def test_st_flipcoordinates(eng, geog, expected):
     eng.assert_query_result(
         f"SELECT ST_FlipCoordinates({geog_or_null(geog)})", expected
     )
-
-
-# =============================================================================
-# ST_Force2D / ST_Force3D
-# =============================================================================
 
 
 @pytest.mark.parametrize("eng", [SedonaDB])
@@ -87,12 +69,8 @@ def test_st_flipcoordinates(eng, geog, expected):
             id="linestring_empty",
         ),
         pytest.param("POINT (0 1)", "POINT (0 1)", "POINT Z (0 1 5)", id="point"),
-        pytest.param(
-            "POINT Z (0 1 9)", "POINT (0 1)", "POINT Z (0 1 9)", id="point_z"
-        ),
-        pytest.param(
-            "POINT M (0 1 9)", "POINT (0 1)", "POINT Z (0 1 5)", id="point_m"
-        ),
+        pytest.param("POINT Z (0 1 9)", "POINT (0 1)", "POINT Z (0 1 9)", id="point_z"),
+        pytest.param("POINT M (0 1 9)", "POINT (0 1)", "POINT Z (0 1 5)", id="point_m"),
         pytest.param(
             "POINT ZM (0 1 9 8)", "POINT (0 1)", "POINT Z (0 1 9)", id="point_zm"
         ),
@@ -102,11 +80,6 @@ def test_st_force_dim(eng, geog, expected_2d, expected_3d):
     eng = eng.create_or_skip()
     eng.assert_query_result(f"SELECT ST_Force2D({geog_or_null(geog)})", expected_2d)
     eng.assert_query_result(f"SELECT ST_Force3D({geog_or_null(geog)}, 5)", expected_3d)
-
-
-# =============================================================================
-# ST_Force3DM
-# =============================================================================
 
 
 @pytest.mark.parametrize("eng", [SedonaDB])
@@ -147,11 +120,6 @@ def test_st_force3dm(eng, geog, m, expected_without_m, expected_with_m):
     eng.assert_query_result(
         f"SELECT ST_Force3DM({geog_or_null(geog)}, {val_or_null(m)})", expected_with_m
     )
-
-
-# =============================================================================
-# ST_Force4D
-# =============================================================================
 
 
 @pytest.mark.parametrize("eng", [SedonaDB])
@@ -212,11 +180,6 @@ def test_st_force4d(eng, geog, z, m, expected_without_defaults, expected_with_de
     )
 
 
-# =============================================================================
-# ST_GeometryN
-# =============================================================================
-
-
 @pytest.mark.parametrize("eng", [SedonaDB])
 @pytest.mark.parametrize(
     ("geog", "index", "expected"),
@@ -266,11 +229,6 @@ def test_st_geometryn(eng, geog, index, expected):
     eng.assert_query_result(
         f"SELECT ST_GeometryN({geog_or_null(geog)}, {val_or_null(index)})", expected
     )
-
-
-# =============================================================================
-# ST_InteriorRingN
-# =============================================================================
 
 
 @pytest.mark.parametrize("eng", [SedonaDB])
@@ -323,11 +281,6 @@ def test_st_interiorringn(eng, geog, index, expected):
     )
 
 
-# =============================================================================
-# ST_Reverse
-# =============================================================================
-
-
 @pytest.mark.parametrize("eng", [SedonaDB])
 @pytest.mark.parametrize(
     ("geog", "expected"),
@@ -346,9 +299,7 @@ def test_st_interiorringn(eng, geog, index, expected):
             "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))",
             id="polygon",
         ),
-        pytest.param(
-            "MULTIPOINT (1 2, 3 4)", "MULTIPOINT (1 2, 3 4)", id="multipoint"
-        ),
+        pytest.param("MULTIPOINT (1 2, 3 4)", "MULTIPOINT (1 2, 3 4)", id="multipoint"),
         pytest.param(
             "LINESTRING Z (0 0 1, 1 1 2, 2 2 3)",
             "LINESTRING Z (2 2 3, 1 1 2, 0 0 1)",
@@ -369,11 +320,6 @@ def test_st_interiorringn(eng, geog, index, expected):
 def test_st_reverse(eng, geog, expected):
     eng = eng.create_or_skip()
     eng.assert_query_result(f"SELECT ST_Reverse({geog_or_null(geog)})", expected)
-
-
-# =============================================================================
-# ST_PointN
-# =============================================================================
 
 
 @pytest.mark.parametrize("eng", [SedonaDB])
@@ -423,20 +369,13 @@ def test_st_pointn(eng, geog, n, expected):
     )
 
 
-# =============================================================================
-# ST_Boundary
-# =============================================================================
-
-
 @pytest.mark.parametrize("eng", [SedonaDB])
 @pytest.mark.parametrize(
     ("geog", "expected"),
     [
         pytest.param(None, None, id="null"),
         pytest.param("POINT (1 2)", "GEOMETRYCOLLECTION EMPTY", id="point"),
-        pytest.param(
-            "LINESTRING (0 0, 1 1)", "MULTIPOINT (0 0, 1 1)", id="linestring"
-        ),
+        pytest.param("LINESTRING (0 0, 1 1)", "MULTIPOINT (0 0, 1 1)", id="linestring"),
         pytest.param(
             "LINESTRING (0 0, 1 1, 0 0)", "MULTIPOINT EMPTY", id="linestring_closed"
         ),
@@ -458,11 +397,6 @@ def test_st_pointn(eng, geog, n, expected):
 def test_st_boundary(eng, geog, expected):
     eng = eng.create_or_skip()
     eng.assert_query_result(f"SELECT ST_Boundary({geog_or_null(geog)})", expected)
-
-
-# =============================================================================
-# ST_LineMerge
-# =============================================================================
 
 
 @pytest.mark.parametrize("eng", [SedonaDB])
@@ -524,11 +458,6 @@ def test_st_linemerge_directed(eng, geog, expected):
     )
 
 
-# =============================================================================
-# ST_Normalize
-# =============================================================================
-
-
 @pytest.mark.parametrize("eng", [SedonaDB])
 @pytest.mark.parametrize(
     ("geog", "expected"),
@@ -570,3 +499,147 @@ def test_st_normalize(eng, geog, expected):
     eng.assert_query_result(
         f"SELECT ST_AsText(ST_Normalize({geog_or_null(geog)}))", expected
     )
+
+
+@pytest.mark.parametrize("eng", [SedonaDB])
+@pytest.mark.parametrize(
+    ("geog", "expected"),
+    [
+        pytest.param(None, None, id="null"),
+        pytest.param("POINT EMPTY", 0, id="point_empty"),
+        pytest.param("LINESTRING EMPTY", 0, id="linestring_empty"),
+        pytest.param("POLYGON EMPTY", 0, id="polygon_empty"),
+        pytest.param("MULTIPOLYGON EMPTY", 0, id="multipolygon_empty"),
+        pytest.param("GEOMETRYCOLLECTION EMPTY", 0, id="geometrycollection_empty"),
+        pytest.param("POINT (1 2)", 0, id="point"),
+        pytest.param("LINESTRING (0 0, 1 1, 2 2)", 0, id="linestring"),
+        pytest.param("MULTIPOINT ((0 0), (1 1))", 0, id="multipoint"),
+        pytest.param(
+            "MULTILINESTRING ((0 0, 1 1), (2 2, 3 3))", 0, id="multilinestring"
+        ),
+        pytest.param("POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))", 1, id="polygon"),
+        pytest.param(
+            "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))",
+            2,
+            id="polygon_with_hole",
+        ),
+        pytest.param(
+            "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1), (5 5, 5 6, 6 6, 6 5, 5 5))",
+            3,
+            id="polygon_two_holes",
+        ),
+        pytest.param(
+            "MULTIPOLYGON (((0 0, 1 0, 1 1, 0 1, 0 0)), ((10 10, 20 10, 20 20, 10 20, 10 10), (12 12, 12 14, 14 14, 14 12, 12 12)))",
+            3,
+            id="multipolygon",
+        ),
+        pytest.param(
+            "POLYGON Z ((0 0 1, 1 0 1, 1 1 1, 0 1 1, 0 0 1))", 1, id="polygon_z"
+        ),
+        pytest.param(
+            "GEOMETRYCOLLECTION(POINT(1 1), POLYGON((0 0, 1 0, 1 1, 0 0)))",
+            1,
+            id="geometrycollection",
+        ),
+    ],
+)
+def test_st_nrings(eng, geog, expected):
+    eng = eng.create_or_skip()
+    eng.assert_query_result(f"SELECT ST_NRings({geog_or_null(geog)})", expected)
+
+
+@pytest.mark.parametrize("eng", [SedonaDB])
+@pytest.mark.parametrize(
+    ("geog", "expected"),
+    [
+        pytest.param(None, None, id="null"),
+        pytest.param("POINT EMPTY", None, id="point_empty"),
+        pytest.param("LINESTRING EMPTY", None, id="linestring_empty"),
+        pytest.param("POLYGON EMPTY", 0, id="polygon_empty"),
+        pytest.param("POINT (1 2)", None, id="point"),
+        pytest.param("LINESTRING (0 0, 1 1, 2 2)", None, id="linestring"),
+        pytest.param("MULTIPOINT ((0 0), (1 1))", None, id="multipoint"),
+        pytest.param(
+            "MULTILINESTRING ((0 0, 0 1, 1 1, 0 0),(0 0, 1 1))",
+            None,
+            id="multilinestring",
+        ),
+        pytest.param("POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0))", 0, id="polygon_no_holes"),
+        pytest.param(
+            "POLYGON ((0 0,6 0,6 6,0 6,0 0),(2 2,4 2,4 4,2 4,2 2))",
+            1,
+            id="polygon_one_hole",
+        ),
+        pytest.param(
+            "POLYGON ((0 0,10 0,10 6,0 6,0 0), (1 1,2 1,2 5,1 5,1 1),(8 5,8 4,9 4,9 5,8 5))",
+            2,
+            id="polygon_two_holes",
+        ),
+        pytest.param(
+            "MULTIPOLYGON (((0 0, 5 0, 5 5, 0 5, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1)),((10 10, 14 10, 14 14, 10 14, 10 10)))",
+            None,
+            id="multipolygon",
+        ),
+        pytest.param(
+            "GEOMETRYCOLLECTION (POINT (1 2),POLYGON ((0 0, 3 0, 3 3, 0 3, 0 0)))",
+            None,
+            id="geometrycollection",
+        ),
+        pytest.param(
+            "POLYGON Z ((0 0 1, 4 0 1, 4 4 1, 0 4 1, 0 0 1), (1 1 1, 2 1 1, 2 2 1, 1 2 1, 1 1 1))",
+            1,
+            id="polygon_z_one_hole",
+        ),
+        pytest.param(
+            "POLYGON M ((0 0 1, 4 0 1, 4 4 1, 0 4 1, 0 0 1), (1 1 1, 2 1 1, 2 2 1, 1 2 1, 1 1 1))",
+            1,
+            id="polygon_m_one_hole",
+        ),
+        pytest.param(
+            "POLYGON ZM ((0 0 1 2, 4 0 1 2, 4 4 1 2, 0 4 1 2, 0 0 1 2), (1 1 1 2, 2 1 1 2, 2 2 1 2, 1 2 1 2, 1 1 1 2))",
+            1,
+            id="polygon_zm_one_hole",
+        ),
+    ],
+)
+def test_st_numinteriorrings(eng, geog, expected):
+    eng = eng.create_or_skip()
+    eng.assert_query_result(
+        f"SELECT ST_NumInteriorRings({geog_or_null(geog)})", expected
+    )
+
+
+@pytest.mark.parametrize("eng", [SedonaDB])
+@pytest.mark.parametrize(
+    ("geog", "expected"),
+    [
+        pytest.param(None, None, id="null"),
+        pytest.param("POINT EMPTY", None, id="point_empty"),
+        pytest.param("LINESTRING EMPTY", 0, id="linestring_empty"),
+        pytest.param("POLYGON EMPTY", None, id="polygon_empty"),
+        pytest.param("MULTIPOINT EMPTY", None, id="multipoint_empty"),
+        pytest.param("MULTILINESTRING EMPTY", None, id="multilinestring_empty"),
+        pytest.param("MULTIPOLYGON EMPTY", None, id="multipolygon_empty"),
+        pytest.param("GEOMETRYCOLLECTION EMPTY", None, id="geometrycollection_empty"),
+        pytest.param("POINT (1 2)", None, id="point"),
+        pytest.param("LINESTRING (0 0, 1 1, 2 2)", 3, id="linestring"),
+        pytest.param("LINESTRING (0 0, 1 1, 0 0)", 3, id="linestring_closed"),
+        pytest.param("LINESTRING Z (0 0 0, 1 1 1, 2 2 2, 3 3 3)", 4, id="linestring_z"),
+        pytest.param("LINESTRING M (0 0 0, 1 1 1, 2 2 2, 3 3 3)", 4, id="linestring_m"),
+        pytest.param("LINESTRING ZM (0 0 0 2, 1 1 1 4)", 2, id="linestring_zm"),
+        pytest.param("POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0))", None, id="polygon"),
+        pytest.param(
+            "MULTILINESTRING ((0 0, 0 1, 1 1, 0 0),(0 0, 1 1))",
+            None,
+            id="multilinestring",
+        ),
+        pytest.param(
+            "GEOMETRYCOLLECTION (LINESTRING (0 0, 0 1, 1 1, 0 0))",
+            None,
+            id="geometrycollection",
+        ),
+    ],
+)
+def test_st_numpoints(eng, geog, expected):
+    eng = eng.create_or_skip()
+    eng.assert_query_result(f"SELECT ST_NumPoints({geog_or_null(geog)})", expected)

--- a/rust/sedona-functions/src/st_flipcoordinates.rs
+++ b/rust/sedona-functions/src/st_flipcoordinates.rs
@@ -43,26 +43,26 @@ use wkb::reader::Wkb;
 pub fn st_flipcoordinates_udf() -> SedonaScalarUDF {
     SedonaScalarUDF::new(
         "st_flipcoordinates",
-        ItemCrsKernel::wrap_impl(vec![Arc::new(STFlipCoordinates {})]),
+        ItemCrsKernel::wrap_impl(vec![
+            Arc::new(STFlipCoordinates {
+                matcher: ArgMatcher::new(vec![ArgMatcher::is_geometry()], WKB_GEOMETRY),
+            }),
+            Arc::new(STFlipCoordinates {
+                matcher: ArgMatcher::new(vec![ArgMatcher::is_geography()], WKB_GEOGRAPHY),
+            }),
+        ]),
         Volatility::Immutable,
     )
 }
 
 #[derive(Debug)]
-struct STFlipCoordinates {}
+struct STFlipCoordinates {
+    matcher: ArgMatcher,
+}
 
 impl SedonaScalarKernel for STFlipCoordinates {
     fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
-        let geom_matcher = ArgMatcher::new(vec![ArgMatcher::is_geometry()], WKB_GEOMETRY);
-        let geog_matcher = ArgMatcher::new(vec![ArgMatcher::is_geography()], WKB_GEOGRAPHY);
-        let matched_geom = geom_matcher.match_args(args)?;
-        let matched_geog = geog_matcher.match_args(args)?;
-
-        match (matched_geom, matched_geog) {
-            (Some(geom_result), _) => Ok(Some(geom_result)),
-            (_, Some(geog_result)) => Ok(Some(geog_result)),
-            _ => Ok(None),
-        }
+        self.matcher.match_args(args)
     }
 
     fn invoke_batch(
@@ -120,9 +120,7 @@ mod tests {
     use super::*;
     use datafusion_expr::ScalarUDF;
     use rstest::rstest;
-    use sedona_schema::crs::lnglat;
-    use sedona_schema::datatypes::SedonaType::Wkb;
-    use sedona_schema::datatypes::{Edges, WKB_GEOMETRY_ITEM_CRS, WKB_VIEW_GEOMETRY};
+    use sedona_schema::datatypes::{WKB_GEOGRAPHY_ITEM_CRS, WKB_GEOMETRY_ITEM_CRS};
     use sedona_testing::{
         compare::assert_array_equal, create::create_array, testers::ScalarUdfTester,
     };
@@ -133,30 +131,12 @@ mod tests {
         assert_eq!(udf.name(), "st_flipcoordinates");
     }
 
-    #[test]
-    fn udf_return_type() {
-        let tester = ScalarUdfTester::new(st_flipcoordinates_udf().into(), vec![WKB_GEOGRAPHY]);
-        tester.assert_return_type(WKB_GEOGRAPHY);
-
-        let tester = ScalarUdfTester::new(st_flipcoordinates_udf().into(), vec![WKB_GEOMETRY]);
-        tester.assert_return_type(WKB_GEOMETRY);
-
-        let tester = ScalarUdfTester::new(st_flipcoordinates_udf().into(), vec![WKB_VIEW_GEOMETRY]);
-        tester.assert_return_type(WKB_GEOMETRY);
-
-        let tester = ScalarUdfTester::new(
-            st_flipcoordinates_udf().into(),
-            vec![Wkb(Edges::Planar, lnglat())],
-        );
-        tester.assert_return_type(Wkb(Edges::Planar, lnglat()));
-    }
-
     #[rstest]
-    fn udf_invoke(
-        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType,
-    ) {
+    fn udf(#[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType) {
         let tester =
             ScalarUdfTester::new(st_flipcoordinates_udf().into(), vec![sedona_type.clone()]);
+
+        tester.assert_return_type(sedona_type.clone());
 
         let result = tester.invoke_scalar("POINT (1 3)").unwrap();
         tester.assert_scalar_result_equals(result, "POINT (3 1)");
@@ -204,7 +184,10 @@ mod tests {
     }
 
     #[rstest]
-    fn udf_invoke_item_crs(#[values(WKB_GEOMETRY_ITEM_CRS.clone())] sedona_type: SedonaType) {
+    fn udf_invoke_item_crs(
+        #[values(WKB_GEOMETRY_ITEM_CRS.clone(), WKB_GEOGRAPHY_ITEM_CRS.clone())]
+        sedona_type: SedonaType,
+    ) {
         let tester =
             ScalarUdfTester::new(st_flipcoordinates_udf().into(), vec![sedona_type.clone()]);
         tester.assert_return_type(sedona_type);

--- a/rust/sedona-functions/src/st_flipcoordinates.rs
+++ b/rust/sedona-functions/src/st_flipcoordinates.rs
@@ -178,7 +178,7 @@ mod tests {
                 Some("MULTIPOLYGON EMPTY"),
                 Some("GEOMETRYCOLLECTION EMPTY"),
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
         assert_array_equal(&tester.invoke_wkb_array(input_wkt).unwrap(), &expected);
     }

--- a/rust/sedona-functions/src/st_force_dim.rs
+++ b/rust/sedona-functions/src/st_force_dim.rs
@@ -428,7 +428,6 @@ mod tests {
     use arrow_array::create_array;
     use datafusion_expr::ScalarUDF;
     use rstest::rstest;
-    use sedona_schema::datatypes::WKB_VIEW_GEOMETRY;
     use sedona_testing::{
         compare::assert_array_equal, create::create_array, testers::ScalarUdfTester,
     };
@@ -451,9 +450,9 @@ mod tests {
     }
 
     #[rstest]
-    fn udf_2d(#[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType) {
+    fn udf_2d(#[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType) {
         let tester = ScalarUdfTester::new(st_force2d_udf().into(), vec![sedona_type.clone()]);
-        tester.assert_return_type(WKB_GEOMETRY);
+        tester.assert_return_type(sedona_type.clone());
 
         let points = create_array(
             &[
@@ -484,9 +483,9 @@ mod tests {
     }
 
     #[rstest]
-    fn udf_3d_without_z(#[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType) {
+    fn udf_3d_without_z(#[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType) {
         let tester = ScalarUdfTester::new(st_force3d_udf().into(), vec![sedona_type.clone()]);
-        tester.assert_return_type(WKB_GEOMETRY);
+        tester.assert_return_type(sedona_type.clone());
 
         let points = create_array(
             &[
@@ -519,12 +518,12 @@ mod tests {
     }
 
     #[rstest]
-    fn udf_3d_with_z(#[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType) {
+    fn udf_3d_with_z(#[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType) {
         let tester = ScalarUdfTester::new(
             st_force3d_udf().into(),
             vec![sedona_type.clone(), SedonaType::Arrow(DataType::Float64)],
         );
-        tester.assert_return_type(WKB_GEOMETRY);
+        tester.assert_return_type(sedona_type.clone());
 
         let points = create_array(
             &[
@@ -569,9 +568,9 @@ mod tests {
     }
 
     #[rstest]
-    fn udf_3dm_without_m(#[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType) {
+    fn udf_3dm_without_m(#[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType) {
         let tester = ScalarUdfTester::new(st_force3dm_udf().into(), vec![sedona_type.clone()]);
-        tester.assert_return_type(WKB_GEOMETRY);
+        tester.assert_return_type(sedona_type.clone());
 
         let points = create_array(
             &[
@@ -604,12 +603,12 @@ mod tests {
     }
 
     #[rstest]
-    fn udf_3dm_with_m(#[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType) {
+    fn udf_3dm_with_m(#[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType) {
         let tester = ScalarUdfTester::new(
             st_force3dm_udf().into(),
             vec![sedona_type.clone(), SedonaType::Arrow(DataType::Float64)],
         );
-        tester.assert_return_type(WKB_GEOMETRY);
+        tester.assert_return_type(sedona_type.clone());
 
         let points = create_array(
             &[
@@ -654,9 +653,9 @@ mod tests {
     }
 
     #[rstest]
-    fn udf_4d_without_defaults(#[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType) {
+    fn udf_4d_without_defaults(#[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType) {
         let tester = ScalarUdfTester::new(st_force4d_udf().into(), vec![sedona_type.clone()]);
-        tester.assert_return_type(WKB_GEOMETRY);
+        tester.assert_return_type(sedona_type.clone());
 
         let points = create_array(
             &[
@@ -691,7 +690,7 @@ mod tests {
     }
 
     #[rstest]
-    fn udf_4d_with_defaults(#[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType) {
+    fn udf_4d_with_defaults(#[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType) {
         let tester = ScalarUdfTester::new(
             st_force4d_udf().into(),
             vec![
@@ -700,7 +699,7 @@ mod tests {
                 SedonaType::Arrow(DataType::Float64),
             ],
         );
-        tester.assert_return_type(WKB_GEOMETRY);
+        tester.assert_return_type(sedona_type.clone());
 
         let points = create_array(
             &[

--- a/rust/sedona-functions/src/st_force_dim.rs
+++ b/rust/sedona-functions/src/st_force_dim.rs
@@ -475,7 +475,7 @@ mod tests {
                 Some("POINT (3 4)"),
                 Some("POINT (8 9)"),
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
 
         let result = tester.invoke_arrays(vec![points]).unwrap();
@@ -510,7 +510,7 @@ mod tests {
                 Some("POINT Z (6 7 0)"),
                 Some("POINT Z (9 10 11)"),
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
 
         let result = tester.invoke_arrays(vec![points]).unwrap();
@@ -560,7 +560,7 @@ mod tests {
                 Some("POINT Z (6 7 9)"),
                 Some("POINT Z (9 10 11)"),
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
 
         let result = tester.invoke_arrays(vec![points, z]).unwrap();
@@ -595,7 +595,7 @@ mod tests {
                 Some("POINT M (6 7 8)"),
                 Some("POINT M (9 10 12)"),
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
 
         let result = tester.invoke_arrays(vec![points]).unwrap();
@@ -645,7 +645,7 @@ mod tests {
                 Some("POINT M (6 7 8)"),
                 Some("POINT M (9 10 12)"),
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
 
         let result = tester.invoke_arrays(vec![points, m]).unwrap();
@@ -682,7 +682,7 @@ mod tests {
                 Some("POINT ZM (6 7 0 8)"),
                 Some("POINT ZM (9 10 11 12)"),
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
 
         let result = tester.invoke_arrays(vec![points]).unwrap();
@@ -748,7 +748,7 @@ mod tests {
                 Some("POINT ZM (6 7 8 8)"),
                 Some("POINT ZM (9 10 11 12)"),
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
 
         let result = tester.invoke_arrays(vec![points, z, m]).unwrap();

--- a/rust/sedona-functions/src/st_geometryn.rs
+++ b/rust/sedona-functions/src/st_geometryn.rs
@@ -29,7 +29,7 @@ use sedona_expr::item_crs::ItemCrsKernel;
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_geometry::wkb_factory::WKB_MIN_PROBABLE_BYTES;
 use sedona_schema::{
-    datatypes::{SedonaType, WKB_GEOMETRY},
+    datatypes::{SedonaType, WKB_GEOGRAPHY, WKB_GEOMETRY},
     matchers::ArgMatcher,
 };
 use wkb::reader::Wkb;
@@ -40,22 +40,32 @@ use wkb::reader::Wkb;
 pub fn st_geometryn_udf() -> SedonaScalarUDF {
     SedonaScalarUDF::new(
         "st_geometryn",
-        ItemCrsKernel::wrap_impl(vec![Arc::new(STGeometryN)]),
+        ItemCrsKernel::wrap_impl(vec![
+            Arc::new(STGeometryN {
+                matcher: ArgMatcher::new(
+                    vec![ArgMatcher::is_geometry(), ArgMatcher::is_integer()],
+                    WKB_GEOMETRY,
+                ),
+            }),
+            Arc::new(STGeometryN {
+                matcher: ArgMatcher::new(
+                    vec![ArgMatcher::is_geography(), ArgMatcher::is_integer()],
+                    WKB_GEOGRAPHY,
+                ),
+            }),
+        ]),
         Volatility::Immutable,
     )
 }
 
 #[derive(Debug)]
-struct STGeometryN;
+struct STGeometryN {
+    matcher: ArgMatcher,
+}
 
 impl SedonaScalarKernel for STGeometryN {
     fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
-        let matcher = ArgMatcher::new(
-            vec![ArgMatcher::is_geometry(), ArgMatcher::is_integer()],
-            WKB_GEOMETRY,
-        );
-
-        matcher.match_args(args)
+        self.matcher.match_args(args)
     }
 
     fn invoke_batch(
@@ -123,14 +133,14 @@ fn invoke_scalar(geom: &Wkb, index: usize, writer: &mut impl std::io::Write) -> 
 mod tests {
     use datafusion_common::ScalarValue;
     use rstest::rstest;
-    use sedona_schema::datatypes::{WKB_GEOMETRY_ITEM_CRS, WKB_VIEW_GEOMETRY};
+    use sedona_schema::datatypes::{WKB_GEOGRAPHY_ITEM_CRS, WKB_GEOMETRY_ITEM_CRS};
     use sedona_testing::testers::ScalarUdfTester;
     use sedona_testing::{compare::assert_array_equal, create::create_array};
 
     use super::*;
 
     #[rstest]
-    fn udf(#[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType) {
+    fn udf(#[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType) {
         let tester = ScalarUdfTester::new(
             st_geometryn_udf().into(),
             vec![
@@ -138,7 +148,7 @@ mod tests {
                 SedonaType::Arrow(arrow_schema::DataType::Int64),
             ],
         );
-        tester.assert_return_type(WKB_GEOMETRY);
+        tester.assert_return_type(sedona_type.clone());
 
         let input_wkt = create_array(
             &[
@@ -264,7 +274,10 @@ mod tests {
     }
 
     #[rstest]
-    fn udf_invoke_item_crs(#[values(WKB_GEOMETRY_ITEM_CRS.clone())] sedona_type: SedonaType) {
+    fn udf_invoke_item_crs(
+        #[values(WKB_GEOMETRY_ITEM_CRS.clone(), WKB_GEOGRAPHY_ITEM_CRS.clone())]
+        sedona_type: SedonaType,
+    ) {
         let tester = ScalarUdfTester::new(
             st_geometryn_udf().into(),
             vec![

--- a/rust/sedona-functions/src/st_geometryn.rs
+++ b/rust/sedona-functions/src/st_geometryn.rs
@@ -186,7 +186,7 @@ mod tests {
                 Some("GEOMETRYCOLLECTION(POINT(1 1), GEOMETRYCOLLECTION(LINESTRING(2 2, 3 3)))"), //  n=2 (Nested: GC)
                 Some("GEOMETRYCOLLECTION(POINT(1 1))"), //  n=0 (OOB)
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
 
         let integers = arrow_array::create_array!(
@@ -264,7 +264,7 @@ mod tests {
                 Some("GEOMETRYCOLLECTION(LINESTRING(2 2, 3 3))"), // The WKB of the GC component itself
                 None,
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
 
         assert_array_equal(

--- a/rust/sedona-functions/src/st_interiorringn.rs
+++ b/rust/sedona-functions/src/st_interiorringn.rs
@@ -27,7 +27,10 @@ use sedona_geometry::wkb_factory::{
     write_wkb_coord_trait, write_wkb_linestring_header, WKB_MIN_PROBABLE_BYTES,
 };
 use sedona_schema::datatypes::SedonaType;
-use sedona_schema::{datatypes::WKB_GEOMETRY, matchers::ArgMatcher};
+use sedona_schema::{
+    datatypes::{WKB_GEOGRAPHY, WKB_GEOMETRY},
+    matchers::ArgMatcher,
+};
 use wkb::reader::Wkb;
 
 use crate::executor::WkbExecutor;
@@ -38,22 +41,32 @@ use crate::executor::WkbExecutor;
 pub fn st_interiorringn_udf() -> SedonaScalarUDF {
     SedonaScalarUDF::new(
         "st_interiorringn",
-        ItemCrsKernel::wrap_impl(vec![Arc::new(STInteriorRingN)]),
+        ItemCrsKernel::wrap_impl(vec![
+            Arc::new(STInteriorRingN {
+                matcher: ArgMatcher::new(
+                    vec![ArgMatcher::is_geometry(), ArgMatcher::is_integer()],
+                    WKB_GEOMETRY,
+                ),
+            }),
+            Arc::new(STInteriorRingN {
+                matcher: ArgMatcher::new(
+                    vec![ArgMatcher::is_geography(), ArgMatcher::is_integer()],
+                    WKB_GEOGRAPHY,
+                ),
+            }),
+        ]),
         datafusion_expr::Volatility::Immutable,
     )
 }
 
 #[derive(Debug)]
-struct STInteriorRingN;
+struct STInteriorRingN {
+    matcher: ArgMatcher,
+}
 
 impl SedonaScalarKernel for STInteriorRingN {
     fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
-        let matcher = ArgMatcher::new(
-            vec![ArgMatcher::is_geometry(), ArgMatcher::is_integer()],
-            WKB_GEOMETRY,
-        );
-
-        matcher.match_args(args)
+        self.matcher.match_args(args)
     }
 
     fn invoke_batch(
@@ -115,7 +128,7 @@ fn invoke_scalar(geom: &Wkb, index: usize, writer: &mut impl std::io::Write) -> 
 mod tests {
     use datafusion_common::ScalarValue;
     use rstest::rstest;
-    use sedona_schema::datatypes::{WKB_GEOMETRY_ITEM_CRS, WKB_VIEW_GEOMETRY};
+    use sedona_schema::datatypes::{WKB_GEOGRAPHY_ITEM_CRS, WKB_GEOMETRY_ITEM_CRS};
     use sedona_testing::{
         compare::assert_array_equal, create::create_array, testers::ScalarUdfTester,
     };
@@ -126,18 +139,18 @@ mod tests {
         let tester = ScalarUdfTester::new(
             st_interiorringn_udf().into(),
             vec![
-                sedona_type,
+                sedona_type.clone(),
                 SedonaType::Arrow(arrow_schema::DataType::Int64),
             ],
         );
-        tester.assert_return_type(WKB_GEOMETRY);
+        tester.assert_return_type(sedona_type);
         tester
     }
 
     // 1. Tests for Non-Polygon Geometries (Should return NULL)
     #[rstest]
     fn test_st_interiorringn_non_polygons(
-        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType,
+        #[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType,
     ) {
         let tester = setup_tester(sedona_type);
 
@@ -181,7 +194,7 @@ mod tests {
     // 2. Tests for Polygon Edge Cases (No holes, Invalid index)
     #[rstest]
     fn test_st_interiorringn_polygon_edge_cases(
-        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType,
+        #[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType,
     ) {
         let tester = setup_tester(sedona_type);
 
@@ -214,7 +227,7 @@ mod tests {
     // 3. Tests for Valid Polygons (Correct Extraction)
     #[rstest]
     fn test_st_interiorringn_valid_polygons(
-        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType,
+        #[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType,
     ) {
         let tester = setup_tester(sedona_type);
 
@@ -254,7 +267,7 @@ mod tests {
     // 4. Tests for Invalid/Malformed Polygons (Checking for error/extraction)
     #[rstest]
     fn test_st_interiorringn_invalid_polygons(
-        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType,
+        #[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType,
     ) {
         let tester = setup_tester(sedona_type);
 
@@ -284,7 +297,7 @@ mod tests {
 
     #[rstest]
     fn test_st_interiorringn_z_dimensions(
-        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType,
+        #[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType,
     ) {
         let tester = setup_tester(sedona_type);
 
@@ -317,7 +330,7 @@ mod tests {
 
     #[rstest]
     fn test_st_interiorringn_m_dimensions(
-        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType,
+        #[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType,
     ) {
         let tester = setup_tester(sedona_type);
 
@@ -350,7 +363,7 @@ mod tests {
 
     #[rstest]
     fn test_st_interiorringn_zm_dimensions(
-        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType,
+        #[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType,
     ) {
         let tester = setup_tester(sedona_type);
 
@@ -382,7 +395,10 @@ mod tests {
     }
 
     #[rstest]
-    fn udf_invoke_item_crs(#[values(WKB_GEOMETRY_ITEM_CRS.clone())] sedona_type: SedonaType) {
+    fn udf_invoke_item_crs(
+        #[values(WKB_GEOMETRY_ITEM_CRS.clone(), WKB_GEOGRAPHY_ITEM_CRS.clone())]
+        sedona_type: SedonaType,
+    ) {
         let tester = ScalarUdfTester::new(
             st_interiorringn_udf().into(),
             vec![

--- a/rust/sedona-functions/src/st_interiorringn.rs
+++ b/rust/sedona-functions/src/st_interiorringn.rs
@@ -152,7 +152,7 @@ mod tests {
     fn test_st_interiorringn_non_polygons(
         #[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType,
     ) {
-        let tester = setup_tester(sedona_type);
+        let tester = setup_tester(sedona_type.clone());
 
         let input_wkt = create_array(
             &[
@@ -165,7 +165,7 @@ mod tests {
                 Some("MULTIPOLYGON (((1 1, 1 3, 3 3, 3 1, 1 1)))"), // MULTIPOLYGON
                 Some("GEOMETRYCOLLECTION (POINT(1 1))"),            // GEOMETRYCOLLECTION
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
         let integers = arrow_array::create_array!(
             Int64,
@@ -182,7 +182,7 @@ mod tests {
         );
         let expected = create_array(
             &[None, None, None, None, None, None, None, None],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
 
         assert_array_equal(
@@ -196,7 +196,7 @@ mod tests {
     fn test_st_interiorringn_polygon_edge_cases(
         #[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType,
     ) {
-        let tester = setup_tester(sedona_type);
+        let tester = setup_tester(sedona_type.clone());
 
         let input_wkt = create_array(
             &[
@@ -205,7 +205,7 @@ mod tests {
                 Some("POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))"), // Invalid index n=0
                 Some("POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))"), // Index n too high (n=2)
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
         let integers = arrow_array::create_array!(Int64, [Some(1), Some(1), Some(0), Some(2)]);
         let expected = create_array(
@@ -215,7 +215,7 @@ mod tests {
                 None, // Invalid index n=0 (Assuming NULL/None on invalid index)
                 None, // Index n too high
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
 
         assert_array_equal(
@@ -229,7 +229,7 @@ mod tests {
     fn test_st_interiorringn_valid_polygons(
         #[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType,
     ) {
-        let tester = setup_tester(sedona_type);
+        let tester = setup_tester(sedona_type.clone());
 
         let input_wkt = create_array(
             &[
@@ -240,7 +240,7 @@ mod tests {
                 Some("POLYGON ((0 0, 6 0, 6 6, 0 6, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1), (4 4, 4 5, 5 5, 5 4, 4 4))"),       // Two holes, n=2
                 Some("POLYGON ((0 0, 6 0, 6 6, 0 6, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1), (4 4, 4 5, 5 5, 5 4, 4 4))"),       // Two holes, n=3 (too high)
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
         let integers = arrow_array::create_array!(
             Int64,
@@ -255,7 +255,7 @@ mod tests {
                 Some("LINESTRING (4 4, 4 5, 5 5, 5 4, 4 4)"),
                 None,
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
 
         assert_array_equal(
@@ -269,7 +269,7 @@ mod tests {
     fn test_st_interiorringn_invalid_polygons(
         #[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType,
     ) {
-        let tester = setup_tester(sedona_type);
+        let tester = setup_tester(sedona_type.clone());
 
         let input_wkt = create_array(
             &[
@@ -277,7 +277,7 @@ mod tests {
                 Some("POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0), (5 5, 5 6, 6 6, 6 5, 5 5))"),                       // External hole
                 Some("POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 1 3, 3 3, 3 1, 1 1), (2 2, 2 2.5, 2.5 2.5, 2.5 2, 2 2))"), // Intersecting holes
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
         let integers = arrow_array::create_array!(Int64, [Some(1), Some(1), Some(2)]);
         let expected = create_array(
@@ -286,7 +286,7 @@ mod tests {
                 Some("LINESTRING (5 5, 5 6, 6 6, 6 5, 5 5)"), // Extraction works even if topologically invalid (external)
                 Some("LINESTRING (2 2, 2 2.5, 2.5 2.5, 2.5 2, 2 2)"), // Extraction works even if topologically invalid (intersecting)
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
 
         assert_array_equal(
@@ -299,7 +299,7 @@ mod tests {
     fn test_st_interiorringn_z_dimensions(
         #[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType,
     ) {
-        let tester = setup_tester(sedona_type);
+        let tester = setup_tester(sedona_type.clone());
 
         let input_wkt = create_array(
             &[
@@ -310,7 +310,7 @@ mod tests {
                 // Polygon Z with no hole (Should be NULL)
                 Some("POLYGON Z ((0 0 10, 4 0 10, 4 4 10, 0 4 10, 0 0 10))"),
             ],
-            &WKB_GEOMETRY
+            &sedona_type
         );
         let integers = arrow_array::create_array!(Int64, [Some(1), Some(1), Some(1)]);
         let expected = create_array(
@@ -319,7 +319,7 @@ mod tests {
                 None,
                 None,
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
 
         assert_array_equal(
@@ -332,7 +332,7 @@ mod tests {
     fn test_st_interiorringn_m_dimensions(
         #[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType,
     ) {
-        let tester = setup_tester(sedona_type);
+        let tester = setup_tester(sedona_type.clone());
 
         let input_wkt = create_array(
             &[
@@ -343,7 +343,7 @@ mod tests {
                 // Polygon M with no hole (Should be NULL)
                 Some("POLYGON M ((0 0 1, 4 0 2, 4 4 3, 0 4 4, 0 0 5))"),
             ],
-            &WKB_GEOMETRY
+            &sedona_type
         );
         let integers = arrow_array::create_array!(Int64, [Some(1), Some(1), Some(1)]);
         let expected = create_array(
@@ -352,7 +352,7 @@ mod tests {
                 None,
                 None,
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
 
         assert_array_equal(
@@ -365,7 +365,7 @@ mod tests {
     fn test_st_interiorringn_zm_dimensions(
         #[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType,
     ) {
-        let tester = setup_tester(sedona_type);
+        let tester = setup_tester(sedona_type.clone());
 
         let input_wkt = create_array(
             &[
@@ -376,7 +376,7 @@ mod tests {
                 // POLYGON ZM EMPTY (Should be NULL)
                 Some("POLYGON ZM EMPTY"),
             ],
-            &WKB_GEOMETRY
+            &sedona_type
         );
         let integers = arrow_array::create_array!(Int64, [Some(1), Some(2), Some(1)]);
         let expected = create_array(
@@ -385,7 +385,7 @@ mod tests {
                 None,
                 None,
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
 
         assert_array_equal(

--- a/rust/sedona-functions/src/st_pointn.rs
+++ b/rust/sedona-functions/src/st_pointn.rs
@@ -29,7 +29,7 @@ use sedona_geometry::{
     wkb_factory::{write_wkb_coord_trait, write_wkb_point_header, WKB_MIN_PROBABLE_BYTES},
 };
 use sedona_schema::{
-    datatypes::{SedonaType, WKB_GEOMETRY},
+    datatypes::{SedonaType, WKB_GEOGRAPHY, WKB_GEOMETRY},
     matchers::ArgMatcher,
 };
 use std::{io::Write, sync::Arc};
@@ -42,22 +42,32 @@ use crate::executor::WkbExecutor;
 pub fn st_pointn_udf() -> SedonaScalarUDF {
     SedonaScalarUDF::new(
         "st_pointn",
-        ItemCrsKernel::wrap_impl(vec![Arc::new(STPointN)]),
+        ItemCrsKernel::wrap_impl(vec![
+            Arc::new(STPointN {
+                matcher: ArgMatcher::new(
+                    vec![ArgMatcher::is_geometry(), ArgMatcher::is_integer()],
+                    WKB_GEOMETRY,
+                ),
+            }),
+            Arc::new(STPointN {
+                matcher: ArgMatcher::new(
+                    vec![ArgMatcher::is_geography(), ArgMatcher::is_integer()],
+                    WKB_GEOGRAPHY,
+                ),
+            }),
+        ]),
         Volatility::Immutable,
     )
 }
 
 #[derive(Debug)]
-struct STPointN;
+struct STPointN {
+    matcher: ArgMatcher,
+}
 
 impl SedonaScalarKernel for STPointN {
     fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
-        let matcher = ArgMatcher::new(
-            vec![ArgMatcher::is_geometry(), ArgMatcher::is_integer()],
-            WKB_GEOMETRY,
-        );
-
-        matcher.match_args(args)
+        self.matcher.match_args(args)
     }
 
     fn invoke_batch(
@@ -129,7 +139,7 @@ fn write_wkb_point_from_coord(
 mod tests {
     use datafusion_expr::ScalarUDF;
     use rstest::rstest;
-    use sedona_schema::datatypes::{WKB_GEOMETRY_ITEM_CRS, WKB_VIEW_GEOMETRY};
+    use sedona_schema::datatypes::{WKB_GEOGRAPHY_ITEM_CRS, WKB_GEOMETRY_ITEM_CRS};
     use sedona_testing::{
         compare::assert_array_equal, create::create_array, testers::ScalarUdfTester,
     };
@@ -144,11 +154,13 @@ mod tests {
     }
 
     #[rstest]
-    fn udf(#[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType) {
+    fn udf(#[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType) {
         let tester_pointn = ScalarUdfTester::new(
             st_pointn_udf().into(),
             vec![sedona_type.clone(), SedonaType::Arrow(DataType::Int64)],
         );
+
+        tester_pointn.assert_return_type(sedona_type.clone());
 
         // valid cases
         let input_linestrings = create_array(
@@ -267,7 +279,10 @@ mod tests {
     }
 
     #[rstest]
-    fn udf_invoke_item_crs(#[values(WKB_GEOMETRY_ITEM_CRS.clone())] sedona_type: SedonaType) {
+    fn udf_invoke_item_crs(
+        #[values(WKB_GEOMETRY_ITEM_CRS.clone(), WKB_GEOGRAPHY_ITEM_CRS.clone())]
+        sedona_type: SedonaType,
+    ) {
         let tester_pointn = ScalarUdfTester::new(
             st_pointn_udf().into(),
             vec![sedona_type.clone(), SedonaType::Arrow(DataType::Int64)],

--- a/rust/sedona-functions/src/st_pointn.rs
+++ b/rust/sedona-functions/src/st_pointn.rs
@@ -181,7 +181,7 @@ mod tests {
                 Some("POINT M (11 12 13)"),
                 Some("POINT ZM (11 12 13 14)"),
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
 
         let result1 = tester_pointn
@@ -197,7 +197,7 @@ mod tests {
                 Some("POINT M (21 22 23)"),
                 Some("POINT ZM (21 22 23 24)"),
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
 
         let result2 = tester_pointn
@@ -213,7 +213,7 @@ mod tests {
                 Some("POINT M (31 32 33)"),
                 Some("POINT ZM (31 32 33 34)"),
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
 
         let result2_tail = tester_pointn
@@ -222,7 +222,7 @@ mod tests {
         assert_array_equal(&result2_tail, &expected2_tail);
 
         // out of range or 0
-        let expected_null = create_array(&[None, None, None, None], &WKB_GEOMETRY);
+        let expected_null = create_array(&[None, None, None, None], &sedona_type);
 
         let result_zero = tester_pointn
             .invoke_array_scalar(input_linestrings.clone(), ScalarValue::Int64(Some(0)))
@@ -270,7 +270,7 @@ mod tests {
             &[
                 None, None, None, None, None, None, None, None, None, None, None, None, None, None,
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
         let result_others = tester_pointn
             .invoke_array_scalar(input_others.clone(), ScalarValue::Int64(Some(2)))

--- a/rust/sedona-functions/src/st_points.rs
+++ b/rust/sedona-functions/src/st_points.rs
@@ -35,7 +35,7 @@ use sedona_geometry::{
     },
 };
 use sedona_schema::{
-    datatypes::{SedonaType, WKB_GEOMETRY},
+    datatypes::{SedonaType, WKB_GEOGRAPHY, WKB_GEOMETRY},
     matchers::ArgMatcher,
 };
 use std::{io::Write, sync::Arc};
@@ -48,19 +48,26 @@ use crate::executor::WkbExecutor;
 pub fn st_points_udf() -> SedonaScalarUDF {
     SedonaScalarUDF::new(
         "st_points",
-        ItemCrsKernel::wrap_impl(vec![Arc::new(STPoints)]),
+        ItemCrsKernel::wrap_impl(vec![
+            Arc::new(STPoints {
+                matcher: ArgMatcher::new(vec![ArgMatcher::is_geometry()], WKB_GEOMETRY),
+            }),
+            Arc::new(STPoints {
+                matcher: ArgMatcher::new(vec![ArgMatcher::is_geography()], WKB_GEOGRAPHY),
+            }),
+        ]),
         Volatility::Immutable,
     )
 }
 
 #[derive(Debug)]
-struct STPoints;
+struct STPoints {
+    matcher: ArgMatcher,
+}
 
 impl SedonaScalarKernel for STPoints {
     fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
-        let matcher = ArgMatcher::new(vec![ArgMatcher::is_geometry()], WKB_GEOMETRY);
-
-        matcher.match_args(args)
+        self.matcher.match_args(args)
     }
 
     fn invoke_batch(
@@ -271,7 +278,9 @@ mod tests {
 
     use datafusion_expr::ScalarUDF;
     use rstest::rstest;
-    use sedona_schema::datatypes::{WKB_GEOMETRY_ITEM_CRS, WKB_VIEW_GEOMETRY};
+    use sedona_schema::datatypes::{
+        WKB_GEOGRAPHY, WKB_GEOGRAPHY_ITEM_CRS, WKB_GEOMETRY_ITEM_CRS, WKB_VIEW_GEOMETRY,
+    };
     use sedona_testing::{
         compare::assert_array_equal, create::create_array, testers::ScalarUdfTester,
     };
@@ -290,7 +299,7 @@ mod tests {
     }
 
     #[rstest]
-    fn udf(#[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType) {
+    fn udf(#[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType) {
         use arrow_array::UInt64Array;
 
         let tester_points = ScalarUdfTester::new(st_points_udf().into(), vec![sedona_type.clone()]);
@@ -351,7 +360,7 @@ mod tests {
                 // null
                 None,
             ],
-            &WKB_GEOMETRY,
+            &sedona_type.clone(),
         );
 
         let result_points = tester_points.invoke_array(input.clone()).unwrap();
@@ -387,7 +396,10 @@ mod tests {
     }
 
     #[rstest]
-    fn udf_invoke_item_crs(#[values(WKB_GEOMETRY_ITEM_CRS.clone())] sedona_type: SedonaType) {
+    fn udf_invoke_item_crs(
+        #[values(WKB_GEOMETRY_ITEM_CRS.clone(), WKB_GEOGRAPHY_ITEM_CRS.clone())]
+        sedona_type: SedonaType,
+    ) {
         let tester = ScalarUdfTester::new(st_points_udf().into(), vec![sedona_type.clone()]);
         tester.assert_return_type(sedona_type);
 

--- a/rust/sedona-functions/src/st_points.rs
+++ b/rust/sedona-functions/src/st_points.rs
@@ -278,7 +278,7 @@ mod tests {
 
     use datafusion_expr::ScalarUDF;
     use rstest::rstest;
-    use sedona_schema::datatypes::{WKB_GEOGRAPHY, WKB_GEOGRAPHY_ITEM_CRS, WKB_GEOMETRY_ITEM_CRS};
+    use sedona_schema::datatypes::{WKB_GEOGRAPHY_ITEM_CRS, WKB_GEOMETRY_ITEM_CRS};
     use sedona_testing::{
         compare::assert_array_equal, create::create_array, testers::ScalarUdfTester,
     };

--- a/rust/sedona-functions/src/st_points.rs
+++ b/rust/sedona-functions/src/st_points.rs
@@ -278,9 +278,7 @@ mod tests {
 
     use datafusion_expr::ScalarUDF;
     use rstest::rstest;
-    use sedona_schema::datatypes::{
-        WKB_GEOGRAPHY, WKB_GEOGRAPHY_ITEM_CRS, WKB_GEOMETRY_ITEM_CRS, WKB_VIEW_GEOMETRY,
-    };
+    use sedona_schema::datatypes::{WKB_GEOGRAPHY, WKB_GEOGRAPHY_ITEM_CRS, WKB_GEOMETRY_ITEM_CRS};
     use sedona_testing::{
         compare::assert_array_equal, create::create_array, testers::ScalarUdfTester,
     };

--- a/rust/sedona-functions/src/st_reverse.rs
+++ b/rust/sedona-functions/src/st_reverse.rs
@@ -430,7 +430,7 @@ mod tests {
                 Some("GEOMETRYCOLLECTION (POINT M (1 2 3), LINESTRING M (4 5 6, 1 2 3))"),
                 Some("GEOMETRYCOLLECTION (POINT ZM (1 2 3 4), LINESTRING ZM (5 6 7 8, 1 2 3 4))"),
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
 
         assert_array_equal(&tester.invoke_wkb_array(input_wkt).unwrap(), &expected);

--- a/rust/sedona-functions/src/st_reverse.rs
+++ b/rust/sedona-functions/src/st_reverse.rs
@@ -35,7 +35,7 @@ use sedona_geometry::wkb_factory::{
     write_wkb_polygon_ring_header, WKB_MIN_PROBABLE_BYTES,
 };
 use sedona_schema::{
-    datatypes::{SedonaType, WKB_GEOMETRY},
+    datatypes::{SedonaType, WKB_GEOGRAPHY, WKB_GEOMETRY},
     matchers::ArgMatcher,
 };
 
@@ -47,19 +47,26 @@ use crate::executor::WkbExecutor;
 pub fn st_reverse_udf() -> SedonaScalarUDF {
     SedonaScalarUDF::new(
         "st_reverse",
-        ItemCrsKernel::wrap_impl(vec![Arc::new(STReverse)]),
+        ItemCrsKernel::wrap_impl(vec![
+            Arc::new(STReverse {
+                matcher: ArgMatcher::new(vec![ArgMatcher::is_geometry()], WKB_GEOMETRY),
+            }),
+            Arc::new(STReverse {
+                matcher: ArgMatcher::new(vec![ArgMatcher::is_geography()], WKB_GEOGRAPHY),
+            }),
+        ]),
         Volatility::Immutable,
     )
 }
 
 #[derive(Debug)]
-struct STReverse;
+struct STReverse {
+    matcher: ArgMatcher,
+}
 
 impl SedonaScalarKernel for STReverse {
     fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
-        let matcher = ArgMatcher::new(vec![ArgMatcher::is_geometry()], WKB_GEOMETRY);
-
-        matcher.match_args(args)
+        self.matcher.match_args(args)
     }
 
     fn invoke_batch(
@@ -184,7 +191,7 @@ where
 mod tests {
     use datafusion_common::ScalarValue;
     use rstest::rstest;
-    use sedona_schema::datatypes::{WKB_GEOMETRY, WKB_GEOMETRY_ITEM_CRS, WKB_VIEW_GEOMETRY};
+    use sedona_schema::datatypes::{WKB_GEOGRAPHY_ITEM_CRS, WKB_GEOMETRY_ITEM_CRS};
     use sedona_testing::compare::assert_array_equal;
     use sedona_testing::create::create_array;
     use sedona_testing::testers::ScalarUdfTester;
@@ -192,9 +199,9 @@ mod tests {
     use super::*;
 
     #[rstest]
-    fn udf(#[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType) {
-        let tester = ScalarUdfTester::new(st_reverse_udf().into(), vec![sedona_type]);
-        tester.assert_return_type(WKB_GEOMETRY);
+    fn udf(#[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType) {
+        let tester = ScalarUdfTester::new(st_reverse_udf().into(), vec![sedona_type.clone()]);
+        tester.assert_return_type(sedona_type.clone());
 
         let result = tester.invoke_scalar("POINT EMPTY").unwrap();
         tester.assert_scalar_result_equals(result, "POINT EMPTY");
@@ -430,7 +437,10 @@ mod tests {
     }
 
     #[rstest]
-    fn udf_invoke_item_crs(#[values(WKB_GEOMETRY_ITEM_CRS.clone())] sedona_type: SedonaType) {
+    fn udf_invoke_item_crs(
+        #[values(WKB_GEOMETRY_ITEM_CRS.clone(), WKB_GEOGRAPHY_ITEM_CRS.clone())]
+        sedona_type: SedonaType,
+    ) {
         let tester = ScalarUdfTester::new(st_reverse_udf().into(), vec![sedona_type.clone()]);
         tester.assert_return_type(sedona_type);
 

--- a/rust/sedona-functions/src/st_start_point.rs
+++ b/rust/sedona-functions/src/st_start_point.rs
@@ -31,7 +31,7 @@ use sedona_geometry::{
     wkb_factory::{write_wkb_coord_trait, write_wkb_point_header, WKB_MIN_PROBABLE_BYTES},
 };
 use sedona_schema::{
-    datatypes::{SedonaType, WKB_GEOMETRY},
+    datatypes::{SedonaType, WKB_GEOGRAPHY, WKB_GEOMETRY},
     matchers::ArgMatcher,
 };
 use std::{io::Write, sync::Arc};
@@ -44,7 +44,16 @@ use crate::executor::WkbExecutor;
 pub fn st_start_point_udf() -> SedonaScalarUDF {
     SedonaScalarUDF::new(
         "st_startpoint",
-        ItemCrsKernel::wrap_impl(vec![Arc::new(STStartOrEndPoint::new(true))]),
+        ItemCrsKernel::wrap_impl(vec![
+            Arc::new(STStartOrEndPoint {
+                matcher: ArgMatcher::new(vec![ArgMatcher::is_geometry()], WKB_GEOMETRY),
+                from_start: true,
+            }),
+            Arc::new(STStartOrEndPoint {
+                matcher: ArgMatcher::new(vec![ArgMatcher::is_geography()], WKB_GEOGRAPHY),
+                from_start: true,
+            }),
+        ]),
         Volatility::Immutable,
     )
 }
@@ -55,27 +64,29 @@ pub fn st_start_point_udf() -> SedonaScalarUDF {
 pub fn st_end_point_udf() -> SedonaScalarUDF {
     SedonaScalarUDF::new(
         "st_endpoint",
-        ItemCrsKernel::wrap_impl(vec![Arc::new(STStartOrEndPoint::new(false))]),
+        ItemCrsKernel::wrap_impl(vec![
+            Arc::new(STStartOrEndPoint {
+                matcher: ArgMatcher::new(vec![ArgMatcher::is_geometry()], WKB_GEOMETRY),
+                from_start: false,
+            }),
+            Arc::new(STStartOrEndPoint {
+                matcher: ArgMatcher::new(vec![ArgMatcher::is_geography()], WKB_GEOGRAPHY),
+                from_start: false,
+            }),
+        ]),
         Volatility::Immutable,
     )
 }
 
 #[derive(Debug)]
 struct STStartOrEndPoint {
+    matcher: ArgMatcher,
     from_start: bool,
-}
-
-impl STStartOrEndPoint {
-    fn new(from_start: bool) -> Self {
-        STStartOrEndPoint { from_start }
-    }
 }
 
 impl SedonaScalarKernel for STStartOrEndPoint {
     fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
-        let matcher = ArgMatcher::new(vec![ArgMatcher::is_geometry()], WKB_GEOMETRY);
-
-        matcher.match_args(args)
+        self.matcher.match_args(args)
     }
 
     fn invoke_batch(
@@ -171,7 +182,7 @@ fn extract_start_or_end_coord<'a>(
 mod tests {
     use datafusion_expr::ScalarUDF;
     use rstest::rstest;
-    use sedona_schema::datatypes::{WKB_GEOMETRY_ITEM_CRS, WKB_VIEW_GEOMETRY};
+    use sedona_schema::datatypes::{WKB_GEOGRAPHY_ITEM_CRS, WKB_GEOMETRY_ITEM_CRS};
     use sedona_testing::{
         compare::assert_array_equal, create::create_array, testers::ScalarUdfTester,
     };
@@ -190,11 +201,14 @@ mod tests {
     }
 
     #[rstest]
-    fn udf(#[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType) {
+    fn udf(#[values(WKB_GEOMETRY, WKB_GEOGRAPHY)] sedona_type: SedonaType) {
         let tester_start_point =
             ScalarUdfTester::new(st_start_point_udf().into(), vec![sedona_type.clone()]);
         let tester_end_point =
             ScalarUdfTester::new(st_end_point_udf().into(), vec![sedona_type.clone()]);
+
+        tester_start_point.assert_return_type(sedona_type.clone());
+        tester_end_point.assert_return_type(sedona_type.clone());
 
         let input = create_array(
             &[
@@ -276,7 +290,10 @@ mod tests {
     }
 
     #[rstest]
-    fn udf_invoke_item_crs(#[values(WKB_GEOMETRY_ITEM_CRS.clone())] sedona_type: SedonaType) {
+    fn udf_invoke_item_crs(
+        #[values(WKB_GEOMETRY_ITEM_CRS.clone(), WKB_GEOGRAPHY_ITEM_CRS.clone())]
+        sedona_type: SedonaType,
+    ) {
         let tester = ScalarUdfTester::new(st_start_point_udf().into(), vec![sedona_type.clone()]);
         tester.assert_return_type(sedona_type);
 

--- a/rust/sedona-functions/src/st_start_point.rs
+++ b/rust/sedona-functions/src/st_start_point.rs
@@ -255,7 +255,7 @@ mod tests {
                 None,
                 None,
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
 
         let result_start_point = tester_start_point.invoke_array(input.clone()).unwrap();
@@ -282,7 +282,7 @@ mod tests {
                 None,
                 None,
             ],
-            &WKB_GEOMETRY,
+            &sedona_type,
         );
 
         let result_end_point = tester_end_point.invoke_array(input).unwrap();


### PR DESCRIPTION
This PR adds geography matchers for a whack of functions whose output is the same for geometry and geography:

- ST_FlipCoordinates
- ST_Force2D, ST_Force3D, ST_Force3DM, ST_Force4D
- ST_GeometryN
- ST_InteriorRingN
- ST_Reverse
- ST_PointN
- ST_Boundary
- ST_LineMerge
- ST_Normalize
- ST_NRings
- ST_NumInteriorRings
- ST_NumPoints
- ST_Points

There's no implementation changes here, only updates to the matchers so that we get geography -> geography and geometry -> geometry.

Closes #819