### PR TITLE
feat(python/sedonadb): add DataFrame __getitem__

### DIFF
--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -88,6 +88,57 @@ class DataFrame:
         """
         return self.limit(n)
 
+    def __getitem__(self, key):
+        """Index into the DataFrame using pandas-style bracket access.
+
+        Three forms are supported:
+
+        - `df["x"]` returns an `Expr` referencing column `x`. Equivalent to
+          `sedonadb.expr.col("x")`. Note that this returns an `Expr`, not a
+          materialized column — the `Series` type that pandas users
+          eventually expect will land in a future phase.
+        - `df[["x", "y"]]` returns a new `DataFrame` with the listed columns
+          (equivalent to `df.select("x", "y")`).
+        - `df[bool_expr]` returns a new `DataFrame` filtered by the boolean
+          expression (equivalent to `df.filter(bool_expr)`).
+
+        Row-position indexing (integers, slices, `.loc`, `.iloc`) is
+        intentionally not supported — SedonaDB has no row ordering or
+        index concept in this scope.
+
+        Examples:
+
+            >>> from sedonadb.expr import col
+            >>> sd = sedona.db.connect()
+            >>> df = sd.sql("SELECT * FROM (VALUES (1, 10), (2, 20), (3, 30)) AS t(x, y)")
+            >>> df["x"]
+            Expr(x)
+            >>> df[["x", "y"]].count()
+            3
+            >>> df[df["x"] > 1].count()
+            2
+        """
+        from sedonadb.expr import Expr
+        from sedonadb.expr import col as _col
+
+        if isinstance(key, str):
+            return _col(key)
+        if isinstance(key, Expr):
+            return self.filter(key)
+        if isinstance(key, list):
+            for k in key:
+                if not isinstance(k, str):
+                    raise TypeError(
+                        f"DataFrame[list] expects a list of column names, "
+                        f"got {type(k).__name__}"
+                    )
+            return self.select(*key)
+        raise TypeError(
+            f"DataFrame indexing is not supported for {type(key).__name__}. "
+            f"Use df['x'] for a column expression, df[['x', 'y']] to project "
+            f"columns, or df[bool_expr] to filter rows."
+        )
+
     def select(self, *exprs: "Expr | str | _SedonaLit") -> "DataFrame":
         """Project a set of columns or expressions.
 

--- a/python/sedonadb/tests/expr/test_dataframe_getitem.py
+++ b/python/sedonadb/tests/expr/test_dataframe_getitem.py
@@ -1,0 +1,90 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Tests for DataFrame.__getitem__ (pandas-style bracket indexing). The
+# three accepted forms dispatch to col(), select(), and filter()
+# respectively; row-position indexing (ints, slices) is intentionally not
+# supported and raises TypeError.
+
+import pandas as pd
+import pandas.testing as pdt
+import pytest
+
+from sedonadb.expr import Expr
+
+
+def test_getitem_string_returns_col_expr(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
+    e = df["x"]
+    assert isinstance(e, Expr)
+    assert repr(e) == "Expr(x)"
+
+
+def test_getitem_list_projects_columns(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3], "y": [10, 20, 30]}))
+    out = df[["x", "y"]].to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [1, 2, 3], "y": [10, 20, 30]}))
+
+
+def test_getitem_single_element_list_projects(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3], "y": [10, 20, 30]}))
+    out = df[["x"]].to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [1, 2, 3]}))
+
+
+def test_getitem_list_reorders_columns(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3], "y": [10, 20, 30]}))
+    out = df[["y", "x"]].to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"y": [10, 20, 30], "x": [1, 2, 3]}))
+
+
+def test_getitem_bool_expr_filters(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3, 4]}))
+    out = df[df["x"] > 2].to_pandas().reset_index(drop=True)
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [3, 4]}))
+
+
+def test_getitem_compose_arithmetic_then_filter(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3], "y": [10, 20, 30]}))
+    out = df[(df["x"] + df["y"]) > 22].to_pandas().reset_index(drop=True)
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [3], "y": [30]}))
+
+
+def test_getitem_compose_filter_then_project(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3], "y": [10, 20, 30]}))
+    out = df[df["x"] > 1][["y"]].to_pandas().reset_index(drop=True)
+    pdt.assert_frame_equal(out, pd.DataFrame({"y": [20, 30]}))
+
+
+def test_getitem_bad_list_element_raises(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
+    with pytest.raises(TypeError, match="list of column names"):
+        df[["x", 5]]
+
+
+def test_getitem_int_raises(con):
+    # Row-position indexing is intentionally unsupported.
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
+    with pytest.raises(TypeError, match="not supported"):
+        df[5]
+
+
+def test_getitem_slice_raises(con):
+    # Row slicing is intentionally unsupported.
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
+    with pytest.raises(TypeError, match="not supported"):
+        df[0:2]


### PR DESCRIPTION
Pandas-style bracket indexing on `DataFrame`, dispatching to the existing `select` / `filter` / `col` paths landed in earlier PRs (#807, #823, #832, #835).

This is a small follow-on PR continuing Phase P1/P2 of #791. Pure Python sugar — no new Rust code.

## What's new

```python
df["x"]                       # → Expr(col("x"))
df[["x", "y"]]                # → DataFrame.select("x", "y")
df[df["x"] > 0]               # → DataFrame.filter(col("x") > 0)
df[(df["x"] + df["y"]) > 30]  # composes cleanly with operator overloads
df[df["x"] > 1][["y"]]        # chain: filter → project
```

Row-position indexing (ints, slices, `.loc`, `.iloc`) is intentionally **not** supported and raises `TypeError` with a message pointing at the three supported forms. SedonaDB has no row-ordering or index concept in this scope; the non-goal is documented in [#791](https://github.com/apache/sedona-db/issues/791).

## Note on `df["x"]` return type

For now, `df["x"]` returns an `Expr` (a column reference). A `Series` wrapper is planned for the next phase — when that lands, `df["x"]` will start returning `Series` instead and `Expr` will fall back to an internal escape hatch. The compose-with-operators idiom continues to work either way because `Series` will share the same operator surface as `Expr`.

## Test plan

10 tests in `tests/expr/test_dataframe_getitem.py`:

- **Positive**: string lookup → Expr (exact `repr()`); list projection (two-col, single-col, reorder); bool-Expr filter; arithmetic compose; filter-then-project chain.
- **Errors**: list with non-string element → `TypeError`; int → `TypeError`; slice → `TypeError`.

All 10 pass locally. No regressions in existing tests; doctests + `ruff format` + `ruff check` all clean.
