### PR TITLE
feat(python/sedonadb): restrict DataFrame __getitem__ to single-column lookup

### DIFF
--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -19,15 +19,16 @@ import io
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Literal, Optional, Union
 
+from sedonadb.expr import Expr
+from sedonadb.expr import Literal as _SedonaLit
+from sedonadb.expr import col as _col
+from sedonadb.expr.expression import _to_expr
 from sedonadb.utility import sedona  # noqa: F401
 
 if TYPE_CHECKING:
     import geopandas
     import pandas
     import pyarrow
-
-    from sedonadb.expr import Expr
-    from sedonadb.expr import Literal as _SedonaLit
 
 
 class DataFrame:
@@ -88,58 +89,65 @@ class DataFrame:
         """
         return self.limit(n)
 
-    def __getitem__(self, key):
-        """Index into the DataFrame using pandas-style bracket access.
+    def __getitem__(self, key: Union[str, int]) -> Expr:
+        """Reference a single column by name or position.
 
-        Three forms are supported:
+        Returns an `Expr` referencing the requested column. The
+        return-type is always `Expr` (no `DataFrame ⏐ Expr` union) so that
+        IDEs and type-aware tools can resolve `df["x"].<method>` cleanly.
 
-        - `df["x"]` returns an `Expr` referencing column `x`. Equivalent to
-          `sedonadb.expr.col("x")`. Note that this returns an `Expr`, not a
-          materialized column — the `Series` type that pandas users
-          eventually expect will land in a future phase.
-        - `df[["x", "y"]]` returns a new `DataFrame` with the listed columns
-          (equivalent to `df.select("x", "y")`).
-        - `df[bool_expr]` returns a new `DataFrame` filtered by the boolean
-          expression (equivalent to `df.filter(bool_expr)`).
+        For row filtering use `df.filter(predicate)`. For multi-column
+        projection use `df.select(*cols)`.
 
-        Row-position indexing (integers, slices, `.loc`, `.iloc`) is
-        intentionally not supported — SedonaDB has no row ordering or
-        index concept in this scope.
+        Args:
+            key: A column name (`str`) or a 0-based column position
+                (`int`, negative indices count from the end).
+
+        Raises:
+            KeyError: A string key that does not match any column. The
+                error message lists the available columns.
+            IndexError: An integer index outside the column range.
+            TypeError: Any other key type, including `bool`, `slice`,
+                `list`, and `Expr`. The message points at `select` or
+                `filter` for those use cases.
 
         Examples:
 
-            >>> from sedonadb.expr import col
             >>> sd = sedona.db.connect()
-            >>> df = sd.sql("SELECT * FROM (VALUES (1, 10), (2, 20), (3, 30)) AS t(x, y)")
+            >>> df = sd.sql("SELECT * FROM (VALUES (1, 10), (2, 20)) AS t(x, y)")
             >>> df["x"]
             Expr(x)
-            >>> df[["x", "y"]].count()
-            3
-            >>> df[df["x"] > 1].count()
-            2
+            >>> df[1]
+            Expr(y)
+            >>> df[-1]
+            Expr(y)
         """
-        from sedonadb.expr import Expr
-        from sedonadb.expr import col as _col
+        # `bool` is a subclass of `int`, so guard explicitly — otherwise
+        # `df[True]` would silently mean `df[1]`.
+        if isinstance(key, bool) or not isinstance(key, (str, int)):
+            raise TypeError(
+                f"DataFrame indexing is not supported for "
+                f"{type(key).__name__}. Use df['name'] or df[i] for a "
+                f"column expression; use df.select(*cols) for multi-column "
+                f"projection and df.filter(expr) for row filtering."
+            )
 
+        columns = self._impl.columns()
         if isinstance(key, str):
+            if key not in columns:
+                raise KeyError(
+                    f"Column {key!r} not found. Available columns: {columns}"
+                )
             return _col(key)
-        if isinstance(key, Expr):
-            return self.filter(key)
-        if isinstance(key, list):
-            for k in key:
-                if not isinstance(k, str):
-                    raise TypeError(
-                        f"DataFrame[list] expects a list of column names, "
-                        f"got {type(k).__name__}"
-                    )
-            return self.select(*key)
-        raise TypeError(
-            f"DataFrame indexing is not supported for {type(key).__name__}. "
-            f"Use df['x'] for a column expression, df[['x', 'y']] to project "
-            f"columns, or df[bool_expr] to filter rows."
-        )
+        # int (and not bool, by the guard above)
+        if not -len(columns) <= key < len(columns):
+            raise IndexError(
+                f"Column index {key} is out of range for DataFrame with "
+                f"{len(columns)} columns"
+            )
+        return _col(columns[key])
 
-    def select(self, *exprs: "Expr | str | _SedonaLit") -> "DataFrame":
+    def select(self, *exprs: Union[Expr, str, _SedonaLit]) -> "DataFrame":
         """Project a set of columns or expressions.
 
         Returns a new lazy `DataFrame` whose columns are exactly the
@@ -167,10 +175,6 @@ class DataFrame:
             │     1 ┆        3 │
             └───────┴──────────┘
         """
-        from sedonadb.expr import Expr, Literal
-        from sedonadb.expr import col as _col
-        from sedonadb.expr.expression import _to_expr
-
         if not exprs:
             raise ValueError("select() requires at least one column or expression")
 
@@ -180,7 +184,7 @@ class DataFrame:
                 coerced.append(e._impl)
             elif isinstance(e, str):
                 coerced.append(_col(e)._impl)
-            elif isinstance(e, Literal):
+            elif isinstance(e, _SedonaLit):
                 # `lit(value)` returns Literal; route it through the same
                 # coercion path operators use so the resulting Expr lands
                 # in the plan with metadata preserved.
@@ -192,7 +196,7 @@ class DataFrame:
                 )
         return DataFrame(self._ctx, self._impl.select(coerced), self._options)
 
-    def filter(self, *exprs: "Expr") -> "DataFrame":
+    def filter(self, *exprs: Expr) -> "DataFrame":
         """Filter rows by one or more boolean expressions.
 
         Multiple expressions are combined with logical AND, so
@@ -225,13 +229,11 @@ class DataFrame:
             │     4 │
             └───────┘
         """
-        from sedonadb.expr import Expr, Literal
-
         if not exprs:
             raise ValueError("filter() requires at least one predicate")
 
         for e in exprs:
-            if isinstance(e, Literal):
+            if isinstance(e, _SedonaLit):
                 raise TypeError(
                     "filter() does not accept Literal arguments. "
                     "filter(lit(value)) is almost always a typo; if you really "

--- a/python/sedonadb/tests/expr/test_dataframe_getitem.py
+++ b/python/sedonadb/tests/expr/test_dataframe_getitem.py
@@ -15,16 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Tests for DataFrame.__getitem__ (pandas-style bracket indexing). The
-# three accepted forms dispatch to col(), select(), and filter()
-# respectively; row-position indexing (ints, slices) is intentionally not
-# supported and raises TypeError.
+# Tests for DataFrame.__getitem__ — single-column lookup by name or
+# position. `__getitem__` is deliberately not a polymorphic
+# select/filter shortcut: keeping the return type strictly `Expr`
+# preserves IDE/type-checker inference on `df["x"].<method>`.
 
 import pandas as pd
-import pandas.testing as pdt
 import pytest
 
-from sedonadb.expr import Expr
+from sedonadb.expr import Expr, col
 
 
 def test_getitem_string_returns_col_expr(con):
@@ -34,57 +33,71 @@ def test_getitem_string_returns_col_expr(con):
     assert repr(e) == "Expr(x)"
 
 
-def test_getitem_list_projects_columns(con):
+def test_getitem_positive_int_returns_col_expr(con):
     df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3], "y": [10, 20, 30]}))
-    out = df[["x", "y"]].to_pandas()
-    pdt.assert_frame_equal(out, pd.DataFrame({"x": [1, 2, 3], "y": [10, 20, 30]}))
+    e = df[1]
+    assert isinstance(e, Expr)
+    assert repr(e) == "Expr(y)"
 
 
-def test_getitem_single_element_list_projects(con):
+def test_getitem_first_int_index(con):
     df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3], "y": [10, 20, 30]}))
-    out = df[["x"]].to_pandas()
-    pdt.assert_frame_equal(out, pd.DataFrame({"x": [1, 2, 3]}))
+    assert repr(df[0]) == "Expr(x)"
 
 
-def test_getitem_list_reorders_columns(con):
+def test_getitem_negative_int_returns_col_expr(con):
     df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3], "y": [10, 20, 30]}))
-    out = df[["y", "x"]].to_pandas()
-    pdt.assert_frame_equal(out, pd.DataFrame({"y": [10, 20, 30], "x": [1, 2, 3]}))
+    assert repr(df[-1]) == "Expr(y)"
+    assert repr(df[-2]) == "Expr(x)"
 
 
-def test_getitem_bool_expr_filters(con):
-    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3, 4]}))
-    out = df[df["x"] > 2].to_pandas().reset_index(drop=True)
-    pdt.assert_frame_equal(out, pd.DataFrame({"x": [3, 4]}))
-
-
-def test_getitem_compose_arithmetic_then_filter(con):
+def test_getitem_string_composes_with_operators(con):
+    # Single-column return preserves the operator-overloading chain.
     df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3], "y": [10, 20, 30]}))
-    out = df[(df["x"] + df["y"]) > 22].to_pandas().reset_index(drop=True)
-    pdt.assert_frame_equal(out, pd.DataFrame({"x": [3], "y": [30]}))
+    e = df["x"] + df["y"]
+    assert isinstance(e, Expr)
+    assert repr(e) == "Expr(x + y)"
 
 
-def test_getitem_compose_filter_then_project(con):
+def test_getitem_unknown_string_raises_keyerror_with_columns(con):
     df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3], "y": [10, 20, 30]}))
-    out = df[df["x"] > 1][["y"]].to_pandas().reset_index(drop=True)
-    pdt.assert_frame_equal(out, pd.DataFrame({"y": [20, 30]}))
+    with pytest.raises(KeyError) as exc:
+        df["nonexistent"]
+    assert (
+        exc.value.args[0]
+        == "Column 'nonexistent' not found. Available columns: ['x', 'y']"
+    )
 
 
-def test_getitem_bad_list_element_raises(con):
-    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
-    with pytest.raises(TypeError, match="list of column names"):
-        df[["x", 5]]
+def test_getitem_int_out_of_range_raises_indexerror(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3], "y": [10, 20, 30]}))
+    with pytest.raises(IndexError, match="out of range"):
+        df[2]
+    with pytest.raises(IndexError, match="out of range"):
+        df[-3]
 
 
-def test_getitem_int_raises(con):
-    # Row-position indexing is intentionally unsupported.
+def test_getitem_bool_raises_typeerror(con):
+    # bool is a subclass of int in Python; reject explicitly so a stray
+    # `df[True]` doesn't silently mean `df[1]`.
     df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
     with pytest.raises(TypeError, match="not supported"):
-        df[5]
+        df[True]
 
 
-def test_getitem_slice_raises(con):
-    # Row slicing is intentionally unsupported.
+def test_getitem_list_raises_typeerror_hinting_select(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3], "y": [10, 20, 30]}))
+    with pytest.raises(TypeError, match="select"):
+        df[["x", "y"]]
+
+
+def test_getitem_expr_raises_typeerror_hinting_filter(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
+    with pytest.raises(TypeError, match="filter"):
+        df[col("x") > 0]
+
+
+def test_getitem_slice_raises_typeerror(con):
     df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
     with pytest.raises(TypeError, match="not supported"):
         df[0:2]


### PR DESCRIPTION
Post-merge follow-up to #846 addressing @paleolimbot's review feedback.

## What changes

**`DataFrame.__getitem__` is now strictly single-column lookup:**

```python
df["x"]    # → Expr referencing column x
df[0]      # → Expr referencing the first column
df[-1]     # → Expr referencing the last column
```

Previously the same method also handled `df[["x","y"]]` (list projection) and `df[bool_expr]` (filter). Those are dropped. Users go through the explicit `df.select(...)` and `df.filter(...)` entry points instead.

The motivation, mirroring Ibis's same deprecation: a single return type (`Expr`) lets IDEs and type checkers resolve `df["x"].<method>` cleanly. With the old polymorphic shape, the return type was `DataFrame | Expr`, which broke autocomplete on the common case.

## Error paths

| Key | Behavior |
|---|---|
| Unknown column name | `KeyError`, message lists available columns |
| Out-of-range int | `IndexError` |
| `bool` | `TypeError` (guarded explicitly; bool is a subclass of int in Python) |
| `list`, `slice`, `Expr`, anything else | `TypeError` with a message pointing at `select` / `filter` |

## While here — import-discipline cleanup

`__getitem__`, `select`, and `filter` previously had lazy in-function imports of `Expr`, `Literal`, `col`, and `_to_expr`. Per the policy in this module ("lazy imports are reserved for optional dependencies like pyarrow"), those move to module level (combined) and the method annotations switch from string forward references to the runtime-imported names.

## Test plan

- 11 tests in `tests/expr/test_dataframe_getitem.py` cover name / positive / negative / first / out-of-range / unknown / bool / list / slice / Expr keys plus the operator-composition path on `df["x"]`.
- All exact `repr() == ...` for the positive cases, per the test-policy convention locked in earlier PRs.
- Existing `test_dataframe_select.py` and `test_dataframe_filter.py` still pass (35 expr-dataframe tests total).
- `pytest --doctest-modules dataframe.py` passes (17 doctests including the updated `__getitem__` example).
- `ruff check` and `ruff format` clean.
