### PR TITLE
docs: update PyPI download badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 # SedonaDB
 
-[![PyPI Version](https://img.shields.io/pypi/v/sedonadb)](https://pypi.org/project/sedonadb/) [![PyPI - Downloads](https://img.shields.io/pypi/dm/sedonadb)](https://pepy.tech/project/sedonadb) [![Downloads](https://static.pepy.tech/personalized-badge/sedonadb?period=total&units=international_system&left_color=black&right_color=brightgreen&left_text=total%20downloads)](https://pepy.tech/project/sedonadb)
+[![PyPI Version](https://img.shields.io/pypi/v/sedonadb)](https://pypi.org/project/sedonadb/) [![PyPI Downloads](https://static.pepy.tech/personalized-badge/sedonadb?period=monthly&units=NONE&left_color=BLACK&right_color=GREEN&left_text=downloads%2Fmonth)](https://pepy.tech/projects/sedonadb) [![Downloads](https://static.pepy.tech/personalized-badge/sedonadb?period=total&units=international_system&left_color=black&right_color=brightgreen&left_text=total%20downloads)](https://pepy.tech/project/sedonadb)
 [![Anaconda Version](
 https://anaconda.org/conda-forge/sedonadb/badges/version.svg)](https://anaconda.org/conda-forge/sedonadb) [![Conda Downloads](https://anaconda.org/conda-forge/sedonadb/badges/downloads.svg)](https://anaconda.org/channels/conda-forge/packages/sedonadb/overview)
 


### PR DESCRIPTION
## What changes were proposed in this PR?

Replace the `img.shields.io/pypi/dm/sedonadb` monthly download badge in `README.md` with a pepy.tech personalized badge. The shields.io PyPI monthly counter has been unreliable; the pepy.tech badge is stable and styled to match the existing total-downloads badge in the same line.

## How was this patch tested?

Visual inspection of the rendered README. No code paths are affected.