### PR TITLE
feat(python/sedonadb): add DataFrame.sort with composable SortExpr

### DIFF
--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -19,7 +19,7 @@ import io
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Literal, Optional, Union
 
-from sedonadb.expr import Expr
+from sedonadb.expr import Expr, SortExpr
 from sedonadb.expr import Literal as _SedonaLit
 from sedonadb.expr import col as _col
 from sedonadb.expr.expression import _to_expr
@@ -250,6 +250,73 @@ class DataFrame:
             self._impl.filter([e._impl for e in exprs]),
             self._options,
         )
+
+    def sort(self, *keys: Union[str, Expr, SortExpr]) -> "DataFrame":
+        """Sort rows by one or more keys.
+
+        Each argument is either a column name (`str`), an `Expr`, or a
+        `SortExpr` (built via `Expr.asc()` / `Expr.desc()` or
+        `sedonadb.expr.sort_expr(...)`). Strings and bare `Expr`s
+        auto-promote to ascending sort keys with nulls placed last; for
+        descending order or null-first placement, use the explicit
+        `SortExpr` forms.
+
+        Null placement defaults to "nulls last" for both ascending and
+        descending sorts (overriding DataFusion's SQL-style nulls-first-
+        on-descending). Override via `sort_expr(expr, asc=..., nulls_first=...)`
+        for the SQL behavior.
+
+        Args:
+            *keys: One or more sort keys, in order of priority. At least
+                one is required.
+
+        Examples:
+
+            >>> from sedonadb.expr import col
+            >>> sd = sedona.db.connect()
+            >>> df = sd.sql("SELECT * FROM (VALUES (3), (1), (2)) AS t(x)")
+            >>> df.sort("x").show()
+            ┌───────┐
+            │   x   │
+            │ int64 │
+            ╞═══════╡
+            │     1 │
+            ├╌╌╌╌╌╌╌┤
+            │     2 │
+            ├╌╌╌╌╌╌╌┤
+            │     3 │
+            └───────┘
+            >>> df.sort(col("x").desc()).show()
+            ┌───────┐
+            │   x   │
+            │ int64 │
+            ╞═══════╡
+            │     3 │
+            ├╌╌╌╌╌╌╌┤
+            │     2 │
+            ├╌╌╌╌╌╌╌┤
+            │     1 │
+            └───────┘
+        """
+        if not keys:
+            raise ValueError("sort() requires at least one sort key")
+
+        coerced: List = []
+        for k in keys:
+            if isinstance(k, SortExpr):
+                coerced.append(k._impl)
+            elif isinstance(k, Expr):
+                # Default direction is ascending, nulls last.
+                coerced.append(k.asc()._impl)
+            elif isinstance(k, str):
+                coerced.append(_col(k).asc()._impl)
+            else:
+                raise TypeError(
+                    f"sort() expects str, Expr, or SortExpr arguments, "
+                    f"got {type(k).__name__}"
+                )
+
+        return DataFrame(self._ctx, self._impl.sort(coerced), self._options)
 
     def limit(self, n: Optional[int], /, *, offset: int = 0) -> "DataFrame":
         """Limit result to n rows starting at offset

--- a/python/sedonadb/python/sedonadb/expr/__init__.py
+++ b/python/sedonadb/python/sedonadb/expr/__init__.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from sedonadb.expr.expression import Expr, col
+from sedonadb.expr.expression import Expr, SortExpr, col, sort_expr
 from sedonadb.expr.literal import Literal, lit
 
-__all__ = ["Expr", "Literal", "col", "lit"]
+__all__ = ["Expr", "Literal", "SortExpr", "col", "lit", "sort_expr"]

--- a/python/sedonadb/python/sedonadb/expr/expression.py
+++ b/python/sedonadb/python/sedonadb/expr/expression.py
@@ -17,11 +17,15 @@
 
 from typing import Any, Iterable, Optional
 
-from sedonadb._lib import InternalExpr as _InternalExpr
-from sedonadb._lib import expr_binary as _expr_binary
-from sedonadb._lib import expr_col as _expr_col
-from sedonadb._lib import expr_lit as _expr_lit
-from sedonadb._lib import expr_not as _expr_not
+from sedonadb._lib import (
+    InternalExpr as _InternalExpr,
+    InternalSortExpr as _InternalSortExpr,
+    expr_binary as _expr_binary,
+    expr_col as _expr_col,
+    expr_lit as _expr_lit,
+    expr_not as _expr_not,
+    expr_sort_expr as _expr_sort_expr,
+)
 from sedonadb.expr.literal import Literal
 
 
@@ -153,6 +157,38 @@ class Expr:
         """
         return Expr(self._impl.negate())
 
+    def asc(self, nulls_first: bool = False) -> "SortExpr":
+        """Wrap this expression as an ascending sort key.
+
+        Returns a `SortExpr` suitable for `DataFrame.sort(...)`. The
+        `nulls_first` argument controls where null values are placed in
+        the sorted output. The default matches the rest of the SedonaDB
+        Python API: nulls last regardless of direction.
+
+        Args:
+            nulls_first: If `True`, null values come before non-nulls.
+                Defaults to `False` (nulls last).
+
+        Examples:
+
+            >>> from sedonadb.expr import col
+            >>> col("x").asc()
+            SortExpr(x ASC NULLS LAST)
+        """
+        return SortExpr(self._impl.asc(nulls_first))
+
+    def desc(self, nulls_first: bool = False) -> "SortExpr":
+        """Wrap this expression as a descending sort key. See `asc` for
+        the meaning of `nulls_first`.
+
+        Examples:
+
+            >>> from sedonadb.expr import col
+            >>> col("x").desc()
+            SortExpr(x DESC NULLS LAST)
+        """
+        return SortExpr(self._impl.desc(nulls_first))
+
     # Arithmetic operators -------------------------------------------------
     #
     # Each binary dunder routes through the shared `_binary` helper, which
@@ -255,6 +291,65 @@ class Expr:
             "Expr has no length. To count rows in a DataFrame, evaluate "
             "the Expr against a frame (e.g. `df.filter(expr).count()`)."
         )
+
+
+class SortExpr:
+    """A sort key — an `Expr` plus direction and null placement.
+
+    Construct via `Expr.asc()` / `Expr.desc()` for the common case, or
+    via `sedonadb.expr.sort_expr(...)` for full control. Consumed by
+    `DataFrame.sort(*keys)`.
+    """
+
+    __slots__ = ("_impl",)
+
+    def __init__(self, impl):
+        if not isinstance(impl, _InternalSortExpr):
+            raise TypeError(
+                f"SortExpr() expects an internal sort-expression handle "
+                f"(sedonadb._lib.InternalSortExpr); got "
+                f"{type(impl).__name__}. Use Expr.asc(), Expr.desc(), or "
+                f"sedonadb.expr.sort_expr() to construct one."
+            )
+        self._impl = impl
+
+    def __repr__(self) -> str:
+        return f"SortExpr({self._impl!r})"
+
+
+def sort_expr(
+    expr: Expr,
+    asc: bool = True,
+    nulls_first: bool = False,
+) -> SortExpr:
+    """Construct a `SortExpr` with explicit direction and null placement.
+
+    Lower-level than `Expr.asc()` / `Expr.desc()` — use when the caller
+    wants to set both `asc` and `nulls_first` deliberately, for example
+    `sort_expr(col("x"), asc=False, nulls_first=True)` to match SQL's
+    standard nulls-first-on-descending convention.
+
+    Args:
+        expr: The `Expr` to sort by.
+        asc: `True` for ascending, `False` for descending. Defaults to
+            `True`.
+        nulls_first: If `True`, null values come before non-nulls.
+            Defaults to `False` (nulls last).
+
+    Examples:
+
+        >>> from sedonadb.expr import col, sort_expr
+        >>> sort_expr(col("x"))
+        SortExpr(x ASC NULLS LAST)
+        >>> sort_expr(col("x"), asc=False, nulls_first=True)
+        SortExpr(x DESC NULLS FIRST)
+    """
+    if not isinstance(expr, Expr):
+        raise TypeError(
+            f"sort_expr() expects an Expr; got {type(expr).__name__}. "
+            f"Use sedonadb.expr.col(name) to build a column expression."
+        )
+    return SortExpr(_expr_sort_expr(expr._impl, asc, nulls_first))
 
 
 def col(name: str, qualifier: Optional[str] = None) -> Expr:

--- a/python/sedonadb/src/dataframe.rs
+++ b/python/sedonadb/src/dataframe.rs
@@ -43,7 +43,7 @@ use tokio::runtime::Runtime;
 
 use crate::context::InternalContext;
 use crate::error::PySedonaError;
-use crate::expr::PyExpr;
+use crate::expr::{PyExpr, PySortExpr};
 use crate::import_from::{import_arrow_scalar, import_arrow_schema};
 use crate::reader::PySedonaStreamReader;
 use crate::runtime::wait_for_future;
@@ -149,6 +149,25 @@ impl InternalDataFrame {
                 "filter() requires at least one predicate".to_string(),
             ))
         }
+    }
+
+    /// Sort rows by the given `SortExpr` keys.
+    ///
+    /// Each key in `sort_exprs` carries its own direction and null
+    /// placement, constructed Python-side via `Expr.asc()`, `Expr.desc()`,
+    /// or `sedonadb.expr.sort_expr(...)`. The Python wrapper auto-promotes
+    /// bare column-name strings and plain `Expr` values to ascending
+    /// `SortExpr` with `nulls_first=false` before they reach this method,
+    /// so we just need to unwrap and pass through.
+    fn sort(&self, sort_exprs: Vec<PySortExpr>) -> Result<InternalDataFrame, PySedonaError> {
+        if sort_exprs.is_empty() {
+            return Err(PySedonaError::SedonaPython(
+                "sort() requires at least one sort key".to_string(),
+            ));
+        }
+        let sort_exprs: Vec<SortExpr> = sort_exprs.into_iter().map(|s| s.inner).collect();
+        let inner = self.inner.clone().sort(sort_exprs)?;
+        Ok(InternalDataFrame::new(inner, self.runtime.clone()))
     }
 
     fn execute<'py>(&self, py: Python<'py>) -> Result<usize, PySedonaError> {

--- a/python/sedonadb/src/expr.rs
+++ b/python/sedonadb/src/expr.rs
@@ -37,7 +37,7 @@
 //! `SedonaDBExprFactory::column` / `::literal`.
 
 use datafusion_common::Column;
-use datafusion_expr::{expr::InList, BinaryExpr, Cast, Expr, Operator};
+use datafusion_expr::{expr::InList, BinaryExpr, Cast, Expr, Operator, SortExpr};
 use pyo3::prelude::*;
 
 use crate::error::PySedonaError;
@@ -165,6 +165,55 @@ impl PyExpr {
             inner: Expr::Negative(Box::new(self.inner.clone())),
         }
     }
+
+    /// Wrap this expression as an ascending `SortExpr` sort key.
+    ///
+    /// `nulls_first` controls where null values land in the sorted output.
+    /// The Python wrapper defaults this to `false` (nulls last), matching
+    /// the default we ship for both directions; users wanting SQL-style
+    /// "nulls last on asc, nulls first on desc" can pass an explicit
+    /// argument or use `sort_expr()` for full control.
+    #[pyo3(signature = (nulls_first=false))]
+    fn asc(&self, nulls_first: bool) -> PySortExpr {
+        PySortExpr {
+            inner: SortExpr::new(self.inner.clone(), /* asc */ true, nulls_first),
+        }
+    }
+
+    /// Wrap this expression as a descending `SortExpr` sort key. See
+    /// `asc` for the meaning of `nulls_first`.
+    #[pyo3(signature = (nulls_first=false))]
+    fn desc(&self, nulls_first: bool) -> PySortExpr {
+        PySortExpr {
+            inner: SortExpr::new(self.inner.clone(), /* asc */ false, nulls_first),
+        }
+    }
+}
+
+/// PyO3 wrapper around `datafusion_expr::SortExpr` (a `(expr, asc,
+/// nulls_first)` triple). Exposed to Python as `_lib.InternalSortExpr`.
+///
+/// `SortExpr` values are produced either via `Expr.asc()` / `Expr.desc()`
+/// (the common case, with `nulls_first` defaulting to false), or via
+/// `sedonadb.expr.sort_expr(expr, asc=..., nulls_first=...)` for full
+/// control. They are consumed by `DataFrame.sort(*keys)`.
+#[pyclass(name = "InternalSortExpr")]
+#[derive(Clone)]
+pub struct PySortExpr {
+    pub inner: SortExpr,
+}
+
+impl PySortExpr {
+    pub fn new(inner: SortExpr) -> Self {
+        Self { inner }
+    }
+}
+
+#[pymethods]
+impl PySortExpr {
+    fn __repr__(&self) -> String {
+        format!("{}", self.inner)
+    }
 }
 
 /// Construct a column reference: `Expr::Column("x")` or `Expr::Column("t.x")`.
@@ -256,5 +305,17 @@ pub fn expr_binary(op: &str, lhs: &PyExpr, rhs: &PyExpr) -> Result<PyExpr, PySed
 pub fn expr_not(expr: &PyExpr) -> PyExpr {
     PyExpr {
         inner: Expr::Not(Box::new(expr.inner.clone())),
+    }
+}
+
+/// Construct a `SortExpr` with explicit direction and null-placement
+/// arguments. Lower-level than `Expr.asc()` / `Expr.desc()` — used when
+/// the caller wants to set both knobs deliberately, e.g. `nulls_first=true`
+/// on an ascending sort.
+#[pyfunction]
+#[pyo3(signature = (expr, asc=true, nulls_first=false))]
+pub fn expr_sort_expr(expr: &PyExpr, asc: bool, nulls_first: bool) -> PySortExpr {
+    PySortExpr {
+        inner: SortExpr::new(expr.inner.clone(), asc, nulls_first),
     }
 }

--- a/python/sedonadb/src/lib.rs
+++ b/python/sedonadb/src/lib.rs
@@ -128,10 +128,12 @@ fn _lib(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(expr::expr_lit, m)?)?;
     m.add_function(wrap_pyfunction!(expr::expr_binary, m)?)?;
     m.add_function(wrap_pyfunction!(expr::expr_not, m)?)?;
+    m.add_function(wrap_pyfunction!(expr::expr_sort_expr, m)?)?;
 
     m.add_class::<context::InternalContext>()?;
     m.add_class::<dataframe::InternalDataFrame>()?;
     m.add_class::<expr::PyExpr>()?;
+    m.add_class::<expr::PySortExpr>()?;
     m.add_class::<datasource::PyExternalFormat>()?;
     m.add_class::<datasource::PyProjectedRecordBatchReader>()?;
     m.add("SedonaError", py.get_type::<error::SedonaError>())?;

--- a/python/sedonadb/tests/expr/test_dataframe_sort.py
+++ b/python/sedonadb/tests/expr/test_dataframe_sort.py
@@ -1,0 +1,134 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Tests for DataFrame.sort(). Each test builds its own input inline.
+# Output compared with `pd.testing.assert_frame_equal` after resetting
+# the index (the materialized output preserves pre-sort row positions
+# in the index).
+
+import pandas as pd
+import pandas.testing as pdt
+import pytest
+
+from sedonadb.dataframe import DataFrame
+from sedonadb.expr import col, sort_expr
+
+
+def test_sort_string_key_ascending(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [3, 1, 2]}))
+    out = df.sort("x").to_pandas().reset_index(drop=True)
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [1, 2, 3]}))
+
+
+def test_sort_expr_key_ascending(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [3, 1, 2]}))
+    out = df.sort(col("x")).to_pandas().reset_index(drop=True)
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [1, 2, 3]}))
+
+
+def test_sort_expr_desc_via_method(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [3, 1, 2]}))
+    out = df.sort(col("x").desc()).to_pandas().reset_index(drop=True)
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [3, 2, 1]}))
+
+
+def test_sort_expr_asc_via_method_is_default(con):
+    # `col("x").asc()` should match the bare-`col("x")` path.
+    df = con.create_data_frame(pd.DataFrame({"x": [3, 1, 2]}))
+    out_method = df.sort(col("x").asc()).to_pandas().reset_index(drop=True)
+    out_bare = df.sort(col("x")).to_pandas().reset_index(drop=True)
+    pdt.assert_frame_equal(out_method, out_bare)
+
+
+def test_sort_computed_expr(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3], "y": [30, 20, 10]}))
+    out = df.sort(col("x") + col("y")).to_pandas().reset_index(drop=True)
+    # x+y = 31, 22, 13 → sorted ascending → rows (3,10), (2,20), (1,30)
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [3, 2, 1], "y": [10, 20, 30]}))
+
+
+def test_sort_multi_key_mixed_directions_varargs(con):
+    # Input is scrambled so each direction has to physically move rows.
+    df = con.create_data_frame(pd.DataFrame({"x": [2, 1, 1, 2], "y": [30, 10, 20, 40]}))
+    out = df.sort(col("x").asc(), col("y").desc()).to_pandas().reset_index(drop=True)
+    # asc on x, desc on y → (1,20), (1,10), (2,40), (2,30)
+    pdt.assert_frame_equal(
+        out, pd.DataFrame({"x": [1, 1, 2, 2], "y": [20, 10, 40, 30]})
+    )
+
+
+def test_sort_mixed_string_and_sort_expr(con):
+    # String key auto-promotes to ascending; SortExpr provides the desc.
+    df = con.create_data_frame(pd.DataFrame({"x": [2, 1, 1, 2], "y": [30, 10, 20, 40]}))
+    out = df.sort("x", col("y").desc()).to_pandas().reset_index(drop=True)
+    pdt.assert_frame_equal(
+        out, pd.DataFrame({"x": [1, 1, 2, 2], "y": [20, 10, 40, 30]})
+    )
+
+
+def test_sort_nulls_last_ascending(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [3, None, 1, 2]}))
+    out = df.sort("x").to_pandas().reset_index(drop=True)
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [1.0, 2.0, 3.0, None]}))
+
+
+def test_sort_nulls_last_descending(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [3, None, 1, 2]}))
+    out = df.sort(col("x").desc()).to_pandas().reset_index(drop=True)
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [3.0, 2.0, 1.0, None]}))
+
+
+def test_sort_with_sort_expr_factory_nulls_first(con):
+    # sort_expr(...) lets the caller put nulls at the front.
+    df = con.create_data_frame(pd.DataFrame({"x": [3, None, 1, 2]}))
+    out = (
+        df.sort(sort_expr(col("x"), asc=True, nulls_first=True))
+        .to_pandas()
+        .reset_index(drop=True)
+    )
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [None, 1.0, 2.0, 3.0]}))
+
+
+def test_sort_returns_lazy_dataframe(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
+    out = df.sort("x")
+    assert isinstance(out, DataFrame)
+
+
+def test_sort_empty_raises(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
+    with pytest.raises(ValueError, match="at least one sort key"):
+        df.sort()
+
+
+def test_sort_bad_arg_type_raises(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
+    with pytest.raises(TypeError, match="str, Expr, or SortExpr"):
+        df.sort(123)
+
+
+def test_sort_unknown_column_lists_valid_columns(con):
+    # DataFusion's plan-build error includes the list of valid field names.
+    # Lock that contract.
+    from sedonadb._lib import SedonaError
+
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}))
+    with pytest.raises(SedonaError) as exc:
+        df.sort("nonexistent")
+    msg = str(exc.value)
+    assert "nonexistent" in msg
+    assert "Valid fields" in msg or "valid fields" in msg

--- a/python/sedonadb/tests/expr/test_expression.py
+++ b/python/sedonadb/tests/expr/test_expression.py
@@ -26,7 +26,7 @@
 import pyarrow as pa
 import pytest
 
-from sedonadb.expr import Expr, col
+from sedonadb.expr import Expr, SortExpr, col, sort_expr
 
 
 def test_col_returns_expr():
@@ -124,6 +124,59 @@ def test_expr_init_rejects_wrong_type():
         Expr("not an internal expr")
     with pytest.raises(TypeError, match="InternalExpr"):
         Expr(42)
+
+
+# --- Sort expressions --------------------------------------------------------
+
+
+def test_expr_asc_default_returns_sort_expr():
+    s = col("x").asc()
+    assert isinstance(s, SortExpr)
+    assert repr(s) == "SortExpr(x ASC NULLS LAST)"
+
+
+def test_expr_desc_default_returns_sort_expr():
+    s = col("x").desc()
+    assert isinstance(s, SortExpr)
+    assert repr(s) == "SortExpr(x DESC NULLS LAST)"
+
+
+def test_expr_asc_nulls_first():
+    s = col("x").asc(nulls_first=True)
+    assert repr(s) == "SortExpr(x ASC NULLS FIRST)"
+
+
+def test_expr_desc_nulls_first():
+    s = col("x").desc(nulls_first=True)
+    assert repr(s) == "SortExpr(x DESC NULLS FIRST)"
+
+
+def test_sort_expr_factory_default():
+    s = sort_expr(col("x"))
+    assert isinstance(s, SortExpr)
+    assert repr(s) == "SortExpr(x ASC NULLS LAST)"
+
+
+def test_sort_expr_factory_explicit_options():
+    s = sort_expr(col("x"), asc=False, nulls_first=True)
+    assert repr(s) == "SortExpr(x DESC NULLS FIRST)"
+
+
+def test_sort_expr_factory_rejects_non_expr():
+    with pytest.raises(TypeError, match="Expr"):
+        sort_expr("x")
+
+
+def test_sort_expr_init_rejects_wrong_type():
+    with pytest.raises(TypeError, match="InternalSortExpr"):
+        SortExpr("not a sort expr")
+
+
+def test_sort_expr_over_compound_expression():
+    # `.asc()` / `.desc()` on a composed Expr should propagate the
+    # rendered Display all the way through.
+    s = (col("x") + col("y")).desc()
+    assert repr(s) == "SortExpr(x + y DESC NULLS LAST)"
 
 
 # --- Binary operators --------------------------------------------------------


### PR DESCRIPTION
Redesigned per @paleolimbot's [review on the earlier draft](https://github.com/apache/sedona-db/pull/859) — replacing pandas-style `sort_values(by=, ascending=)` with the composable API pattern from DataFusion-python / DuckDB / Ibis.

Continues Phase P2 of #791.

## API

```python
from sedonadb.expr import col, sort_expr

# Common cases — Expr.asc()/.desc() return SortExpr
df.sort("x")                          # str auto-promotes to ascending
df.sort(col("x").desc())
df.sort(col("x"), col("y").desc())    # varargs, multi-key
df.sort(col("x") + col("y"))          # arbitrary Expr key

# Full control via the factory
df.sort(sort_expr(col("x"), asc=False, nulls_first=True))
```

`DataFrame.sort` accepts each key as `str | Expr | SortExpr`. Strings and bare `Expr` auto-promote to ascending keys with nulls last; `Expr.asc()` / `Expr.desc()` cover the common direction switch; `sedonadb.expr.sort_expr(expr, asc=..., nulls_first=...)` exposes the full DataFusion `SortExpr` knobs.

## What's gone vs. the earlier draft

- `sort_values()` — removed entirely. Per the discussion: no pandas-compat duplicate at this layer; that can come later in a dedicated GeoPandas-compat surface.
- `by=` / `ascending=` keyword args — replaced by varargs (formats better with Ruff and matches the three reference interfaces).

## Null placement

`Expr.asc()` and `Expr.desc()` default to `nulls_first=False` (nulls last) regardless of direction — matches the previous draft's pandas-style default and what the rest of the SedonaDB Python API ships. SQL-style nulls-first-on-descending is available via `sort_expr(col("x"), asc=False, nulls_first=True)`.

## Implementation

| File | Change |
|---|---|
| `python/sedonadb/src/expr.rs` | New `PySortExpr` PyO3 class wrapping `datafusion_expr::SortExpr`. `Expr.asc(nulls_first)` / `.desc(nulls_first)` methods. `expr_sort_expr(expr, asc, nulls_first)` factory. |
| `python/sedonadb/src/dataframe.rs` | `InternalDataFrame::sort(Vec<PySortExpr>)`; old `sort_by_keys` gone. |
| `python/sedonadb/src/lib.rs` | Register `PySortExpr` + `expr_sort_expr`. |
| `python/sedonadb/python/sedonadb/expr/expression.py` | Python `SortExpr` class, `sort_expr()` factory, `Expr.asc/.desc` methods. |
| `python/sedonadb/python/sedonadb/expr/__init__.py` | Re-export `SortExpr`, `sort_expr`. |
| `python/sedonadb/python/sedonadb/dataframe.py` | `DataFrame.sort(*keys)`. Module-level `SortExpr` import (no lazy imports, per the policy locked on #852). |

## Tests

- `tests/expr/test_dataframe_sort.py` — 14 tests covering string/Expr/SortExpr keys, mixed-direction multi-key, computed-Expr keys, nulls-last default in both directions, `sort_expr(nulls_first=True)`, lazy return type (`isinstance(out, DataFrame)`), and the empty / bad-type / unknown-column error paths.
- `tests/expr/test_expression.py` — 9 new tests pinning the exact `repr()` of `SortExpr` for asc / desc / both null placements / the factory / both type-guard rejections.

Local: 97 unit + 29 doctests + `ruff format` + `ruff check` all clean.
