### PR TITLE
Fix ST_AsBinary return type for WkbView input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5327,6 +5327,7 @@ dependencies = [
  "geo-types",
  "object_store",
  "parking_lot",
+ "parquet",
  "regex",
  "rstest",
  "sedona-common",

--- a/rust/sedona-functions/src/st_asbinary.rs
+++ b/rust/sedona-functions/src/st_asbinary.rs
@@ -42,13 +42,6 @@ struct STAsBinary {}
 
 impl SedonaScalarKernel for STAsBinary {
     fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
-        // If we have WkbView input, return BinaryView to avoid a cast
-        if args.len() == 1 {
-            if let SedonaType::WkbView(_, _) = args[0] {
-                return Ok(Some(SedonaType::Arrow(DataType::BinaryView)));
-            }
-        }
-
         let matcher = ArgMatcher::new(
             vec![ArgMatcher::is_geometry_or_geography()],
             SedonaType::Arrow(DataType::Binary),
@@ -57,15 +50,22 @@ impl SedonaScalarKernel for STAsBinary {
         matcher.match_args(args)
     }
 
-    fn invoke_batch(&self, _: &[SedonaType], args: &[ColumnarValue]) -> Result<ColumnarValue> {
-        // This currently works because our return_type() ensure we didn't need a cast
-        Ok(args[0].clone())
+    fn invoke_batch(
+        &self,
+        arg_types: &[SedonaType],
+        args: &[ColumnarValue],
+    ) -> Result<ColumnarValue> {
+        if matches!(arg_types[0], SedonaType::Wkb(_, _)) {
+            Ok(args[0].clone())
+        } else {
+            args[0].clone().cast_to(&DataType::Binary, None)
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::{ArrayRef, BinaryArray, BinaryViewArray};
+    use arrow_array::{ArrayRef, BinaryArray};
     use datafusion_common::scalar::ScalarValue;
     use datafusion_expr::ScalarUDF;
     use rstest::rstest;
@@ -129,15 +129,15 @@ mod tests {
 
         assert_eq!(
             tester.invoke_wkb_scalar(Some("POINT (1 2)")).unwrap(),
-            ScalarValue::BinaryView(Some(POINT12.to_vec()))
+            ScalarValue::Binary(Some(POINT12.to_vec()))
         );
 
         assert_eq!(
             tester.invoke_wkb_scalar(None).unwrap(),
-            ScalarValue::BinaryView(None)
+            ScalarValue::Binary(None)
         );
 
-        let expected_array: BinaryViewArray = [Some(POINT12), None, Some(POINT12)].iter().collect();
+        let expected_array: BinaryArray = [Some(POINT12), None, Some(POINT12)].iter().collect();
         assert_eq!(
             &tester
                 .invoke_wkb_array(vec![Some("POINT (1 2)"), None, Some("POINT (1 2)")])

--- a/rust/sedona/Cargo.toml
+++ b/rust/sedona/Cargo.toml
@@ -47,6 +47,7 @@ gpu = ["dep:sedona-spatial-join-gpu", "sedona-spatial-join-gpu/gpu"]
 s2geography = ["dep:sedona-s2geography", "dep:sedona-spatial-join-geography", "sedona-geoparquet/s2geography"]
 
 [dev-dependencies]
+parquet = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 rstest = { workspace = true }

--- a/rust/sedona/src/context.rs
+++ b/rust/sedona/src/context.rs
@@ -631,16 +631,28 @@ impl ThreadSafeDialect {
 #[cfg(test)]
 mod tests {
 
-    use arrow_array::{create_array, ArrayRef, RecordBatchIterator, RecordBatchReader};
+    use std::{fs::File, path::Path, sync::Arc};
+
+    use arrow_array::{
+        create_array, ArrayRef, BinaryViewArray, Int32Array, RecordBatch, RecordBatchIterator,
+        RecordBatchReader,
+    };
     use arrow_schema::{DataType, Field, Schema};
     use datafusion::assert_batches_eq;
+    use datafusion_expr::ScalarUDF;
+    use parquet::{
+        arrow::ArrowWriter,
+        file::{metadata::KeyValue, properties::WriterProperties},
+    };
     use sedona_datasource::spec::{Object, OpenReaderArgs};
+    use sedona_functions::register::default_function_set;
     use sedona_schema::{
         crs::{deserialize_crs, lnglat},
         datatypes::{Edges, SedonaType},
         schema::SedonaSchema,
     };
     use sedona_testing::data::test_geoparquet;
+    use sedona_testing::testers::ScalarUdfTester;
     use tempfile::tempdir;
 
     use super::*;
@@ -774,6 +786,84 @@ mod tests {
             sedona_types[1],
             SedonaType::WkbView(Edges::Planar, lnglat())
         );
+    }
+
+    #[tokio::test]
+    async fn st_asbinary_geoparquet_returns_binary() {
+        let ctx = SedonaContext::new_local_interactive().await.unwrap();
+        let tmpdir = tempdir().unwrap();
+        let tmp_parquet = tmpdir.path().join("single_point.parquet");
+        write_binary_view_geoparquet(&tmp_parquet);
+
+        let df = ctx
+            .read_parquet(
+                tmp_parquet.to_string_lossy().to_string(),
+                GeoParquetReadOptions::default(),
+            )
+            .await
+            .unwrap();
+        let sedona_types = df
+            .schema()
+            .sedona_types()
+            .collect::<Result<Vec<_>>>()
+            .unwrap();
+        assert!(matches!(sedona_types[1], SedonaType::WkbView(_, _)));
+
+        let batches = df.collect().await.unwrap();
+        assert_eq!(
+            *batches[0].schema().field(1).data_type(),
+            DataType::BinaryView
+        );
+
+        let udf: ScalarUDF = default_function_set()
+            .scalar_udf("st_asbinary")
+            .unwrap()
+            .clone()
+            .into();
+        let tester = ScalarUdfTester::new(udf, vec![sedona_types[1].clone()]);
+        let result = tester.invoke_array(batches[0].column(1).clone()).unwrap();
+        assert_eq!(*result.data_type(), DataType::Binary);
+    }
+
+    fn write_binary_view_geoparquet(path: &Path) {
+        const POINT12: [u8; 21] = [
+            0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0x3f, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40,
+        ];
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("geometry", DataType::BinaryView, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1])) as ArrayRef,
+                Arc::new(BinaryViewArray::from_iter_values([POINT12])) as ArrayRef,
+            ],
+        )
+        .unwrap();
+
+        let geo_metadata = r#"{
+            "version": "1.1.0",
+            "primary_column": "geometry",
+            "columns": {
+                "geometry": {
+                    "encoding": "WKB",
+                    "geometry_types": ["Point"]
+                }
+            }
+        }"#;
+        let props = WriterProperties::builder()
+            .set_key_value_metadata(Some(vec![KeyValue {
+                key: "geo".to_string(),
+                value: Some(geo_metadata.to_string()),
+            }]))
+            .build();
+        let file = File::create(path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, schema, Some(props)).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
     }
 
     #[derive(Debug)]


### PR DESCRIPTION
## Summary

This updates `ST_AsBinary` / `ST_AsWKB` so the return type is consistently Arrow `Binary`, including when the input geometry is stored as `WkbView`.

The previous implementation returned Arrow `BinaryView` for `WkbView` input to avoid a cast. That exposed an internal storage detail through the SQL-visible return type and required downstream callers to add their own simplification/cast workaround.

This change keeps the no-copy clone path for plain `Wkb` input and casts non-`Wkb` inputs to Arrow `Binary`.

Fixes #864.

## Changes

- Remove the special-case `WkbView -> BinaryView` return type.
- Preserve the clone fast path for `SedonaType::Wkb`.
- Cast `WkbView` output to Arrow `Binary`.
- Update existing `WkbView` UDF tests to expect `Binary`.
- Add a regression test that writes a valid GeoParquet file with WKB geometry stored as Arrow `BinaryView`, reads it as `WkbView`, and verifies `ST_AsBinary` returns Arrow `Binary`.

## Testing

- `pixi run cargo fmt --all -- --check`
- `pixi run test-st-asbinary-rust`
- `pixi run test-st-asbinary-geoparquet`

I also verified the new GeoParquet regression test catches the previous behavior. With the old `WkbView -> BinaryView` special case restored, this command fails:

```shell
pixi run test-st-asbinary-geoparquet
```

Failure excerpt:

```text
thread 'context::tests::st_asbinary_geoparquet_returns_binary' panicked at rust/sedona/src/context.rs:825:9:
assertion `left == right` failed
  left: BinaryView
 right: Binary
```
