### PR TITLE
feat(python/sedonadb): add DataFrame.drop

### DIFF
--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -318,6 +318,51 @@ class DataFrame:
 
         return DataFrame(self._ctx, self._impl.sort(coerced), self._options)
 
+    def drop(self, *cols: str) -> "DataFrame":
+        """Drop the named columns.
+
+        Returns a new lazy `DataFrame` with each named column removed.
+        Only column-name strings are accepted; expression arguments are
+        rejected because "drop a computed expression" has no meaning at
+        the schema level. Unknown column names raise a `SedonaError` at
+        plan-build time, with the list of valid field names included in
+        the message.
+
+        Args:
+            *cols: One or more column names to drop. At least one is
+                required.
+
+        Examples:
+
+            >>> sd = sedona.db.connect()
+            >>> df = sd.sql("SELECT 1 AS a, 2 AS b, 3 AS c")
+            >>> df.drop("b").show()
+            ┌───────┬───────┐
+            │   a   ┆   c   │
+            │ int64 ┆ int64 │
+            ╞═══════╪═══════╡
+            │     1 ┆     3 │
+            └───────┴───────┘
+        """
+        if not cols:
+            raise ValueError("drop() requires at least one column name")
+
+        for c in cols:
+            if not isinstance(c, str):
+                raise TypeError(f"drop() expects str arguments, got {type(c).__name__}")
+
+        # DataFusion's `drop_columns` silently ignores names not in the
+        # schema — that hides typos. Validate Python-side so the user
+        # gets an immediate KeyError listing the available columns.
+        columns = self._impl.columns()
+        unknown = [c for c in cols if c not in columns]
+        if unknown:
+            raise KeyError(
+                f"Column(s) {unknown} not found. Available columns: {columns}"
+            )
+
+        return DataFrame(self._ctx, self._impl.drop_columns(list(cols)), self._options)
+
     def limit(self, n: Optional[int], /, *, offset: int = 0) -> "DataFrame":
         """Limit result to n rows starting at offset
 

--- a/python/sedonadb/src/dataframe.rs
+++ b/python/sedonadb/src/dataframe.rs
@@ -170,6 +170,25 @@ impl InternalDataFrame {
         Ok(InternalDataFrame::new(inner, self.runtime.clone()))
     }
 
+    /// Drop the named columns, producing a new lazy `DataFrame`.
+    ///
+    /// The Python side guarantees `cols` is non-empty and that every
+    /// element is a string. DataFusion's `drop_columns` accepts `&[&str]`,
+    /// so we materialize a slice of borrowed string references and hand
+    /// it off; the plan-build step raises a `SchemaError` if any name
+    /// doesn't resolve to a column, and that error already includes the
+    /// list of valid field names for the user.
+    fn drop_columns(&self, cols: Vec<String>) -> Result<InternalDataFrame, PySedonaError> {
+        if cols.is_empty() {
+            return Err(PySedonaError::SedonaPython(
+                "drop() requires at least one column name".to_string(),
+            ));
+        }
+        let borrowed: Vec<&str> = cols.iter().map(String::as_str).collect();
+        let inner = self.inner.clone().drop_columns(&borrowed)?;
+        Ok(InternalDataFrame::new(inner, self.runtime.clone()))
+    }
+
     fn execute<'py>(&self, py: Python<'py>) -> Result<usize, PySedonaError> {
         let df = self.inner.clone();
         let count = wait_for_future(py, &self.runtime, async move {

--- a/python/sedonadb/tests/expr/test_dataframe_drop.py
+++ b/python/sedonadb/tests/expr/test_dataframe_drop.py
@@ -1,0 +1,96 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Tests for DataFrame.drop(*cols). Each test builds its own input
+# inline; output is compared with `pd.testing.assert_frame_equal`.
+
+import pandas as pd
+import pandas.testing as pdt
+import pytest
+
+from sedonadb.dataframe import DataFrame
+from sedonadb.expr import col
+
+
+def test_drop_single_column(con):
+    df = con.create_data_frame(
+        pd.DataFrame({"a": [1, 2, 3], "b": [10, 20, 30], "c": [100, 200, 300]})
+    )
+    out = df.drop("b").to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"a": [1, 2, 3], "c": [100, 200, 300]}))
+
+
+def test_drop_multiple_columns(con):
+    df = con.create_data_frame(
+        pd.DataFrame({"a": [1, 2, 3], "b": [10, 20, 30], "c": [100, 200, 300]})
+    )
+    out = df.drop("a", "c").to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"b": [10, 20, 30]}))
+
+
+def test_drop_preserves_remaining_column_order(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1], "b": [2], "c": [3], "d": [4]}))
+    out = df.drop("b").to_pandas()
+    # Surviving columns keep their original positional order.
+    assert list(out.columns) == ["a", "c", "d"]
+
+
+def test_drop_returns_lazy_dataframe(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1], "b": [2]}))
+    out = df.drop("b")
+    assert isinstance(out, DataFrame)
+
+
+def test_drop_empty_raises(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1]}))
+    with pytest.raises(ValueError, match="at least one column name"):
+        df.drop()
+
+
+def test_drop_non_string_arg_raises(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1]}))
+    with pytest.raises(TypeError, match="drop\\(\\) expects str arguments"):
+        df.drop(0)
+
+
+def test_drop_expr_arg_raises(con):
+    # Expr is not accepted (drop is a schema op, not an expression op).
+    df = con.create_data_frame(pd.DataFrame({"a": [1]}))
+    with pytest.raises(TypeError, match="drop\\(\\) expects str arguments"):
+        df.drop(col("a"))
+
+
+def test_drop_columns_kwarg_raises(con):
+    # We deliberately do not accept `columns=`; Python raises the standard
+    # unexpected-keyword-argument TypeError. Locks the contract.
+    df = con.create_data_frame(pd.DataFrame({"a": [1], "b": [2]}))
+    with pytest.raises(TypeError, match="columns"):
+        df.drop(columns=["a"])
+
+
+def test_drop_unknown_column_raises_keyerror(con):
+    # DataFusion's `drop_columns` is permissive — it silently no-ops on a
+    # name that isn't in the schema, which would hide typos. We validate
+    # Python-side and raise a KeyError with the exact list of available
+    # column names.
+    df = con.create_data_frame(pd.DataFrame({"a": [1], "b": [2]}))
+    with pytest.raises(KeyError) as exc:
+        df.drop("nonexistent")
+    assert (
+        exc.value.args[0]
+        == "Column(s) ['nonexistent'] not found. Available columns: ['a', 'b']"
+    )


### PR DESCRIPTION
Continues Phase P2 of #791 with `DataFrame.drop` — the smallest of the remaining P2 ops.

## API

```python
df.drop("a")
df.drop("a", "b", "c")
```

- **Varargs** of column names (no `columns=` kwarg). Same pattern as `sort()` from #859 — matches DataFusion-python / Ibis / Polars, avoids the pandas-style keyword.
- **Strings only**. `Expr` arguments are rejected at the Python boundary; "drop a computed expression" has no meaning at the schema level.

## Unknown-column behavior

Worth calling out — DataFusion's `DataFrame::drop_columns` is **permissive**: it silently no-ops on names that aren't in the schema. That hides typos. To match user expectations (and pandas' `KeyError` behavior), this PR validates the column names Python-side and raises a `KeyError` listing the available columns when one is missing. The exact message format is pinned by `test_drop_unknown_column_raises_keyerror`.

This is more restrictive than `select`/`filter` (where DataFusion validates at plan-build time and includes "Valid fields are X, Y" in the error). The asymmetry is forced by DataFusion's silent-no-op default on `drop_columns`; the workaround is one Python-side schema lookup per call, which is cheap.

## Implementation

| File | Change |
|---|---|
| `python/sedonadb/src/dataframe.rs` | New `InternalDataFrame::drop_columns(Vec<String>)`. Materializes a `Vec<&str>` and calls DataFusion's `DataFrame::drop_columns`. Step-by-step comments. |
| `python/sedonadb/python/sedonadb/dataframe.py` | `DataFrame.drop(*cols: str)`. Validates non-empty, str-only, and known columns. |

## Test plan

9 tests in `tests/expr/test_dataframe_drop.py`:

- **Positive**: single-column, multi-column, column-order preservation.
- **Lazy return**: `isinstance(out, DataFrame)`.
- **Errors**: empty args → `ValueError`; non-str arg → `TypeError`; `Expr` arg → `TypeError`; `columns=` kwarg → Python's unexpected-keyword `TypeError`; unknown column → `KeyError` with exact pinned message listing available columns.

Local: 9 unit + 19 doctests + `ruff format` + `ruff check` all clean.
