### PR TITLE
chore(docker): Add Dockerfile for building GPU-enabled sedonadb image

### DIFF
--- a/docker/sedonadb-gpu.dockerfile
+++ b/docker/sedonadb-gpu.dockerfile
@@ -64,7 +64,7 @@ ENV CMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake
 ENV PKG_CONFIG_PATH=$VCPKG_ROOT/installed/x64-linux/lib/pkgconfig
 ENV CC=clang-18
 ENV CXX=clang++-18
-ARG CMAKE_CUDA_ARCHITECTURES=native
+ARG CMAKE_CUDA_ARCHITECTURES="86"
 ENV CMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH}
 
@@ -76,7 +76,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 ENV MATURIN_PEP517_ARGS="--features s2geography,gpu"
 
 # Install maturin AND JupyterLab inside the virtual environment
-RUN pip3 install maturin jupyterlab pyproj
+RUN pip3 install maturin jupyterlab pyproj geoarrow-pyarrow pandas
 
 # Install the project. You may add '-e' to enable the editable mode (uses pyproject -> maturin under the hood) for debug/development purposes
 RUN pip3 install "python/sedonadb" -vv

--- a/docker/sedonadb-gpu.dockerfile
+++ b/docker/sedonadb-gpu.dockerfile
@@ -77,16 +77,26 @@ ENV MATURIN_PEP517_ARGS="--features s2geography,gpu"
 # Install maturin AND JupyterLab inside the virtual environment
 RUN pip3 install maturin jupyterlab pyproj
 
-# Install the project in editable mode (uses pyproject -> maturin under the hood)
-RUN pip3 install -e "python/sedonadb" -vv
+# Install the project. You may add '-e' to enable the editable mode (uses pyproject -> maturin under the hood) for debug/development purposes
+RUN pip3 install "python/sedonadb" -vv
 
 # Clean up the library path so the container uses the real driver at runtime
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64
-
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics
+
+# --- SECURITY CONFIGURATION ---
+# Create a non-root user
+RUN useradd -ms /bin/bash jupyteruser
+
+# Change ownership of the workspace and virtual environment to the new user
+RUN chown -R jupyteruser:jupyteruser /workspace /opt/venv
+
+# Switch to the non-root user
+USER jupyteruser
+# ------------------------------
 
 # Expose the default JupyterLab port
 EXPOSE 8888
 
-# Launch JupyterLab by default when the container starts
-CMD ["jupyter", "lab", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--allow-root"]
+# Launch JupyterLab
+CMD ["jupyter", "lab", "--ip=0.0.0.0", "--port=8888", "--no-browser"]

--- a/docker/sedonadb-gpu.dockerfile
+++ b/docker/sedonadb-gpu.dockerfile
@@ -64,7 +64,8 @@ ENV CMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake
 ENV PKG_CONFIG_PATH=$VCPKG_ROOT/installed/x64-linux/lib/pkgconfig
 ENV CC=clang-18
 ENV CXX=clang++-18
-ENV CMAKE_CUDA_ARCHITECTURES="86"
+ARG CMAKE_CUDA_ARCHITECTURES=native
+ENV CMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH}
 
 # Create and activate virtual environment

--- a/docker/sedonadb-gpu.dockerfile
+++ b/docker/sedonadb-gpu.dockerfile
@@ -1,0 +1,92 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM nvidia/cuda:13.1.2-devel-ubuntu24.04
+
+# Install system dependencies (initial set; clang added from LLVM apt repo below)
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    git \
+    pkg-config \
+    curl \
+    python3 \
+    python3-dev \
+    python3-pip \
+    gnupg \
+    lsb-release \
+    ca-certificates \
+    wget \
+    zip \
+    unzip \
+    tar \
+    clang-18 \
+    clang++-18 \
+    libc++-18-dev \
+    libc++abi-18-dev \
+    lld-18 \
+    python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add Kitware APT repository and install the latest CMake (Updated for Ubuntu 24.04)
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null \
+ && echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/kitware.list >/dev/null \
+ && apt-get update \
+ && apt-get install -y cmake \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install vcpkg
+RUN git clone https://github.com/Microsoft/vcpkg.git /home/ubuntu/vcpkg
+WORKDIR /home/ubuntu/vcpkg
+RUN ./bootstrap-vcpkg.sh
+RUN ./vcpkg install geos
+
+# Copy your project
+COPY . /workspace
+WORKDIR /workspace
+
+# Set environment variables for build
+ENV VCPKG_ROOT=/home/ubuntu/vcpkg
+ENV CMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake
+ENV PKG_CONFIG_PATH=$VCPKG_ROOT/installed/x64-linux/lib/pkgconfig
+ENV CC=clang-18
+ENV CXX=clang++-18
+ENV CMAKE_CUDA_ARCHITECTURES="86"
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH}
+
+# Create and activate virtual environment
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Pass features to maturin when pip builds the package via PEP517
+ENV MATURIN_PEP517_ARGS="--features s2geography,gpu"
+
+# Install maturin AND JupyterLab inside the virtual environment
+RUN pip3 install maturin jupyterlab pyproj
+
+# Install the project in editable mode (uses pyproject -> maturin under the hood)
+RUN pip3 install -e "python/sedonadb" -vv
+
+# Clean up the library path so the container uses the real driver at runtime
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64
+
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics
+
+# Expose the default JupyterLab port
+EXPOSE 8888
+
+# Launch JupyterLab by default when the container starts
+CMD ["jupyter", "lab", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--allow-root"]

--- a/docker/sedonadb-gpu.dockerfile.dockerignore
+++ b/docker/sedonadb-gpu.dockerfile.dockerignore
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Git
+.git
+.github
+.gitmodules
+
+# IDEs
+.idea
+.vscode
+.history
+
+# Rust build artifacts
+target/
+python/sedonadb/target/
+
+# Python cache & tests
+.pytest_cache/
+python/sedonadb/.pytest_cache/
+**/__pycache__/
+**/*.pyc
+**/*.pyo
+**/*.pyd
+
+# Python distribution / packaging
+python/sedonadb/build/
+python/sedonadb/dist/
+python/sedonadb/*.egg-info/
+python/sedonadb/.eggs/
+.eggs/
+build/
+dist/
+*.egg-info/
+.venv/
+venv/
+env/
+
+# Documentation
+site/
+.ipynb_checkpoints/
+docs/.ipynb_checkpoints/
+docs/hf-data/
+
+# Release management
+dev/release/.env
+
+# Benchmarks & local outputs
+benchmarks/
+rat.txt
+filtered_rat.txt
+apache-rat-0.13.jar
+
+# R-related
+r/sedonadb/.Rproj.user/

--- a/docs/gpu-acceleration.ipynb
+++ b/docs/gpu-acceleration.ipynb
@@ -87,14 +87,15 @@
     "Common environment variables used by the GPU build:\n",
     "\n",
     "- `CUDA_HOME`: points to your CUDA toolkit root.\n",
-    "- `CMAKE_CUDA_ARCHITECTURES`: CUDA SM targets (default falls back to `86;89` if not set). Change this according to your [GPU models](https://developer.nvidia.com/cuda/gpus).\n",
+    "- `CMAKE_CUDA_ARCHITECTURES`: CUDA SM targets (default falls back to `native` to auto-detect the host GPU architecture). Change this according to your [GPU models](https://developer.nvidia.com/cuda/gpus).\n",
     "\n",
     "- `LIBGPUSPATIAL_LOGGING_LEVEL`: Logging level, including `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `CRITICAL`.\n",
     "- `GPUSPATIAL_PROFILING=ON`: Profiling mode (`ON`, `OFF`) to compile profiling instrumentation.\n",
     "\n",
     "**Using Docker**\n",
     "\n",
-    "We also provide a Dockerfile for the users. Make sure you have installed Docker, the NVIDIA Driver, and NVIDIA Container Toolkit by `sudo nvidia-ctk runtime configure --runtime=docker`. Then, you may run `docker build -f docker/sedonadb-gpu.dockerfile --build-arg CMAKE_CUDA_ARCHITECTURES=\"86;89\" -t sedonadb-gpu .` to build an image. Finally, you may run `docker run -it --rm --gpus all sedonadb-gpu` to start a JupyterLab instance."
+    "We also provide a Dockerfile for the users. Make sure you have installed Docker, the NVIDIA Driver, and NVIDIA Container Toolkit by `sudo nvidia-ctk runtime configure --runtime=docker`. Then, you may run `docker build -f docker/sedonadb-gpu.dockerfile --build-arg CMAKE_CUDA_ARCHITECTURES=\"86;89\" -t sedonadb-gpu .` to build an image. Finally, you may run `docker run -it --rm --gpus all -p 8888:8888 sedonadb-gpu` to start a JupyterLab instance.\n",
+    "\n> **Note:** This Docker image is currently source-built directly from the repository's active codebase and is not tied to a released SedonaDB GPU wheel yet. This is to support development and early testing before an official SedonaDB GPU wheel is published."
    ]
   },
   {

--- a/docs/gpu-acceleration.ipynb
+++ b/docs/gpu-acceleration.ipynb
@@ -81,7 +81,7 @@
     "## Install from Source with the GPU Feature\n",
     "**Build from source**\n",
     "\n",
-    "If you build the Python package from source, enable GPU at build time, and configure the CUDA\n",
+    "For building the Python package from source, you should enable the GPU at build time and configure the CUDA\n",
     "environment before running `MATURIN_PEP517_ARGS=\"--features gpu\" pip install`.\n",
     "\n",
     "Common environment variables used by the GPU build:\n",
@@ -127,7 +127,7 @@
     "\n",
     "ctx = sedonadb.connect()\n",
     "\n",
-    "ctx.sql(\"SET gpu.enable = true\")"
+    "ctx.sql(\"SET gpu.enable = true\").execute()"
    ]
   },
   {
@@ -145,7 +145,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ctx.sql(\"SET datafusion.execution.batch_size = 100000\")"
+    "ctx.sql(\"SET datafusion.execution.batch_size = 100000\").execute()"
    ]
   },
   {
@@ -196,7 +196,7 @@
     "ctx.sql(\"SET gpu.memory_pool_init_percentage = 60\")\n",
     "ctx.sql(\"SET gpu.pipeline_batches = 2\")\n",
     "ctx.sql(\"SET gpu.compress_bvh = false\")\n",
-    "ctx.sql(\"SET datafusion.execution.batch_size = 100000\")"
+    "ctx.sql(\"SET datafusion.execution.batch_size = 100000\").execute()"
    ]
   },
   {
@@ -204,6 +204,56 @@
    "metadata": {},
    "source": [
     "## Example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Check GPU environment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tue May 26 20:49:41 2026       \n",
+      "+-----------------------------------------------------------------------------------------+\n",
+      "| NVIDIA-SMI 580.105.08             Driver Version: 580.105.08     CUDA Version: 13.0     |\n",
+      "+-----------------------------------------+------------------------+----------------------+\n",
+      "| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |\n",
+      "| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |\n",
+      "|                                         |                        |               MIG M. |\n",
+      "|=========================================+========================+======================|\n",
+      "|   0  NVIDIA L4                      On  |   00000000:31:00.0 Off |                    0 |\n",
+      "| N/A   41C    P0             28W /   72W |   11610MiB /  23034MiB |      0%      Default |\n",
+      "|                                         |                        |                  N/A |\n",
+      "+-----------------------------------------+------------------------+----------------------+\n",
+      "\n",
+      "+-----------------------------------------------------------------------------------------+\n",
+      "| Processes:                                                                              |\n",
+      "|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |\n",
+      "|        ID   ID                                                               Usage      |\n",
+      "|=========================================================================================|\n",
+      "|    0   N/A  N/A           20603      C   ...a3/envs/sedona/bin/python3.11      11602MiB |\n",
+      "+-----------------------------------------------------------------------------------------+\n"
+     ]
+    }
+   ],
+   "source": [
+    "!nvidia-smi"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Install required packages for the example"
    ]
   },
   {
@@ -215,30 +265,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Mon May 18 16:57:05 2026       \n",
-      "+-----------------------------------------------------------------------------------------+\n",
-      "| NVIDIA-SMI 580.105.08             Driver Version: 580.105.08     CUDA Version: 13.0     |\n",
-      "+-----------------------------------------+------------------------+----------------------+\n",
-      "| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |\n",
-      "| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |\n",
-      "|                                         |                        |               MIG M. |\n",
-      "|=========================================+========================+======================|\n",
-      "|   0  NVIDIA L4                      On  |   00000000:31:00.0 Off |                    0 |\n",
-      "| N/A   41C    P8             17W /   72W |       0MiB /  23034MiB |      0%      Default |\n",
-      "|                                         |                        |                  N/A |\n",
-      "+-----------------------------------------+------------------------+----------------------+\n",
-      "\n",
-      "+-----------------------------------------------------------------------------------------+\n",
-      "| Processes:                                                                              |\n",
-      "|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |\n",
-      "|        ID   ID                                                               Usage      |\n",
-      "|=========================================================================================|\n",
-      "|  No running processes found                                                             |\n",
-      "+-----------------------------------------------------------------------------------------+\n",
       "Requirement already satisfied: huggingface_hub in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (1.4.1)\n",
-      "Requirement already satisfied: ipywidgets in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (8.1.8)\n",
-      "Collecting rasterio\n",
-      "  Downloading rasterio-1.4.4-cp311-cp311-manylinux_2_28_x86_64.whl.metadata (9.3 kB)\n",
+      "Requirement already satisfied: rasterio in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (1.4.4)\n",
       "Requirement already satisfied: pyogrio in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (0.12.1)\n",
       "Requirement already satisfied: filelock in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (3.20.1)\n",
       "Requirement already satisfied: fsspec>=2023.5.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (2026.2.0)\n",
@@ -255,67 +283,42 @@
       "Requirement already satisfied: httpcore==1.* in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from httpx<1,>=0.23.0->huggingface_hub) (1.0.9)\n",
       "Requirement already satisfied: idna in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from httpx<1,>=0.23.0->huggingface_hub) (3.11)\n",
       "Requirement already satisfied: h11>=0.16 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from httpcore==1.*->httpx<1,>=0.23.0->huggingface_hub) (0.16.0)\n",
-      "Requirement already satisfied: comm>=0.1.3 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipywidgets) (0.2.3)\n",
-      "Requirement already satisfied: ipython>=6.1.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipywidgets) (9.10.1)\n",
-      "Requirement already satisfied: traitlets>=4.3.1 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipywidgets) (5.14.3)\n",
-      "Requirement already satisfied: widgetsnbextension~=4.0.14 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipywidgets) (4.0.15)\n",
-      "Requirement already satisfied: jupyterlab_widgets~=3.0.15 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipywidgets) (3.0.16)\n",
-      "Collecting affine (from rasterio)\n",
-      "  Downloading affine-2.4.0-py3-none-any.whl.metadata (4.0 kB)\n",
+      "Requirement already satisfied: affine in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (2.4.0)\n",
       "Requirement already satisfied: attrs in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (26.1.0)\n",
       "Requirement already satisfied: click!=8.2.*,>=4.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (8.3.1)\n",
-      "Collecting cligj>=0.5 (from rasterio)\n",
-      "  Downloading cligj-0.7.2-py3-none-any.whl.metadata (5.0 kB)\n",
+      "Requirement already satisfied: cligj>=0.5 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (0.7.2)\n",
       "Requirement already satisfied: numpy>=1.24 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (2.4.0)\n",
-      "Collecting click-plugins (from rasterio)\n",
-      "  Downloading click_plugins-1.1.1.2-py2.py3-none-any.whl.metadata (6.5 kB)\n",
-      "Collecting pyparsing (from rasterio)\n",
-      "  Downloading pyparsing-3.3.2-py3-none-any.whl.metadata (5.8 kB)\n",
-      "Requirement already satisfied: decorator>=4.3.2 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (5.2.1)\n",
-      "Requirement already satisfied: ipython-pygments-lexers>=1.0.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (1.1.1)\n",
-      "Requirement already satisfied: jedi>=0.18.1 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (0.19.2)\n",
-      "Requirement already satisfied: matplotlib-inline>=0.1.5 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (0.2.1)\n",
-      "Requirement already satisfied: pexpect>4.3 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (4.9.0)\n",
-      "Requirement already satisfied: prompt_toolkit<3.1.0,>=3.0.41 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (3.0.52)\n",
-      "Requirement already satisfied: pygments>=2.11.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (2.19.2)\n",
-      "Requirement already satisfied: stack_data>=0.6.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (0.6.3)\n",
-      "Requirement already satisfied: wcwidth in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from prompt_toolkit<3.1.0,>=3.0.41->ipython>=6.1.0->ipywidgets) (0.6.0)\n",
-      "Requirement already satisfied: parso<0.9.0,>=0.8.4 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from jedi>=0.18.1->ipython>=6.1.0->ipywidgets) (0.8.6)\n",
-      "Requirement already satisfied: ptyprocess>=0.5 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from pexpect>4.3->ipython>=6.1.0->ipywidgets) (0.7.0)\n",
-      "Requirement already satisfied: executing>=1.2.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from stack_data>=0.6.0->ipython>=6.1.0->ipywidgets) (2.2.1)\n",
-      "Requirement already satisfied: asttokens>=2.1.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from stack_data>=0.6.0->ipython>=6.1.0->ipywidgets) (3.0.1)\n",
-      "Requirement already satisfied: pure-eval in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from stack_data>=0.6.0->ipython>=6.1.0->ipywidgets) (0.2.3)\n",
+      "Requirement already satisfied: click-plugins in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (1.1.1.2)\n",
+      "Requirement already satisfied: pyparsing in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (3.3.2)\n",
       "Requirement already satisfied: typer>=0.24.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from typer-slim->huggingface_hub) (0.24.1)\n",
       "Requirement already satisfied: rich>=12.3.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from typer>=0.24.0->typer-slim->huggingface_hub) (14.3.3)\n",
       "Requirement already satisfied: annotated-doc>=0.0.2 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from typer>=0.24.0->typer-slim->huggingface_hub) (0.0.4)\n",
       "Requirement already satisfied: markdown-it-py>=2.2.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rich>=12.3.0->typer>=0.24.0->typer-slim->huggingface_hub) (4.0.0)\n",
-      "Requirement already satisfied: mdurl~=0.1 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from markdown-it-py>=2.2.0->rich>=12.3.0->typer>=0.24.0->typer-slim->huggingface_hub) (0.1.2)\n",
-      "Downloading rasterio-1.4.4-cp311-cp311-manylinux_2_28_x86_64.whl (35.9 MB)\n",
-      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m35.9/35.9 MB\u001b[0m \u001b[31m55.1 MB/s\u001b[0m  \u001b[33m0:00:00\u001b[0mm0:00:01\u001b[0m00:01\u001b[0m\n",
-      "\u001b[?25hDownloading cligj-0.7.2-py3-none-any.whl (7.1 kB)\n",
-      "Downloading affine-2.4.0-py3-none-any.whl (15 kB)\n",
-      "Downloading click_plugins-1.1.1.2-py2.py3-none-any.whl (11 kB)\n",
-      "Downloading pyparsing-3.3.2-py3-none-any.whl (122 kB)\n",
-      "Installing collected packages: pyparsing, cligj, click-plugins, affine, rasterio\n",
-      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m5/5\u001b[0m [rasterio]4/5\u001b[0m [rasterio]\n",
-      "\u001b[1A\u001b[2KSuccessfully installed affine-2.4.0 click-plugins-1.1.1.2 cligj-0.7.2 pyparsing-3.3.2 rasterio-1.4.4\n"
+      "Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rich>=12.3.0->typer>=0.24.0->typer-slim->huggingface_hub) (2.19.2)\n",
+      "Requirement already satisfied: mdurl~=0.1 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from markdown-it-py>=2.2.0->rich>=12.3.0->typer>=0.24.0->typer-slim->huggingface_hub) (0.1.2)\n"
      ]
     }
    ],
    "source": [
-    "!nvidia-smi\n",
-    "!pip install huggingface_hub ipywidgets rasterio pyogrio"
+    "!pip install huggingface_hub rasterio pyogrio"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Download datasets"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d5f2130c1fb04469a451c8ac0b03e9a4",
+       "model_id": "eb667a82591c44be916ea5ea90bf174a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -329,7 +332,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "642b01d0202d407098f5d15ee13bf7e4",
+       "model_id": "fc953b32973542198fd1c2c29bb8866c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -341,19 +344,12 @@
      "output_type": "display_data"
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
-       "'/mnt/data/sedona-db-docker/docs/hf-data'"
+       "'/mnt/data/sedona-db/docs/hf-data'"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -370,17 +366,24 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create sedonadb context and load datasets"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<sedonadb.dataframe.DataFrame object at 0x759fd0436750>"
+       "0"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -390,26 +393,7 @@
     "\n",
     "ctx = sedonadb.connect()\n",
     "ctx.options.memory_limit = \"unlimited\"\n",
-    "ctx.sql(\"SET datafusion.execution.batch_size = 100000\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<sedonadb.dataframe.DataFrame object at 0x759fd045b5d0>"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
+    "\n",
     "ctx.sql(\"\"\"\n",
     "    CREATE EXTERNAL TABLE zone\n",
     "    STORED AS PARQUET\n",
@@ -419,212 +403,172 @@
     "    CREATE EXTERNAL TABLE trip\n",
     "    STORED AS PARQUET\n",
     "    LOCATION 'hf-data/v0.1.0/sf1/trip/'\n",
-    "\"\"\")"
+    "\"\"\").execute()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define query"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the query once to ensure both executions use the exact same logic\n",
+    "query = \"\"\"\n",
+    "SELECT COUNT(*) AS cross_zone_trip_count\n",
+    "FROM trip t\n",
+    "    JOIN zone pickup_zone\n",
+    "        ON ST_Within(ST_GeomFromWKB(t.t_pickuploc), ST_GeomFromWKB(pickup_zone.z_boundary))\n",
+    "    JOIN zone dropoff_zone\n",
+    "        ON ST_Within(ST_GeomFromWKB(t.t_dropoffloc), ST_GeomFromWKB(dropoff_zone.z_boundary))\n",
+    "WHERE pickup_zone.z_zonekey != dropoff_zone.z_zonekey\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, we will run this query using the standard CPU execution to establish our baseline correctness and get a sense of the standard execution time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<h3>🚀 Running Spatial Benchmark...</h3>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8cc548972a614276b3319842400cdb7b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output(layout=Layout(border_bottom='1px solid #ccc', border_left='1px solid #ccc', border_right='1px solid #cc…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9f60924de5354583944b6505bdff17df",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "CPU Executions:   0%|          | 0/6 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c2f32881f4894135be8f92620daeb0bd",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "GPU Executions:   0%|          | 0/6 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<h3>📊 Benchmark Results (Averaged over 5 runs)</h3>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "    <table style=\"width: 60%; text-align: center; border-collapse: collapse; font-family: sans-serif; margin-top: 15px;\">\n",
-       "        <tr style=\"background-color: #f8f9fa; border-bottom: 2px solid #dee2e6;\">\n",
-       "            <th style=\"padding: 12px; border: 1px solid #dee2e6;\">Mode</th>\n",
-       "            <th style=\"padding: 12px; border: 1px solid #dee2e6;\">Average Time (s)</th>\n",
-       "            <th style=\"padding: 12px; border: 1px solid #dee2e6;\">Speedup</th>\n",
-       "        </tr>\n",
-       "        <tr>\n",
-       "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\"><b>CPU</b> (Baseline)</td>\n",
-       "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\">8.4922</td>\n",
-       "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\">1.00x</td>\n",
-       "        </tr>\n",
-       "        <tr>\n",
-       "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\"><b>GPU</b></td>\n",
-       "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\">3.0277</td>\n",
-       "            <td style=\"padding: 12px; border: 1px solid #dee2e6; color: green; font-weight: bold;\">2.80x</td>\n",
-       "        </tr>\n",
-       "    </table>\n",
-       "    "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Executing on CPU (Baseline)...\n",
+      "  Run 1: 7.7795 seconds\n",
+      "  Run 2: 6.8287 seconds\n",
+      "  Run 3: 7.0688 seconds\n",
+      "  Run 4: 7.2434 seconds\n",
+      "  Run 5: 7.1739 seconds\n",
+      "------------------------------\n",
+      "CPU Average Time: 7.2189 seconds | Rows: 176391\n"
+     ]
     }
    ],
    "source": [
     "import time\n",
-    "from tqdm.notebook import tqdm\n",
-    "from IPython.display import display, HTML\n",
-    "import ipywidgets as widgets\n",
     "\n",
+    "print(\"Executing on CPU (Baseline)...\")\n",
+    "ctx.sql(\"SET gpu.enable = false\")  # Disable the GPU feature\n",
+    "ctx.sql(\"SET datafusion.execution.batch_size = 8192\")  # Default configuration\n",
     "\n",
-    "def interactive_spatial_benchmark(ctx, runs=6):\n",
-    "    query = \"\"\"\n",
-    "    SELECT COUNT(*) AS cross_zone_trip_count\n",
-    "    FROM trip t\n",
-    "        JOIN zone pickup_zone\n",
-    "            ON ST_Within(ST_GeomFromWKB(t.t_pickuploc), ST_GeomFromWKB(pickup_zone.z_boundary))\n",
-    "        JOIN zone dropoff_zone\n",
-    "            ON ST_Within(ST_GeomFromWKB(t.t_dropoffloc), ST_GeomFromWKB(dropoff_zone.z_boundary))\n",
-    "    WHERE pickup_zone.z_zonekey != dropoff_zone.z_zonekey\n",
-    "    \"\"\"\n",
+    "runs = 5\n",
+    "cpu_times = []\n",
+    "cpu_count = 0\n",
     "\n",
-    "    modes = [(\"CPU\", \"false\"), (\"GPU\", \"true\")]\n",
-    "    averages = {}\n",
+    "for i in range(runs):\n",
+    "    start_time = time.time()\n",
+    "    cpu_df = ctx.sql(query).to_pandas()\n",
+    "    elapsed = time.time() - start_time\n",
     "\n",
-    "    # 1. Create a scrollable widget to catch the verbose `.show()` output\n",
-    "    log_output = widgets.Output(\n",
-    "        layout={\"border\": \"1px solid #ccc\", \"height\": \"150px\", \"overflow_y\": \"auto\"}\n",
-    "    )\n",
-    "    display(HTML(\"<h3>🚀 Running Spatial Benchmark...</h3>\"))\n",
-    "    display(log_output)\n",
+    "    cpu_times.append(elapsed)\n",
+    "    cpu_count = cpu_df.iloc[0, 0]\n",
+    "    print(f\"  Run {i + 1}: {elapsed:.4f} seconds\")\n",
     "\n",
-    "    # 2. Execute the Benchmark\n",
-    "    for mode_name, gpu_flag in modes:\n",
-    "        ctx.sql(f\"SET gpu.enable = {gpu_flag}\")\n",
-    "        if gpu_flag:\n",
-    "            ctx.sql(\n",
-    "                \"SET datafusion.execution.batch_size = 2000000\"\n",
-    "            )  # Increase batch size\n",
-    "        else:\n",
-    "            ctx.sql(\"SET datafusion.execution.batch_size = 8192\")  # Default\n",
-    "        execution_times = []\n",
+    "cpu_avg_time = sum(cpu_times) / runs\n",
+    "print(\"-\" * 30)\n",
+    "print(f\"CPU Average Time: {cpu_avg_time:.4f} seconds | Rows: {cpu_count}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we enable GPU execution. We also increase the batch size, which is a crucial optimization step to ensure we are feeding enough data to the GPU to maximize its parallel processing capabilities."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Executing on GPU (Accelerated)...\n",
+      "  Run 1: 3.2582 seconds\n",
+      "  Run 2: 3.3126 seconds\n",
+      "  Run 3: 3.0703 seconds\n",
+      "  Run 4: 3.2604 seconds\n",
+      "  Run 5: 3.1418 seconds\n",
+      "------------------------------\n",
+      "GPU Average Time: 3.2087 seconds | Rows: 176391\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Executing on GPU (Accelerated)...\")\n",
+    "ctx.sql(\"SET gpu.enable = true\")\n",
+    "ctx.sql(\"SET datafusion.execution.batch_size = 1000000\")  # Optimized for GPU throughput\n",
     "\n",
-    "        # Display a Jupyter-native progress bar\n",
-    "        for i in tqdm(range(runs), desc=f\"{mode_name} Executions\"):\n",
-    "            start_time = time.time()\n",
+    "runs = 5\n",
+    "gpu_times = []\n",
+    "gpu_count = 0\n",
     "\n",
-    "            result = ctx.sql(query)\n",
+    "for i in range(runs):\n",
+    "    start_time = time.time()\n",
+    "    gpu_df = ctx.sql(query).to_pandas()\n",
+    "    elapsed = time.time() - start_time\n",
     "\n",
-    "            # Execute physical plan and catch the output inside our widget\n",
-    "            with log_output:\n",
-    "                print(f\"--- {mode_name} Run {i + 1} ---\")\n",
-    "                result.show()\n",
+    "    gpu_times.append(elapsed)\n",
+    "    gpu_count = gpu_df.iloc[0, 0]\n",
+    "    print(f\"  Run {i + 1}: {elapsed:.4f} seconds\")\n",
     "\n",
-    "            elapsed = time.time() - start_time\n",
+    "gpu_avg_time = sum(gpu_times) / runs\n",
+    "print(\"-\" * 30)\n",
+    "print(f\"GPU Average Time: {gpu_avg_time:.4f} seconds | Rows: {gpu_count}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Compare Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Query Validation (Based on Averages) ---\n",
+      "Row Count Validated : 176391 (✅ Match)\n",
+      "Average CPU Time    : 7.2189s\n",
+      "Average GPU Time    : 3.2087s\n",
+      "Calculated Speedup  : 2.25x\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Validate correctness\n",
+    "match_status = \"✅ Match\" if cpu_count == gpu_count else \"❌ Mismatch\"\n",
     "\n",
-    "            # Record everything except the first run (warmup)\n",
-    "            if i > 0:\n",
-    "                execution_times.append(elapsed)\n",
+    "# Calculate speedup based on the new averages\n",
+    "speedup = cpu_avg_time / gpu_avg_time if gpu_avg_time > 0 else 0\n",
     "\n",
-    "        # Calculate average\n",
-    "        averages[mode_name] = sum(execution_times) / len(execution_times)\n",
-    "\n",
-    "    # 3. Clean up the UI\n",
-    "    log_output.clear_output()\n",
-    "    log_output.layout.display = \"none\"\n",
-    "\n",
-    "    # 4. Generate Table Results\n",
-    "    cpu_avg = averages[\"CPU\"]\n",
-    "    gpu_avg = averages[\"GPU\"]\n",
-    "\n",
-    "    # Calculate speedup (using CPU as the 1.0x baseline)\n",
-    "    cpu_speedup = 1.0\n",
-    "    gpu_speedup = cpu_avg / gpu_avg if gpu_avg > 0 else 0\n",
-    "\n",
-    "    # Color code the GPU speedup (green if faster, red if slower)\n",
-    "    gpu_color = \"green\" if gpu_speedup >= 1.0 else \"red\"\n",
-    "\n",
-    "    html_table = f\"\"\"\n",
-    "    <table style=\"width: 60%; text-align: center; border-collapse: collapse; font-family: sans-serif; margin-top: 15px;\">\n",
-    "        <tr style=\"background-color: #f8f9fa; border-bottom: 2px solid #dee2e6;\">\n",
-    "            <th style=\"padding: 12px; border: 1px solid #dee2e6;\">Mode</th>\n",
-    "            <th style=\"padding: 12px; border: 1px solid #dee2e6;\">Average Time (s)</th>\n",
-    "            <th style=\"padding: 12px; border: 1px solid #dee2e6;\">Speedup</th>\n",
-    "        </tr>\n",
-    "        <tr>\n",
-    "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\"><b>CPU</b> (Baseline)</td>\n",
-    "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\">{cpu_avg:.4f}</td>\n",
-    "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\">{cpu_speedup:.2f}x</td>\n",
-    "        </tr>\n",
-    "        <tr>\n",
-    "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\"><b>GPU</b></td>\n",
-    "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\">{gpu_avg:.4f}</td>\n",
-    "            <td style=\"padding: 12px; border: 1px solid #dee2e6; color: {gpu_color}; font-weight: bold;\">{gpu_speedup:.2f}x</td>\n",
-    "        </tr>\n",
-    "    </table>\n",
-    "    \"\"\"\n",
-    "\n",
-    "    display(HTML(\"<h3>📊 Benchmark Results (Averaged over 5 runs)</h3>\"))\n",
-    "    display(HTML(html_table))\n",
-    "\n",
-    "\n",
-    "# --- Execution Block ---\n",
-    "# Run the interactive function with your Sedona Context\n",
-    "interactive_spatial_benchmark(ctx)"
+    "print(\"--- Query Validation (Based on Averages) ---\")\n",
+    "print(f\"Row Count Validated : {gpu_count} ({match_status})\")\n",
+    "print(f\"Average CPU Time    : {cpu_avg_time:.4f}s\")\n",
+    "print(f\"Average GPU Time    : {gpu_avg_time:.4f}s\")\n",
+    "print(f\"Calculated Speedup  : {speedup:.2f}x\")"
    ]
   },
   {

--- a/docs/gpu-acceleration.ipynb
+++ b/docs/gpu-acceleration.ipynb
@@ -82,7 +82,7 @@
     "**Build from source**\n",
     "\n",
     "For building the Python package from source, you should enable the GPU at build time and configure the CUDA\n",
-    "environment before running `MATURIN_PEP517_ARGS=\"--features gpu\" pip install`.\n",
+    "environment before running `MATURIN_PEP517_ARGS=\"--features='gpu,s2geography,pyo3/extension-module' pip install`.\n",
     "\n",
     "Common environment variables used by the GPU build:\n",
     "\n",

--- a/docs/gpu-acceleration.ipynb
+++ b/docs/gpu-acceleration.ipynb
@@ -79,17 +79,22 @@
    "metadata": {},
    "source": [
     "## Install from Source with the GPU Feature\n",
+    "**Build from source**\n",
     "\n",
-    "If you build the Python package from source, enable GPU at build time and configure the CUDA\n",
+    "If you build the Python package from source, enable GPU at build time, and configure the CUDA\n",
     "environment before running `MATURIN_PEP517_ARGS=\"--features gpu\" pip install`.\n",
     "\n",
     "Common environment variables used by the GPU build:\n",
     "\n",
     "- `CUDA_HOME`: points to your CUDA toolkit root.\n",
-    "- `CMAKE_CUDA_ARCHITECTURES`: CUDA SM targets (default falls back to `86;89` if not set). Change this according to your GPU architecture.\n",
+    "- `CMAKE_CUDA_ARCHITECTURES`: CUDA SM targets (default falls back to `86;89` if not set). Change this according to your [GPU models](https://developer.nvidia.com/cuda/gpus).\n",
     "\n",
     "- `LIBGPUSPATIAL_LOGGING_LEVEL`: Logging level, including `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `CRITICAL`.\n",
-    "- `GPUSPATIAL_PROFILING=ON`: Profiling mode (`ON`, `OFF`) to compile profiling instrumentation."
+    "- `GPUSPATIAL_PROFILING=ON`: Profiling mode (`ON`, `OFF`) to compile profiling instrumentation.\n",
+    "\n",
+    "**Using Docker**\n",
+    "\n",
+    "We also provide a Dockerfile for the users. Make sure you have installed Docker, the NVIDIA Driver, and NVIDIA Container Toolkit by `sudo nvidia-ctk runtime configure --runtime=docker`. Then, you may run `docker build -f docker/sedonadb-gpu.dockerfile --build-arg CMAKE_CUDA_ARCHITECTURES=\"86;89\" -t sedonadb-gpu .` to build an image. Finally, you may run `docker run -it --rm --gpus all sedonadb-gpu` to start a JupyterLab instance."
    ]
   },
   {
@@ -103,9 +108,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<sedonadb.dataframe.DataFrame object at 0x70b85c1b7850>"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import sedonadb\n",
     "\n",
@@ -199,7 +215,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Mon Apr 20 19:26:08 2026       \n",
+      "Mon May 18 16:57:05 2026       \n",
       "+-----------------------------------------------------------------------------------------+\n",
       "| NVIDIA-SMI 580.105.08             Driver Version: 580.105.08     CUDA Version: 13.0     |\n",
       "+-----------------------------------------+------------------------+----------------------+\n",
@@ -208,7 +224,7 @@
       "|                                         |                        |               MIG M. |\n",
       "|=========================================+========================+======================|\n",
       "|   0  NVIDIA L4                      On  |   00000000:31:00.0 Off |                    0 |\n",
-      "| N/A   36C    P8             19W /   72W |       0MiB /  23034MiB |      0%      Default |\n",
+      "| N/A   41C    P8             17W /   72W |       0MiB /  23034MiB |      0%      Default |\n",
       "|                                         |                        |                  N/A |\n",
       "+-----------------------------------------+------------------------+----------------------+\n",
       "\n",
@@ -218,23 +234,88 @@
       "|        ID   ID                                                               Usage      |\n",
       "|=========================================================================================|\n",
       "|  No running processes found                                                             |\n",
-      "+-----------------------------------------------------------------------------------------+\n"
+      "+-----------------------------------------------------------------------------------------+\n",
+      "Requirement already satisfied: huggingface_hub in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (1.4.1)\n",
+      "Requirement already satisfied: ipywidgets in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (8.1.8)\n",
+      "Collecting rasterio\n",
+      "  Downloading rasterio-1.4.4-cp311-cp311-manylinux_2_28_x86_64.whl.metadata (9.3 kB)\n",
+      "Requirement already satisfied: pyogrio in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (0.12.1)\n",
+      "Requirement already satisfied: filelock in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (3.20.1)\n",
+      "Requirement already satisfied: fsspec>=2023.5.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (2026.2.0)\n",
+      "Requirement already satisfied: hf-xet<2.0.0,>=1.2.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (1.3.0)\n",
+      "Requirement already satisfied: httpx<1,>=0.23.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (0.28.1)\n",
+      "Requirement already satisfied: packaging>=20.9 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (25.0)\n",
+      "Requirement already satisfied: pyyaml>=5.1 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (6.0.3)\n",
+      "Requirement already satisfied: shellingham in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (1.5.4)\n",
+      "Requirement already satisfied: tqdm>=4.42.1 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (4.67.3)\n",
+      "Requirement already satisfied: typer-slim in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (0.24.0)\n",
+      "Requirement already satisfied: typing-extensions>=4.1.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (4.15.0)\n",
+      "Requirement already satisfied: anyio in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from httpx<1,>=0.23.0->huggingface_hub) (4.12.1)\n",
+      "Requirement already satisfied: certifi in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from httpx<1,>=0.23.0->huggingface_hub) (2025.11.12)\n",
+      "Requirement already satisfied: httpcore==1.* in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from httpx<1,>=0.23.0->huggingface_hub) (1.0.9)\n",
+      "Requirement already satisfied: idna in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from httpx<1,>=0.23.0->huggingface_hub) (3.11)\n",
+      "Requirement already satisfied: h11>=0.16 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from httpcore==1.*->httpx<1,>=0.23.0->huggingface_hub) (0.16.0)\n",
+      "Requirement already satisfied: comm>=0.1.3 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipywidgets) (0.2.3)\n",
+      "Requirement already satisfied: ipython>=6.1.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipywidgets) (9.10.1)\n",
+      "Requirement already satisfied: traitlets>=4.3.1 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipywidgets) (5.14.3)\n",
+      "Requirement already satisfied: widgetsnbextension~=4.0.14 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipywidgets) (4.0.15)\n",
+      "Requirement already satisfied: jupyterlab_widgets~=3.0.15 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipywidgets) (3.0.16)\n",
+      "Collecting affine (from rasterio)\n",
+      "  Downloading affine-2.4.0-py3-none-any.whl.metadata (4.0 kB)\n",
+      "Requirement already satisfied: attrs in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (26.1.0)\n",
+      "Requirement already satisfied: click!=8.2.*,>=4.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (8.3.1)\n",
+      "Collecting cligj>=0.5 (from rasterio)\n",
+      "  Downloading cligj-0.7.2-py3-none-any.whl.metadata (5.0 kB)\n",
+      "Requirement already satisfied: numpy>=1.24 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (2.4.0)\n",
+      "Collecting click-plugins (from rasterio)\n",
+      "  Downloading click_plugins-1.1.1.2-py2.py3-none-any.whl.metadata (6.5 kB)\n",
+      "Collecting pyparsing (from rasterio)\n",
+      "  Downloading pyparsing-3.3.2-py3-none-any.whl.metadata (5.8 kB)\n",
+      "Requirement already satisfied: decorator>=4.3.2 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (5.2.1)\n",
+      "Requirement already satisfied: ipython-pygments-lexers>=1.0.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (1.1.1)\n",
+      "Requirement already satisfied: jedi>=0.18.1 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (0.19.2)\n",
+      "Requirement already satisfied: matplotlib-inline>=0.1.5 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (0.2.1)\n",
+      "Requirement already satisfied: pexpect>4.3 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (4.9.0)\n",
+      "Requirement already satisfied: prompt_toolkit<3.1.0,>=3.0.41 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (3.0.52)\n",
+      "Requirement already satisfied: pygments>=2.11.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (2.19.2)\n",
+      "Requirement already satisfied: stack_data>=0.6.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (0.6.3)\n",
+      "Requirement already satisfied: wcwidth in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from prompt_toolkit<3.1.0,>=3.0.41->ipython>=6.1.0->ipywidgets) (0.6.0)\n",
+      "Requirement already satisfied: parso<0.9.0,>=0.8.4 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from jedi>=0.18.1->ipython>=6.1.0->ipywidgets) (0.8.6)\n",
+      "Requirement already satisfied: ptyprocess>=0.5 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from pexpect>4.3->ipython>=6.1.0->ipywidgets) (0.7.0)\n",
+      "Requirement already satisfied: executing>=1.2.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from stack_data>=0.6.0->ipython>=6.1.0->ipywidgets) (2.2.1)\n",
+      "Requirement already satisfied: asttokens>=2.1.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from stack_data>=0.6.0->ipython>=6.1.0->ipywidgets) (3.0.1)\n",
+      "Requirement already satisfied: pure-eval in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from stack_data>=0.6.0->ipython>=6.1.0->ipywidgets) (0.2.3)\n",
+      "Requirement already satisfied: typer>=0.24.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from typer-slim->huggingface_hub) (0.24.1)\n",
+      "Requirement already satisfied: rich>=12.3.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from typer>=0.24.0->typer-slim->huggingface_hub) (14.3.3)\n",
+      "Requirement already satisfied: annotated-doc>=0.0.2 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from typer>=0.24.0->typer-slim->huggingface_hub) (0.0.4)\n",
+      "Requirement already satisfied: markdown-it-py>=2.2.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rich>=12.3.0->typer>=0.24.0->typer-slim->huggingface_hub) (4.0.0)\n",
+      "Requirement already satisfied: mdurl~=0.1 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from markdown-it-py>=2.2.0->rich>=12.3.0->typer>=0.24.0->typer-slim->huggingface_hub) (0.1.2)\n",
+      "Downloading rasterio-1.4.4-cp311-cp311-manylinux_2_28_x86_64.whl (35.9 MB)\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m35.9/35.9 MB\u001b[0m \u001b[31m55.1 MB/s\u001b[0m  \u001b[33m0:00:00\u001b[0mm0:00:01\u001b[0m00:01\u001b[0m\n",
+      "\u001b[?25hDownloading cligj-0.7.2-py3-none-any.whl (7.1 kB)\n",
+      "Downloading affine-2.4.0-py3-none-any.whl (15 kB)\n",
+      "Downloading click_plugins-1.1.1.2-py2.py3-none-any.whl (11 kB)\n",
+      "Downloading pyparsing-3.3.2-py3-none-any.whl (122 kB)\n",
+      "Installing collected packages: pyparsing, cligj, click-plugins, affine, rasterio\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m5/5\u001b[0m [rasterio]4/5\u001b[0m [rasterio]\n",
+      "\u001b[1A\u001b[2KSuccessfully installed affine-2.4.0 click-plugins-1.1.1.2 cligj-0.7.2 pyparsing-3.3.2 rasterio-1.4.4\n"
      ]
     }
    ],
    "source": [
-    "!nvidia-smi"
+    "!nvidia-smi\n",
+    "!pip install huggingface_hub ipywidgets rasterio pyogrio"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f61963ba7f544dd1893c8e2b06a4e36b",
+       "model_id": "d5f2130c1fb04469a451c8ac0b03e9a4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -248,7 +329,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ae7cc720cd314a738216d16440984434",
+       "model_id": "642b01d0202d407098f5d15ee13bf7e4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -269,10 +350,10 @@
     {
      "data": {
       "text/plain": [
-       "'/mnt/data/sedona-db/docs/hf-data'"
+       "'/mnt/data/sedona-db-docker/docs/hf-data'"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -290,28 +371,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import sedonadb\n",
-    "\n",
-    "ctx = sedonadb.connect()\n",
-    "ctx.options.memory_limit = \"unlimited\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<sedonadb.dataframe.DataFrame object at 0x7ff5213d96d0>"
+       "<sedonadb.dataframe.DataFrame object at 0x759fd0436750>"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import sedonadb\n",
+    "\n",
+    "ctx = sedonadb.connect()\n",
+    "ctx.options.memory_limit = \"unlimited\"\n",
+    "ctx.sql(\"SET datafusion.execution.batch_size = 100000\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<sedonadb.dataframe.DataFrame object at 0x759fd045b5d0>"
+      ]
+     },
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -331,7 +424,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -349,7 +442,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9bb04f6f098d45c690ee3267196ac846",
+       "model_id": "8cc548972a614276b3319842400cdb7b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -363,7 +456,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c8acccbeb09147cbb8f56db7423778d8",
+       "model_id": "9f60924de5354583944b6505bdff17df",
        "version_major": 2,
        "version_minor": 0
       },
@@ -377,7 +470,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fa04532f673945598267fee06055a1d9",
+       "model_id": "c2f32881f4894135be8f92620daeb0bd",
        "version_major": 2,
        "version_minor": 0
       },
@@ -412,13 +505,13 @@
        "        </tr>\n",
        "        <tr>\n",
        "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\"><b>CPU</b> (Baseline)</td>\n",
-       "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\">21.5221</td>\n",
+       "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\">8.4922</td>\n",
        "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\">1.00x</td>\n",
        "        </tr>\n",
        "        <tr>\n",
        "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\"><b>GPU</b></td>\n",
-       "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\">2.8889</td>\n",
-       "            <td style=\"padding: 12px; border: 1px solid #dee2e6; color: green; font-weight: bold;\">7.45x</td>\n",
+       "            <td style=\"padding: 12px; border: 1px solid #dee2e6;\">3.0277</td>\n",
+       "            <td style=\"padding: 12px; border: 1px solid #dee2e6; color: green; font-weight: bold;\">2.80x</td>\n",
        "        </tr>\n",
        "    </table>\n",
        "    "

--- a/docs/gpu-acceleration.ipynb
+++ b/docs/gpu-acceleration.ipynb
@@ -87,15 +87,16 @@
     "Common environment variables used by the GPU build:\n",
     "\n",
     "- `CUDA_HOME`: points to your CUDA toolkit root.\n",
-    "- `CMAKE_CUDA_ARCHITECTURES`: CUDA SM targets (default falls back to `native` to auto-detect the host GPU architecture). Change this according to your [GPU models](https://developer.nvidia.com/cuda/gpus).\n",
+    "- `CMAKE_CUDA_ARCHITECTURES`: CUDA SM targets (default falls back to `86` if not set; You can specify multiple arcs, e.g., \"86;89\"). Change this according to your [GPU models](https://developer.nvidia.com/cuda/gpus). **Otherwise, it requires JIT to compile kernels, making the first-time run very slow!**\n",
     "\n",
     "- `LIBGPUSPATIAL_LOGGING_LEVEL`: Logging level, including `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `CRITICAL`.\n",
     "- `GPUSPATIAL_PROFILING=ON`: Profiling mode (`ON`, `OFF`) to compile profiling instrumentation.\n",
     "\n",
     "**Using Docker**\n",
     "\n",
-    "We also provide a Dockerfile for the users. Make sure you have installed Docker, the NVIDIA Driver, and NVIDIA Container Toolkit by `sudo nvidia-ctk runtime configure --runtime=docker`. Then, you may run `docker build -f docker/sedonadb-gpu.dockerfile --build-arg CMAKE_CUDA_ARCHITECTURES=\"86;89\" -t sedonadb-gpu .` to build an image. Finally, you may run `docker run -it --rm --gpus all -p 8888:8888 sedonadb-gpu` to start a JupyterLab instance.\n",
-    "\n> **Note:** This Docker image is currently source-built directly from the repository's active codebase and is not tied to a released SedonaDB GPU wheel yet. This is to support development and early testing before an official SedonaDB GPU wheel is published."
+    "We also provide a Dockerfile for the users. Make sure you have installed Docker, the NVIDIA Driver, and NVIDIA Container Toolkit by `sudo nvidia-ctk runtime configure --runtime=docker`. Then, you may run `docker build -f docker/sedonadb-gpu.dockerfile --build-arg CMAKE_CUDA_ARCHITECTURES=\"Your GPU compute capability\" -t sedonadb-gpu .` to build an image. Finally, you may run `docker run -it --rm --gpus all -p 8888:8888 sedonadb-gpu` to start a JupyterLab instance.\n",
+    "\n",
+    "> **Note:** This Docker image is currently source-built directly from the repository's active codebase and is not tied to a released SedonaDB GPU wheel yet. This is to support development and early testing before an official SedonaDB GPU wheel is published."
    ]
   },
   {

--- a/docs/gpu-acceleration.ipynb
+++ b/docs/gpu-acceleration.ipynb
@@ -258,47 +258,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: huggingface_hub in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (1.4.1)\n",
-      "Requirement already satisfied: rasterio in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (1.4.4)\n",
-      "Requirement already satisfied: pyogrio in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (0.12.1)\n",
-      "Requirement already satisfied: filelock in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (3.20.1)\n",
-      "Requirement already satisfied: fsspec>=2023.5.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (2026.2.0)\n",
-      "Requirement already satisfied: hf-xet<2.0.0,>=1.2.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (1.3.0)\n",
-      "Requirement already satisfied: httpx<1,>=0.23.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (0.28.1)\n",
-      "Requirement already satisfied: packaging>=20.9 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (25.0)\n",
-      "Requirement already satisfied: pyyaml>=5.1 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (6.0.3)\n",
-      "Requirement already satisfied: shellingham in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (1.5.4)\n",
-      "Requirement already satisfied: tqdm>=4.42.1 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (4.67.3)\n",
-      "Requirement already satisfied: typer-slim in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (0.24.0)\n",
-      "Requirement already satisfied: typing-extensions>=4.1.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (4.15.0)\n",
-      "Requirement already satisfied: anyio in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from httpx<1,>=0.23.0->huggingface_hub) (4.12.1)\n",
-      "Requirement already satisfied: certifi in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from httpx<1,>=0.23.0->huggingface_hub) (2025.11.12)\n",
-      "Requirement already satisfied: httpcore==1.* in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from httpx<1,>=0.23.0->huggingface_hub) (1.0.9)\n",
-      "Requirement already satisfied: idna in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from httpx<1,>=0.23.0->huggingface_hub) (3.11)\n",
-      "Requirement already satisfied: h11>=0.16 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from httpcore==1.*->httpx<1,>=0.23.0->huggingface_hub) (0.16.0)\n",
-      "Requirement already satisfied: affine in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (2.4.0)\n",
-      "Requirement already satisfied: attrs in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (26.1.0)\n",
-      "Requirement already satisfied: click!=8.2.*,>=4.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (8.3.1)\n",
-      "Requirement already satisfied: cligj>=0.5 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (0.7.2)\n",
-      "Requirement already satisfied: numpy>=1.24 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (2.4.0)\n",
-      "Requirement already satisfied: click-plugins in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (1.1.1.2)\n",
-      "Requirement already satisfied: pyparsing in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (3.3.2)\n",
-      "Requirement already satisfied: typer>=0.24.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from typer-slim->huggingface_hub) (0.24.1)\n",
-      "Requirement already satisfied: rich>=12.3.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from typer>=0.24.0->typer-slim->huggingface_hub) (14.3.3)\n",
-      "Requirement already satisfied: annotated-doc>=0.0.2 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from typer>=0.24.0->typer-slim->huggingface_hub) (0.0.4)\n",
-      "Requirement already satisfied: markdown-it-py>=2.2.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rich>=12.3.0->typer>=0.24.0->typer-slim->huggingface_hub) (4.0.0)\n",
-      "Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rich>=12.3.0->typer>=0.24.0->typer-slim->huggingface_hub) (2.19.2)\n",
-      "Requirement already satisfied: mdurl~=0.1 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from markdown-it-py>=2.2.0->rich>=12.3.0->typer>=0.24.0->typer-slim->huggingface_hub) (0.1.2)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!pip install huggingface_hub rasterio pyogrio"
    ]

--- a/docs/gpu-acceleration.md
+++ b/docs/gpu-acceleration.md
@@ -80,17 +80,16 @@ environment before running `MATURIN_PEP517_ARGS="--features='gpu,s2geography,pyo
 Common environment variables used by the GPU build:
 
 - `CUDA_HOME`: points to your CUDA toolkit root.
-- `CMAKE_CUDA_ARCHITECTURES`: CUDA SM targets (default falls back to `native` to auto-detect the host GPU architecture). Change this according to your [GPU models](https://developer.nvidia.com/cuda/gpus).
+- `CMAKE_CUDA_ARCHITECTURES`: CUDA SM targets (default falls back to `86` if not set; You can specify multiple arcs, e.g., "86;89"). Change this according to your [GPU models](https://developer.nvidia.com/cuda/gpus). **Otherwise, it requires JIT to compile kernels, making the first-time run very slow!**
 
 - `LIBGPUSPATIAL_LOGGING_LEVEL`: Logging level, including `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `CRITICAL`.
 - `GPUSPATIAL_PROFILING=ON`: Profiling mode (`ON`, `OFF`) to compile profiling instrumentation.
 
 **Using Docker**
 
-We also provide a Dockerfile for the users. Make sure you have installed Docker, the NVIDIA Driver, and NVIDIA Container Toolkit by `sudo nvidia-ctk runtime configure --runtime=docker`. Then, you may run `docker build -f docker/sedonadb-gpu.dockerfile --build-arg CMAKE_CUDA_ARCHITECTURES="native" -t sedonadb-gpu .` to build an image (defaults to `native` to auto-detect the host's GPU architecture, or you can specify target architectures like `"86;89"`). Finally, you may run `docker run -it --rm --gpus all -p 8888:8888 sedonadb-gpu` to start a JupyterLab instance.
+We also provide a Dockerfile for the users. Make sure you have installed Docker, the NVIDIA Driver, and NVIDIA Container Toolkit by `sudo nvidia-ctk runtime configure --runtime=docker`. Then, you may run `docker build -f docker/sedonadb-gpu.dockerfile --build-arg CMAKE_CUDA_ARCHITECTURES="Your GPU compute capability" -t sedonadb-gpu .` to build an image. Finally, you may run `docker run -it --rm --gpus all -p 8888:8888 sedonadb-gpu` to start a JupyterLab instance.
 
-> [!NOTE]
-> This Docker image is currently source-built directly from the repository's active codebase and is not tied to a released SedonaDB GPU wheel yet. This is to support development and early testing before an official SedonaDB GPU wheel is published.
+> **Note:** This Docker image is currently source-built directly from the repository's active codebase and is not tied to a released SedonaDB GPU wheel yet. This is to support development and early testing before an official SedonaDB GPU wheel is published.
 
 ## Enable GPU Join with SQL `SET`
 

--- a/docs/gpu-acceleration.md
+++ b/docs/gpu-acceleration.md
@@ -80,14 +80,17 @@ environment before running `MATURIN_PEP517_ARGS="--features='gpu,s2geography,pyo
 Common environment variables used by the GPU build:
 
 - `CUDA_HOME`: points to your CUDA toolkit root.
-- `CMAKE_CUDA_ARCHITECTURES`: CUDA SM targets (default falls back to `86;89` if not set). Change this according to your [GPU models](https://developer.nvidia.com/cuda/gpus).
+- `CMAKE_CUDA_ARCHITECTURES`: CUDA SM targets (default falls back to `native` to auto-detect the host GPU architecture). Change this according to your [GPU models](https://developer.nvidia.com/cuda/gpus).
 
 - `LIBGPUSPATIAL_LOGGING_LEVEL`: Logging level, including `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `CRITICAL`.
 - `GPUSPATIAL_PROFILING=ON`: Profiling mode (`ON`, `OFF`) to compile profiling instrumentation.
 
 **Using Docker**
 
-We also provide a Dockerfile for the users. Make sure you have installed Docker, the NVIDIA Driver, and NVIDIA Container Toolkit by `sudo nvidia-ctk runtime configure --runtime=docker`. Then, you may run `docker build -f docker/sedonadb-gpu.dockerfile --build-arg CMAKE_CUDA_ARCHITECTURES="86;89" -t sedonadb-gpu .` to build an image. Finally, you may run `docker run -it --rm --gpus all sedonadb-gpu` to start a JupyterLab instance.
+We also provide a Dockerfile for the users. Make sure you have installed Docker, the NVIDIA Driver, and NVIDIA Container Toolkit by `sudo nvidia-ctk runtime configure --runtime=docker`. Then, you may run `docker build -f docker/sedonadb-gpu.dockerfile --build-arg CMAKE_CUDA_ARCHITECTURES="native" -t sedonadb-gpu .` to build an image (defaults to `native` to auto-detect the host's GPU architecture, or you can specify target architectures like `"86;89"`). Finally, you may run `docker run -it --rm --gpus all -p 8888:8888 sedonadb-gpu` to start a JupyterLab instance.
+
+> [!NOTE]
+> This Docker image is currently source-built directly from the repository's active codebase and is not tied to a released SedonaDB GPU wheel yet. This is to support development and early testing before an official SedonaDB GPU wheel is published.
 
 ## Enable GPU Join with SQL `SET`
 

--- a/docs/gpu-acceleration.md
+++ b/docs/gpu-acceleration.md
@@ -72,17 +72,22 @@ When `gpu.fallback_to_cpu = true` (default), unsupported predicates fall back to
 When `gpu.fallback_to_cpu = false`, unsupported predicates fail the query.
 
 ## Install from Source with the GPU Feature
+**Build from source**
 
-If you build the Python package from source, enable GPU at build time and configure the CUDA
+If you build the Python package from source, enable GPU at build time, and configure the CUDA
 environment before running `MATURIN_PEP517_ARGS="--features gpu" pip install`.
 
 Common environment variables used by the GPU build:
 
 - `CUDA_HOME`: points to your CUDA toolkit root.
-- `CMAKE_CUDA_ARCHITECTURES`: CUDA SM targets (default falls back to `86;89` if not set). Change this according to your GPU architecture.
+- `CMAKE_CUDA_ARCHITECTURES`: CUDA SM targets (default falls back to `86;89` if not set). Change this according to your [GPU models](https://developer.nvidia.com/cuda/gpus).
 
 - `LIBGPUSPATIAL_LOGGING_LEVEL`: Logging level, including `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `CRITICAL`.
 - `GPUSPATIAL_PROFILING=ON`: Profiling mode (`ON`, `OFF`) to compile profiling instrumentation.
+
+**Using Docker**
+
+We also provide a Dockerfile for the users. Make sure you have installed Docker, the NVIDIA Driver, and NVIDIA Container Toolkit by `sudo nvidia-ctk runtime configure --runtime=docker`. Then, you may run `docker build -f docker/sedonadb-gpu.dockerfile --build-arg CMAKE_CUDA_ARCHITECTURES="86;89" -t sedonadb-gpu .` to build an image. Finally, you may run `docker run -it --rm --gpus all sedonadb-gpu` to start a JupyterLab instance.
 
 ## Enable GPU Join with SQL `SET`
 
@@ -96,6 +101,13 @@ ctx = sedonadb.connect()
 
 ctx.sql("SET gpu.enable = true")
 ```
+
+
+
+
+    <sedonadb.dataframe.DataFrame object at 0x70b85c1b7850>
+
+
 
 ## Performance Tuning and Special Cautions
 
@@ -148,9 +160,10 @@ ctx.sql("SET datafusion.execution.batch_size = 100000")
 
 ```python
 !nvidia-smi
+!pip install huggingface_hub ipywidgets rasterio pyogrio
 ```
 
-    Mon Apr 20 19:26:08 2026
+    Mon May 18 16:57:05 2026
     +-----------------------------------------------------------------------------------------+
     | NVIDIA-SMI 580.105.08             Driver Version: 580.105.08     CUDA Version: 13.0     |
     +-----------------------------------------+------------------------+----------------------+
@@ -159,7 +172,7 @@ ctx.sql("SET datafusion.execution.batch_size = 100000")
     |                                         |                        |               MIG M. |
     |=========================================+========================+======================|
     |   0  NVIDIA L4                      On  |   00000000:31:00.0 Off |                    0 |
-    | N/A   36C    P8             19W /   72W |       0MiB /  23034MiB |      0%      Default |
+    | N/A   41C    P8             17W /   72W |       0MiB /  23034MiB |      0%      Default |
     |                                         |                        |                  N/A |
     +-----------------------------------------+------------------------+----------------------+
 
@@ -170,20 +183,81 @@ ctx.sql("SET datafusion.execution.batch_size = 100000")
     |=========================================================================================|
     |  No running processes found                                                             |
     +-----------------------------------------------------------------------------------------+
+    Requirement already satisfied: huggingface_hub in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (1.4.1)
+    Requirement already satisfied: ipywidgets in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (8.1.8)
+    Collecting rasterio
+      Downloading rasterio-1.4.4-cp311-cp311-manylinux_2_28_x86_64.whl.metadata (9.3 kB)
+    Requirement already satisfied: pyogrio in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (0.12.1)
+    Requirement already satisfied: filelock in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (3.20.1)
+    Requirement already satisfied: fsspec>=2023.5.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (2026.2.0)
+    Requirement already satisfied: hf-xet<2.0.0,>=1.2.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (1.3.0)
+    Requirement already satisfied: httpx<1,>=0.23.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (0.28.1)
+    Requirement already satisfied: packaging>=20.9 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (25.0)
+    Requirement already satisfied: pyyaml>=5.1 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (6.0.3)
+    Requirement already satisfied: shellingham in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (1.5.4)
+    Requirement already satisfied: tqdm>=4.42.1 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (4.67.3)
+    Requirement already satisfied: typer-slim in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (0.24.0)
+    Requirement already satisfied: typing-extensions>=4.1.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (4.15.0)
+    Requirement already satisfied: anyio in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from httpx<1,>=0.23.0->huggingface_hub) (4.12.1)
+    Requirement already satisfied: certifi in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from httpx<1,>=0.23.0->huggingface_hub) (2025.11.12)
+    Requirement already satisfied: httpcore==1.* in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from httpx<1,>=0.23.0->huggingface_hub) (1.0.9)
+    Requirement already satisfied: idna in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from httpx<1,>=0.23.0->huggingface_hub) (3.11)
+    Requirement already satisfied: h11>=0.16 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from httpcore==1.*->httpx<1,>=0.23.0->huggingface_hub) (0.16.0)
+    Requirement already satisfied: comm>=0.1.3 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipywidgets) (0.2.3)
+    Requirement already satisfied: ipython>=6.1.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipywidgets) (9.10.1)
+    Requirement already satisfied: traitlets>=4.3.1 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipywidgets) (5.14.3)
+    Requirement already satisfied: widgetsnbextension~=4.0.14 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipywidgets) (4.0.15)
+    Requirement already satisfied: jupyterlab_widgets~=3.0.15 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipywidgets) (3.0.16)
+    Collecting affine (from rasterio)
+      Downloading affine-2.4.0-py3-none-any.whl.metadata (4.0 kB)
+    Requirement already satisfied: attrs in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (26.1.0)
+    Requirement already satisfied: click!=8.2.*,>=4.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (8.3.1)
+    Collecting cligj>=0.5 (from rasterio)
+      Downloading cligj-0.7.2-py3-none-any.whl.metadata (5.0 kB)
+    Requirement already satisfied: numpy>=1.24 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (2.4.0)
+    Collecting click-plugins (from rasterio)
+      Downloading click_plugins-1.1.1.2-py2.py3-none-any.whl.metadata (6.5 kB)
+    Collecting pyparsing (from rasterio)
+      Downloading pyparsing-3.3.2-py3-none-any.whl.metadata (5.8 kB)
+    Requirement already satisfied: decorator>=4.3.2 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (5.2.1)
+    Requirement already satisfied: ipython-pygments-lexers>=1.0.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (1.1.1)
+    Requirement already satisfied: jedi>=0.18.1 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (0.19.2)
+    Requirement already satisfied: matplotlib-inline>=0.1.5 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (0.2.1)
+    Requirement already satisfied: pexpect>4.3 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (4.9.0)
+    Requirement already satisfied: prompt_toolkit<3.1.0,>=3.0.41 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (3.0.52)
+    Requirement already satisfied: pygments>=2.11.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (2.19.2)
+    Requirement already satisfied: stack_data>=0.6.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (0.6.3)
+    Requirement already satisfied: wcwidth in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from prompt_toolkit<3.1.0,>=3.0.41->ipython>=6.1.0->ipywidgets) (0.6.0)
+    Requirement already satisfied: parso<0.9.0,>=0.8.4 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from jedi>=0.18.1->ipython>=6.1.0->ipywidgets) (0.8.6)
+    Requirement already satisfied: ptyprocess>=0.5 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from pexpect>4.3->ipython>=6.1.0->ipywidgets) (0.7.0)
+    Requirement already satisfied: executing>=1.2.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from stack_data>=0.6.0->ipython>=6.1.0->ipywidgets) (2.2.1)
+    Requirement already satisfied: asttokens>=2.1.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from stack_data>=0.6.0->ipython>=6.1.0->ipywidgets) (3.0.1)
+    Requirement already satisfied: pure-eval in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from stack_data>=0.6.0->ipython>=6.1.0->ipywidgets) (0.2.3)
+    Requirement already satisfied: typer>=0.24.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from typer-slim->huggingface_hub) (0.24.1)
+    Requirement already satisfied: rich>=12.3.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from typer>=0.24.0->typer-slim->huggingface_hub) (14.3.3)
+    Requirement already satisfied: annotated-doc>=0.0.2 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from typer>=0.24.0->typer-slim->huggingface_hub) (0.0.4)
+    Requirement already satisfied: markdown-it-py>=2.2.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rich>=12.3.0->typer>=0.24.0->typer-slim->huggingface_hub) (4.0.0)
+    Requirement already satisfied: mdurl~=0.1 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from markdown-it-py>=2.2.0->rich>=12.3.0->typer>=0.24.0->typer-slim->huggingface_hub) (0.1.2)
+    Downloading rasterio-1.4.4-cp311-cp311-manylinux_2_28_x86_64.whl (35.9 MB)
+    [2K   [90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[0m [32m35.9/35.9 MB[0m [31m55.1 MB/s[0m  [33m0:00:00[0mm0:00:01[0m00:01[0m
+    [?25hDownloading cligj-0.7.2-py3-none-any.whl (7.1 kB)
+    Downloading affine-2.4.0-py3-none-any.whl (15 kB)
+    Downloading click_plugins-1.1.1.2-py2.py3-none-any.whl (11 kB)
+    Downloading pyparsing-3.3.2-py3-none-any.whl (122 kB)
+    Installing collected packages: pyparsing, cligj, click-plugins, affine, rasterio
+    [2K   [90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[0m [32m5/5[0m [rasterio]4/5[0m [rasterio]
+    [1A[2KSuccessfully installed affine-2.4.0 click-plugins-1.1.1.2 cligj-0.7.2 pyparsing-3.3.2 rasterio-1.4.4
 
 
 
 ```python
 from huggingface_hub import snapshot_download
-import os
 
 snapshot_download(
-  repo_id='apache-sedona/spatialbench',
-  repo_type='dataset',
-  local_dir='hf-data',
-  allow_patterns=[
-    "v0.1.0/sf1/zone/*",
-    "v0.1.0/sf1/trip/*"],
+    repo_id="apache-sedona/spatialbench",
+    repo_type="dataset",
+    local_dir="hf-data",
+    allow_patterns=["v0.1.0/sf1/zone/*", "v0.1.0/sf1/trip/*"],
 )
 ```
 
@@ -201,7 +275,7 @@ snapshot_download(
 
 
 
-    '/mnt/data/sedona-db/docs/hf-data'
+    '/mnt/data/sedona-db-docker/docs/hf-data'
 
 
 
@@ -211,16 +285,24 @@ import sedonadb
 
 ctx = sedonadb.connect()
 ctx.options.memory_limit = "unlimited"
+ctx.sql("SET datafusion.execution.batch_size = 100000")
 ```
 
 
+
+
+    <sedonadb.dataframe.DataFrame object at 0x759fd0436750>
+
+
+
+
 ```python
-ctx.sql(f"""
+ctx.sql("""
     CREATE EXTERNAL TABLE zone
     STORED AS PARQUET
     LOCATION 'hf-data/v0.1.0/sf1/zone/'
 """)
-ctx.sql(f"""
+ctx.sql("""
     CREATE EXTERNAL TABLE trip
     STORED AS PARQUET
     LOCATION 'hf-data/v0.1.0/sf1/trip/'
@@ -230,7 +312,7 @@ ctx.sql(f"""
 
 
 
-    <sedonadb.dataframe.DataFrame object at 0x7ff5213d96d0>
+    <sedonadb.dataframe.DataFrame object at 0x759fd045b5d0>
 
 
 
@@ -240,6 +322,7 @@ import time
 from tqdm.notebook import tqdm
 from IPython.display import display, HTML
 import ipywidgets as widgets
+
 
 def interactive_spatial_benchmark(ctx, runs=6):
     query = """
@@ -256,7 +339,9 @@ def interactive_spatial_benchmark(ctx, runs=6):
     averages = {}
 
     # 1. Create a scrollable widget to catch the verbose `.show()` output
-    log_output = widgets.Output(layout={'border': '1px solid #ccc', 'height': '150px', 'overflow_y': 'auto'})
+    log_output = widgets.Output(
+        layout={"border": "1px solid #ccc", "height": "150px", "overflow_y": "auto"}
+    )
     display(HTML("<h3>🚀 Running Spatial Benchmark...</h3>"))
     display(log_output)
 
@@ -264,9 +349,11 @@ def interactive_spatial_benchmark(ctx, runs=6):
     for mode_name, gpu_flag in modes:
         ctx.sql(f"SET gpu.enable = {gpu_flag}")
         if gpu_flag:
-            ctx.sql("SET datafusion.execution.batch_size = 2000000") # Increase batch size
+            ctx.sql(
+                "SET datafusion.execution.batch_size = 2000000"
+            )  # Increase batch size
         else:
-            ctx.sql("SET datafusion.execution.batch_size = 8192") # Default
+            ctx.sql("SET datafusion.execution.batch_size = 8192")  # Default
         execution_times = []
 
         # Display a Jupyter-native progress bar
@@ -277,7 +364,7 @@ def interactive_spatial_benchmark(ctx, runs=6):
 
             # Execute physical plan and catch the output inside our widget
             with log_output:
-                print(f"--- {mode_name} Run {i+1} ---")
+                print(f"--- {mode_name} Run {i + 1} ---")
                 result.show()
 
             elapsed = time.time() - start_time
@@ -291,7 +378,7 @@ def interactive_spatial_benchmark(ctx, runs=6):
 
     # 3. Clean up the UI
     log_output.clear_output()
-    log_output.layout.display = 'none'
+    log_output.layout.display = "none"
 
     # 4. Generate Table Results
     cpu_avg = averages["CPU"]
@@ -326,6 +413,7 @@ def interactive_spatial_benchmark(ctx, runs=6):
 
     display(HTML("<h3>📊 Benchmark Results (Averaged over 5 runs)</h3>"))
     display(HTML(html_table))
+
 
 # --- Execution Block ---
 # Run the interactive function with your Sedona Context
@@ -362,13 +450,13 @@ interactive_spatial_benchmark(ctx)
     </tr>
     <tr>
         <td style="padding: 12px; border: 1px solid #dee2e6;"><b>CPU</b> (Baseline)</td>
-        <td style="padding: 12px; border: 1px solid #dee2e6;">21.5221</td>
+        <td style="padding: 12px; border: 1px solid #dee2e6;">8.4922</td>
         <td style="padding: 12px; border: 1px solid #dee2e6;">1.00x</td>
     </tr>
     <tr>
         <td style="padding: 12px; border: 1px solid #dee2e6;"><b>GPU</b></td>
-        <td style="padding: 12px; border: 1px solid #dee2e6;">2.8889</td>
-        <td style="padding: 12px; border: 1px solid #dee2e6; color: green; font-weight: bold;">7.45x</td>
+        <td style="padding: 12px; border: 1px solid #dee2e6;">3.0277</td>
+        <td style="padding: 12px; border: 1px solid #dee2e6; color: green; font-weight: bold;">2.80x</td>
     </tr>
 </table>
 

--- a/docs/gpu-acceleration.md
+++ b/docs/gpu-acceleration.md
@@ -74,7 +74,7 @@ When `gpu.fallback_to_cpu = false`, unsupported predicates fail the query.
 ## Install from Source with the GPU Feature
 **Build from source**
 
-If you build the Python package from source, enable GPU at build time, and configure the CUDA
+For building the Python package from source, you should enable the GPU at build time and configure the CUDA
 environment before running `MATURIN_PEP517_ARGS="--features gpu" pip install`.
 
 Common environment variables used by the GPU build:
@@ -99,7 +99,7 @@ import sedonadb
 
 ctx = sedonadb.connect()
 
-ctx.sql("SET gpu.enable = true")
+ctx.sql("SET gpu.enable = true").execute()
 ```
 
 
@@ -115,7 +115,7 @@ To keep the GPU efficiently utilized, use larger execution batches:
 
 
 ```python
-ctx.sql("SET datafusion.execution.batch_size = 100000")
+ctx.sql("SET datafusion.execution.batch_size = 100000").execute()
 ```
 
 Important guidance:
@@ -152,18 +152,19 @@ ctx.sql("SET gpu.use_memory_pool = true")
 ctx.sql("SET gpu.memory_pool_init_percentage = 60")
 ctx.sql("SET gpu.pipeline_batches = 2")
 ctx.sql("SET gpu.compress_bvh = false")
-ctx.sql("SET datafusion.execution.batch_size = 100000")
+ctx.sql("SET datafusion.execution.batch_size = 100000").execute()
 ```
 
 ## Example
 
+### Check GPU environment
+
 
 ```python
 !nvidia-smi
-!pip install huggingface_hub ipywidgets rasterio pyogrio
 ```
 
-    Mon May 18 16:57:05 2026
+    Tue May 26 20:49:41 2026
     +-----------------------------------------------------------------------------------------+
     | NVIDIA-SMI 580.105.08             Driver Version: 580.105.08     CUDA Version: 13.0     |
     +-----------------------------------------+------------------------+----------------------+
@@ -172,7 +173,7 @@ ctx.sql("SET datafusion.execution.batch_size = 100000")
     |                                         |                        |               MIG M. |
     |=========================================+========================+======================|
     |   0  NVIDIA L4                      On  |   00000000:31:00.0 Off |                    0 |
-    | N/A   41C    P8             17W /   72W |       0MiB /  23034MiB |      0%      Default |
+    | N/A   41C    P0             28W /   72W |   11610MiB /  23034MiB |      0%      Default |
     |                                         |                        |                  N/A |
     +-----------------------------------------+------------------------+----------------------+
 
@@ -181,12 +182,19 @@ ctx.sql("SET datafusion.execution.batch_size = 100000")
     |  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
     |        ID   ID                                                               Usage      |
     |=========================================================================================|
-    |  No running processes found                                                             |
+    |    0   N/A  N/A           20603      C   ...a3/envs/sedona/bin/python3.11      11602MiB |
     +-----------------------------------------------------------------------------------------+
+
+
+### Install required packages for the example
+
+
+```python
+!pip install huggingface_hub rasterio pyogrio
+```
+
     Requirement already satisfied: huggingface_hub in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (1.4.1)
-    Requirement already satisfied: ipywidgets in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (8.1.8)
-    Collecting rasterio
-      Downloading rasterio-1.4.4-cp311-cp311-manylinux_2_28_x86_64.whl.metadata (9.3 kB)
+    Requirement already satisfied: rasterio in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (1.4.4)
     Requirement already satisfied: pyogrio in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (0.12.1)
     Requirement already satisfied: filelock in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (3.20.1)
     Requirement already satisfied: fsspec>=2023.5.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (2026.2.0)
@@ -203,51 +211,22 @@ ctx.sql("SET datafusion.execution.batch_size = 100000")
     Requirement already satisfied: httpcore==1.* in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from httpx<1,>=0.23.0->huggingface_hub) (1.0.9)
     Requirement already satisfied: idna in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from httpx<1,>=0.23.0->huggingface_hub) (3.11)
     Requirement already satisfied: h11>=0.16 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from httpcore==1.*->httpx<1,>=0.23.0->huggingface_hub) (0.16.0)
-    Requirement already satisfied: comm>=0.1.3 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipywidgets) (0.2.3)
-    Requirement already satisfied: ipython>=6.1.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipywidgets) (9.10.1)
-    Requirement already satisfied: traitlets>=4.3.1 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipywidgets) (5.14.3)
-    Requirement already satisfied: widgetsnbextension~=4.0.14 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipywidgets) (4.0.15)
-    Requirement already satisfied: jupyterlab_widgets~=3.0.15 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipywidgets) (3.0.16)
-    Collecting affine (from rasterio)
-      Downloading affine-2.4.0-py3-none-any.whl.metadata (4.0 kB)
+    Requirement already satisfied: affine in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (2.4.0)
     Requirement already satisfied: attrs in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (26.1.0)
     Requirement already satisfied: click!=8.2.*,>=4.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (8.3.1)
-    Collecting cligj>=0.5 (from rasterio)
-      Downloading cligj-0.7.2-py3-none-any.whl.metadata (5.0 kB)
+    Requirement already satisfied: cligj>=0.5 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (0.7.2)
     Requirement already satisfied: numpy>=1.24 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (2.4.0)
-    Collecting click-plugins (from rasterio)
-      Downloading click_plugins-1.1.1.2-py2.py3-none-any.whl.metadata (6.5 kB)
-    Collecting pyparsing (from rasterio)
-      Downloading pyparsing-3.3.2-py3-none-any.whl.metadata (5.8 kB)
-    Requirement already satisfied: decorator>=4.3.2 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (5.2.1)
-    Requirement already satisfied: ipython-pygments-lexers>=1.0.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (1.1.1)
-    Requirement already satisfied: jedi>=0.18.1 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (0.19.2)
-    Requirement already satisfied: matplotlib-inline>=0.1.5 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (0.2.1)
-    Requirement already satisfied: pexpect>4.3 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (4.9.0)
-    Requirement already satisfied: prompt_toolkit<3.1.0,>=3.0.41 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (3.0.52)
-    Requirement already satisfied: pygments>=2.11.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (2.19.2)
-    Requirement already satisfied: stack_data>=0.6.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from ipython>=6.1.0->ipywidgets) (0.6.3)
-    Requirement already satisfied: wcwidth in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from prompt_toolkit<3.1.0,>=3.0.41->ipython>=6.1.0->ipywidgets) (0.6.0)
-    Requirement already satisfied: parso<0.9.0,>=0.8.4 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from jedi>=0.18.1->ipython>=6.1.0->ipywidgets) (0.8.6)
-    Requirement already satisfied: ptyprocess>=0.5 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from pexpect>4.3->ipython>=6.1.0->ipywidgets) (0.7.0)
-    Requirement already satisfied: executing>=1.2.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from stack_data>=0.6.0->ipython>=6.1.0->ipywidgets) (2.2.1)
-    Requirement already satisfied: asttokens>=2.1.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from stack_data>=0.6.0->ipython>=6.1.0->ipywidgets) (3.0.1)
-    Requirement already satisfied: pure-eval in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from stack_data>=0.6.0->ipython>=6.1.0->ipywidgets) (0.2.3)
+    Requirement already satisfied: click-plugins in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (1.1.1.2)
+    Requirement already satisfied: pyparsing in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (3.3.2)
     Requirement already satisfied: typer>=0.24.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from typer-slim->huggingface_hub) (0.24.1)
     Requirement already satisfied: rich>=12.3.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from typer>=0.24.0->typer-slim->huggingface_hub) (14.3.3)
     Requirement already satisfied: annotated-doc>=0.0.2 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from typer>=0.24.0->typer-slim->huggingface_hub) (0.0.4)
     Requirement already satisfied: markdown-it-py>=2.2.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rich>=12.3.0->typer>=0.24.0->typer-slim->huggingface_hub) (4.0.0)
+    Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rich>=12.3.0->typer>=0.24.0->typer-slim->huggingface_hub) (2.19.2)
     Requirement already satisfied: mdurl~=0.1 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from markdown-it-py>=2.2.0->rich>=12.3.0->typer>=0.24.0->typer-slim->huggingface_hub) (0.1.2)
-    Downloading rasterio-1.4.4-cp311-cp311-manylinux_2_28_x86_64.whl (35.9 MB)
-    [2K   [90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[0m [32m35.9/35.9 MB[0m [31m55.1 MB/s[0m  [33m0:00:00[0mm0:00:01[0m00:01[0m
-    [?25hDownloading cligj-0.7.2-py3-none-any.whl (7.1 kB)
-    Downloading affine-2.4.0-py3-none-any.whl (15 kB)
-    Downloading click_plugins-1.1.1.2-py2.py3-none-any.whl (11 kB)
-    Downloading pyparsing-3.3.2-py3-none-any.whl (122 kB)
-    Installing collected packages: pyparsing, cligj, click-plugins, affine, rasterio
-    [2K   [90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[0m [32m5/5[0m [rasterio]4/5[0m [rasterio]
-    [1A[2KSuccessfully installed affine-2.4.0 click-plugins-1.1.1.2 cligj-0.7.2 pyparsing-3.3.2 rasterio-1.4.4
 
+
+### Download datasets
 
 
 ```python
@@ -269,15 +248,14 @@ snapshot_download(
     Fetching 8 files:   0%|          | 0/8 [00:00<?, ?it/s]
 
 
-    Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
 
 
 
+    '/mnt/data/sedona-db/docs/hf-data'
 
 
-    '/mnt/data/sedona-db-docker/docs/hf-data'
 
-
+### Create sedonadb context and load datasets
 
 
 ```python
@@ -285,18 +263,7 @@ import sedonadb
 
 ctx = sedonadb.connect()
 ctx.options.memory_limit = "unlimited"
-ctx.sql("SET datafusion.execution.batch_size = 100000")
-```
 
-
-
-
-    <sedonadb.dataframe.DataFrame object at 0x759fd0436750>
-
-
-
-
-```python
 ctx.sql("""
     CREATE EXTERNAL TABLE zone
     STORED AS PARQUET
@@ -306,160 +273,128 @@ ctx.sql("""
     CREATE EXTERNAL TABLE trip
     STORED AS PARQUET
     LOCATION 'hf-data/v0.1.0/sf1/trip/'
-""")
+""").execute()
 ```
 
 
 
 
-    <sedonadb.dataframe.DataFrame object at 0x759fd045b5d0>
+    0
 
 
+
+### Define query
+
+
+```python
+# Define the query once to ensure both executions use the exact same logic
+query = """
+SELECT COUNT(*) AS cross_zone_trip_count
+FROM trip t
+    JOIN zone pickup_zone
+        ON ST_Within(ST_GeomFromWKB(t.t_pickuploc), ST_GeomFromWKB(pickup_zone.z_boundary))
+    JOIN zone dropoff_zone
+        ON ST_Within(ST_GeomFromWKB(t.t_dropoffloc), ST_GeomFromWKB(dropoff_zone.z_boundary))
+WHERE pickup_zone.z_zonekey != dropoff_zone.z_zonekey
+"""
+```
+
+First, we will run this query using the standard CPU execution to establish our baseline correctness and get a sense of the standard execution time.
 
 
 ```python
 import time
-from tqdm.notebook import tqdm
-from IPython.display import display, HTML
-import ipywidgets as widgets
 
+print("Executing on CPU (Baseline)...")
+ctx.sql("SET gpu.enable = false") # Disable the GPU feature
+ctx.sql("SET datafusion.execution.batch_size = 8192") # Default configuration
 
-def interactive_spatial_benchmark(ctx, runs=6):
-    query = """
-    SELECT COUNT(*) AS cross_zone_trip_count
-    FROM trip t
-        JOIN zone pickup_zone
-            ON ST_Within(ST_GeomFromWKB(t.t_pickuploc), ST_GeomFromWKB(pickup_zone.z_boundary))
-        JOIN zone dropoff_zone
-            ON ST_Within(ST_GeomFromWKB(t.t_dropoffloc), ST_GeomFromWKB(dropoff_zone.z_boundary))
-    WHERE pickup_zone.z_zonekey != dropoff_zone.z_zonekey
-    """
+runs = 5
+cpu_times = []
+cpu_count = 0
 
-    modes = [("CPU", "false"), ("GPU", "true")]
-    averages = {}
+for i in range(runs):
+    start_time = time.time()
+    cpu_df = ctx.sql(query).to_pandas()
+    elapsed = time.time() - start_time
 
-    # 1. Create a scrollable widget to catch the verbose `.show()` output
-    log_output = widgets.Output(
-        layout={"border": "1px solid #ccc", "height": "150px", "overflow_y": "auto"}
-    )
-    display(HTML("<h3>🚀 Running Spatial Benchmark...</h3>"))
-    display(log_output)
+    cpu_times.append(elapsed)
+    cpu_count = cpu_df.iloc[0, 0]
+    print(f"  Run {i + 1}: {elapsed:.4f} seconds")
 
-    # 2. Execute the Benchmark
-    for mode_name, gpu_flag in modes:
-        ctx.sql(f"SET gpu.enable = {gpu_flag}")
-        if gpu_flag:
-            ctx.sql(
-                "SET datafusion.execution.batch_size = 2000000"
-            )  # Increase batch size
-        else:
-            ctx.sql("SET datafusion.execution.batch_size = 8192")  # Default
-        execution_times = []
-
-        # Display a Jupyter-native progress bar
-        for i in tqdm(range(runs), desc=f"{mode_name} Executions"):
-            start_time = time.time()
-
-            result = ctx.sql(query)
-
-            # Execute physical plan and catch the output inside our widget
-            with log_output:
-                print(f"--- {mode_name} Run {i + 1} ---")
-                result.show()
-
-            elapsed = time.time() - start_time
-
-            # Record everything except the first run (warmup)
-            if i > 0:
-                execution_times.append(elapsed)
-
-        # Calculate average
-        averages[mode_name] = sum(execution_times) / len(execution_times)
-
-    # 3. Clean up the UI
-    log_output.clear_output()
-    log_output.layout.display = "none"
-
-    # 4. Generate Table Results
-    cpu_avg = averages["CPU"]
-    gpu_avg = averages["GPU"]
-
-    # Calculate speedup (using CPU as the 1.0x baseline)
-    cpu_speedup = 1.0
-    gpu_speedup = cpu_avg / gpu_avg if gpu_avg > 0 else 0
-
-    # Color code the GPU speedup (green if faster, red if slower)
-    gpu_color = "green" if gpu_speedup >= 1.0 else "red"
-
-    html_table = f"""
-    <table style="width: 60%; text-align: center; border-collapse: collapse; font-family: sans-serif; margin-top: 15px;">
-        <tr style="background-color: #f8f9fa; border-bottom: 2px solid #dee2e6;">
-            <th style="padding: 12px; border: 1px solid #dee2e6;">Mode</th>
-            <th style="padding: 12px; border: 1px solid #dee2e6;">Average Time (s)</th>
-            <th style="padding: 12px; border: 1px solid #dee2e6;">Speedup</th>
-        </tr>
-        <tr>
-            <td style="padding: 12px; border: 1px solid #dee2e6;"><b>CPU</b> (Baseline)</td>
-            <td style="padding: 12px; border: 1px solid #dee2e6;">{cpu_avg:.4f}</td>
-            <td style="padding: 12px; border: 1px solid #dee2e6;">{cpu_speedup:.2f}x</td>
-        </tr>
-        <tr>
-            <td style="padding: 12px; border: 1px solid #dee2e6;"><b>GPU</b></td>
-            <td style="padding: 12px; border: 1px solid #dee2e6;">{gpu_avg:.4f}</td>
-            <td style="padding: 12px; border: 1px solid #dee2e6; color: {gpu_color}; font-weight: bold;">{gpu_speedup:.2f}x</td>
-        </tr>
-    </table>
-    """
-
-    display(HTML("<h3>📊 Benchmark Results (Averaged over 5 runs)</h3>"))
-    display(HTML(html_table))
-
-
-# --- Execution Block ---
-# Run the interactive function with your Sedona Context
-interactive_spatial_benchmark(ctx)
+cpu_avg_time = sum(cpu_times) / runs
+print("-" * 30)
+print(f"CPU Average Time: {cpu_avg_time:.4f} seconds | Rows: {cpu_count}")
 ```
 
-
-<h3>🚀 Running Spatial Benchmark...</h3>
-
-
-
-    Output(layout=Layout(border_bottom='1px solid #ccc', border_left='1px solid #ccc', border_right='1px solid #cc…
-
-
-
-    CPU Executions:   0%|          | 0/6 [00:00<?, ?it/s]
+    Executing on CPU (Baseline)...
+      Run 1: 7.7795 seconds
+      Run 2: 6.8287 seconds
+      Run 3: 7.0688 seconds
+      Run 4: 7.2434 seconds
+      Run 5: 7.1739 seconds
+    ------------------------------
+    CPU Average Time: 7.2189 seconds | Rows: 176391
 
 
-
-    GPU Executions:   0%|          | 0/6 [00:00<?, ?it/s]
-
+Next, we enable GPU execution. We also increase the batch size, which is a crucial optimization step to ensure we are feeding enough data to the GPU to maximize its parallel processing capabilities.
 
 
-<h3>📊 Benchmark Results (Averaged over 5 runs)</h3>
+```python
+print("Executing on GPU (Accelerated)...")
+ctx.sql("SET gpu.enable = true")
+ctx.sql("SET datafusion.execution.batch_size = 1000000") # Optimized for GPU throughput
+
+runs = 5
+gpu_times = []
+gpu_count = 0
+
+for i in range(runs):
+    start_time = time.time()
+    gpu_df = ctx.sql(query).to_pandas()
+    elapsed = time.time() - start_time
+
+    gpu_times.append(elapsed)
+    gpu_count = gpu_df.iloc[0, 0]
+    print(f"  Run {i + 1}: {elapsed:.4f} seconds")
+
+gpu_avg_time = sum(gpu_times) / runs
+print("-" * 30)
+print(f"GPU Average Time: {gpu_avg_time:.4f} seconds | Rows: {gpu_count}")
+```
+
+    Executing on GPU (Accelerated)...
+      Run 1: 3.2582 seconds
+      Run 2: 3.3126 seconds
+      Run 3: 3.0703 seconds
+      Run 4: 3.2604 seconds
+      Run 5: 3.1418 seconds
+    ------------------------------
+    GPU Average Time: 3.2087 seconds | Rows: 176391
 
 
+### Compare Results
 
 
-<table style="width: 60%; text-align: center; border-collapse: collapse; font-family: sans-serif; margin-top: 15px;">
-    <tr style="background-color: #f8f9fa; border-bottom: 2px solid #dee2e6;">
-        <th style="padding: 12px; border: 1px solid #dee2e6;">Mode</th>
-        <th style="padding: 12px; border: 1px solid #dee2e6;">Average Time (s)</th>
-        <th style="padding: 12px; border: 1px solid #dee2e6;">Speedup</th>
-    </tr>
-    <tr>
-        <td style="padding: 12px; border: 1px solid #dee2e6;"><b>CPU</b> (Baseline)</td>
-        <td style="padding: 12px; border: 1px solid #dee2e6;">8.4922</td>
-        <td style="padding: 12px; border: 1px solid #dee2e6;">1.00x</td>
-    </tr>
-    <tr>
-        <td style="padding: 12px; border: 1px solid #dee2e6;"><b>GPU</b></td>
-        <td style="padding: 12px; border: 1px solid #dee2e6;">3.0277</td>
-        <td style="padding: 12px; border: 1px solid #dee2e6; color: green; font-weight: bold;">2.80x</td>
-    </tr>
-</table>
+```python
+# Validate correctness
+match_status = "✅ Match" if cpu_count == gpu_count else "❌ Mismatch"
 
+# Calculate speedup based on the new averages
+speedup = cpu_avg_time / gpu_avg_time if gpu_avg_time > 0 else 0
+
+print("--- Query Validation (Based on Averages) ---")
+print(f"Row Count Validated : {gpu_count} ({match_status})")
+print(f"Average CPU Time    : {cpu_avg_time:.4f}s")
+print(f"Average GPU Time    : {gpu_avg_time:.4f}s")
+print(f"Calculated Speedup  : {speedup:.2f}x")
+```
+
+    --- Query Validation (Based on Averages) ---
+    Row Count Validated : 176391 (✅ Match)
+    Average CPU Time    : 7.2189s
+    Average GPU Time    : 3.2087s
+    Calculated Speedup  : 2.25x
 
 
 ## References

--- a/docs/gpu-acceleration.md
+++ b/docs/gpu-acceleration.md
@@ -75,7 +75,7 @@ When `gpu.fallback_to_cpu = false`, unsupported predicates fail the query.
 **Build from source**
 
 For building the Python package from source, you should enable the GPU at build time and configure the CUDA
-environment before running `MATURIN_PEP517_ARGS="--features gpu" pip install`.
+environment before running `MATURIN_PEP517_ARGS="--features='gpu,s2geography,pyo3/extension-module' pip install`.
 
 Common environment variables used by the GPU build:
 

--- a/docs/gpu-acceleration.md
+++ b/docs/gpu-acceleration.md
@@ -193,39 +193,6 @@ ctx.sql("SET datafusion.execution.batch_size = 100000").execute()
 !pip install huggingface_hub rasterio pyogrio
 ```
 
-    Requirement already satisfied: huggingface_hub in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (1.4.1)
-    Requirement already satisfied: rasterio in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (1.4.4)
-    Requirement already satisfied: pyogrio in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (0.12.1)
-    Requirement already satisfied: filelock in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (3.20.1)
-    Requirement already satisfied: fsspec>=2023.5.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (2026.2.0)
-    Requirement already satisfied: hf-xet<2.0.0,>=1.2.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (1.3.0)
-    Requirement already satisfied: httpx<1,>=0.23.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (0.28.1)
-    Requirement already satisfied: packaging>=20.9 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (25.0)
-    Requirement already satisfied: pyyaml>=5.1 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (6.0.3)
-    Requirement already satisfied: shellingham in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (1.5.4)
-    Requirement already satisfied: tqdm>=4.42.1 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (4.67.3)
-    Requirement already satisfied: typer-slim in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (0.24.0)
-    Requirement already satisfied: typing-extensions>=4.1.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from huggingface_hub) (4.15.0)
-    Requirement already satisfied: anyio in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from httpx<1,>=0.23.0->huggingface_hub) (4.12.1)
-    Requirement already satisfied: certifi in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from httpx<1,>=0.23.0->huggingface_hub) (2025.11.12)
-    Requirement already satisfied: httpcore==1.* in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from httpx<1,>=0.23.0->huggingface_hub) (1.0.9)
-    Requirement already satisfied: idna in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from httpx<1,>=0.23.0->huggingface_hub) (3.11)
-    Requirement already satisfied: h11>=0.16 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from httpcore==1.*->httpx<1,>=0.23.0->huggingface_hub) (0.16.0)
-    Requirement already satisfied: affine in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (2.4.0)
-    Requirement already satisfied: attrs in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (26.1.0)
-    Requirement already satisfied: click!=8.2.*,>=4.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (8.3.1)
-    Requirement already satisfied: cligj>=0.5 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (0.7.2)
-    Requirement already satisfied: numpy>=1.24 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (2.4.0)
-    Requirement already satisfied: click-plugins in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (1.1.1.2)
-    Requirement already satisfied: pyparsing in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rasterio) (3.3.2)
-    Requirement already satisfied: typer>=0.24.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from typer-slim->huggingface_hub) (0.24.1)
-    Requirement already satisfied: rich>=12.3.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from typer>=0.24.0->typer-slim->huggingface_hub) (14.3.3)
-    Requirement already satisfied: annotated-doc>=0.0.2 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from typer>=0.24.0->typer-slim->huggingface_hub) (0.0.4)
-    Requirement already satisfied: markdown-it-py>=2.2.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rich>=12.3.0->typer>=0.24.0->typer-slim->huggingface_hub) (4.0.0)
-    Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from rich>=12.3.0->typer>=0.24.0->typer-slim->huggingface_hub) (2.19.2)
-    Requirement already satisfied: mdurl~=0.1 in /home/ubuntu/miniconda3/envs/sedona/lib/python3.11/site-packages (from markdown-it-py>=2.2.0->rich>=12.3.0->typer>=0.24.0->typer-slim->huggingface_hub) (0.1.2)
-
-
 ### Download datasets
 
 
@@ -306,8 +273,8 @@ First, we will run this query using the standard CPU execution to establish our 
 import time
 
 print("Executing on CPU (Baseline)...")
-ctx.sql("SET gpu.enable = false") # Disable the GPU feature
-ctx.sql("SET datafusion.execution.batch_size = 8192") # Default configuration
+ctx.sql("SET gpu.enable = false")  # Disable the GPU feature
+ctx.sql("SET datafusion.execution.batch_size = 8192")  # Default configuration
 
 runs = 5
 cpu_times = []
@@ -343,7 +310,7 @@ Next, we enable GPU execution. We also increase the batch size, which is a cruci
 ```python
 print("Executing on GPU (Accelerated)...")
 ctx.sql("SET gpu.enable = true")
-ctx.sql("SET datafusion.execution.batch_size = 1000000") # Optimized for GPU throughput
+ctx.sql("SET datafusion.execution.batch_size = 1000000")  # Optimized for GPU throughput
 
 runs = 5
 gpu_times = []


### PR DESCRIPTION
This PR provides a Dockerfile to build a Sedona-DB image with GPU support. When a container is created with the image, users can use JupyterLab to use sedona-db.

Here's the example:
```
docker build -f docker/sedonadb-gpu.dockerfile --build-arg CMAKE_CUDA_ARCHITECTURES=“86;89” -t sedonadb-gpu . # Build image (taking about 20mins)
docker run -it --rm --gpus all sedonadb-gpu # Start a container with the image
```

This PR also updates the docs on using the image.