### PR TITLE
Expose simplified Arrow stream export

### DIFF
--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -28,7 +28,7 @@ from sedonadb.utility import sedona  # noqa: F401
 if TYPE_CHECKING:
     import geopandas
     import pandas
-    import pyarrow
+    import pyarrow as pa
 
 
 class DataFrame:
@@ -457,9 +457,7 @@ class DataFrame:
             requested_schema=requested_schema
         )
 
-    def to_record_batch_reader(
-        self, *, simplify: bool = False
-    ) -> "pyarrow.RecordBatchReader":
+    def to_arrow_reader(self, *, simplify: bool = False) -> "pa.RecordBatchReader":
         """Execute and stream results as a PyArrow RecordBatchReader
 
         Executes the logical plan represented by this object and returns a
@@ -475,7 +473,7 @@ class DataFrame:
             >>> sd = sedona.db.connect()
             >>> reader = sd.sql(
             ...     "SELECT ST_Point(0, 1) as geometry"
-            ... ).to_record_batch_reader()
+            ... ).to_arrow_reader()
             >>> reader.read_all()
             pyarrow.Table
             geometry: extension<geoarrow.wkb<WkbType>> not null
@@ -489,6 +487,10 @@ class DataFrame:
         return pa.RecordBatchReader.from_stream(
             self._impl.to_stream(self._ctx, simplify=simplify)
         )
+
+    def arrow(self, *, simplify: bool = False) -> "pa.RecordBatchReader":
+        """Alias of `to_arrow_reader()`"""
+        return self.to_arrow_reader(simplify=simplify)
 
     def to_view(self, name: str, overwrite: bool = False):
         """Create a view based on the query represented by this object
@@ -541,7 +543,7 @@ class DataFrame:
     def __datafusion_table_provider__(self):
         return self._impl.__datafusion_table_provider__()
 
-    def to_arrow_table(self, schema: Any = None) -> "pyarrow.Table":
+    def to_arrow_table(self, schema: Any = None) -> "pa.Table":
         """Execute and collect results as a PyArrow Table
 
         Executes the logical plan represented by this object and returns a

--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -457,6 +457,39 @@ class DataFrame:
             requested_schema=requested_schema
         )
 
+    def to_record_batch_reader(
+        self, *, simplify: bool = False
+    ) -> "pyarrow.RecordBatchReader":
+        """Execute and stream results as a PyArrow RecordBatchReader
+
+        Executes the logical plan represented by this object and returns a
+        PyArrow RecordBatchReader. This requires that pyarrow is installed.
+
+        Args:
+            simplify: Use `True` to simplify Arrow storage types at the export
+                boundary, for example `Utf8View` to `Utf8` and `BinaryView` to
+                `Binary`.
+
+        Examples:
+
+            >>> sd = sedona.db.connect()
+            >>> reader = sd.sql(
+            ...     "SELECT ST_Point(0, 1) as geometry"
+            ... ).to_record_batch_reader()
+            >>> reader.read_all()
+            pyarrow.Table
+            geometry: extension<geoarrow.wkb<WkbType>> not null
+            ----
+            geometry: [[01010000000000000000000000000000000000F03F]]
+
+        """
+        import geoarrow.pyarrow  # noqa: F401
+        import pyarrow as pa
+
+        return pa.RecordBatchReader.from_stream(
+            self._impl.to_stream(self._ctx, simplify=simplify)
+        )
+
     def to_view(self, name: str, overwrite: bool = False):
         """Create a view based on the query represented by this object
 

--- a/python/sedonadb/tests/test_dataframe.py
+++ b/python/sedonadb/tests/test_dataframe.py
@@ -313,6 +313,33 @@ def test_dataframe_to_arrow(con):
         df.to_arrow_table(schema=pa.schema({}))
 
 
+def test_dataframe_to_record_batch_reader(con):
+    df = con.sql("SELECT 1 as one, ST_GeomFromWKT('POINT (0 1)') as geom")
+
+    reader = df.to_record_batch_reader()
+
+    assert reader.read_all().columns == df.to_arrow_table().columns
+
+
+def test_dataframe_to_record_batch_reader_simplify_storage(con):
+    tab = pa.table(
+        {
+            "s": pa.array(["abcde"], pa.string_view()),
+            "b": pa.array([b"abcde"], pa.binary_view()),
+        }
+    )
+    df = con.create_data_frame(tab)
+
+    default_reader = df.to_record_batch_reader()
+    assert default_reader.schema.field("s").type == pa.string_view()
+    assert default_reader.schema.field("b").type == pa.binary_view()
+
+    simplified_reader = df.to_record_batch_reader(simplify=True)
+    assert simplified_reader.schema.field("s").type == pa.string()
+    assert simplified_reader.schema.field("b").type == pa.binary()
+    assert simplified_reader.read_all().to_pydict() == tab.to_pydict()
+
+
 def test_dataframe_to_arrow_empty_batches(con, geoarrow_data):
     # It's difficult to trigger this with a simpler example
     # https://github.com/apache/sedona-db/issues/156

--- a/python/sedonadb/tests/test_dataframe.py
+++ b/python/sedonadb/tests/test_dataframe.py
@@ -313,15 +313,23 @@ def test_dataframe_to_arrow(con):
         df.to_arrow_table(schema=pa.schema({}))
 
 
-def test_dataframe_to_record_batch_reader(con):
+def test_dataframe_to_arrow_reader(con):
     df = con.sql("SELECT 1 as one, ST_GeomFromWKT('POINT (0 1)') as geom")
 
-    reader = df.to_record_batch_reader()
+    reader = df.to_arrow_reader()
 
     assert reader.read_all().columns == df.to_arrow_table().columns
 
 
-def test_dataframe_to_record_batch_reader_simplify_storage(con):
+def test_dataframe_arrow_alias(con):
+    df = con.sql("SELECT 1 as one")
+
+    reader = df.arrow()
+
+    assert reader.read_all().columns == df.to_arrow_table().columns
+
+
+def test_dataframe_to_arrow_reader_simplify_storage(con):
     tab = pa.table(
         {
             "s": pa.array(["abcde"], pa.string_view()),
@@ -330,11 +338,11 @@ def test_dataframe_to_record_batch_reader_simplify_storage(con):
     )
     df = con.create_data_frame(tab)
 
-    default_reader = df.to_record_batch_reader()
+    default_reader = df.to_arrow_reader()
     assert default_reader.schema.field("s").type == pa.string_view()
     assert default_reader.schema.field("b").type == pa.binary_view()
 
-    simplified_reader = df.to_record_batch_reader(simplify=True)
+    simplified_reader = df.to_arrow_reader(simplify=True)
     assert simplified_reader.schema.field("s").type == pa.string()
     assert simplified_reader.schema.field("b").type == pa.binary()
     assert simplified_reader.read_all().to_pydict() == tab.to_pydict()


### PR DESCRIPTION
## Summary
- add `DataFrame.to_record_batch_reader(simplify=False)` for public Arrow streaming export
- map `simplify=True` to the existing simplified stream path
- cover default storage preservation and `Utf8View`/`BinaryView` simplification

Fixes #869.

## Tests
- `python -m pytest python/sedonadb/tests/test_dataframe.py`