### PR TITLE
feat(python/sedonadb): add DataFrame.rename

### DIFF
--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -363,6 +363,73 @@ class DataFrame:
 
         return DataFrame(self._ctx, self._impl.drop_columns(list(cols)), self._options)
 
+    def rename(self, mapping: Dict[str, str]) -> "DataFrame":
+        """Rename one or more columns.
+
+        Takes a single dict mapping old names to new names. Multiple
+        renames in one call are applied as a unit; the resulting set of
+        column names must be unique. Unknown old-names raise a
+        `KeyError` listing the available columns (DataFusion's
+        `with_column_renamed` is permissive and silently no-ops on an
+        unknown name, which would hide typos; we validate Python-side).
+
+        Args:
+            mapping: A `dict[str, str]` mapping current column names to
+                new names. Direction is `{old: new}` — matching Polars
+                and the inner shape of pandas' `rename(columns={...})`.
+
+        Examples:
+
+            >>> sd = sedona.db.connect()
+            >>> df = sd.sql("SELECT 1 AS a, 2 AS b")
+            >>> df.rename({"a": "x"}).show()
+            ┌───────┬───────┐
+            │   x   ┆   b   │
+            │ int64 ┆ int64 │
+            ╞═══════╪═══════╡
+            │     1 ┆     2 │
+            └───────┴───────┘
+        """
+        if not isinstance(mapping, dict):
+            raise TypeError(
+                f"rename() expects a dict[str, str] mapping, "
+                f"got {type(mapping).__name__}"
+            )
+        if not mapping:
+            raise ValueError("rename() requires at least one mapping entry")
+
+        for old, new in mapping.items():
+            if not isinstance(old, str) or not isinstance(new, str):
+                raise TypeError(
+                    f"rename() expects str keys and values, "
+                    f"got {type(old).__name__} -> {type(new).__name__}"
+                )
+
+        # DataFusion's `with_column_renamed` is permissive — it silently
+        # no-ops on an old-name that isn't in the schema. Validate
+        # Python-side and raise a KeyError listing available columns.
+        columns = self._impl.columns()
+        unknown = [old for old in mapping if old not in columns]
+        if unknown:
+            raise KeyError(
+                f"Column(s) {unknown} not found. Available columns: {columns}"
+            )
+
+        # Reject collisions: the resulting set of column names must be
+        # unique. A collision happens when two renames target the same
+        # new-name, or when a rename targets an existing column name that
+        # isn't itself being renamed.
+        kept = [c for c in columns if c not in mapping]
+        result_names = kept + list(mapping.values())
+        if len(result_names) != len(set(result_names)):
+            raise ValueError(
+                f"rename() would produce duplicate column names. "
+                f"After applying {mapping}, columns would be {result_names}."
+            )
+
+        pairs = list(mapping.items())
+        return DataFrame(self._ctx, self._impl.rename(pairs), self._options)
+
     def limit(self, n: Optional[int], /, *, offset: int = 0) -> "DataFrame":
         """Limit result to n rows starting at offset
 

--- a/python/sedonadb/src/dataframe.rs
+++ b/python/sedonadb/src/dataframe.rs
@@ -189,6 +189,34 @@ impl InternalDataFrame {
         Ok(InternalDataFrame::new(inner, self.runtime.clone()))
     }
 
+    /// Rename one or more columns. `mapping` is a list of `(old, new)`
+    /// pairs.
+    ///
+    /// The Python side has already validated that the dict is non-empty,
+    /// that every old-name resolves to a real column in the current
+    /// schema, and that the resulting set of column names is unique
+    /// (no two renames collide on the same target, and no rename targets
+    /// an already-present column name). All this Python-side validation
+    /// is forced by DataFusion's permissive behavior — `with_column_renamed`
+    /// silently no-ops on an unknown old-name, which would hide typos,
+    /// and there's no engine-level uniqueness check on the resulting
+    /// column names.
+    ///
+    /// Internally this fold-applies `with_column_renamed` one pair at a
+    /// time. DataFusion doesn't have a multi-rename helper; the loop is
+    /// O(n) in the number of renames which is dominated by plan-build
+    /// overhead, not the rename itself.
+    fn rename(
+        &self,
+        mapping: Vec<(String, String)>,
+    ) -> Result<InternalDataFrame, PySedonaError> {
+        let mut df = self.inner.clone();
+        for (old, new) in mapping {
+            df = df.with_column_renamed(old, new.as_str())?;
+        }
+        Ok(InternalDataFrame::new(df, self.runtime.clone()))
+    }
+
     fn execute<'py>(&self, py: Python<'py>) -> Result<usize, PySedonaError> {
         let df = self.inner.clone();
         let count = wait_for_future(py, &self.runtime, async move {

--- a/python/sedonadb/tests/expr/test_dataframe_rename.py
+++ b/python/sedonadb/tests/expr/test_dataframe_rename.py
@@ -1,0 +1,124 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Tests for DataFrame.rename(mapping). Each test builds its own input
+# inline; output is compared with `pd.testing.assert_frame_equal`.
+
+import pandas as pd
+import pandas.testing as pdt
+import pytest
+
+from sedonadb._lib import SedonaError
+from sedonadb.dataframe import DataFrame
+
+
+def test_rename_single_column(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1, 2, 3], "b": [10, 20, 30]}))
+    out = df.rename({"a": "x"}).to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [1, 2, 3], "b": [10, 20, 30]}))
+
+
+def test_rename_multiple_columns(con):
+    df = con.create_data_frame(
+        pd.DataFrame({"a": [1, 2], "b": [10, 20], "c": [100, 200]})
+    )
+    out = df.rename({"a": "x", "c": "z"}).to_pandas()
+    pdt.assert_frame_equal(
+        out, pd.DataFrame({"x": [1, 2], "b": [10, 20], "z": [100, 200]})
+    )
+
+
+def test_rename_swap_pair_raises_at_plan_build(con):
+    # `{"a": "b", "b": "a"}` ends with a final schema of `[b, a]` that
+    # has no duplicates, so the Python-side final-state check passes.
+    # But DataFusion applies renames sequentially and the intermediate
+    # state after `a→b` collides with the original `b`. The error
+    # surfaces as `SedonaError` from plan-build. Users who want a swap
+    # must route through a temporary name explicitly.
+    df = con.create_data_frame(pd.DataFrame({"a": [1], "b": [2]}))
+    with pytest.raises(SedonaError, match="unique expression names"):
+        df.rename({"a": "b", "b": "a"})
+
+
+def test_rename_preserves_column_order(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1], "b": [2], "c": [3], "d": [4]}))
+    out = df.rename({"b": "B", "d": "D"}).to_pandas()
+    # The renamed columns stay in their original positions.
+    assert list(out.columns) == ["a", "B", "c", "D"]
+
+
+def test_rename_returns_lazy_dataframe(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1]}))
+    out = df.rename({"a": "x"})
+    assert isinstance(out, DataFrame)
+
+
+def test_rename_non_dict_arg_raises(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1]}))
+    with pytest.raises(TypeError, match="dict\\[str, str\\]"):
+        df.rename(["a", "x"])
+
+
+def test_rename_empty_dict_raises(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1]}))
+    with pytest.raises(ValueError, match="at least one mapping entry"):
+        df.rename({})
+
+
+def test_rename_non_string_key_raises(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1]}))
+    with pytest.raises(TypeError, match="str keys and values"):
+        df.rename({0: "x"})
+
+
+def test_rename_non_string_value_raises(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1]}))
+    with pytest.raises(TypeError, match="str keys and values"):
+        df.rename({"a": 1})
+
+
+def test_rename_columns_kwarg_raises(con):
+    # We deliberately do not accept `columns=`; Python raises the standard
+    # unexpected-keyword TypeError.
+    df = con.create_data_frame(pd.DataFrame({"a": [1]}))
+    with pytest.raises(TypeError, match="columns"):
+        df.rename(columns={"a": "x"})
+
+
+def test_rename_unknown_column_raises_keyerror(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1], "b": [2]}))
+    with pytest.raises(KeyError) as exc:
+        df.rename({"nonexistent": "x"})
+    assert (
+        exc.value.args[0]
+        == "Column(s) ['nonexistent'] not found. Available columns: ['a', 'b']"
+    )
+
+
+def test_rename_to_existing_column_raises(con):
+    # Renaming to a name that already exists (and isn't itself being
+    # renamed) would produce duplicate column names. Reject Python-side.
+    df = con.create_data_frame(pd.DataFrame({"a": [1], "b": [2]}))
+    with pytest.raises(ValueError, match="duplicate column names"):
+        df.rename({"a": "b"})
+
+
+def test_rename_collision_between_new_names_raises(con):
+    # Two renames targeting the same new name → collision.
+    df = con.create_data_frame(pd.DataFrame({"a": [1], "b": [2], "c": [3]}))
+    with pytest.raises(ValueError, match="duplicate column names"):
+        df.rename({"a": "z", "b": "z"})


### PR DESCRIPTION
Continues Phase P2 of #791 with `DataFrame.rename`. Same shape as `drop` from #871 — small schema op, strings only, varargs-style (well, dict-style) API instead of pandas' `columns=` keyword.

## API

```python
df.rename({"a": "x"})
df.rename({"a": "x", "b": "y"})
```

- **Single `dict[str, str]` arg.** No `columns=` kwarg.
- **Direction is `{old: new}`** — matches Polars and the inner shape of `pandas.rename(columns={...})`. Not Ibis's kwarg-flipped style.
- **Strings only** for both keys and values; no `Expr`.
- **Multi-rename in one call**, applied as a single plan transformation.

## Validation

All Python-side, locked with exact-message tests where the message is the feature being verified:

- Empty dict → `ValueError`.
- Non-dict arg / non-str key or value → `TypeError`.
- Unknown old-name → `KeyError` listing available columns. Forced by DataFusion's `with_column_renamed` being permissive (same trap as `drop_columns`).
- Final-state collisions (`{"a": "z", "b": "z"}` or `{"a": "b"}` when `b` already exists) → `ValueError("duplicate column names")`.

## Swap-pair behavior (worth flagging)

`{"a": "b", "b": "a"}` has a unique final schema `[b, a]` so the Python-side collision check passes. But DataFusion applies renames sequentially, and the intermediate state after `a→b` collides with the original `b`. The error surfaces as `SedonaError` from plan-build with message `Projections require unique expression names...`.

I considered building a rename-graph and detecting cycles Python-side, but the DataFusion error is correct, clear-enough, and trying to reorder Python-side would either reimplement DataFusion's check or miss edge cases. Locked in `test_rename_swap_pair_raises_at_plan_build`. Users wanting a swap route through a temporary name explicitly.

## Tests

13 in `tests/expr/test_dataframe_rename.py`:

- **Positive**: single, multi, column-order preservation.
- **Lazy return**: `isinstance(out, DataFrame)`.
- **Errors**: empty dict; non-dict; non-str key; non-str value; `columns=` kwarg; unknown old-name (exact `KeyError` message); rename-onto-existing collision; new-name-to-new-name collision; sequential-application swap.

Local: 13 unit + 20 doctests + `ruff format` + `ruff check` all clean.
