### PR TITLE
feat(python/sedonadb): add aggregate expression methods on Expr

### DIFF
--- a/python/sedonadb/python/sedonadb/expr/expression.py
+++ b/python/sedonadb/python/sedonadb/expr/expression.py
@@ -157,6 +157,69 @@ class Expr:
         """
         return Expr(self._impl.negate())
 
+    # Aggregate expressions ------------------------------------------------
+    #
+    # These build aggregate nodes (SUM, COUNT, AVG, MIN, MAX). They are
+    # meaningful only inside an aggregation context — `DataFrame.agg(...)`
+    # or `DataFrame.group_by(...).agg(...)` — which land in follow-up PRs.
+    # As standalone expressions they are valid AST nodes but cannot be
+    # evaluated by `select` / `filter`.
+
+    def sum(self) -> "Expr":
+        """Aggregate this expression with SUM.
+
+        Examples:
+
+            >>> from sedonadb.expr import col
+            >>> col("x").sum()
+            Expr(sum(x))
+        """
+        return Expr(self._impl.sum())
+
+    def count(self) -> "Expr":
+        """Aggregate this expression with COUNT.
+
+        Examples:
+
+            >>> from sedonadb.expr import col
+            >>> col("x").count()
+            Expr(count(x))
+        """
+        return Expr(self._impl.count())
+
+    def mean(self) -> "Expr":
+        """Aggregate this expression with AVG (mean).
+
+        Examples:
+
+            >>> from sedonadb.expr import col
+            >>> col("x").mean()
+            Expr(avg(x))
+        """
+        return Expr(self._impl.mean())
+
+    def min(self) -> "Expr":
+        """Aggregate this expression with MIN.
+
+        Examples:
+
+            >>> from sedonadb.expr import col
+            >>> col("x").min()
+            Expr(min(x))
+        """
+        return Expr(self._impl.min())
+
+    def max(self) -> "Expr":
+        """Aggregate this expression with MAX.
+
+        Examples:
+
+            >>> from sedonadb.expr import col
+            >>> col("x").max()
+            Expr(max(x))
+        """
+        return Expr(self._impl.max())
+
     def asc(self, nulls_first: bool = False) -> "SortExpr":
         """Wrap this expression as an ascending sort key.
 

--- a/python/sedonadb/src/expr.rs
+++ b/python/sedonadb/src/expr.rs
@@ -36,6 +36,7 @@
 //! role of `SedonaDBExpr` and `expr_col` / `expr_lit` mirror
 //! `SedonaDBExprFactory::column` / `::literal`.
 
+use datafusion::functions_aggregate::expr_fn::{avg, count, max, min, sum};
 use datafusion_common::Column;
 use datafusion_expr::{expr::InList, BinaryExpr, Cast, Expr, Operator, SortExpr};
 use pyo3::prelude::*;
@@ -163,6 +164,45 @@ impl PyExpr {
     fn negate(&self) -> Self {
         Self {
             inner: Expr::Negative(Box::new(self.inner.clone())),
+        }
+    }
+
+    /// Aggregate this expression with SUM. Valid only inside an
+    /// aggregation context (`DataFrame.agg` / `group_by().agg()`); as a
+    /// standalone `Expr` it is just an unbound aggregate node.
+    fn sum(&self) -> Self {
+        Self {
+            inner: sum(self.inner.clone()),
+        }
+    }
+
+    /// Aggregate this expression with COUNT.
+    fn count(&self) -> Self {
+        Self {
+            inner: count(self.inner.clone()),
+        }
+    }
+
+    /// Aggregate this expression with AVG (mean). DataFusion names the
+    /// underlying function `avg`; we expose it Python-side as `mean` to
+    /// match the pandas/Polars vocabulary.
+    fn mean(&self) -> Self {
+        Self {
+            inner: avg(self.inner.clone()),
+        }
+    }
+
+    /// Aggregate this expression with MIN.
+    fn min(&self) -> Self {
+        Self {
+            inner: min(self.inner.clone()),
+        }
+    }
+
+    /// Aggregate this expression with MAX.
+    fn max(&self) -> Self {
+        Self {
+            inner: max(self.inner.clone()),
         }
     }
 

--- a/python/sedonadb/tests/expr/test_expression.py
+++ b/python/sedonadb/tests/expr/test_expression.py
@@ -126,6 +126,31 @@ def test_expr_init_rejects_wrong_type():
         Expr(42)
 
 
+# --- Aggregate expressions ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "method,expected",
+    [
+        ("sum", "Expr(sum(x))"),
+        ("count", "Expr(count(x))"),
+        ("mean", "Expr(avg(x))"),
+        ("min", "Expr(min(x))"),
+        ("max", "Expr(max(x))"),
+    ],
+)
+def test_aggregate_expression_repr(method, expected):
+    e = getattr(col("x"), method)()
+    assert isinstance(e, Expr)
+    assert repr(e) == expected
+
+
+def test_aggregate_over_compound_expression():
+    # An aggregate over a composed expression should wrap the whole thing.
+    e = (col("x") + col("y")).sum()
+    assert repr(e) == "Expr(sum(x + y))"
+
+
 # --- Sort expressions --------------------------------------------------------
 
 


### PR DESCRIPTION
First step toward grouping/aggregation, per the reprioritization recorded on #791 (aggregation/join/UDFs ahead of the remaining small schema ops).

## What's new

Aggregate builder methods on `Expr`:

```python
col("x").sum()      # Expr(sum(x))
col("x").count()    # Expr(count(x))
col("x").mean()     # Expr(avg(x))
col("x").min()      # Expr(min(x))
col("x").max()      # Expr(max(x))
```

- **Methods on `Expr`** (matching Polars / PySpark) rather than free functions — consistent with the operator-method pattern already on `Expr`.
- **`mean`** maps to DataFusion's `avg` aggregate but is named for the pandas/Polars vocabulary.
- Each wraps the corresponding helper from `datafusion::functions_aggregate::expr_fn`.

## Scope

This PR ships **only the expression builders**. The resulting `Expr` is an aggregate AST node — valid only inside an aggregation context (`DataFrame.agg(...)` / `group_by().agg()`), which come in follow-up PRs. Shipping the builders in isolation mirrors how the original `Expr` foundation (#807) landed before any DataFrame integration existed; tests are repr-level.

Planned follow-ups:
1. `df.agg(*exprs)` — global (ungrouped) aggregation.
2. `df.group_by(*keys).agg(*exprs)` — the `GroupedDataFrame` layer.

## Test plan

6 tests in `tests/expr/test_expression.py`:
- Parametrized exact-`repr()` check for all five aggregates.
- Aggregate over a compound expression (`(col("x") + col("y")).sum()` → `Expr(sum(x + y))`).

Local: 54 expression tests + 15 doctests + `ruff format` + `ruff check` all clean.
