### PR TITLE
feat(python/sedonadb): Make expressions context-aware for piped functions

### DIFF
--- a/python/sedonadb/python/sedonadb/context.py
+++ b/python/sedonadb/python/sedonadb/context.py
@@ -87,6 +87,13 @@ class SedonaContext:
         self.__impl = None
         self.options = Options()
 
+    @classmethod
+    def _init_from_impl(cls, impl, options):
+        instance = cls()
+        instance.__impl = impl
+        instance.options = options
+        return instance
+
     @property
     def _impl(self):
         """Lazily initialize the internal Rust context on first use.
@@ -509,7 +516,7 @@ class SedonaContext:
             >>> sd.col("x", "t")
             Expr(t.x)
         """
-        return col_expr(name, qualifier=qualifier)
+        return col_expr(name, qualifier=qualifier, ctx=self)
 
     def lit(self, value: Any) -> LiteralExpr:
         """Create a literal (constant) expression
@@ -536,7 +543,7 @@ class SedonaContext:
         - pyproj CRS objects become PROJJSON strings (e.g., so they may be used
         in `ST_SetCRS()`, `ST_Point()`, or `ST_GeomFromWKT()`).
         """
-        return lit_expr(value)
+        return lit_expr(value, ctx=self)
 
 
 def connect() -> SedonaContext:

--- a/python/sedonadb/python/sedonadb/context.py
+++ b/python/sedonadb/python/sedonadb/context.py
@@ -152,7 +152,7 @@ class SedonaContext:
             │     1 │
             └───────┘
         """
-        return _create_data_frame(self._impl, obj, schema, self.options)
+        return _create_data_frame(self, obj, schema)
 
     def view(self, name: str) -> DataFrame:
         """Create a [DataFrame][sedonadb.dataframe.DataFrame] from a named view
@@ -176,7 +176,7 @@ class SedonaContext:
             >>> sd.drop_view("foofy")
 
         """
-        return DataFrame(self._impl, self._impl.view(name), self.options)
+        return DataFrame(self, self._impl.view(name))
 
     def drop_view(self, name: str) -> None:
         """Remove a named view
@@ -278,11 +278,10 @@ class SedonaContext:
             geometry_columns = json.dumps(geometry_columns)
 
         return DataFrame(
-            self._impl,
+            self,
             self._impl.read_parquet(
                 [str(path) for path in table_paths], options, geometry_columns, validate
             ),
-            self.options,
         )
 
     def read_pyogrio(
@@ -351,11 +350,10 @@ class SedonaContext:
             spec = spec.with_options(options)
 
         return DataFrame(
-            self._impl,
+            self,
             self._impl.read_external_format(
                 spec, [str(path) for path in table_paths], False
             ),
-            self.options,
         )
 
     def read_format(
@@ -395,11 +393,10 @@ class SedonaContext:
             table_paths = [table_paths]
 
         return DataFrame(
-            self._impl,
+            self,
             self._impl.read_external_format(
                 spec, [str(path) for path in table_paths], check_extension
             ),
-            self.options,
         )
 
     def sql(
@@ -445,7 +442,7 @@ class SedonaContext:
             └────────────┘
 
         """
-        df = DataFrame(self._impl, self._impl.sql(sql), self.options)
+        df = DataFrame(self, self._impl.sql(sql))
 
         if params is not None:
             if isinstance(params, (tuple, list)):

--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -142,10 +142,9 @@ class DataFrame:
         └────────────┘
     """
 
-    def __init__(self, ctx, impl, options):
+    def __init__(self, ctx, impl):
         self._ctx = ctx
         self._impl = impl
-        self._options = options
 
     @property
     def schema(self):
@@ -199,11 +198,7 @@ class DataFrame:
         references in join expressions. This is the equivalent of aliasing a subquery
         in SQL (`(SELECT * FROM df) AS name`).
         """
-        return DataFrame(
-            self._ctx,
-            self._impl.alias(name),
-            self._options,
-        )
+        return DataFrame(self._ctx, self._impl.alias(name))
 
     def __getitem__(self, key: Union[str, int]) -> Expr:
         """Reference a single column by name or position.
@@ -238,8 +233,6 @@ class DataFrame:
             >>> df[-1]
             Expr(t.y)
         """
-        from sedonadb.context import SedonaContext
-
         # `bool` is a subclass of `int`, so guard explicitly — otherwise
         # `df[True]` would silently mean `df[1]`.
         if isinstance(key, bool):
@@ -266,7 +259,7 @@ class DataFrame:
             )
 
         inner_expr = self._impl.qualified_column_expr(key)
-        return Expr(inner_expr, SedonaContext._init_from_impl(self._ctx, self._options))
+        return Expr(inner_expr, self._ctx)
 
     def __getattr__(self, name):
         """Syntactic sugar for column access
@@ -375,7 +368,7 @@ class DataFrame:
                     f"got {type(e).__name__} for '{name}'"
                 )
 
-        return DataFrame(self._ctx, self._impl.select(coerced), self._options)
+        return DataFrame(self._ctx, self._impl.select(coerced))
 
     def filter(self, *exprs: Expr) -> "DataFrame":
         """Filter rows by one or more boolean expressions.
@@ -428,7 +421,6 @@ class DataFrame:
         return DataFrame(
             self._ctx,
             self._impl.filter([e._impl for e in exprs]),
-            self._options,
         )
 
     def sort(self, *keys: Union[str, Expr, SortExpr]) -> "DataFrame":
@@ -495,7 +487,7 @@ class DataFrame:
                     f"got {type(k).__name__}"
                 )
 
-        return DataFrame(self._ctx, self._impl.sort(coerced), self._options)
+        return DataFrame(self._ctx, self._impl.sort(coerced))
 
     def drop(self, *cols: str) -> "DataFrame":
         """Drop the named columns.
@@ -540,7 +532,7 @@ class DataFrame:
                 f"Column(s) {unknown} not found. Available columns: {columns}"
             )
 
-        return DataFrame(self._ctx, self._impl.drop_columns(list(cols)), self._options)
+        return DataFrame(self._ctx, self._impl.drop_columns(list(cols)))
 
     def agg(self, *exprs: Expr, **named_exprs: Expr) -> "DataFrame":
         """Aggregate the entire DataFrame to a single row.
@@ -596,7 +588,6 @@ class DataFrame:
         return DataFrame(
             self._ctx,
             self._impl.aggregate([], [e._impl for e in all_exprs]),
-            self._options,
         )
 
     def group_by(self, *keys: Union[str, Expr]) -> "GroupedDataFrame":
@@ -673,7 +664,7 @@ class DataFrame:
             └───────┘
 
         """
-        return DataFrame(self._ctx, self._impl.limit(n, offset), self._options)
+        return DataFrame(self._ctx, self._impl.limit(n, offset))
 
     def execute(self) -> None:
         """Execute the plan represented by this DataFrame
@@ -754,7 +745,6 @@ class DataFrame:
         return DataFrame(
             self._ctx,
             self._impl.with_params(positional_params, named_params),
-            self._options,
         )
 
     def __arrow_c_schema__(self):
@@ -840,7 +830,7 @@ class DataFrame:
             └────────────┘
 
         """
-        self._impl.to_view(self._ctx, name, overwrite)
+        self._impl.to_view(self._ctx._impl, name, overwrite)
 
     def to_memtable(self) -> "DataFrame":
         """Collect a data frame into a memtable
@@ -863,7 +853,7 @@ class DataFrame:
             └────────────┘
 
         """
-        return DataFrame(self._ctx, self._impl.to_memtable(self._ctx), self._options)
+        return DataFrame(self._ctx, self._impl.to_memtable(self._ctx._impl))
 
     def __datafusion_table_provider__(self):
         return self._impl.__datafusion_table_provider__()
@@ -1037,7 +1027,7 @@ class DataFrame:
             sort_by = []
 
         self._impl.to_parquet(
-            self._ctx,
+            self._ctx._impl,
             str(path),
             options,
             partition_by,
@@ -1119,7 +1109,7 @@ class DataFrame:
 
         # GDAL does not support newer Arrow types like string views util 3.14, so we export a
         # reader with simpler types here
-        self_simplified = self._impl.to_stream(self._ctx, simplify=True)
+        self_simplified = self._impl.to_stream(self._ctx._impl, simplify=True)
 
         # Writer: pyogrio.write_arrow() via Cython ogr_write_arrow()
         # https://github.com/geopandas/pyogrio/blob/3b2d40273b501c10ecf46cbd37c6e555754c89af/pyogrio/raw.py#L755-L897
@@ -1167,7 +1157,7 @@ class DataFrame:
 
         """
         width = self._out_width(width)
-        print(self._impl.show(self._ctx, limit, width, ascii), end="")
+        print(self._impl.show(self._ctx._impl, limit, width, ascii), end="")
 
     def explain(
         self,
@@ -1210,23 +1200,21 @@ class DataFrame:
             │               ┆                                 │
             └───────────────┴─────────────────────────────────┘
         """
-        return DataFrame(self._ctx, self._impl.explain(type, format), self._options)
+        return DataFrame(self._ctx, self._impl.explain(type, format))
 
     def __repr__(self) -> str:
-        if self._options.interactive:
+        if self._ctx.options.interactive:
             width = self._out_width()
-            return self._impl.show(self._ctx, 10, width, ascii=False).strip()
+            return self._impl.show(self._ctx._impl, 10, width, ascii=False).strip()
         else:
             return super().__repr__()
 
     def _simplify_storage_types(self):
-        return DataFrame(
-            self._ctx, self._impl.simplify_storage_types(self._ctx), self._options
-        )
+        return DataFrame(self._ctx, self._impl.simplify_storage_types(self._ctx._impl))
 
     def _out_width(self, width=None) -> int:
         if width is None:
-            width = self._options.width
+            width = self._ctx.options.width
 
         if width is None:
             import shutil
@@ -1236,7 +1224,7 @@ class DataFrame:
         return width
 
 
-def _create_data_frame(ctx_impl, obj, schema, options) -> DataFrame:
+def _create_data_frame(ctx, obj, schema) -> DataFrame:
     """Create a DataFrame (internal)
 
     This is defined here because we need it in future dataframe methods like
@@ -1246,7 +1234,7 @@ def _create_data_frame(ctx_impl, obj, schema, options) -> DataFrame:
     # If we're dealing with an anonymous data frame on the same context,
     # just return it. Otherwise, fall back to the default interpretation
     # (which uses __datafusion_table_provider__).
-    if isinstance(obj, DataFrame) and obj._ctx is ctx_impl and schema is None:
+    if isinstance(obj, DataFrame) and obj._ctx is ctx and schema is None:
         return obj
 
     # We special case a few object types where collecting the __arrow_c_stream__
@@ -1255,22 +1243,22 @@ def _create_data_frame(ctx_impl, obj, schema, options) -> DataFrame:
     # This includes geopandas/pandas DataFrames, pyarrow tables, and Polars tables.
     type_name = _qualified_type_name(obj)
     if type_name in SPECIAL_CASED_SCANS:
-        return SPECIAL_CASED_SCANS[type_name](ctx_impl, obj, schema, options)
+        return SPECIAL_CASED_SCANS[type_name](ctx, obj, schema)
 
     # The default implementation handles objects that implement
     # __datafusion_table_provider__ or __arrow_c_stream__. For objects implementing
     # __arrow_c_stream__, this currently will only work for a single scan (i.e.,
     # the returned data frame can't be previewed before the query is computed).
-    return _scan_default(ctx_impl, obj, schema, options)
+    return _scan_default(ctx, obj, schema)
 
 
-def _scan_default(ctx_impl, obj, schema, options):
-    impl = ctx_impl.create_data_frame(obj, schema)
-    return DataFrame(ctx_impl, impl, options)
+def _scan_default(ctx, obj, schema):
+    impl = ctx._impl.create_data_frame(obj, schema)
+    return DataFrame(ctx, impl)
 
 
-def _scan_collected_default(ctx_impl, obj, schema, options):
-    return _scan_default(ctx_impl, obj, schema, options).to_memtable()
+def _scan_collected_default(ctx, obj, schema):
+    return _scan_default(ctx, obj, schema).to_memtable()
 
 
 class GroupedDataFrame:
@@ -1320,14 +1308,11 @@ class GroupedDataFrame:
                 [g._impl for g in self._group_exprs],
                 [e._impl for e in all_exprs],
             ),
-            self._df._options,
         )
 
 
-def _scan_geopandas(ctx_impl, obj, schema, options):
-    return _scan_collected_default(
-        ctx_impl, obj.to_arrow(geometry_encoding="WKB"), schema, options
-    )
+def _scan_geopandas(ctx, obj, schema):
+    return _scan_collected_default(ctx, obj.to_arrow(geometry_encoding="WKB"), schema)
 
 
 def _qualified_type_name(obj):

--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -768,7 +768,7 @@ class DataFrame:
         Args:
             requested_schema: A PyCapsule representing the desired output schema.
         """
-        return self._impl.to_stream(self._ctx, simplify=False).__arrow_c_stream__(
+        return self._impl.to_stream(self._ctx._impl, simplify=False).__arrow_c_stream__(
             requested_schema=requested_schema
         )
 
@@ -800,7 +800,7 @@ class DataFrame:
         import pyarrow as pa
 
         return pa.RecordBatchReader.from_stream(
-            self._impl.to_stream(self._ctx, simplify=simplify)
+            self._impl.to_stream(self._ctx._impl, simplify=simplify)
         )
 
     def arrow(self, *, simplify: bool = False) -> "pa.RecordBatchReader":

--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -238,6 +238,8 @@ class DataFrame:
             >>> df[-1]
             Expr(t.y)
         """
+        from sedonadb.context import SedonaContext
+
         # `bool` is a subclass of `int`, so guard explicitly — otherwise
         # `df[True]` would silently mean `df[1]`.
         if isinstance(key, bool):
@@ -262,8 +264,9 @@ class DataFrame:
                 "DataFrame slicing is not supported. "
                 "Use df.limit(n) or df.limit(n, offset=k)."
             )
+
         inner_expr = self._impl.qualified_column_expr(key)
-        return Expr(inner_expr)
+        return Expr(inner_expr, SedonaContext._init_from_impl(self._ctx, self._options))
 
     def __getattr__(self, name):
         """Syntactic sugar for column access

--- a/python/sedonadb/python/sedonadb/expr/expression.py
+++ b/python/sedonadb/python/sedonadb/expr/expression.py
@@ -191,6 +191,8 @@ class Expr:
         return SortExpr(self._impl.desc(nulls_first))
 
     def _call(self, name, *args) -> "Expr":
+        if self._ctx is None:
+            raise ValueError("Can't _call() Expr constructed without a SedonaContext")
         return self._ctx.funcs[name](*args)
 
     # Arithmetic operators -------------------------------------------------

--- a/python/sedonadb/python/sedonadb/expr/expression.py
+++ b/python/sedonadb/python/sedonadb/expr/expression.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Any, Iterable, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Iterable, Optional
 
 from sedonadb._lib import (
     InternalExpr as _InternalExpr,
@@ -27,6 +27,7 @@ from sedonadb._lib import (
     expr_sort_expr as _expr_sort_expr,
 )
 from sedonadb.expr.literal import Literal
+from sedonadb.utility import sedona  # noqa: F401
 
 
 if TYPE_CHECKING:
@@ -71,6 +72,14 @@ class Expr:
 
     @property
     def funcs(self) -> "Functions":
+        """Pipe this expression into another SedonaDB function
+
+        Examples:
+
+            >>> sd = sedona.db.connect()
+            >>> sd.col("geom").funcs.st_envelope()
+            Expr(st_envelope(geom))
+        """
         from sedonadb.functions import Functions
 
         return Functions(self._ctx, self)
@@ -83,8 +92,8 @@ class Expr:
 
         Examples:
 
-            >>> from sedonadb.expr import col
-            >>> col("x").alias("y")
+            >>> sd = sedona.db.connect()
+            >>> sd.col("x").alias("y")
             Expr(x AS y)
         """
         return Expr(self._impl.alias(name), self._ctx)
@@ -103,8 +112,8 @@ class Expr:
         Examples:
 
             >>> import pyarrow as pa
-            >>> from sedonadb.expr import col
-            >>> col("x").cast(pa.int32())
+            >>> sd = sedona.db.connect()
+            >>> sd.col("x").cast(pa.int32())
             Expr(CAST(x AS Int32))
         """
         return Expr(self._impl.cast(target), self._ctx)
@@ -119,8 +128,8 @@ class Expr:
 
         Examples:
 
-            >>> from sedonadb.expr import col
-            >>> col("x").is_null()
+            >>> sd = sedona.db.connect()
+            >>> sd.col("x").is_null()
             Expr(x IS NULL)
         """
         return Expr(self._impl.is_null(), self._ctx)
@@ -131,8 +140,8 @@ class Expr:
 
         Examples:
 
-            >>> from sedonadb.expr import col
-            >>> col("x").is_not_null()
+            >>> sd = sedona.db.connect()
+            >>> sd.col("x").is_not_null()
             Expr(x IS NOT NULL)
         """
         return Expr(self._impl.is_not_null(), self._ctx)
@@ -150,8 +159,8 @@ class Expr:
 
         Examples:
 
-            >>> from sedonadb.expr import col
-            >>> col("x").isin([1, 2, 3])
+            >>> sd = sedona.db.connect()
+            >>> sd.col("x").isin([1, 2, 3])
             Expr(x IN ([Int64(1), Int64(2), Int64(3)]))
         """
         coerced = [_to_expr(v) for v in values]
@@ -162,8 +171,8 @@ class Expr:
 
         Examples:
 
-            >>> from sedonadb.expr import col
-            >>> col("x").negate()
+            >>> sd = sedona.db.connect()
+            >>> sd.col("x").negate()
             Expr((- x))
         """
         return Expr(self._impl.negate(), self._ctx)
@@ -182,8 +191,8 @@ class Expr:
 
         Examples:
 
-            >>> from sedonadb.expr import col
-            >>> col("x").asc()
+            >>> sd = sedona.db.connect()
+            >>> sd.col("x").asc()
             SortExpr(x ASC NULLS LAST)
         """
         return SortExpr(self._impl.asc(nulls_first))
@@ -194,8 +203,8 @@ class Expr:
 
         Examples:
 
-            >>> from sedonadb.expr import col
-            >>> col("x").desc()
+            >>> sd = sedona.db.connect()
+            >>> sd.col("x").desc()
             SortExpr(x DESC NULLS LAST)
         """
         return SortExpr(self._impl.desc(nulls_first))
@@ -355,10 +364,11 @@ def sort_expr(
 
     Examples:
 
-        >>> from sedonadb.expr import col, sort_expr
-        >>> sort_expr(col("x"))
+        >>> from sedonadb.expr import sort_expr
+        >>> sd = sedona.db.connect()
+        >>> sort_expr(sd.col("x"))
         SortExpr(x ASC NULLS LAST)
-        >>> sort_expr(col("x"), asc=False, nulls_first=True)
+        >>> sort_expr(sd.col("x"), asc=False, nulls_first=True)
         SortExpr(x DESC NULLS FIRST)
     """
     if not isinstance(expr, Expr):
@@ -371,6 +381,9 @@ def sort_expr(
 
 def col(name: str, qualifier: Optional[str] = None, ctx: Any = None) -> Expr:
     """Reference a column by name.
+
+    This is typically constructed using `sd.col()`, which provides the
+    associated context automatically.
 
     Args:
         name: The column name to reference.
@@ -411,9 +424,11 @@ class ScalarUdf:
         return f"ScalarUdf({self._impl!r})"
 
     def __call__(self, *args: Any) -> Expr:
+        # When generated from a piped Functions, self._expr should be
+        # the first argument
         args = [_to_expr(arg)._impl for arg in args]
         if self._expr is not None:
-            args = [self._expr._impl] + args
+            args = [_to_expr(self._expr)._impl] + args
 
         return Expr(self._impl.call(args), self._ctx)
 
@@ -438,6 +453,8 @@ class AggregateUdf:
         return f"AggregateUdf({self._impl!r})"
 
     def __call__(self, *args: Any) -> Expr:
+        # When generated from a piped Functions, self._expr should be
+        # the first argument
         args = [_to_expr(arg)._impl for arg in args]
         if self._expr is not None:
             args = [self._expr._impl] + args

--- a/python/sedonadb/python/sedonadb/expr/expression.py
+++ b/python/sedonadb/python/sedonadb/expr/expression.py
@@ -46,9 +46,9 @@ class Expr:
     that accept value lists (e.g. `isin`).
     """
 
-    __slots__ = ("_impl",)
+    __slots__ = ("_impl", "_ctx")
 
-    def __init__(self, impl):
+    def __init__(self, impl, ctx=None):
         # `impl` is the underlying _lib.InternalExpr handle. Users normally do
         # not construct `Expr` directly; use `col()` (or operator composition)
         # instead. Validate the type so a misuse fails clearly here rather
@@ -60,6 +60,7 @@ class Expr:
                 f"Use sedonadb.expr.col() to construct a column expression."
             )
         self._impl = impl
+        self._ctx = ctx
 
     def __repr__(self) -> str:
         return f"Expr({self._impl!r})"
@@ -76,7 +77,7 @@ class Expr:
             >>> col("x").alias("y")
             Expr(x AS y)
         """
-        return Expr(self._impl.alias(name))
+        return Expr(self._impl.alias(name), self._ctx)
 
     def cast(self, target) -> "Expr":
         """Cast the expression to the given Arrow type.
@@ -96,7 +97,7 @@ class Expr:
             >>> col("x").cast(pa.int32())
             Expr(CAST(x AS Int32))
         """
-        return Expr(self._impl.cast(target))
+        return Expr(self._impl.cast(target), self._ctx)
 
     def is_null(self) -> "Expr":
         """Return a boolean expression that is true where this expression is
@@ -112,7 +113,7 @@ class Expr:
             >>> col("x").is_null()
             Expr(x IS NULL)
         """
-        return Expr(self._impl.is_null())
+        return Expr(self._impl.is_null(), self._ctx)
 
     def is_not_null(self) -> "Expr":
         """Return a boolean expression that is true where this expression is
@@ -124,7 +125,7 @@ class Expr:
             >>> col("x").is_not_null()
             Expr(x IS NOT NULL)
         """
-        return Expr(self._impl.is_not_null())
+        return Expr(self._impl.is_not_null(), self._ctx)
 
     def isin(self, values: Iterable[Any]) -> "Expr":
         """Return a boolean expression that is true where this expression
@@ -144,7 +145,7 @@ class Expr:
             Expr(x IN ([Int64(1), Int64(2), Int64(3)]))
         """
         coerced = [_to_expr(v) for v in values]
-        return Expr(self._impl.isin([e._impl for e in coerced], False))
+        return Expr(self._impl.isin([e._impl for e in coerced], False), self._ctx)
 
     def negate(self) -> "Expr":
         """Return the arithmetic negation of this expression.
@@ -155,7 +156,7 @@ class Expr:
             >>> col("x").negate()
             Expr((- x))
         """
-        return Expr(self._impl.negate())
+        return Expr(self._impl.negate(), self._ctx)
 
     def asc(self, nulls_first: bool = False) -> "SortExpr":
         """Wrap this expression as an ascending sort key.
@@ -188,6 +189,9 @@ class Expr:
             SortExpr(x DESC NULLS LAST)
         """
         return SortExpr(self._impl.desc(nulls_first))
+
+    def _call(self, name, *args) -> "Expr":
+        return self._ctx.funcs[name](*args)
 
     # Arithmetic operators -------------------------------------------------
     #
@@ -352,7 +356,7 @@ def sort_expr(
     return SortExpr(_expr_sort_expr(expr._impl, asc, nulls_first))
 
 
-def col(name: str, qualifier: Optional[str] = None) -> Expr:
+def col(name: str, qualifier: Optional[str] = None, ctx: Any = None) -> Expr:
     """Reference a column by name.
 
     Args:
@@ -361,6 +365,7 @@ def col(name: str, qualifier: Optional[str] = None) -> Expr:
             when the same column name appears in multiple input tables of a
             join. Defaults to `None`, which leaves the column unqualified and
             lets the planner resolve against the surrounding schema.
+        ctx: A SedonaContext from which function definitions should be derived
 
     Examples:
 
@@ -370,7 +375,7 @@ def col(name: str, qualifier: Optional[str] = None) -> Expr:
         >>> col("x", "t")
         Expr(t.x)
     """
-    return Expr(_expr_col(name, qualifier))
+    return Expr(_expr_col(name, qualifier), ctx)
 
 
 class ScalarUdf:
@@ -380,18 +385,19 @@ class ScalarUdf:
     the Python expression API.
     """
 
-    def __init__(self, impl):
+    def __init__(self, impl, ctx=None):
         if type(impl).__name__ not in ("PySedonaScalarUdf", "PyScalarUdf"):
             raise TypeError(
                 "ScalarUdf must be constructed from internal scalar UDF wrapper"
             )
         self._impl = impl
+        self._ctx = ctx
 
     def __repr__(self) -> str:
         return f"ScalarUdf({self._impl!r})"
 
     def __call__(self, *args: Any) -> Expr:
-        return Expr(self._impl.call([_to_expr(arg)._impl for arg in args]))
+        return Expr(self._impl.call([_to_expr(arg)._impl for arg in args]), self._ctx)
 
 
 class AggregateUdf:
@@ -401,21 +407,22 @@ class AggregateUdf:
     the Python expression API.
     """
 
-    def __init__(self, impl):
+    def __init__(self, impl, ctx=None):
         if type(impl).__name__ not in ("PyAggregateUdf",):
             raise TypeError(
                 "AggregateUdf must be constructed from internal aggregate UDF wrapper"
             )
         self._impl = impl
+        self._ctx = ctx
 
     def __repr__(self) -> str:
         return f"AggregateUdf({self._impl!r})"
 
     def __call__(self, *args: Any) -> Expr:
-        return Expr(self._impl.call([_to_expr(arg)._impl for arg in args]))
+        return Expr(self._impl.call([_to_expr(arg)._impl for arg in args]), self._ctx)
 
 
-def _to_expr(value: Any) -> Expr:
+def _to_expr(value: Any, ctx=None) -> Expr:
     """Coerce a Python value to an `Expr`.
 
     `Expr` values pass through unchanged. Anything else is wrapped as a
@@ -428,7 +435,7 @@ def _to_expr(value: Any) -> Expr:
     if isinstance(value, Expr):
         return value
     arrow_obj = value if isinstance(value, Literal) else Literal(value)
-    return Expr(_expr_lit(arrow_obj))
+    return Expr(_expr_lit(arrow_obj), ctx)
 
 
 def _binary(op: str, lhs: Any, rhs: Any) -> Expr:
@@ -440,4 +447,5 @@ def _binary(op: str, lhs: Any, rhs: Any) -> Expr:
     """
     lhs_expr = _to_expr(lhs)
     rhs_expr = _to_expr(rhs)
-    return Expr(_expr_binary(op, lhs_expr._impl, rhs_expr._impl))
+    ctx = lhs_expr._ctx if lhs_expr._ctx is not None else rhs_expr._ctx
+    return Expr(_expr_binary(op, lhs_expr._impl, rhs_expr._impl), ctx)

--- a/python/sedonadb/python/sedonadb/expr/expression.py
+++ b/python/sedonadb/python/sedonadb/expr/expression.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable, Optional, TYPE_CHECKING
 
 from sedonadb._lib import (
     InternalExpr as _InternalExpr,
@@ -27,6 +27,10 @@ from sedonadb._lib import (
     expr_sort_expr as _expr_sort_expr,
 )
 from sedonadb.expr.literal import Literal
+
+
+if TYPE_CHECKING:
+    from sedonadb.functions import Functions
 
 
 class Expr:
@@ -64,6 +68,12 @@ class Expr:
 
     def __repr__(self) -> str:
         return f"Expr({self._impl!r})"
+
+    @property
+    def funcs(self) -> "Functions":
+        from sedonadb.functions import Functions
+
+        return Functions(self._ctx, self)
 
     def alias(self, name: str) -> "Expr":
         """Return a copy of the expression with a new output name.
@@ -193,7 +203,8 @@ class Expr:
     def _call(self, name, *args) -> "Expr":
         if self._ctx is None:
             raise ValueError("Can't _call() Expr constructed without a SedonaContext")
-        return self._ctx.funcs[name](*args)
+
+        return self._ctx.funcs[name](self, *args)
 
     # Arithmetic operators -------------------------------------------------
     #
@@ -387,19 +398,24 @@ class ScalarUdf:
     the Python expression API.
     """
 
-    def __init__(self, impl, ctx=None):
+    def __init__(self, impl, ctx=None, expr=None):
         if type(impl).__name__ not in ("PySedonaScalarUdf", "PyScalarUdf"):
             raise TypeError(
                 "ScalarUdf must be constructed from internal scalar UDF wrapper"
             )
         self._impl = impl
         self._ctx = ctx
+        self._expr = expr
 
     def __repr__(self) -> str:
         return f"ScalarUdf({self._impl!r})"
 
     def __call__(self, *args: Any) -> Expr:
-        return Expr(self._impl.call([_to_expr(arg)._impl for arg in args]), self._ctx)
+        args = [_to_expr(arg)._impl for arg in args]
+        if self._expr is not None:
+            args = [self._expr._impl] + args
+
+        return Expr(self._impl.call(args), self._ctx)
 
 
 class AggregateUdf:
@@ -409,19 +425,24 @@ class AggregateUdf:
     the Python expression API.
     """
 
-    def __init__(self, impl, ctx=None):
+    def __init__(self, impl, ctx=None, expr=None):
         if type(impl).__name__ not in ("PyAggregateUdf",):
             raise TypeError(
                 "AggregateUdf must be constructed from internal aggregate UDF wrapper"
             )
         self._impl = impl
         self._ctx = ctx
+        self._expr = expr
 
     def __repr__(self) -> str:
         return f"AggregateUdf({self._impl!r})"
 
     def __call__(self, *args: Any) -> Expr:
-        return Expr(self._impl.call([_to_expr(arg)._impl for arg in args]), self._ctx)
+        args = [_to_expr(arg)._impl for arg in args]
+        if self._expr is not None:
+            args = [self._expr._impl] + args
+
+        return Expr(self._impl.call(args), self._ctx)
 
 
 def _to_expr(value: Any, ctx=None) -> Expr:

--- a/python/sedonadb/python/sedonadb/expr/expression.py
+++ b/python/sedonadb/python/sedonadb/expr/expression.py
@@ -454,7 +454,7 @@ class AggregateUdf:
         # the first argument
         args = [_to_expr(arg)._impl for arg in args]
         if self._expr is not None:
-            args = [self._expr._impl] + args
+            args = [_to_expr(self._expr)._impl] + args
 
         return Expr(self._impl.call(args), self._ctx)
 
@@ -470,9 +470,13 @@ def _to_expr(value: Any, ctx=None) -> Expr:
     literal-handling logic.
     """
     if isinstance(value, Expr):
+        ctx = value._ctx if value._ctx is not None else ctx
         return value
-    arrow_obj = value if isinstance(value, Literal) else Literal(value)
-    return Expr(_expr_lit(arrow_obj), ctx)
+    elif isinstance(value, Literal):
+        ctx = value._ctx if value._ctx is not None else ctx
+        return Expr(_expr_lit(value), ctx)
+    else:
+        return Expr(_expr_lit(Literal(value)), ctx)
 
 
 def _binary(op: str, lhs: Any, rhs: Any) -> Expr:

--- a/python/sedonadb/python/sedonadb/expr/expression.py
+++ b/python/sedonadb/python/sedonadb/expr/expression.py
@@ -288,7 +288,7 @@ class Expr:
         return _binary("|", other, self)
 
     def __invert__(self) -> "Expr":
-        return Expr(_expr_not(self._impl))
+        return Expr(_expr_not(self._impl), self._ctx)
 
     # Defining `__eq__` makes the class unhashable by default. Be explicit
     # so users see a clear error instead of a confusing one. Expressions are

--- a/python/sedonadb/python/sedonadb/expr/expression.py
+++ b/python/sedonadb/python/sedonadb/expr/expression.py
@@ -82,6 +82,9 @@ class Expr:
         """
         from sedonadb.functions import Functions
 
+        if self._ctx is None:
+            raise ValueError("Can't pipe Expr without context into Functions")
+
         return Functions(self._ctx, self)
 
     def alias(self, name: str) -> "Expr":
@@ -208,12 +211,6 @@ class Expr:
             SortExpr(x DESC NULLS LAST)
         """
         return SortExpr(self._impl.desc(nulls_first))
-
-    def _call(self, name, *args) -> "Expr":
-        if self._ctx is None:
-            raise ValueError("Can't _call() Expr constructed without a SedonaContext")
-
-        return self._ctx.funcs[name](self, *args)
 
     # Arithmetic operators -------------------------------------------------
     #

--- a/python/sedonadb/python/sedonadb/expr/literal.py
+++ b/python/sedonadb/python/sedonadb/expr/literal.py
@@ -66,6 +66,9 @@ class Literal:
         """
         from sedonadb.functions import Functions
 
+        if self._ctx is None:
+            raise ValueError("Can't pipe Literal without context into Functions")
+
         return Functions(self._ctx, self)
 
     def alias(self, name: str):

--- a/python/sedonadb/python/sedonadb/expr/literal.py
+++ b/python/sedonadb/python/sedonadb/expr/literal.py
@@ -38,8 +38,9 @@ class Literal:
         value: An arbitrary Python object.
     """
 
-    def __init__(self, value: Any):
+    def __init__(self, value: Any, ctx=None):
         self._value = value
+        self._ctx = ctx
 
     def __arrow_c_array__(self, requested_schema=None):
         resolved_lit = _resolve_arrow_lit(self._value)
@@ -64,18 +65,20 @@ class Literal:
         """
         from sedonadb.expr.expression import _to_expr
 
-        return _to_expr(self).alias(name)
+        return _to_expr(self, self._ctx).alias(name)
 
 
-def lit(value: Any) -> Literal:
+def lit(value: Any, ctx: Any=None) -> Literal:
     """Create a literal (constant) expression
 
     See documentation in `SedonaContext`.
     """
     if isinstance(value, Literal):
+        if value._ctx is None:
+            value._ctx = ctx
         return value
     else:
-        return Literal(value)
+        return Literal(value, ctx)
 
 
 def _resolve_arrow_lit(obj: Any):

--- a/python/sedonadb/python/sedonadb/expr/literal.py
+++ b/python/sedonadb/python/sedonadb/expr/literal.py
@@ -15,7 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+from sedonadb.utility import sedona  # noqa: F401
+
+if TYPE_CHECKING:
+    from sedonadb.functions import Functions
 
 
 class Literal:
@@ -49,6 +54,20 @@ class Literal:
     def __repr__(self):
         return f"<Literal>\n{repr(self._value)}"
 
+    @property
+    def funcs(self) -> "Functions":
+        """Pipe this expression into another SedonaDB function
+
+        Examples:
+
+            >>> sd = sedona.db.connect()
+            >>> sd.lit(5.0).funcs.sqrt()
+            Expr(sqrt(Float64(5)))
+        """
+        from sedonadb.functions import Functions
+
+        return Functions(self._ctx, self)
+
     def alias(self, name: str):
         """Give this literal a column name.
 
@@ -68,7 +87,7 @@ class Literal:
         return _to_expr(self, self._ctx).alias(name)
 
 
-def lit(value: Any, ctx: Any=None) -> Literal:
+def lit(value: Any, ctx: Any = None) -> Literal:
     """Create a literal (constant) expression
 
     See documentation in `SedonaContext`.
@@ -149,8 +168,8 @@ def _lit_from_shapely(obj):
 
 
 def _lit_from_wkb_and_crs(wkb, crs):
-    import pyarrow as pa
     import geoarrow.pyarrow as ga
+    import pyarrow as pa
 
     type = ga.wkb().with_crs(crs)
     storage = pa.array([wkb], type.storage_type)

--- a/python/sedonadb/python/sedonadb/expr/literal.py
+++ b/python/sedonadb/python/sedonadb/expr/literal.py
@@ -96,9 +96,12 @@ def lit(value: Any, ctx: Any = None) -> Literal:
     See documentation in `SedonaContext`.
     """
     if isinstance(value, Literal):
-        if value._ctx is None:
-            value._ctx = ctx
-        return value
+        if ctx is not None:
+            # Create a new literal with the assigned context
+            return Literal(value._value, ctx)
+        else:
+            # Otherwise just return the existing literal
+            return value
     else:
         return Literal(value, ctx)
 

--- a/python/sedonadb/python/sedonadb/functions/__init__.py
+++ b/python/sedonadb/python/sedonadb/functions/__init__.py
@@ -53,7 +53,9 @@ class Functions:
             pass
 
         try:
-            return AggregateUdf(self._ctx._impl.aggregate_udf(name), self._ctx, self._expr)
+            return AggregateUdf(
+                self._ctx._impl.aggregate_udf(name), self._ctx, self._expr
+            )
         except SedonaError:
             pass
 

--- a/python/sedonadb/python/sedonadb/functions/__init__.py
+++ b/python/sedonadb/python/sedonadb/functions/__init__.py
@@ -44,12 +44,12 @@ class Functions:
 
     def __getattr__(self, name) -> Union["ScalarUdf", "AggregateUdf"]:
         try:
-            return ScalarUdf(self._ctx._impl.scalar_udf(name))
+            return ScalarUdf(self._ctx._impl.scalar_udf(name), self._ctx)
         except SedonaError:
             pass
 
         try:
-            return AggregateUdf(self._ctx._impl.aggregate_udf(name))
+            return AggregateUdf(self._ctx._impl.aggregate_udf(name), self._ctx)
         except SedonaError:
             pass
 

--- a/python/sedonadb/python/sedonadb/functions/__init__.py
+++ b/python/sedonadb/python/sedonadb/functions/__init__.py
@@ -32,24 +32,28 @@ class Functions:
     given a specific SedonaDB context.
     """
 
-    def __init__(self, ctx):
+    def __init__(self, ctx, expr=None):
         self._ctx = ctx
+        self._expr = expr
 
     @cached_property
     def table(self) -> "TableFunctions":
         """Access SedonaDB Table functions"""
         from sedonadb.functions.table import TableFunctions
 
+        if self._expr is not None:
+            raise ValueError("Expr piping into table functions is not supported")
+
         return TableFunctions(self._ctx)
 
     def __getattr__(self, name) -> Union["ScalarUdf", "AggregateUdf"]:
         try:
-            return ScalarUdf(self._ctx._impl.scalar_udf(name), self._ctx)
+            return ScalarUdf(self._ctx._impl.scalar_udf(name), self._ctx, self._expr)
         except SedonaError:
             pass
 
         try:
-            return AggregateUdf(self._ctx._impl.aggregate_udf(name), self._ctx)
+            return AggregateUdf(self._ctx._impl.aggregate_udf(name), self._ctx, self._expr)
         except SedonaError:
             pass
 

--- a/python/sedonadb/tests/expr/test_dataframe_getitem.py
+++ b/python/sedonadb/tests/expr/test_dataframe_getitem.py
@@ -31,6 +31,7 @@ def test_getitem_string_returns_col_expr(con):
     e = df["x"]
     assert isinstance(e, Expr)
     assert repr(e) == "Expr(foofy.x)"
+    assert e._ctx is not None
 
 
 def test_getitem_positive_int_returns_col_expr(con):
@@ -40,6 +41,7 @@ def test_getitem_positive_int_returns_col_expr(con):
     e = df[1]
     assert isinstance(e, Expr)
     assert repr(e) == "Expr(foofy.y)"
+    assert e._ctx is not None
 
 
 def test_getitem_first_int_index(con):
@@ -65,6 +67,7 @@ def test_getitem_string_composes_with_operators(con):
     e = df["x"] + df["y"]
     assert isinstance(e, Expr)
     assert repr(e) == "Expr(foofy.x + foofy.y)"
+    assert e._ctx is not None
 
 
 def test_getitem_unknown_string_raises_keyerror_with_columns(con):
@@ -108,3 +111,20 @@ def test_getitem_slice_raises_typeerror(con):
     df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
     with pytest.raises(TypeError, match="not supported"):
         df[0:2]
+
+
+def test_getattr_returns_col_expr(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]})).alias("foofy")
+    e = df.x
+    assert isinstance(e, Expr)
+    assert repr(e) == "Expr(foofy.x)"
+    assert e._ctx is not None
+
+
+def test_getattr_unknown_raises_attributeerror(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3], "y": [10, 20, 30]}))
+    with pytest.raises(AttributeError, match="not found") as exc:
+        df.nonexistent
+    assert "nonexistent" in str(exc.value)
+    assert "x" in str(exc.value)
+    assert "y" in str(exc.value)

--- a/python/sedonadb/tests/expr/test_expression.py
+++ b/python/sedonadb/tests/expr/test_expression.py
@@ -283,6 +283,19 @@ def test_len_raises():
         len(col("x"))
 
 
+def test_literal_funcs(con):
+    e = con.col("foofy").funcs.sqrt()
+    assert isinstance(e, Expr)
+    assert repr(e) == "Expr(sqrt(foofy))"
+
+
+def test_contextless_literal():
+    e = col("foofy")
+
+    with pytest.raises(ValueError, match="Can't pipe Expr"):
+        e.funcs
+
+
 def test_ctx_propagation(con):
     e = con.col("foofy")
     assert e._ctx is con

--- a/python/sedonadb/tests/expr/test_expression.py
+++ b/python/sedonadb/tests/expr/test_expression.py
@@ -281,3 +281,45 @@ def test_bool_raises_for_not():
 def test_len_raises():
     with pytest.raises(TypeError, match="Expr has no length"):
         len(col("x"))
+
+
+def test_ctx_propagation(con):
+    e = con.col("foofy")
+    assert e._ctx is con
+
+    assert e.alias("bar")._ctx is con
+    assert e.cast(pa.int32())._ctx is con
+    assert e.is_null()._ctx is con
+    assert e.is_not_null()._ctx is con
+    assert e.isin([1, 2])._ctx is con
+    assert e.negate()._ctx is con
+
+    assert (e + 1)._ctx is con
+    assert (e - 1)._ctx is con
+    assert (e * 2)._ctx is con
+    assert (e / 2)._ctx is con
+    assert (-e)._ctx is con
+
+    assert (1 + e)._ctx is con
+    assert (1 - e)._ctx is con
+    assert (2 * e)._ctx is con
+    assert (2 / e)._ctx is con
+
+    assert (e == 0)._ctx is con
+    assert (e != 0)._ctx is con
+    assert (e < 0)._ctx is con
+    assert (e <= 0)._ctx is con
+    assert (e > 0)._ctx is con
+    assert (e >= 0)._ctx is con
+
+    assert (e & e)._ctx is con
+    assert (e | e)._ctx is con
+    assert (~e)._ctx is con
+
+    assert con.col("geom").funcs.st_area()._ctx is con
+    assert ((e + 1) * 2).is_null().alias("check")._ctx is con
+
+    bare_expr = col("y")
+    assert bare_expr._ctx is None
+    assert (e + bare_expr)._ctx is con
+    assert (bare_expr + e)._ctx is con

--- a/python/sedonadb/tests/expr/test_expression.py
+++ b/python/sedonadb/tests/expr/test_expression.py
@@ -283,13 +283,13 @@ def test_len_raises():
         len(col("x"))
 
 
-def test_literal_funcs(con):
+def test_expr_funcs(con):
     e = con.col("foofy").funcs.sqrt()
     assert isinstance(e, Expr)
     assert repr(e) == "Expr(sqrt(foofy))"
 
 
-def test_contextless_literal():
+def test_contextless_expr():
     e = col("foofy")
 
     with pytest.raises(ValueError, match="Can't pipe Expr"):

--- a/python/sedonadb/tests/expr/test_function_expression.py
+++ b/python/sedonadb/tests/expr/test_function_expression.py
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import pytest
-
 from sedonadb.expr import Expr
 from sedonadb.expr.expression import ScalarUdf, AggregateUdf
 
@@ -110,37 +108,3 @@ def test_function_expression_composed(con):
         repr(e)
         == 'Expr(st_area(st_geomfromwkt(Utf8("POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))"))))'
     )
-
-
-def test_funcs_getitem_access(con):
-    st_area = con.funcs["st_area"]
-    assert isinstance(st_area, ScalarUdf)
-
-    e = st_area(con.col("geom"))
-    assert repr(e) == "Expr(st_area(geom))"
-
-    sum = con.funcs["sum"]
-    assert isinstance(sum, AggregateUdf)
-
-    e = sum(con.col("x"))
-    assert repr(e) == "Expr(sum(x))"
-
-
-def test_funcs_getattr_not_found_raises_attribute_error(con):
-    with pytest.raises(AttributeError, match="Can't find scalar or aggregate function"):
-        con.funcs.nonexistent_function_xyz
-
-
-def test_funcs_getitem_not_found_raises_key_error(con):
-    with pytest.raises(KeyError, match="Can't find scalar or aggregate function"):
-        con.funcs["nonexistent_function_xyz"]
-
-
-def test_scalar_udf_repr(con):
-    st_area = con.funcs.st_area
-    assert repr(st_area) == "ScalarUdf(st_area)"
-
-
-def test_aggregate_udf_repr(con):
-    st_collect_agg = con.funcs.st_collect_agg
-    assert repr(st_collect_agg) == "AggregateUdf(st_collect_agg)"

--- a/python/sedonadb/tests/expr/test_literal.py
+++ b/python/sedonadb/tests/expr/test_literal.py
@@ -185,11 +185,3 @@ def test_contextless_literal():
 
     with pytest.raises(ValueError, match="Can't pipe Literal"):
         literal.funcs
-
-
-def test_ctx_propagation(con):
-    literal = con.lit(5.0)
-    assert literal._ctx is con
-
-    assert literal.alias("five")._ctx is con
-    assert literal.funcs.sqrt()._ctx is con

--- a/python/sedonadb/tests/expr/test_literal.py
+++ b/python/sedonadb/tests/expr/test_literal.py
@@ -23,6 +23,7 @@ import geoarrow.pyarrow as ga
 import geopandas.testing
 
 from sedonadb.expr.literal import lit
+from sedonadb.expr.expression import Expr
 import pytest
 
 
@@ -170,3 +171,25 @@ def test_crs_literal():
     # A StringCrs
     ga_crs = ga.wkb().with_crs("EPSG:26920").crs
     assert pa.array(lit(ga_crs)) == pa.array([crs.to_json()])
+
+
+def test_literal_funcs(con):
+    literal = con.lit(5.0)
+    e = literal.funcs.sqrt()
+    assert isinstance(e, Expr)
+    assert repr(e) == "Expr(sqrt(Float64(5)))"
+
+
+def test_contextless_literal():
+    literal = lit(5.0)
+
+    with pytest.raises(ValueError, match="Can't pipe Literal"):
+        literal.funcs
+
+
+def test_ctx_propagation(con):
+    literal = con.lit(5.0)
+    assert literal._ctx is con
+
+    assert literal.alias("five")._ctx is con
+    assert literal.funcs.sqrt()._ctx is con

--- a/python/sedonadb/tests/test_funcs.py
+++ b/python/sedonadb/tests/test_funcs.py
@@ -15,6 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import pytest
+
+from sedonadb.expr.expression import AggregateUdf, ScalarUdf
+
 
 def test_random_geometry(con):
     df = con.funcs.table.sd_random_geometry("Point", 5, seed=99873)
@@ -24,3 +28,50 @@ def test_random_geometry(con):
 
     # Ensure the output is reproducible
     assert df.to_arrow_table() == df.to_arrow_table()
+
+
+def test_funcs_dir(con):
+    funcs_dir = dir(con.funcs)
+    assert "st_area" in funcs_dir
+    assert "st_buffer" in funcs_dir
+    assert "st_intersection" in funcs_dir
+
+
+def test_funcs_ipython_completions(con):
+    completions = con.funcs._ipython_key_completions_()
+    assert "st_area" in completions
+    assert "st_buffer" in completions
+
+
+def test_funcs_getitem_access(con):
+    st_area = con.funcs["st_area"]
+    assert isinstance(st_area, ScalarUdf)
+
+    e = st_area(con.col("geom"))
+    assert repr(e) == "Expr(st_area(geom))"
+
+    sum_fn = con.funcs["sum"]
+    assert isinstance(sum_fn, AggregateUdf)
+
+    e = sum_fn(con.col("x"))
+    assert repr(e) == "Expr(sum(x))"
+
+
+def test_funcs_getattr_not_found_raises_attribute_error(con):
+    with pytest.raises(AttributeError, match="Can't find scalar or aggregate function"):
+        con.funcs.nonexistent_function_xyz
+
+
+def test_funcs_getitem_not_found_raises_key_error(con):
+    with pytest.raises(KeyError, match="Can't find scalar or aggregate function"):
+        con.funcs["nonexistent_function_xyz"]
+
+
+def test_scalar_udf_repr(con):
+    st_area = con.funcs.st_area
+    assert repr(st_area) == "ScalarUdf(st_area)"
+
+
+def test_aggregate_udf_repr(con):
+    st_collect_agg = con.funcs.st_collect_agg
+    assert repr(st_collect_agg) == "AggregateUdf(st_collect_agg)"

--- a/python/sedonadb/tests/test_funcs.py
+++ b/python/sedonadb/tests/test_funcs.py
@@ -18,6 +18,7 @@
 import pytest
 
 from sedonadb.expr.expression import AggregateUdf, ScalarUdf
+from sedonadb.functions import Functions
 
 
 def test_random_geometry(con):
@@ -28,6 +29,27 @@ def test_random_geometry(con):
 
     # Ensure the output is reproducible
     assert df.to_arrow_table() == df.to_arrow_table()
+
+
+def test_ctx_expr_propagation(con):
+    e = con.col("foofy")
+    funcs_expr = Functions(con, expr=e)
+
+    scalar_func = funcs_expr["st_area"]
+    assert scalar_func._ctx is con
+    assert scalar_func._expr is e
+
+    scalar_func_call = scalar_func()
+    assert scalar_func_call._ctx is con
+    assert repr(scalar_func_call) == "Expr(st_area(foofy))"
+
+    aggregate_func = funcs_expr["sum"]
+    assert aggregate_func._ctx is con
+    assert aggregate_func._expr is e
+
+    aggregate_func_call = aggregate_func()
+    assert aggregate_func_call._ctx is con
+    assert repr(aggregate_func_call) == "Expr(sum(foofy))"
 
 
 def test_funcs_dir(con):


### PR DESCRIPTION
In https://github.com/apache/sedona-db/pull/885 we expose scalar and aggregate functions from `sd.funcs` but this still didn't allow for the piped syntax that pandas and polars allow like `sd.col("foofy").sum()` because there was no way for `Expr` to look up the `sum` function from the context's registry.

This PR adds a `_ctx` member on the expression and adds `funcs` to get *any* function from the context (piping `self` in as the first argument).

This was extracted from https://github.com/apache/sedona-db/pull/862 which is a bit more ambitious but not strictly needed (generating source code for inline documentation).


```python
import sedona.db

sd = sedona.db.connect()
t = sd.funcs.table.sd_random_geometry()
t.select(geom=t.geometry.funcs.st_buffer(10)).show(2)
# ┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
# │                                               geom                                               │
# │                                             geometry                                             │
# ╞══════════════════════════════════════════════════════════════════════════════════════════════════╡
# │ MULTIPOLYGON(((77.01165169396903 4.571593672098363,77.20379888993672 2.620690451937078,77.77285… │
# ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
# │ MULTIPOLYGON(((2.2288873806768237 68.82846911756472,2.4210345766445194 66.87756589740344,2.9900… │
# └──────────────────────────────────────────────────────────────────────────────────────────────────┘
```