### PR TITLE
feat(sedonadb/python): Add informative error for len() of a DataFrame

### DIFF
--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -1216,6 +1216,12 @@ class DataFrame:
         else:
             return super().__repr__()
 
+    def __len__(self):
+        raise ValueError(
+            "Can't compute len() of a lazy SedonaDB DataFrame. "
+            "Use .count() to execute and resolve the number of rows."
+        )
+
     def _simplify_storage_types(self):
         return DataFrame(
             self._ctx, self._impl.simplify_storage_types(self._ctx), self._options

--- a/python/sedonadb/tests/test_dataframe.py
+++ b/python/sedonadb/tests/test_dataframe.py
@@ -599,3 +599,10 @@ def test_repr(con):
         assert repr_interactive == expected
     finally:
         con.options.interactive = False
+
+
+def test_len_error(con):
+    with pytest.raises(
+        ValueError, match=r"Can't compute len\(\) of a lazy SedonaDB DataFrame"
+    ):
+        len(con.sql("SELECT 1 as one"))


### PR DESCRIPTION
Adds an implementation of __len__ that errors and informs the user of how to get a row count.

```python
import sedona.db

sd = sedona.db.connect()
len(sd.sql("SELECT 1 as one"))
#> ValueError: Can't compute len() of a lazy SedonaDB DataFrame. Use .count() to execute and resolve the number of rows.
```

Closes #553.