### PR TITLE
feat(rust/sedona-geoparquet,rust/sedona-datasource)!: Add support for partition columns and discovery

### DIFF
--- a/python/sedonadb/python/sedonadb/context.py
+++ b/python/sedonadb/python/sedonadb/context.py
@@ -410,7 +410,7 @@ class SedonaContext:
             partitioning:
                 Optional list of column names for hive-style partitioning. When reading
                 from a directory with paths like `/col=value/file.ext`, partition
-                column names are auto-discovered by setting `partitioning=None`). Explicitly
+                column names are auto-discovered by setting `partitioning=None`. Explicitly
                 specify column names (e.g., `["col"]`) to override auto-discovery, or pass an
                 empty list `[]` to disable partitioning entirely. The current
                 default is to disable partitioning but this may change in a future

--- a/python/sedonadb/python/sedonadb/context.py
+++ b/python/sedonadb/python/sedonadb/context.py
@@ -256,7 +256,7 @@ class SedonaContext:
             partitioning:
                 Optional list of column names for hive-style partitioning. When reading
                 from a directory with paths like `/col=value/file.parquet`, partition
-                column names are auto-discovered when `partitioning=None`). Explicitly
+                column names are auto-discovered when `partitioning=None`. Explicitly
                 specify column names (e.g., `["col"]`) to override auto-discovery, or
                 pass an empty list `[]` to disable partitioning entirely. The current
                 default is to disable partitioning but this may change in a future
@@ -279,6 +279,9 @@ class SedonaContext:
         if geometry_columns is not None and not isinstance(geometry_columns, str):
             geometry_columns = json.dumps(geometry_columns)
 
+        if isinstance(partitioning, str):
+            partitioning = [partitioning]
+
         return DataFrame(
             self._impl,
             self._impl.read_parquet(
@@ -296,7 +299,7 @@ class SedonaContext:
         table_paths: Union[str, Path, Iterable[str]],
         options: Optional[Dict[str, Any]] = None,
         extension: str = "",
-        partitioning: Optional[Iterable[str]] = (),
+        partitioning: Union[str, Iterable[str], None] = (),
     ) -> DataFrame:
         """Read spatial file formats using GDAL/OGR via pyogrio
 
@@ -365,6 +368,9 @@ class SedonaContext:
         if options is not None:
             spec = spec.with_options(options)
 
+        if isinstance(partitioning, str):
+            partitioning = [partitioning]
+
         return DataFrame(
             self._impl,
             self._impl.read_external_format(
@@ -381,7 +387,7 @@ class SedonaContext:
         spec: "ExternalFormatSpec",
         table_paths: Union[str, Path, Iterable[str]],
         check_extension: bool = False,
-        partitioning: Optional[List[str]] = None,
+        partitioning: Union[str, List[str], None] = (),
     ) -> DataFrame:
         """Read one or more paths using a Python-defined `ExternalFormatSpec`.
 
@@ -404,8 +410,8 @@ class SedonaContext:
             partitioning:
                 Optional list of column names for hive-style partitioning. When reading
                 from a directory with paths like `/col=value/file.ext`, partition
-                column names are auto-discovered by default (`None`). Explicitly specify
-                column names (e.g., `["col"]`) to override auto-discovery, or pass an
+                column names are auto-discovered by setting `partitioning=None`). Explicitly
+                specify column names (e.g., `["col"]`) to override auto-discovery, or pass an
                 empty list `[]` to disable partitioning entirely. The current
                 default is to disable partitioning but this may change in a future
                 release.
@@ -420,6 +426,9 @@ class SedonaContext:
         """
         if isinstance(table_paths, (str, Path)):
             table_paths = [table_paths]
+
+        if isinstance(partitioning, str):
+            partitioning = [partitioning]
 
         return DataFrame(
             self._impl,

--- a/python/sedonadb/python/sedonadb/context.py
+++ b/python/sedonadb/python/sedonadb/context.py
@@ -192,7 +192,7 @@ class SedonaContext:
         options: Optional[Dict[str, Any]] = None,
         geometry_columns: Optional[Union[str, Dict[str, Any]]] = None,
         validate: bool = False,
-        partitioning: Optional[List[str]] = None,
+        partitioning: Optional[Iterable[str]] = (),
     ) -> DataFrame:
         """Create a [DataFrame][sedonadb.dataframe.DataFrame] from one or more Parquet files
 
@@ -256,9 +256,11 @@ class SedonaContext:
             partitioning:
                 Optional list of column names for hive-style partitioning. When reading
                 from a directory with paths like `/col=value/file.parquet`, partition
-                column names are auto-discovered by default (`None`). Explicitly specify
-                column names (e.g., `["col"]`) to override auto-discovery, or pass an
-                empty list `[]` to disable partitioning entirely.
+                column names are auto-discovered when `partitioning=None`). Explicitly
+                specify column names (e.g., `["col"]`) to override auto-discovery, or
+                pass an empty list `[]` to disable partitioning entirely. The current
+                default is to disable partitioning but this may change in a future
+                release.
 
 
         Examples:
@@ -284,7 +286,7 @@ class SedonaContext:
                 options,
                 geometry_columns,
                 validate,
-                partitioning,
+                None if partitioning is None else list(partitioning),
             ),
             self.options,
         )
@@ -294,7 +296,7 @@ class SedonaContext:
         table_paths: Union[str, Path, Iterable[str]],
         options: Optional[Dict[str, Any]] = None,
         extension: str = "",
-        partitioning: Optional[List[str]] = None,
+        partitioning: Optional[Iterable[str]] = (),
     ) -> DataFrame:
         """Read spatial file formats using GDAL/OGR via pyogrio
 
@@ -327,9 +329,11 @@ class SedonaContext:
             partitioning:
                 Optional list of column names for hive-style partitioning. When reading
                 from a directory with paths like `/col=value/file.fgb`, partition
-                column names are auto-discovered by default (`None`). Explicitly specify
-                column names (e.g., `["col"]`) to override auto-discovery, or pass an
-                empty list `[]` to disable partitioning entirely.
+                column names are auto-discovered when `partitioning=None`. Explicitly
+                specify column names (e.g., `["col"]`) to override auto-discovery, or
+                pass an empty list `[]` to disable partitioning entirely.  The current
+                default is to disable partitioning but this may change in a future
+                release.
 
         Examples:
 
@@ -364,7 +368,10 @@ class SedonaContext:
         return DataFrame(
             self._impl,
             self._impl.read_external_format(
-                spec, [str(path) for path in table_paths], False, partitioning
+                spec,
+                [str(path) for path in table_paths],
+                False,
+                None if partitioning is None else list(partitioning),
             ),
             self.options,
         )
@@ -399,7 +406,9 @@ class SedonaContext:
                 from a directory with paths like `/col=value/file.ext`, partition
                 column names are auto-discovered by default (`None`). Explicitly specify
                 column names (e.g., `["col"]`) to override auto-discovery, or pass an
-                empty list `[]` to disable partitioning entirely.
+                empty list `[]` to disable partitioning entirely. The current
+                default is to disable partitioning but this may change in a future
+                release.
 
         Examples:
             >>> import sedonadb_zarr  # doctest: +SKIP
@@ -415,7 +424,10 @@ class SedonaContext:
         return DataFrame(
             self._impl,
             self._impl.read_external_format(
-                spec, [str(path) for path in table_paths], check_extension, partitioning
+                spec,
+                [str(path) for path in table_paths],
+                check_extension,
+                None if partitioning is None else list(partitioning),
             ),
             self.options,
         )

--- a/python/sedonadb/python/sedonadb/context.py
+++ b/python/sedonadb/python/sedonadb/context.py
@@ -192,7 +192,7 @@ class SedonaContext:
         options: Optional[Dict[str, Any]] = None,
         geometry_columns: Optional[Union[str, Dict[str, Any]]] = None,
         validate: bool = False,
-        partitioning: Optional[Iterable[str]] = (),
+        partitioning: Optional[Iterable[str]] = None,
     ) -> DataFrame:
         """Create a [DataFrame][sedonadb.dataframe.DataFrame] from one or more Parquet files
 
@@ -256,12 +256,10 @@ class SedonaContext:
             partitioning:
                 Optional list of column names for hive-style partitioning. When reading
                 from a directory with paths like `/col=value/file.parquet`, partition
-                column names are auto-discovered when `partitioning=None`. Explicitly
-                specify column names (e.g., `["col"]`) to override auto-discovery, or
-                pass an empty list `[]` to disable partitioning entirely. The current
-                default is to disable partitioning but this may change in a future
-                release.
-
+                column names are auto-discovered by default (`partitioning=None`).
+                Explicitly specify column names (e.g., `["col"]`) to override
+                auto-discovery, or pass an empty list `[]` to disable partitioning
+                entirely.
 
         Examples:
 
@@ -299,7 +297,7 @@ class SedonaContext:
         table_paths: Union[str, Path, Iterable[str]],
         options: Optional[Dict[str, Any]] = None,
         extension: str = "",
-        partitioning: Union[str, Iterable[str], None] = (),
+        partitioning: Union[str, Iterable[str], None] = None,
     ) -> DataFrame:
         """Read spatial file formats using GDAL/OGR via pyogrio
 
@@ -332,11 +330,10 @@ class SedonaContext:
             partitioning:
                 Optional list of column names for hive-style partitioning. When reading
                 from a directory with paths like `/col=value/file.fgb`, partition
-                column names are auto-discovered when `partitioning=None`. Explicitly
-                specify column names (e.g., `["col"]`) to override auto-discovery, or
-                pass an empty list `[]` to disable partitioning entirely.  The current
-                default is to disable partitioning but this may change in a future
-                release.
+                column names are auto-discovered by default (`partitioning=None`).
+                Explicitly specify column names (e.g., `["col"]`) to override
+                auto-discovery, or pass an empty list `[]` to disable partitioning
+                entirely.
 
         Examples:
 
@@ -387,7 +384,7 @@ class SedonaContext:
         spec: "ExternalFormatSpec",
         table_paths: Union[str, Path, Iterable[str]],
         check_extension: bool = False,
-        partitioning: Union[str, List[str], None] = (),
+        partitioning: Union[str, List[str], None] = None,
     ) -> DataFrame:
         """Read one or more paths using a Python-defined `ExternalFormatSpec`.
 
@@ -410,11 +407,10 @@ class SedonaContext:
             partitioning:
                 Optional list of column names for hive-style partitioning. When reading
                 from a directory with paths like `/col=value/file.ext`, partition
-                column names are auto-discovered by setting `partitioning=None`. Explicitly
-                specify column names (e.g., `["col"]`) to override auto-discovery, or pass an
-                empty list `[]` to disable partitioning entirely. The current
-                default is to disable partitioning but this may change in a future
-                release.
+                column names are auto-discovered by default (`partitioning=None`).
+                Explicitly specify column names (e.g., `["col"]`) to override
+                auto-discovery, or pass an empty list `[]` to disable partitioning
+                entirely.
 
         Examples:
             >>> import sedonadb_zarr  # doctest: +SKIP

--- a/python/sedonadb/python/sedonadb/context.py
+++ b/python/sedonadb/python/sedonadb/context.py
@@ -294,6 +294,7 @@ class SedonaContext:
         table_paths: Union[str, Path, Iterable[str]],
         options: Optional[Dict[str, Any]] = None,
         extension: str = "",
+        partitioning: Optional[List[str]] = None,
     ) -> DataFrame:
         """Read spatial file formats using GDAL/OGR via pyogrio
 
@@ -323,6 +324,12 @@ class SedonaContext:
             extension: An optional file extension (e.g., `"fgb"`) used when
                 `table_paths` specifies one or more directories or a glob
                 that does not enforce a file extension.
+            partitioning:
+                Optional list of column names for hive-style partitioning. When reading
+                from a directory with paths like `/col=value/file.fgb`, partition
+                column names are auto-discovered by default (`None`). Explicitly specify
+                column names (e.g., `["col"]`) to override auto-discovery, or pass an
+                empty list `[]` to disable partitioning entirely.
 
         Examples:
 
@@ -357,7 +364,7 @@ class SedonaContext:
         return DataFrame(
             self._impl,
             self._impl.read_external_format(
-                spec, [str(path) for path in table_paths], False
+                spec, [str(path) for path in table_paths], False, partitioning
             ),
             self.options,
         )
@@ -367,6 +374,7 @@ class SedonaContext:
         spec: "ExternalFormatSpec",
         table_paths: Union[str, Path, Iterable[str]],
         check_extension: bool = False,
+        partitioning: Optional[List[str]] = None,
     ) -> DataFrame:
         """Read one or more paths using a Python-defined `ExternalFormatSpec`.
 
@@ -386,6 +394,12 @@ class SedonaContext:
             table_paths: A str, Path, or iterable of paths/URLs.
             check_extension: When `True`, error if a non-collection path
                 doesn't end in the spec's `extension`. Defaults to `False`.
+            partitioning:
+                Optional list of column names for hive-style partitioning. When reading
+                from a directory with paths like `/col=value/file.ext`, partition
+                column names are auto-discovered by default (`None`). Explicitly specify
+                column names (e.g., `["col"]`) to override auto-discovery, or pass an
+                empty list `[]` to disable partitioning entirely.
 
         Examples:
             >>> import sedonadb_zarr  # doctest: +SKIP
@@ -401,7 +415,7 @@ class SedonaContext:
         return DataFrame(
             self._impl,
             self._impl.read_external_format(
-                spec, [str(path) for path in table_paths], check_extension
+                spec, [str(path) for path in table_paths], check_extension, partitioning
             ),
             self.options,
         )

--- a/python/sedonadb/python/sedonadb/context.py
+++ b/python/sedonadb/python/sedonadb/context.py
@@ -192,6 +192,7 @@ class SedonaContext:
         options: Optional[Dict[str, Any]] = None,
         geometry_columns: Optional[Union[str, Dict[str, Any]]] = None,
         validate: bool = False,
+        partitioning: Optional[List[str]] = None,
     ) -> DataFrame:
         """Create a [DataFrame][sedonadb.dataframe.DataFrame] from one or more Parquet files
 
@@ -252,6 +253,12 @@ class SedonaContext:
 
                 Currently the only property that is validated is the WKB of input geometry
                 columns.
+            partitioning:
+                Optional list of column names for hive-style partitioning. When reading
+                from a directory with paths like `/col=value/file.parquet`, partition
+                column names are auto-discovered by default (`None`). Explicitly specify
+                column names (e.g., `["col"]`) to override auto-discovery, or pass an
+                empty list `[]` to disable partitioning entirely.
 
 
         Examples:
@@ -273,7 +280,11 @@ class SedonaContext:
         return DataFrame(
             self._impl,
             self._impl.read_parquet(
-                [str(path) for path in table_paths], options, geometry_columns, validate
+                [str(path) for path in table_paths],
+                options,
+                geometry_columns,
+                validate,
+                partitioning,
             ),
             self.options,
         )

--- a/python/sedonadb/python/sedonadb/context.py
+++ b/python/sedonadb/python/sedonadb/context.py
@@ -192,7 +192,7 @@ class SedonaContext:
         options: Optional[Dict[str, Any]] = None,
         geometry_columns: Optional[Union[str, Dict[str, Any]]] = None,
         validate: bool = False,
-        partitioning: Optional[Iterable[str]] = None,
+        partitioning: Union[str, Iterable[str], None] = None,
     ) -> DataFrame:
         """Create a [DataFrame][sedonadb.dataframe.DataFrame] from one or more Parquet files
 
@@ -384,7 +384,7 @@ class SedonaContext:
         spec: "ExternalFormatSpec",
         table_paths: Union[str, Path, Iterable[str]],
         check_extension: bool = False,
-        partitioning: Union[str, List[str], None] = None,
+        partitioning: Union[str, Iterable[str], None] = None,
     ) -> DataFrame:
         """Read one or more paths using a Python-defined `ExternalFormatSpec`.
 

--- a/python/sedonadb/src/context.rs
+++ b/python/sedonadb/src/context.rs
@@ -134,6 +134,7 @@ impl InternalContext {
         format_spec: Bound<PyAny>,
         table_paths: Vec<String>,
         check_extension: bool,
+        partitioning: Option<Vec<String>>,
     ) -> Result<InternalDataFrame, PySedonaError> {
         let spec = format_spec
             .call_method0("__sedona_external_format__")?
@@ -141,8 +142,13 @@ impl InternalContext {
         let df = wait_for_future(
             py,
             &self.runtime,
-            self.inner
-                .read_external_format(Arc::new(spec), table_paths, None, check_extension),
+            self.inner.read_external_format(
+                Arc::new(spec),
+                table_paths,
+                None,
+                check_extension,
+                partitioning,
+            ),
         )??;
 
         Ok(InternalDataFrame::new(df, self.runtime.clone()))

--- a/python/sedonadb/src/context.rs
+++ b/python/sedonadb/src/context.rs
@@ -16,6 +16,7 @@
 // under the License.
 use std::{collections::HashMap, sync::Arc};
 
+use arrow_schema::DataType;
 use datafusion_expr::ScalarUDFImpl;
 use pyo3::prelude::*;
 use sedona::context::SedonaContext;
@@ -117,7 +118,12 @@ impl InternalContext {
         }
         geo_options = geo_options.with_validate(validate);
         if let Some(partitioning) = partitioning {
-            geo_options = geo_options.with_table_partition_cols(partitioning);
+            geo_options = geo_options.with_table_partition_cols(
+                partitioning
+                    .iter()
+                    .map(|name| (name.clone(), DataType::Utf8View))
+                    .collect(),
+            );
         }
 
         let df = wait_for_future(
@@ -147,7 +153,11 @@ impl InternalContext {
                 table_paths,
                 None,
                 check_extension,
-                partitioning,
+                partitioning.map(|cols| {
+                    cols.iter()
+                        .map(|name| (name.clone(), DataType::Utf8View))
+                        .collect()
+                }),
             ),
         )??;
 

--- a/python/sedonadb/src/context.rs
+++ b/python/sedonadb/src/context.rs
@@ -87,6 +87,7 @@ impl InternalContext {
         options: HashMap<String, PyObject>,
         geometry_columns: Option<String>,
         validate: bool,
+        partitioning: Option<Vec<String>>,
     ) -> Result<InternalDataFrame, PySedonaError> {
         // Convert Python options to strings, filtering out None values
         let rust_options: HashMap<String, String> = options
@@ -115,6 +116,9 @@ impl InternalContext {
                 })?;
         }
         geo_options = geo_options.with_validate(validate);
+        if let Some(partitioning) = partitioning {
+            geo_options = geo_options.with_table_partition_cols(partitioning);
+        }
 
         let df = wait_for_future(
             py,

--- a/python/sedonadb/tests/io/test_parquet.py
+++ b/python/sedonadb/tests/io/test_parquet.py
@@ -760,9 +760,9 @@ def test_prune_geography_parquet():
 def test_write_partitioned_parquet(con):
     t = con.funcs.table.sd_random_geometry(seed=3847)
     t = t.select(
-        grp=con.funcs.floor(t.id / 100),
         id=t.id,
         geom=con.funcs.st_setsrid(t.geometry, 3857),
+        grp=con.funcs.floor(t.id / 100).cast(pa.string()),
     )
 
     with tempfile.TemporaryDirectory() as td:
@@ -770,8 +770,26 @@ def test_write_partitioned_parquet(con):
 
         t.to_parquet(out_dir, partition_by="grp")
 
-        assert con.read_parquet(out_dir).columns == t.columns
-
+        # Test auto-discovery of partition columns (partitioning=None)
+        result = con.read_parquet(out_dir)
+        assert result.columns == t.columns
         geopandas.testing.assert_geodataframe_equal(
-            con.read_parquet(out_dir).sort("id").to_pandas(), t.sort("id").to_pandas()
+            result.sort("id").to_pandas(),
+            t.sort("id").to_pandas(),
+        )
+
+        # The default is to discover the partitioning
+        result_explicit = con.read_parquet(out_dir, partitioning=["grp"])
+        assert result_explicit.columns == t.columns
+        geopandas.testing.assert_geodataframe_equal(
+            result_explicit.sort("id").to_pandas(),
+            t.sort("id").to_pandas(),
+        )
+
+        # partitioning=[] disables auto-discovery
+        result_disabled = con.read_parquet(out_dir, partitioning=[])
+        assert result_disabled.columns == ["id", "geom"]
+        geopandas.testing.assert_geodataframe_equal(
+            result_disabled.sort("id").to_pandas(),
+            t.sort("id").to_pandas()[["id", "geom"]],
         )

--- a/python/sedonadb/tests/io/test_parquet.py
+++ b/python/sedonadb/tests/io/test_parquet.py
@@ -757,7 +757,7 @@ def test_prune_geography_parquet():
         )
 
 
-def test_write_partitioned_parquet(con):
+def test_read_partitioned_parquet(con):
     t = con.funcs.table.sd_random_geometry(seed=3847)
     t = t.select(
         id=t.id,
@@ -769,6 +769,14 @@ def test_write_partitioned_parquet(con):
         out_dir = Path(td) / "out_dir"
 
         t.to_parquet(out_dir, partition_by="grp")
+
+        # Test default partitioning read behaviour (autodiscover)
+        result = con.read_parquet(out_dir)
+        assert result.columns == t.columns
+        geopandas.testing.assert_geodataframe_equal(
+            result.sort("id").to_pandas(),
+            t.sort("id").to_pandas(),
+        )
 
         # Test auto-discovery of partition columns (partitioning=None)
         result = con.read_parquet(out_dir, partitioning=None)

--- a/python/sedonadb/tests/io/test_parquet.py
+++ b/python/sedonadb/tests/io/test_parquet.py
@@ -778,8 +778,16 @@ def test_write_partitioned_parquet(con):
             t.sort("id").to_pandas(),
         )
 
-        # The default is to discover the partitioning
+        # Explicit partitioning (list)
         result_explicit = con.read_parquet(out_dir, partitioning=["grp"])
+        assert result_explicit.columns == t.columns
+        geopandas.testing.assert_geodataframe_equal(
+            result_explicit.sort("id").to_pandas(),
+            t.sort("id").to_pandas(),
+        )
+
+        # Explicit partitioning (str)
+        result_explicit = con.read_parquet(out_dir, partitioning="grp")
         assert result_explicit.columns == t.columns
         geopandas.testing.assert_geodataframe_equal(
             result_explicit.sort("id").to_pandas(),

--- a/python/sedonadb/tests/io/test_parquet.py
+++ b/python/sedonadb/tests/io/test_parquet.py
@@ -755,3 +755,23 @@ def test_prune_geography_parquet():
         assert matched < total, (
             f"Expected pruning to reduce row groups: {matched} matched out of {total}"
         )
+
+
+def test_write_partitioned_parquet(con):
+    t = con.funcs.table.sd_random_geometry(seed=3847)
+    t = t.select(
+        grp=con.funcs.floor(t.id / 100),
+        id=t.id,
+        geom=con.funcs.st_setsrid(t.geometry, 3857),
+    )
+
+    with tempfile.TemporaryDirectory() as td:
+        out_dir = Path(td) / "out_dir"
+
+        t.to_parquet(out_dir, partition_by="grp")
+
+        assert con.read_parquet(out_dir).columns == t.columns
+
+        geopandas.testing.assert_geodataframe_equal(
+            con.read_parquet(out_dir).sort("id").to_pandas(), t.sort("id").to_pandas()
+        )

--- a/python/sedonadb/tests/io/test_parquet.py
+++ b/python/sedonadb/tests/io/test_parquet.py
@@ -771,7 +771,7 @@ def test_write_partitioned_parquet(con):
         t.to_parquet(out_dir, partition_by="grp")
 
         # Test auto-discovery of partition columns (partitioning=None)
-        result = con.read_parquet(out_dir)
+        result = con.read_parquet(out_dir, partitioning=None)
         assert result.columns == t.columns
         geopandas.testing.assert_geodataframe_equal(
             result.sort("id").to_pandas(),

--- a/python/sedonadb/tests/io/test_pyogrio.py
+++ b/python/sedonadb/tests/io/test_pyogrio.py
@@ -91,8 +91,7 @@ def test_read_ogr_multi_file(con):
             con.read_parquet(parquet_path).to_pandas().to_file(fgb_path)
 
         # Reading a directory while specifying the extension should work
-        # Disable partitioning since this test focuses on multi-file reading
-        con.read_pyogrio(f"{td}", extension="fgb", partitioning=[]).to_view(
+        con.read_pyogrio(f"{td}", extension="fgb").to_view(
             "gdf_from_dir", overwrite=True
         )
         geopandas.testing.assert_geodataframe_equal(
@@ -101,9 +100,7 @@ def test_read_ogr_multi_file(con):
         )
 
         # Reading using a glob without specifying the extension should work
-        con.read_pyogrio(f"{td}/**/*.fgb", partitioning=[]).to_view(
-            "gdf_from_glob", overwrite=True
-        )
+        con.read_pyogrio(f"{td}/**/*.fgb").to_view("gdf_from_glob", overwrite=True)
         geopandas.testing.assert_geodataframe_equal(
             con.sql("SELECT * FROM gdf_from_glob ORDER BY idx").to_pandas(),
             gdf.filter(["idx", "wkb_geometry"]),
@@ -319,7 +316,7 @@ def test_read_ogr_partitioned(con):
             subset.to_file(grp_dir / "data.fgb")
 
         # Test auto-discovery of partition columns (partitioning=None)
-        con.read_pyogrio(td, extension="fgb").to_view(
+        con.read_pyogrio(td, extension="fgb", partitioning=None).to_view(
             "partitioned_auto", overwrite=True
         )
         geopandas.testing.assert_geodataframe_equal(

--- a/python/sedonadb/tests/io/test_pyogrio.py
+++ b/python/sedonadb/tests/io/test_pyogrio.py
@@ -91,7 +91,8 @@ def test_read_ogr_multi_file(con):
             con.read_parquet(parquet_path).to_pandas().to_file(fgb_path)
 
         # Reading a directory while specifying the extension should work
-        con.read_pyogrio(f"{td}", extension="fgb").to_view(
+        # Disable partitioning since this test focuses on multi-file reading
+        con.read_pyogrio(f"{td}", extension="fgb", partitioning=[]).to_view(
             "gdf_from_dir", overwrite=True
         )
         geopandas.testing.assert_geodataframe_equal(
@@ -100,7 +101,9 @@ def test_read_ogr_multi_file(con):
         )
 
         # Reading using a glob without specifying the extension should work
-        con.read_pyogrio(f"{td}/**/*.fgb").to_view("gdf_from_glob", overwrite=True)
+        con.read_pyogrio(f"{td}/**/*.fgb", partitioning=[]).to_view(
+            "gdf_from_glob", overwrite=True
+        )
         geopandas.testing.assert_geodataframe_equal(
             con.sql("SELECT * FROM gdf_from_glob ORDER BY idx").to_pandas(),
             gdf.filter(["idx", "wkb_geometry"]),
@@ -290,3 +293,58 @@ def test_write_ogr_from_view_types(con):
         con.create_data_frame(tab).to_pyogrio(f"{td}/foofy.fgb")
         tab_roundtrip = con.read_pyogrio(f"{td}/foofy.fgb").to_arrow_table()
         assert tab_roundtrip.sort_by("string_col") == tab_simple
+
+
+def test_read_ogr_partitioned(con):
+    n = 100
+    series = geopandas.GeoSeries.from_xy(
+        list(range(n)), list(range(1, n + 1)), crs="EPSG:3857"
+    )
+    gdf = geopandas.GeoDataFrame(
+        {
+            "idx": list(range(n)),
+            "grp": [str(i // 10) for i in range(n)],
+            "wkb_geometry": series,
+        }
+    )
+    gdf = gdf.set_geometry(gdf["wkb_geometry"])
+
+    with tempfile.TemporaryDirectory() as td:
+        # Write partitioned FGB files using hive-style directories because
+        # write_pyogrio doesn't support writing partitions yet
+        for grp_val in gdf["grp"].unique():
+            grp_dir = Path(td) / f"grp={grp_val}"
+            grp_dir.mkdir()
+            subset = gdf[gdf["grp"] == grp_val].drop(columns=["grp"])
+            subset.to_file(grp_dir / "data.fgb")
+
+        # Test auto-discovery of partition columns (partitioning=None)
+        con.read_pyogrio(td, extension="fgb").to_view(
+            "partitioned_auto", overwrite=True
+        )
+        geopandas.testing.assert_geodataframe_equal(
+            con.sql(
+                "SELECT idx, grp, wkb_geometry FROM partitioned_auto ORDER BY idx"
+            ).to_pandas(),
+            gdf,
+        )
+
+        # Test explicit partitioning specification
+        con.read_pyogrio(td, extension="fgb", partitioning=["grp"]).to_view(
+            "partitioned_explicit", overwrite=True
+        )
+        geopandas.testing.assert_geodataframe_equal(
+            con.sql(
+                "SELECT idx, grp, wkb_geometry FROM partitioned_explicit ORDER BY idx"
+            ).to_pandas(),
+            gdf,
+        )
+
+        # Test partitioning=[] disables auto-discovery
+        con.read_pyogrio(td, extension="fgb", partitioning=[]).to_view(
+            "partitioned_disabled", overwrite=True
+        )
+        geopandas.testing.assert_geodataframe_equal(
+            con.sql("SELECT * FROM partitioned_disabled ORDER BY idx").to_pandas(),
+            gdf.filter(["idx", "wkb_geometry"]),
+        )

--- a/python/sedonadb/tests/io/test_pyogrio.py
+++ b/python/sedonadb/tests/io/test_pyogrio.py
@@ -64,7 +64,7 @@ def test_read_ogr_projection(con):
 
 def test_read_ogr_multi_file(con):
     n = 1024 * 16
-    partitions = ["part_{c}" for c in "abcdefghijklmnop"]
+    partitions = [f"part_{c}" for c in "abcdefghijklmnop"]
     series = geopandas.GeoSeries.from_xy(
         list(range(n)), list(range(1, n + 1)), crs="EPSG:3857"
     )
@@ -91,19 +91,24 @@ def test_read_ogr_multi_file(con):
             con.read_parquet(parquet_path).to_pandas().to_file(fgb_path)
 
         # Reading a directory while specifying the extension should work
+        # Partition columns are auto-discovered from the directory structure
         con.read_pyogrio(f"{td}", extension="fgb").to_view(
             "gdf_from_dir", overwrite=True
         )
         geopandas.testing.assert_geodataframe_equal(
-            con.sql("SELECT * FROM gdf_from_dir ORDER BY idx").to_pandas(),
-            gdf.filter(["idx", "wkb_geometry"]),
+            con.sql(
+                "SELECT idx, partition, wkb_geometry FROM gdf_from_dir ORDER BY idx"
+            ).to_pandas(),
+            gdf,
         )
 
         # Reading using a glob without specifying the extension should work
         con.read_pyogrio(f"{td}/**/*.fgb").to_view("gdf_from_glob", overwrite=True)
         geopandas.testing.assert_geodataframe_equal(
-            con.sql("SELECT * FROM gdf_from_glob ORDER BY idx").to_pandas(),
-            gdf.filter(["idx", "wkb_geometry"]),
+            con.sql(
+                "SELECT idx, partition, wkb_geometry FROM gdf_from_glob ORDER BY idx"
+            ).to_pandas(),
+            gdf,
         )
 
 
@@ -314,6 +319,18 @@ def test_read_ogr_partitioned(con):
             grp_dir.mkdir()
             subset = gdf[gdf["grp"] == grp_val].drop(columns=["grp"])
             subset.to_file(grp_dir / "data.fgb")
+
+        # Test auto-discovery of partition columns with the default value
+        # (which is to autodiscover partitions)
+        con.read_pyogrio(td, extension="fgb").to_view(
+            "partitioned_auto", overwrite=True
+        )
+        geopandas.testing.assert_geodataframe_equal(
+            con.sql(
+                "SELECT idx, grp, wkb_geometry FROM partitioned_auto ORDER BY idx"
+            ).to_pandas(),
+            gdf,
+        )
 
         # Test auto-discovery of partition columns (partitioning=None)
         con.read_pyogrio(td, extension="fgb", partitioning=None).to_view(

--- a/python/sedonadb/tests/io/test_pyogrio.py
+++ b/python/sedonadb/tests/io/test_pyogrio.py
@@ -326,8 +326,19 @@ def test_read_ogr_partitioned(con):
             gdf,
         )
 
-        # Test explicit partitioning specification
+        # Test explicit partitioning specification (list)
         con.read_pyogrio(td, extension="fgb", partitioning=["grp"]).to_view(
+            "partitioned_explicit", overwrite=True
+        )
+        geopandas.testing.assert_geodataframe_equal(
+            con.sql(
+                "SELECT idx, grp, wkb_geometry FROM partitioned_explicit ORDER BY idx"
+            ).to_pandas(),
+            gdf,
+        )
+
+        # Test explicit partitioning specification (str)
+        con.read_pyogrio(td, extension="fgb", partitioning="grp").to_view(
             "partitioned_explicit", overwrite=True
         )
         geopandas.testing.assert_geodataframe_equal(

--- a/rust/sedona-datasource/src/format.rs
+++ b/rust/sedona-datasource/src/format.rs
@@ -402,7 +402,6 @@ mod test {
         prelude::{col, lit, SessionContext},
     };
     use datafusion_common::plan_err;
-    use datafusion_physical_plan::filter_pushdown::PushedDown::No;
     use std::{
         io::{Read, Write},
         path::PathBuf,

--- a/rust/sedona-datasource/src/format.rs
+++ b/rust/sedona-datasource/src/format.rs
@@ -402,6 +402,7 @@ mod test {
         prelude::{col, lit, SessionContext},
     };
     use datafusion_common::plan_err;
+    use datafusion_physical_plan::filter_pushdown::PushedDown::No;
     use std::{
         io::{Read, Write},
         path::PathBuf,
@@ -621,6 +622,7 @@ mod test {
                 .map(|f| ListingTableUrl::parse(f.to_string_lossy()).unwrap())
                 .collect(),
             true,
+            None,
         )
         .await
         .unwrap();
@@ -651,6 +653,7 @@ mod test {
                 .map(|f| ListingTableUrl::parse(f.to_string_lossy()).unwrap())
                 .collect(),
             true,
+            None,
         )
         .await
         .unwrap();
@@ -686,7 +689,7 @@ mod test {
         let (temp_dir, mut files) = create_echo_spec_temp_dir();
 
         // Listing table with no files should error
-        let err = external_table(spec.clone(), &ctx, vec![], true)
+        let err = external_table(spec.clone(), &ctx, vec![], true, None)
             .await
             .unwrap_err();
         assert_eq!(err.message(), "No table paths were provided");
@@ -708,6 +711,7 @@ mod test {
                 .map(|f| ListingTableUrl::parse(f.to_string_lossy()).unwrap())
                 .collect(),
             true,
+            None,
         )
         .await
         .unwrap_err();
@@ -725,6 +729,7 @@ mod test {
                 .map(|f| ListingTableUrl::parse(f.to_string_lossy()).unwrap())
                 .collect(),
             false,
+            None,
         )
         .await
         .unwrap();
@@ -810,7 +815,9 @@ mod test {
 
         let ctx = SessionContext::new();
         let url = ListingTableUrl::parse(dir_path.to_string_lossy()).unwrap();
-        let provider = external_table(spec, &ctx, vec![url], false).await.unwrap();
+        let provider = external_table(spec, &ctx, vec![url], false, None)
+            .await
+            .unwrap();
 
         let batches = ctx.read_table(provider).unwrap().collect().await.unwrap();
 
@@ -837,7 +844,7 @@ mod test {
         // doesn't try to span.
         let url_a = ListingTableUrl::parse("file:///tmp/a.dirfmt").unwrap();
         let url_b = ListingTableUrl::parse("https://example.com/b.dirfmt").unwrap();
-        let err = external_table(spec, &ctx, vec![url_a, url_b], false)
+        let err = external_table(spec, &ctx, vec![url_a, url_b], false, None)
             .await
             .unwrap_err();
         assert!(

--- a/rust/sedona-datasource/src/provider.rs
+++ b/rust/sedona-datasource/src/provider.rs
@@ -60,8 +60,8 @@ use crate::{
 ///
 /// The `partitioning` parameter controls hive-style partition discovery:
 /// - `None`: auto-discover partition columns from directory structure
-/// - `Some([])`: disable partition discovery
-/// - `Some([cols])`: use explicit partition columns
+/// - `Some(vec![])`: disable partition discovery
+/// - `Some(vec![...])`: use explicit partition columns
 pub async fn external_table(
     spec: Arc<dyn ExternalFormatSpec>,
     context: &SessionContext,

--- a/rust/sedona-datasource/src/provider.rs
+++ b/rust/sedona-datasource/src/provider.rs
@@ -18,7 +18,7 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use arrow_schema::SchemaRef;
+use arrow_schema::{DataType, SchemaRef};
 use async_trait::async_trait;
 use datafusion::{
     catalog::TableProvider,
@@ -57,11 +57,17 @@ use crate::{
 /// - `true`: builds a [`SingleObjectExternalTable`] that treats each
 ///   URI as one opaque object, skipping listing entirely. Required
 ///   for directory-shaped formats like Zarr.
+///
+/// The `partitioning` parameter controls hive-style partition discovery:
+/// - `None`: auto-discover partition columns from directory structure
+/// - `Some([])`: disable partition discovery
+/// - `Some([cols])`: use explicit partition columns
 pub async fn external_table(
     spec: Arc<dyn ExternalFormatSpec>,
     context: &SessionContext,
     table_paths: Vec<ListingTableUrl>,
     check_extension: bool,
+    partitioning: Option<Vec<String>>,
 ) -> Result<Arc<dyn TableProvider>> {
     if table_paths.is_empty() {
         return exec_err!("No table paths were provided");
@@ -71,7 +77,9 @@ pub async fn external_table(
         let provider = SingleObjectExternalTable::try_new(spec, context, table_paths).await?;
         Ok(Arc::new(provider) as Arc<dyn TableProvider>)
     } else {
-        let provider = listing_table_provider(spec, context, table_paths, check_extension).await?;
+        let provider =
+            listing_table_provider(spec, context, table_paths, check_extension, partitioning)
+                .await?;
         Ok(Arc::new(provider) as Arc<dyn TableProvider>)
     }
 }
@@ -81,13 +89,15 @@ async fn listing_table_provider(
     context: &SessionContext,
     table_paths: Vec<ListingTableUrl>,
     check_extension: bool,
+    partitioning: Option<Vec<String>>,
 ) -> Result<ListingTable> {
     let session_config = context.copied_config();
     let options = RecordBatchReaderTableOptions {
         spec,
         check_extension,
+        table_partition_cols: partitioning,
     };
-    let listing_options =
+    let mut listing_options =
         options.to_listing_options(&session_config, context.copied_table_options());
 
     let option_extension = listing_options.file_extension.clone();
@@ -101,6 +111,22 @@ async fn listing_table_provider(
                         "File path '{file_path}' does not match the expected extension '{option_extension}'"
                     );
             }
+        }
+    }
+
+    // Auto-discover partition columns only if not explicitly provided (None)
+    // If explicitly set to empty (Some([])), skip auto-discovery
+    if options.table_partition_cols.is_none() {
+        let inferred_partitions = listing_options
+            .infer_partitions(&context.state(), &table_paths[0])
+            .await?;
+        if !inferred_partitions.is_empty() {
+            listing_options = listing_options.with_table_partition_cols(
+                inferred_partitions
+                    .into_iter()
+                    .map(|name| (name, DataType::Utf8))
+                    .collect(),
+            );
         }
     }
 
@@ -118,6 +144,8 @@ async fn listing_table_provider(
 struct RecordBatchReaderTableOptions {
     spec: Arc<dyn ExternalFormatSpec>,
     check_extension: bool,
+    /// None = auto-discover, Some([]) = disabled, Some([cols]) = explicit
+    table_partition_cols: Option<Vec<String>>,
 }
 
 #[async_trait]
@@ -133,9 +161,22 @@ impl ReadOptions<'_> for RecordBatchReaderTableOptions {
             ExternalFileFormat::new(self.spec.clone())
         };
 
-        ListingOptions::new(Arc::new(format))
+        let mut options = ListingOptions::new(Arc::new(format))
             .with_file_extension(self.spec.extension())
-            .with_session_config_options(config)
+            .with_session_config_options(config);
+
+        // Apply partition columns if explicitly specified (Some)
+        // None means auto-discover later, Some([]) means no partitioning
+        if let Some(ref partition_cols) = self.table_partition_cols {
+            options = options.with_table_partition_cols(
+                partition_cols
+                    .iter()
+                    .map(|name| (name.clone(), DataType::Utf8))
+                    .collect(),
+            );
+        }
+
+        options
     }
 
     async fn get_resolved_schema(

--- a/rust/sedona-datasource/src/provider.rs
+++ b/rust/sedona-datasource/src/provider.rs
@@ -67,7 +67,7 @@ pub async fn external_table(
     context: &SessionContext,
     table_paths: Vec<ListingTableUrl>,
     check_extension: bool,
-    partitioning: Option<Vec<String>>,
+    partitioning: Option<Vec<(String, DataType)>>,
 ) -> Result<Arc<dyn TableProvider>> {
     if table_paths.is_empty() {
         return exec_err!("No table paths were provided");
@@ -89,7 +89,7 @@ async fn listing_table_provider(
     context: &SessionContext,
     table_paths: Vec<ListingTableUrl>,
     check_extension: bool,
-    partitioning: Option<Vec<String>>,
+    partitioning: Option<Vec<(String, DataType)>>,
 ) -> Result<ListingTable> {
     let session_config = context.copied_config();
     let options = RecordBatchReaderTableOptions {
@@ -150,7 +150,7 @@ struct RecordBatchReaderTableOptions {
     spec: Arc<dyn ExternalFormatSpec>,
     check_extension: bool,
     /// None = auto-discover, Some([]) = disabled, Some([cols]) = explicit
-    table_partition_cols: Option<Vec<String>>,
+    table_partition_cols: Option<Vec<(String, DataType)>>,
 }
 
 #[async_trait]
@@ -173,12 +173,7 @@ impl ReadOptions<'_> for RecordBatchReaderTableOptions {
         // Apply partition columns if explicitly specified (Some)
         // None means auto-discover later, Some([]) means no partitioning
         if let Some(ref partition_cols) = self.table_partition_cols {
-            options = options.with_table_partition_cols(
-                partition_cols
-                    .iter()
-                    .map(|name| (name.clone(), DataType::Utf8))
-                    .collect(),
-            );
+            options = options.with_table_partition_cols(partition_cols.to_vec());
         }
 
         options

--- a/rust/sedona-datasource/src/provider.rs
+++ b/rust/sedona-datasource/src/provider.rs
@@ -114,9 +114,14 @@ async fn listing_table_provider(
         }
     }
 
-    // Auto-discover partition columns only if not explicitly provided (None)
-    // If explicitly set to empty (Some([])), skip auto-discovery
-    if options.table_partition_cols.is_none() {
+    // Auto-discover partition columns if not explicitly set and config allows it
+    let should_infer = options.table_partition_cols.is_none()
+        && session_config
+            .options()
+            .execution
+            .listing_table_factory_infer_partitions;
+
+    if should_infer {
         let inferred_partitions = listing_options
             .infer_partitions(&context.state(), &table_paths[0])
             .await?;
@@ -124,7 +129,7 @@ async fn listing_table_provider(
             listing_options = listing_options.with_table_partition_cols(
                 inferred_partitions
                     .into_iter()
-                    .map(|name| (name, DataType::Utf8))
+                    .map(|name| (name, DataType::Utf8View))
                     .collect(),
             );
         }

--- a/rust/sedona-geoparquet/src/provider.rs
+++ b/rust/sedona-geoparquet/src/provider.rs
@@ -262,12 +262,8 @@ impl GeoParquetReadOptions<'_> {
     /// All partition columns are assumed to be `Utf8` type.
     ///
     /// Pass an empty vector to explicitly disable partition auto-discovery.
-    pub fn with_table_partition_cols(mut self, cols: Vec<String>) -> Self {
-        self.inner = self.inner.table_partition_cols(
-            cols.into_iter()
-                .map(|name| (name, DataType::Utf8))
-                .collect(),
-        );
+    pub fn with_table_partition_cols(mut self, cols: Vec<(String, DataType)>) -> Self {
+        self.inner = self.inner.table_partition_cols(cols);
         self.partition_cols_set = true;
         self
     }

--- a/rust/sedona-geoparquet/src/provider.rs
+++ b/rust/sedona-geoparquet/src/provider.rs
@@ -343,11 +343,18 @@ impl ReadOptions<'_> for GeoParquetReadOptions<'_> {
 mod test {
 
     use arrow_schema::DataType;
+    use datafusion::datasource::file_format::format_as_file_type;
+    use datafusion::execution::SessionStateBuilder;
+    use datafusion::prelude::{col, lit};
+    use datafusion_expr::LogicalPlanBuilder;
     use sedona_schema::{
         crs::lnglat,
         datatypes::{Edges, SedonaType},
     };
-    use sedona_testing::data::geoarrow_data_dir;
+    use sedona_testing::data::{geoarrow_data_dir, test_geoparquet};
+    use tempfile::tempdir;
+
+    use crate::format::GeoParquetFormatFactory;
 
     use super::*;
 
@@ -425,5 +432,84 @@ mod test {
             err.message(),
             "Can't infer Parquet schema for zero objects. Does the input path exist?"
         );
+    }
+
+    fn setup_context() -> SessionContext {
+        let mut state = SessionStateBuilder::new().build();
+        state
+            .register_file_format(Arc::new(GeoParquetFormatFactory::new()), true)
+            .unwrap();
+        SessionContext::new_with_state(state).enable_url_table()
+    }
+
+    #[tokio::test]
+    async fn listing_table_with_partition_discovery() {
+        // Set up a context with our GeoParquet format registered
+        let ctx = setup_context();
+
+        // Read an existing GeoParquet file and add a partition column
+        let example = test_geoparquet("example", "point").unwrap();
+        let df = ctx
+            .table(&example)
+            .await
+            .unwrap()
+            .select(vec![
+                lit("partition_value").alias("part"),
+                col("wkt"),
+                col("geometry"),
+            ])
+            .unwrap();
+        let df_count = df.clone().count().await.unwrap();
+
+        // Write the data to a temp directory with hive-style partitioning
+        let tmpdir = tempdir().unwrap();
+        let tmp_parquet = tmpdir.path().join("partitioned.parquet");
+
+        let format = GeoParquetFormatFactory::new();
+        let file_type = format_as_file_type(Arc::new(format));
+
+        let plan = LogicalPlanBuilder::copy_to(
+            df.into_unoptimized_plan(),
+            tmp_parquet.to_string_lossy().into(),
+            file_type,
+            Default::default(),
+            // Partition by the "part" column
+            vec!["part".into()],
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+        datafusion::prelude::DataFrame::new(ctx.state(), plan)
+            .collect()
+            .await
+            .unwrap();
+
+        // Now read it back using geoparquet_listing_table with partition discovery
+        let tab = geoparquet_listing_table(
+            &ctx,
+            vec![ListingTableUrl::parse(format!("{}/**", tmp_parquet.to_string_lossy())).unwrap()],
+            GeoParquetReadOptions::default(),
+        )
+        .await
+        .unwrap();
+
+        let df = ctx.read_table(Arc::new(tab)).unwrap();
+
+        // Check that the partition column is in the schema
+        let schema = df.schema();
+        let field_names: Vec<_> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+        assert!(
+            field_names.contains(&"part"),
+            "Partition column 'part' should be in the schema: {field_names:?}"
+        );
+
+        // Verify we can read the data
+        let batches = df.collect().await.unwrap();
+        let mut total_rows = 0;
+        for batch in &batches {
+            total_rows += batch.num_rows();
+        }
+        assert_eq!(total_rows, df_count);
     }
 }

--- a/rust/sedona-geoparquet/src/provider.rs
+++ b/rust/sedona-geoparquet/src/provider.rs
@@ -65,6 +65,31 @@ pub async fn geoparquet_listing_table(
         }
     }
 
+    // Auto-discover partition columns if not explicitly set and config allows it
+    let should_infer = !options.partition_cols_set
+        && session_config
+            .options()
+            .execution
+            .listing_table_factory_infer_partitions;
+
+    let listing_options = if should_infer {
+        let inferred_partitions = listing_options
+            .infer_partitions(&context.state(), &table_paths[0])
+            .await?;
+        if !inferred_partitions.is_empty() {
+            listing_options.with_table_partition_cols(
+                inferred_partitions
+                    .into_iter()
+                    .map(|name| (name, DataType::Utf8))
+                    .collect(),
+            )
+        } else {
+            listing_options
+        }
+    } else {
+        listing_options
+    };
+
     let resolved_schema = options
         .get_resolved_schema(&session_config, context.state(), table_paths[0].clone())
         .await?;
@@ -85,6 +110,8 @@ pub struct GeoParquetReadOptions<'a> {
     table_options: Option<HashMap<String, String>>,
     geometry_columns: Option<HashMap<String, GeoParquetColumnMetadata>>,
     validate: bool,
+    /// When true, partition columns were explicitly set (skip auto-discovery)
+    partition_cols_set: bool,
 }
 
 impl GeoParquetReadOptions<'_> {
@@ -191,6 +218,7 @@ impl GeoParquetReadOptions<'_> {
             table_options: Some(options),
             geometry_columns: None,
             validate: false,
+            partition_cols_set: false,
         })
     }
 
@@ -232,18 +260,26 @@ impl GeoParquetReadOptions<'_> {
     ///
     /// Partition columns are extracted from directory paths like `/col=value/`.
     /// All partition columns are assumed to be `Utf8` type.
+    ///
+    /// Pass an empty vector to explicitly disable partition auto-discovery.
     pub fn with_table_partition_cols(mut self, cols: Vec<String>) -> Self {
         self.inner = self.inner.table_partition_cols(
             cols.into_iter()
                 .map(|name| (name, DataType::Utf8))
                 .collect(),
         );
+        self.partition_cols_set = true;
         self
     }
 
     /// Get the table partition columns
     pub fn table_partition_cols(&self) -> &[(String, DataType)] {
         &self.inner.table_partition_cols
+    }
+
+    /// Returns true if partition columns were explicitly set
+    pub fn partition_cols_explicitly_set(&self) -> bool {
+        self.partition_cols_set
     }
 }
 

--- a/rust/sedona-geoparquet/src/provider.rs
+++ b/rust/sedona-geoparquet/src/provider.rs
@@ -80,7 +80,7 @@ pub async fn geoparquet_listing_table(
             listing_options.with_table_partition_cols(
                 inferred_partitions
                     .into_iter()
-                    .map(|name| (name, DataType::Utf8))
+                    .map(|name| (name, DataType::Utf8View))
                     .collect(),
             )
         } else {

--- a/rust/sedona-geoparquet/src/provider.rs
+++ b/rust/sedona-geoparquet/src/provider.rs
@@ -44,7 +44,7 @@ pub async fn geoparquet_listing_table(
     options: GeoParquetReadOptions<'_>,
 ) -> Result<ListingTable> {
     let session_config = context.copied_config();
-    let mut listing_options =
+    let listing_options =
         options.to_listing_options(&session_config, context.copied_table_options());
 
     let option_extension = listing_options.file_extension.clone();
@@ -62,22 +62,6 @@ pub async fn geoparquet_listing_table(
             return exec_err!(
                     "File path '{file_path}' does not match the expected extension '{option_extension}'"
                 );
-        }
-    }
-
-    // Auto-discover partition columns only if not explicitly provided (None)
-    // If explicitly set to empty (Some([])), skip auto-discovery
-    if options.table_partition_cols().is_none() {
-        let inferred_partitions = listing_options
-            .infer_partitions(&context.state(), &table_paths[0])
-            .await?;
-        if !inferred_partitions.is_empty() {
-            listing_options = listing_options.with_table_partition_cols(
-                inferred_partitions
-                    .into_iter()
-                    .map(|name| (name, DataType::Utf8))
-                    .collect(),
-            );
         }
     }
 
@@ -101,8 +85,6 @@ pub struct GeoParquetReadOptions<'a> {
     table_options: Option<HashMap<String, String>>,
     geometry_columns: Option<HashMap<String, GeoParquetColumnMetadata>>,
     validate: bool,
-    /// None = auto-discover, Some([]) = disabled, Some([cols]) = explicit
-    table_partition_cols: Option<Vec<(String, DataType)>>,
 }
 
 impl GeoParquetReadOptions<'_> {
@@ -209,7 +191,6 @@ impl GeoParquetReadOptions<'_> {
             table_options: Some(options),
             geometry_columns: None,
             validate: false,
-            table_partition_cols: None,
         })
     }
 
@@ -251,10 +232,8 @@ impl GeoParquetReadOptions<'_> {
     ///
     /// Partition columns are extracted from directory paths like `/col=value/`.
     /// All partition columns are assumed to be `Utf8` type.
-    ///
-    /// Pass an empty vector to explicitly disable partition auto-discovery.
     pub fn with_table_partition_cols(mut self, cols: Vec<String>) -> Self {
-        self.table_partition_cols = Some(
+        self.inner = self.inner.table_partition_cols(
             cols.into_iter()
                 .map(|name| (name, DataType::Utf8))
                 .collect(),
@@ -263,8 +242,8 @@ impl GeoParquetReadOptions<'_> {
     }
 
     /// Get the table partition columns
-    pub fn table_partition_cols(&self) -> Option<&[(String, DataType)]> {
-        self.table_partition_cols.as_deref()
+    pub fn table_partition_cols(&self) -> &[(String, DataType)] {
+        &self.inner.table_partition_cols
     }
 }
 
@@ -298,12 +277,6 @@ impl ReadOptions<'_> for GeoParquetReadOptions<'_> {
         }
 
         let mut options = self.inner.to_listing_options(config, table_options);
-
-        // Apply partition columns if explicitly specified (Some)
-        // None means auto-discover later, Some([]) means no partitioning
-        if let Some(ref partition_cols) = self.table_partition_cols {
-            options = options.with_table_partition_cols(partition_cols.clone());
-        }
 
         if let Some(parquet_format) = options.format.as_any().downcast_ref::<ParquetFormat>() {
             let mut geoparquet_options =

--- a/rust/sedona-geoparquet/src/provider.rs
+++ b/rust/sedona-geoparquet/src/provider.rs
@@ -16,7 +16,7 @@
 // under the License.
 use std::{collections::HashMap, sync::Arc};
 
-use arrow_schema::SchemaRef;
+use arrow_schema::{DataType, SchemaRef};
 use async_trait::async_trait;
 use datafusion::{
     config::TableOptions,
@@ -44,7 +44,7 @@ pub async fn geoparquet_listing_table(
     options: GeoParquetReadOptions<'_>,
 ) -> Result<ListingTable> {
     let session_config = context.copied_config();
-    let listing_options =
+    let mut listing_options =
         options.to_listing_options(&session_config, context.copied_table_options());
 
     let option_extension = listing_options.file_extension.clone();
@@ -62,6 +62,22 @@ pub async fn geoparquet_listing_table(
             return exec_err!(
                     "File path '{file_path}' does not match the expected extension '{option_extension}'"
                 );
+        }
+    }
+
+    // Auto-discover partition columns only if not explicitly provided (None)
+    // If explicitly set to empty (Some([])), skip auto-discovery
+    if options.table_partition_cols().is_none() {
+        let inferred_partitions = listing_options
+            .infer_partitions(&context.state(), &table_paths[0])
+            .await?;
+        if !inferred_partitions.is_empty() {
+            listing_options = listing_options.with_table_partition_cols(
+                inferred_partitions
+                    .into_iter()
+                    .map(|name| (name, DataType::Utf8))
+                    .collect(),
+            );
         }
     }
 
@@ -85,6 +101,8 @@ pub struct GeoParquetReadOptions<'a> {
     table_options: Option<HashMap<String, String>>,
     geometry_columns: Option<HashMap<String, GeoParquetColumnMetadata>>,
     validate: bool,
+    /// None = auto-discover, Some([]) = disabled, Some([cols]) = explicit
+    table_partition_cols: Option<Vec<(String, DataType)>>,
 }
 
 impl GeoParquetReadOptions<'_> {
@@ -191,6 +209,7 @@ impl GeoParquetReadOptions<'_> {
             table_options: Some(options),
             geometry_columns: None,
             validate: false,
+            table_partition_cols: None,
         })
     }
 
@@ -227,6 +246,26 @@ impl GeoParquetReadOptions<'_> {
     pub fn validate(&self) -> bool {
         self.validate
     }
+
+    /// Set table partition columns for hive-style partitioning
+    ///
+    /// Partition columns are extracted from directory paths like `/col=value/`.
+    /// All partition columns are assumed to be `Utf8` type.
+    ///
+    /// Pass an empty vector to explicitly disable partition auto-discovery.
+    pub fn with_table_partition_cols(mut self, cols: Vec<String>) -> Self {
+        self.table_partition_cols = Some(
+            cols.into_iter()
+                .map(|name| (name, DataType::Utf8))
+                .collect(),
+        );
+        self
+    }
+
+    /// Get the table partition columns
+    pub fn table_partition_cols(&self) -> Option<&[(String, DataType)]> {
+        self.table_partition_cols.as_deref()
+    }
 }
 
 fn parse_geometry_columns_json(
@@ -259,6 +298,13 @@ impl ReadOptions<'_> for GeoParquetReadOptions<'_> {
         }
 
         let mut options = self.inner.to_listing_options(config, table_options);
+
+        // Apply partition columns if explicitly specified (Some)
+        // None means auto-discover later, Some([]) means no partitioning
+        if let Some(ref partition_cols) = self.table_partition_cols {
+            options = options.with_table_partition_cols(partition_cols.clone());
+        }
+
         if let Some(parquet_format) = options.format.as_any().downcast_ref::<ParquetFormat>() {
             let mut geoparquet_options =
                 TableGeoParquetOptions::from(parquet_format.options().clone());

--- a/rust/sedona-geoparquet/src/provider.rs
+++ b/rust/sedona-geoparquet/src/provider.rs
@@ -259,7 +259,7 @@ impl GeoParquetReadOptions<'_> {
     /// Set table partition columns for hive-style partitioning
     ///
     /// Partition columns are extracted from directory paths like `/col=value/`.
-    /// All partition columns are assumed to be `Utf8` type.
+    /// All partition columns are assumed to be `Utf8View` type.
     ///
     /// Pass an empty vector to explicitly disable partition auto-discovery.
     pub fn with_table_partition_cols(mut self, cols: Vec<(String, DataType)>) -> Self {

--- a/rust/sedona/src/context.rs
+++ b/rust/sedona/src/context.rs
@@ -390,12 +390,18 @@ impl SedonaContext {
     }
 
     /// Creates a [`DataFrame`] for reading a [ExternalFormatSpec]
+    ///
+    /// The `partitioning` parameter controls hive-style partition discovery:
+    /// - `None`: auto-discover partition columns from directory structure
+    /// - `Some([])`: disable partition discovery
+    /// - `Some([cols])`: use explicit partition columns
     pub async fn read_external_format<P: DataFilePaths>(
         &self,
         spec: Arc<dyn ExternalFormatSpec>,
         table_paths: P,
         options: Option<&HashMap<String, String>>,
         check_extension: bool,
+        partitioning: Option<Vec<String>>,
     ) -> Result<DataFrame> {
         let urls = table_paths.to_urls()?;
 
@@ -418,9 +424,9 @@ impl SedonaContext {
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect::<HashMap<String, String>>();
             let spec = spec.with_options(&options_without_filesystems)?;
-            external_table(spec, &self.ctx, urls, check_extension).await?
+            external_table(spec, &self.ctx, urls, check_extension, partitioning).await?
         } else {
-            external_table(spec, &self.ctx, urls, check_extension).await?
+            external_table(spec, &self.ctx, urls, check_extension, partitioning).await?
         };
 
         self.ctx.read_table(provider)
@@ -826,7 +832,7 @@ mod tests {
 
         // Ensure read_external_format() works
         let df = ctx
-            .read_external_format(spec.clone(), file_that_exists.clone(), None, false)
+            .read_external_format(spec.clone(), file_that_exists.clone(), None, false, None)
             .await
             .unwrap();
         let batches = df.collect().await.unwrap();
@@ -852,6 +858,7 @@ mod tests {
             file_that_exists.clone(),
             Some(&kv_options),
             false,
+            None,
         )
         .await
         .expect_err("should error for unsupported key/value options");
@@ -865,6 +872,7 @@ mod tests {
             file_that_exists.clone(),
             Some(&kv_options),
             false,
+            None,
         )
         .await
         .expect("should succeed because aws and gcs options were stripped");

--- a/rust/sedona/src/context.rs
+++ b/rust/sedona/src/context.rs
@@ -393,8 +393,8 @@ impl SedonaContext {
     ///
     /// The `partitioning` parameter controls hive-style partition discovery:
     /// - `None`: auto-discover partition columns from directory structure
-    /// - `Some([])`: disable partition discovery
-    /// - `Some([cols])`: use explicit partition columns
+    /// - `Some(vec![])`: disable partition discovery
+    /// - `Some(vec![...])`: use explicit partition columns
     pub async fn read_external_format<P: DataFilePaths>(
         &self,
         spec: Arc<dyn ExternalFormatSpec>,

--- a/rust/sedona/src/context.rs
+++ b/rust/sedona/src/context.rs
@@ -27,6 +27,7 @@ use crate::{
     show::{show_batches, DisplayTableOptions},
 };
 use arrow_array::RecordBatch;
+use arrow_schema::DataType;
 use async_trait::async_trait;
 use datafusion::datasource::file_format::format_as_file_type;
 use datafusion::{
@@ -401,7 +402,7 @@ impl SedonaContext {
         table_paths: P,
         options: Option<&HashMap<String, String>>,
         check_extension: bool,
-        partitioning: Option<Vec<String>>,
+        partitioning: Option<Vec<(String, DataType)>>,
     ) -> Result<DataFrame> {
         let urls = table_paths.to_urls()?;
 


### PR DESCRIPTION
This PR adds auto-discovery to hive style partitions (can be turned of globally or per read).

This is breaking change because the schema that is read pointing SedonaDB at a directory of partitioned Parquet files is now different. The old behaviour can be resurrected with `SET datafusion.execution.listing_table_factory_infer_partitions = false`.

```python
import sedona.db

sd = sedona.db.connect()

t = sd.funcs.table.sd_random_geometry()
t.select(
    grp=sd.funcs.floor(t.id / 100), geom=sd.funcs.st_setsrid(t.geometry, 3857)
).to_parquet("out_dir", partition_by="grp")

sd.read_parquet("out_dir").show(5)
# ┌──────────────────────────────────────────────┬──────┐
# │                     geom                     ┆  grp │
# │                   geometry                   ┆ utf8 │
# ╞══════════════════════════════════════════════╪══════╡
# │ POINT(59.63310565314948 22.488904786369556)  ┆ 9    │
# ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
# │ POINT(83.12076970430842 21.796712564259458)  ┆ 9    │
# ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
# │ POINT(30.891948399833048 18.511790453362643) ┆ 9    │
# ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
# │ POINT(87.62900829596556 90.36699740467581)   ┆ 9    │
# ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
# │ POINT(89.95104383376538 57.37266977967324)   ┆ 9    │
# └──────────────────────────────────────────────┴──────┘
```

Before this PR, the `grp` col wasn't shown (and there was no way to reconstruct it).

I made this the default, because it's been the default in DataFusion since 50.0.0 (about a year).

Closes #765.