### PR TITLE
chore(r/sedonafns): Install build requirements when building source tarball on r-universe

### DIFF
--- a/r/sedonafns/bootstrap.R
+++ b/r/sedonafns/bootstrap.R
@@ -15,6 +15,20 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# On r-universe, bootstrap.R runs before dependencies are installed.
+# Install the packages we need for source generation.
+required_packages <- c("yaml", "here", "glue", "rlang", "roxygen2")
+missing_packages <- required_packages[
+  !vapply(required_packages, requireNamespace, logical(1), quietly = TRUE)
+]
+if (length(missing_packages) > 0 && nzchar(Sys.getenv("MY_UNIVERSE"))) {
+  message(
+    "Running on r-universe, installing bootstrap dependencies: ",
+    paste(missing_packages, collapse = ", ")
+  )
+  install.packages(missing_packages)
+}
+
 source("tools/update-sd-funcs.R")
 update_sd_funcs()
 


### PR DESCRIPTION
Currently for r-universe we get an error when building the source tarball for sedonafns. This is a unique package because it's mostly generated at bootstrap time (i.e., when the docs/reference/sql sources are available, before the R source tarball has been created). There's no real provision for this in R (in Python it's something like build dependencies), but in most circumstances the appropriate dependencies are installed already except in the r-universe container.

This package installs the build dependencies in bootstrap.R only on r-universe (i.e., MY_UNIVERSE env var is defined).