### PR TITLE
feat(python/sedonadb): add DataFrame.join

### DIFF
--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -634,6 +634,168 @@ class DataFrame:
 
         return GroupedDataFrame(self, coerced)
 
+    def join(
+        self,
+        other: "DataFrame",
+        on: Union[str, List[str], Expr, List[Expr]],
+        how: Literal[
+            "inner",
+            "left",
+            "right",
+            "outer",
+            "full",
+            "left_semi",
+            "semi",
+            "left_anti",
+            "anti",
+            "right_semi",
+            "right_anti",
+        ] = "inner",
+    ) -> "DataFrame":
+        """Join two DataFrames.
+
+        `on` accepts either common column names or arbitrary boolean
+        predicates:
+
+        - **Column names** (`str` or `list[str]`): the named column(s)
+          must exist on both sides. Result has a single copy of each
+          join key — matching pandas / Polars / PySpark output shape.
+        - **Predicate expressions** (`Expr` or `list[Expr]`): each Expr
+          is a boolean predicate combining columns from both sides
+          (e.g. `left.k == right.k`, or `f.st_intersects(left.g, right.g)`).
+          Result keeps both sides' columns verbatim — disambiguate
+          with `df.alias(...)` on either side.
+
+        Args:
+            other: The right-hand DataFrame to join against.
+            on: Join key(s). A column name (`str`), a list of column
+                names, a single boolean `Expr`, or a list of boolean
+                `Expr`s combined with logical AND.
+            how: Join type. Canonical: `"inner"` (default), `"left"`,
+                `"right"`, `"outer"`, `"left_semi"`, `"left_anti"`,
+                `"right_semi"`, `"right_anti"`. PySpark aliases also
+                accepted: `"full"` (= outer), `"semi"` (= left_semi),
+                `"anti"` (= left_anti).
+
+        Examples:
+
+            >>> sd = sedona.db.connect()
+            >>> left = sd.sql(
+            ...     "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS t(k, v)"
+            ... )
+            >>> right = sd.sql(
+            ...     "SELECT * FROM (VALUES (1, 'x'), (2, 'y'), (3, 'z')) AS t(k, w)"
+            ... )
+            >>> left.join(right, on="k").sort("k").show()
+            ┌───────┬──────┬──────┐
+            │   k   ┆   v  ┆   w  │
+            │ int64 ┆ utf8 ┆ utf8 │
+            ╞═══════╪══════╪══════╡
+            │     1 ┆ a    ┆ x    │
+            ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌┤
+            │     2 ┆ b    ┆ y    │
+            └───────┴──────┴──────┘
+        """
+        if not isinstance(other, DataFrame):
+            raise TypeError(
+                f"join() expects a DataFrame as the first argument, "
+                f"got {type(other).__name__}"
+            )
+
+        HOW_ALIASES = {"semi": "left_semi", "anti": "left_anti", "full": "outer"}
+        valid_canonical = {
+            "inner",
+            "left",
+            "right",
+            "outer",
+            "left_semi",
+            "left_anti",
+            "right_semi",
+            "right_anti",
+        }
+        canonical_how = HOW_ALIASES.get(how, how)
+        if canonical_how not in valid_canonical:
+            accepted = sorted(valid_canonical | set(HOW_ALIASES))
+            raise ValueError(f"join() `how` must be one of {accepted}, got {how!r}")
+
+        if isinstance(on, (str, Expr)):
+            on_list = [on]
+        elif isinstance(on, list):
+            on_list = on
+        else:
+            raise TypeError(
+                f"join() `on` expects str, Expr, or a list of either, "
+                f"got {type(on).__name__}"
+            )
+
+        if not on_list:
+            raise ValueError("join() requires at least one element in `on`")
+
+        is_str_keys = all(isinstance(x, str) for x in on_list)
+        is_expr_keys = all(isinstance(x, Expr) for x in on_list)
+        if not (is_str_keys or is_expr_keys):
+            raise TypeError(
+                "join() `on` list must contain only str or only Expr, not a mix"
+            )
+
+        if is_expr_keys:
+            joined_impl = self._impl.join_on(
+                other._impl, [p._impl for p in on_list], canonical_how
+            )
+            return DataFrame(self._ctx, joined_impl)
+
+        # String-keys path: alias both sides, synthesize equi-join
+        # predicates from the qualified columns, then project to dedupe
+        # the join keys so the output shape matches pandas / PySpark
+        # rather than DataFusion's keep-both-copies default.
+        LEFT_ALIAS = "_sd_join_left_"
+        RIGHT_ALIAS = "_sd_join_right_"
+        left_cols = self._impl.columns()
+        right_cols = other._impl.columns()
+
+        missing_left = [k for k in on_list if k not in left_cols]
+        missing_right = [k for k in on_list if k not in right_cols]
+        if missing_left or missing_right:
+            raise KeyError(
+                f"Join keys missing — left: {missing_left}, "
+                f"right: {missing_right}. "
+                f"Left columns: {left_cols}; right columns: {right_cols}"
+            )
+
+        left_aliased = self.alias(LEFT_ALIAS)
+        right_aliased = other.alias(RIGHT_ALIAS)
+
+        predicates = [(left_aliased[k] == right_aliased[k])._impl for k in on_list]
+        joined_impl = left_aliased._impl.join_on(
+            right_aliased._impl, predicates, canonical_how
+        )
+
+        if canonical_how in ("left_semi", "left_anti"):
+            projection = [left_aliased[c]._impl for c in left_cols]
+        elif canonical_how in ("right_semi", "right_anti"):
+            projection = [right_aliased[c]._impl for c in right_cols]
+        else:
+            # For the unified key column, pick the side that is always
+            # populated: right join takes from the right, outer COALESCEs
+            # so unmatched-on-either-side rows still carry a key value.
+            key_set = set(on_list)
+            projection = []
+            for c in left_cols:
+                if c in key_set and canonical_how == "right":
+                    projection.append(right_aliased[c]._impl)
+                elif c in key_set and canonical_how == "outer":
+                    coalesced = self._ctx.funcs.coalesce(
+                        left_aliased[c], right_aliased[c]
+                    ).alias(c)
+                    projection.append(coalesced._impl)
+                else:
+                    projection.append(left_aliased[c]._impl)
+            for c in right_cols:
+                if c not in key_set:
+                    projection.append(right_aliased[c]._impl)
+
+        return DataFrame(self._ctx, joined_impl.select(projection))
+
     def limit(self, n: Optional[int], /, *, offset: int = 0) -> "DataFrame":
         """Limit result to n rows starting at offset
 

--- a/python/sedonadb/src/dataframe.rs
+++ b/python/sedonadb/src/dataframe.rs
@@ -28,7 +28,7 @@ use datafusion::logical_expr::SortExpr;
 use datafusion::prelude::{DataFrame, SessionContext};
 use datafusion_common::{Column, DataFusionError, ParamValues};
 use datafusion_execution::TaskContextProvider;
-use datafusion_expr::{ExplainFormat, ExplainOption, Expr};
+use datafusion_expr::{ExplainFormat, ExplainOption, Expr, JoinType};
 use datafusion_ffi::table_provider::FFI_TableProvider;
 use futures::lock::Mutex;
 use futures::TryStreamExt;
@@ -254,6 +254,35 @@ impl InternalDataFrame {
         let group_exprs: Vec<Expr> = group_exprs.into_iter().map(|e| e.inner).collect();
         let agg_exprs: Vec<Expr> = agg_exprs.into_iter().map(|e| e.inner).collect();
         let inner = self.inner.clone().aggregate(group_exprs, agg_exprs)?;
+        Ok(InternalDataFrame::new(inner, self.runtime.clone()))
+    }
+
+    fn join_on(
+        &self,
+        right: &InternalDataFrame,
+        predicates: Vec<PyExpr>,
+        how: &str,
+    ) -> Result<InternalDataFrame, PySedonaError> {
+        let join_type = match how {
+            "inner" => JoinType::Inner,
+            "left" => JoinType::Left,
+            "right" => JoinType::Right,
+            "outer" => JoinType::Full,
+            "left_semi" => JoinType::LeftSemi,
+            "left_anti" => JoinType::LeftAnti,
+            "right_semi" => JoinType::RightSemi,
+            "right_anti" => JoinType::RightAnti,
+            other => {
+                return Err(PySedonaError::SedonaPython(format!(
+                    "Unsupported join type '{other}'"
+                )))
+            }
+        };
+        let on_exprs: Vec<Expr> = predicates.into_iter().map(|p| p.inner).collect();
+        let inner = self
+            .inner
+            .clone()
+            .join_on(right.inner.clone(), join_type, on_exprs)?;
         Ok(InternalDataFrame::new(inner, self.runtime.clone()))
     }
 

--- a/python/sedonadb/tests/expr/test_dataframe_join.py
+++ b/python/sedonadb/tests/expr/test_dataframe_join.py
@@ -1,0 +1,261 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pandas as pd
+import pandas.testing as pdt
+import pytest
+
+from sedonadb.dataframe import DataFrame
+
+
+def test_join_inner_single_key(con):
+    left = con.create_data_frame(pd.DataFrame({"k": [1, 2, 3], "v": ["a", "b", "c"]}))
+    right = con.create_data_frame(pd.DataFrame({"k": [1, 2, 4], "w": ["x", "y", "z"]}))
+    out = left.join(right, on="k").sort("k").to_pandas()
+    pdt.assert_frame_equal(
+        out,
+        pd.DataFrame({"k": [1, 2], "v": ["a", "b"], "w": ["x", "y"]}),
+    )
+
+
+def test_join_inner_multiple_keys(con):
+    left = con.create_data_frame(
+        pd.DataFrame({"k1": [1, 1, 2], "k2": ["a", "b", "a"], "v": [10, 20, 30]})
+    )
+    right = con.create_data_frame(
+        pd.DataFrame({"k1": [1, 2, 2], "k2": ["a", "a", "b"], "w": [100, 200, 300]})
+    )
+    out = left.join(right, on=["k1", "k2"]).sort("k1", "k2").to_pandas()
+    # Only (1, 'a') and (2, 'a') match on both sides.
+    pdt.assert_frame_equal(
+        out,
+        pd.DataFrame({"k1": [1, 2], "k2": ["a", "a"], "v": [10, 30], "w": [100, 200]}),
+    )
+
+
+def test_join_left(con):
+    left = con.create_data_frame(pd.DataFrame({"k": [1, 2, 3], "v": ["a", "b", "c"]}))
+    right = con.create_data_frame(pd.DataFrame({"k": [1, 2], "w": ["x", "y"]}))
+    out = left.join(right, on="k", how="left").sort("k").to_pandas()
+    pdt.assert_frame_equal(
+        out,
+        pd.DataFrame({"k": [1, 2, 3], "v": ["a", "b", "c"], "w": ["x", "y", None]}),
+    )
+
+
+def test_join_right(con):
+    left = con.create_data_frame(pd.DataFrame({"k": [1, 2], "v": ["a", "b"]}))
+    right = con.create_data_frame(pd.DataFrame({"k": [1, 2, 3], "w": ["x", "y", "z"]}))
+    out = left.join(right, on="k", how="right").sort("k").to_pandas()
+    # The right-join key is sourced from the right side; v is NULL for
+    # the row unmatched on the left.
+    pdt.assert_frame_equal(
+        out,
+        pd.DataFrame({"k": [1, 2, 3], "v": ["a", "b", None], "w": ["x", "y", "z"]}),
+    )
+
+
+def test_join_outer(con):
+    left = con.create_data_frame(pd.DataFrame({"k": [1, 2], "v": ["a", "b"]}))
+    right = con.create_data_frame(pd.DataFrame({"k": [2, 3], "w": ["y", "z"]}))
+    # Outer join: COALESCE picks the populated side for the unified key
+    # column. Unmatched rows on either side appear with NULL in the
+    # other side's value column.
+    out = left.join(right, on="k", how="outer").sort("k").to_pandas()
+    pdt.assert_frame_equal(
+        out,
+        pd.DataFrame(
+            {
+                "k": [1, 2, 3],
+                "v": ["a", "b", None],
+                "w": [None, "y", "z"],
+            }
+        ),
+    )
+
+
+def test_join_left_semi(con):
+    # Left-semi: rows from the left that have a match on the right, no
+    # right-side columns returned.
+    left = con.create_data_frame(pd.DataFrame({"k": [1, 2, 3], "v": ["a", "b", "c"]}))
+    right = con.create_data_frame(pd.DataFrame({"k": [1, 3], "w": ["x", "z"]}))
+    out = left.join(right, on="k", how="left_semi").sort("k").to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"k": [1, 3], "v": ["a", "c"]}))
+
+
+def test_join_left_anti(con):
+    # Left-anti: rows from the left with no match on the right.
+    left = con.create_data_frame(pd.DataFrame({"k": [1, 2, 3], "v": ["a", "b", "c"]}))
+    right = con.create_data_frame(pd.DataFrame({"k": [1, 3], "w": ["x", "z"]}))
+    out = left.join(right, on="k", how="left_anti").sort("k").to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"k": [2], "v": ["b"]}))
+
+
+def test_join_right_semi(con):
+    # Right-semi: rows from the right that have a match on the left, no
+    # left-side columns returned.
+    left = con.create_data_frame(pd.DataFrame({"k": [1, 3], "v": ["a", "c"]}))
+    right = con.create_data_frame(pd.DataFrame({"k": [1, 2, 3], "w": ["x", "y", "z"]}))
+    out = left.join(right, on="k", how="right_semi").sort("k").to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"k": [1, 3], "w": ["x", "z"]}))
+
+
+def test_join_right_anti(con):
+    # Right-anti: rows from the right with no match on the left.
+    left = con.create_data_frame(pd.DataFrame({"k": [1, 3], "v": ["a", "c"]}))
+    right = con.create_data_frame(pd.DataFrame({"k": [1, 2, 3], "w": ["x", "y", "z"]}))
+    out = left.join(right, on="k", how="right_anti").sort("k").to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"k": [2], "w": ["y"]}))
+
+
+def test_join_how_pyspark_aliases(con):
+    # PySpark-style aliases route to the canonical join types.
+    left = con.create_data_frame(pd.DataFrame({"k": [1, 2, 3], "v": ["a", "b", "c"]}))
+    right = con.create_data_frame(pd.DataFrame({"k": [1, 3], "w": ["x", "z"]}))
+
+    semi = left.join(right, on="k", how="semi").sort("k").to_pandas()
+    pdt.assert_frame_equal(semi, pd.DataFrame({"k": [1, 3], "v": ["a", "c"]}))
+
+    anti = left.join(right, on="k", how="anti").sort("k").to_pandas()
+    pdt.assert_frame_equal(anti, pd.DataFrame({"k": [2], "v": ["b"]}))
+
+    left2 = con.create_data_frame(pd.DataFrame({"k": [1, 2], "v": ["a", "b"]}))
+    right2 = con.create_data_frame(pd.DataFrame({"k": [2, 3], "w": ["y", "z"]}))
+    full = left2.join(right2, on="k", how="full").sort("k").to_pandas()
+    pdt.assert_frame_equal(
+        full,
+        pd.DataFrame({"k": [1, 2, 3], "v": ["a", "b", None], "w": [None, "y", "z"]}),
+    )
+
+
+def test_join_on_expr_predicate_single(con):
+    # Expr-predicate path keeps both sides' columns verbatim with no
+    # auto-dedup; using distinct key names here avoids ambiguous
+    # references in the output.
+    left = con.create_data_frame(pd.DataFrame({"k": [1, 2, 3], "v": ["a", "b", "c"]}))
+    right = con.create_data_frame(pd.DataFrame({"kr": [1, 2, 4], "w": ["x", "y", "z"]}))
+    out = left.join(right, on=left.k == right.kr).sort(left.k).to_pandas()
+    pdt.assert_frame_equal(
+        out,
+        pd.DataFrame({"k": [1, 2], "v": ["a", "b"], "kr": [1, 2], "w": ["x", "y"]}),
+    )
+
+
+def test_join_on_expr_predicate_list_multi_key(con):
+    # List of Expr predicates is combined with logical AND.
+    left = con.create_data_frame(
+        pd.DataFrame({"k1": [1, 1, 2], "k2": ["a", "b", "a"], "v": [10, 20, 30]})
+    )
+    right = con.create_data_frame(
+        pd.DataFrame({"kr1": [1, 2, 2], "kr2": ["a", "a", "b"], "w": [100, 200, 300]})
+    )
+    out = (
+        left.join(right, on=[left.k1 == right.kr1, left.k2 == right.kr2])
+        .sort(left.k1, left.k2)
+        .to_pandas()
+    )
+    pdt.assert_frame_equal(
+        out,
+        pd.DataFrame(
+            {
+                "k1": [1, 2],
+                "k2": ["a", "a"],
+                "v": [10, 30],
+                "kr1": [1, 2],
+                "kr2": ["a", "a"],
+                "w": [100, 200],
+            }
+        ),
+    )
+
+
+def test_join_on_expr_non_equi_predicate(con):
+    # Non-equi predicate (analogue of a spatial-join shape): every
+    # left.x is paired with every right.y where x < y.
+    left = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
+    right = con.create_data_frame(pd.DataFrame({"y": [2, 4]}))
+    out = left.join(right, on=left.x < right.y).sort(left.x, right.y).to_pandas()
+    pdt.assert_frame_equal(
+        out,
+        pd.DataFrame({"x": [1, 1, 2, 3], "y": [2, 4, 4, 4]}),
+    )
+
+
+def test_join_returns_lazy_dataframe(con):
+    left = con.create_data_frame(pd.DataFrame({"k": [1], "v": ["a"]}))
+    right = con.create_data_frame(pd.DataFrame({"k": [1], "w": ["x"]}))
+    out = left.join(right, on="k")
+    assert isinstance(out, DataFrame)
+
+
+def test_join_non_dataframe_other_raises(con):
+    left = con.create_data_frame(pd.DataFrame({"k": [1]}))
+    with pytest.raises(TypeError, match="join\\(\\) expects a DataFrame"):
+        left.join({"k": 1}, on="k")
+
+
+def test_join_on_bad_type_raises(con):
+    left = con.create_data_frame(pd.DataFrame({"k": [1]}))
+    right = con.create_data_frame(pd.DataFrame({"k": [1]}))
+    with pytest.raises(TypeError, match="`on` expects str, Expr, or a list of either"):
+        left.join(right, on=123)
+
+
+def test_join_on_empty_list_raises(con):
+    left = con.create_data_frame(pd.DataFrame({"k": [1]}))
+    right = con.create_data_frame(pd.DataFrame({"k": [1]}))
+    with pytest.raises(ValueError, match="at least one element"):
+        left.join(right, on=[])
+
+
+def test_join_on_mixed_list_raises(con):
+    # A list mixing str and non-str (or str and Expr) is rejected.
+    left = con.create_data_frame(pd.DataFrame({"k": [1]})).alias("l")
+    right = con.create_data_frame(pd.DataFrame({"k": [1]})).alias("r")
+    with pytest.raises(TypeError, match="only str or only Expr"):
+        left.join(right, on=["k", left.k == right.k])
+    with pytest.raises(TypeError, match="only str or only Expr"):
+        left.join(right, on=["k", 1])
+
+
+def test_join_bad_how_raises(con):
+    left = con.create_data_frame(pd.DataFrame({"k": [1]}))
+    right = con.create_data_frame(pd.DataFrame({"k": [1]}))
+    with pytest.raises(ValueError, match="`how` must be one of"):
+        left.join(right, on="k", how="cross")
+
+
+def test_join_unknown_column_errors(con):
+    # Pre-flight validation surfaces a single KeyError that names which
+    # side(s) are missing the key, so the user doesn't have to guess.
+    left = con.create_data_frame(pd.DataFrame({"a": [1]}))
+    right = con.create_data_frame(pd.DataFrame({"b": [1]}))
+    with pytest.raises(
+        KeyError, match=r"left: \['nonexistent'\].*right: \['nonexistent'\]"
+    ):
+        left.join(right, on="nonexistent")
+
+
+def test_join_key_missing_on_one_side_errors(con):
+    # When a key exists on only one side, the error message says
+    # which side is missing it.
+    left = con.create_data_frame(pd.DataFrame({"k": [1, 2], "v": ["a", "b"]}))
+    right = con.create_data_frame(pd.DataFrame({"j": [1, 2], "w": ["x", "y"]}))
+    with pytest.raises(KeyError, match=r"left: \[\].*right: \['k'\]"):
+        left.join(right, on="k")
+    with pytest.raises(KeyError, match=r"left: \['j'\].*right: \[\]"):
+        left.join(right, on="j")


### PR DESCRIPTION
First of the join sub-PRs from #791. `cross_join` is a separate small follow-up.

## API

```python
df.join(other, on="k")                              # equi-join on common name
df.join(other, on=["k1", "k2"], how="left")         # multi-key
df.join(other, on="k", how="outer")
df.join(other, on=left.k == right.kr)               # arbitrary predicate
df.join(other, on=[left.a == right.a, left.b > right.b])
```

- `on` accepts a column name (`str`), a list of column names, a boolean `Expr`, or a list of boolean `Expr`s combined with logical AND.
- `how`: `inner` (default), `left`, `right`, `outer`, `left_semi`, `left_anti`, `right_semi`, `right_anti`. PySpark aliases also accepted: `full` → outer, `semi` → left_semi, `anti` → left_anti.

## Output shape

- **Column names (`on="k"` / `on=["k1", "k2"]`)**: result has a single copy of each join key — matches pandas / Polars / PySpark, not DataFusion's keep-both-copies default.
- **Predicate `Expr` (`on=left.k == right.k`)**: both sides' columns are kept verbatim — same as PySpark's predicate join. Caller controls disambiguation via `df.alias(...)` when the same column name appears on both sides.

## Worth flagging — the auto-dedup machinery (column-name path)

DataFusion's DataFrame join has two behaviors that diverge from user expectations:

1. **Rejects two unaliased inputs that share column names** with "duplicate qualified field name". Both default to the `?table?` qualifier; the merged schema has unresolvable collisions before the join even runs.
2. **Keeps both copies of the join key** in the result when inputs are aliased. The SQL `USING` parser does the dedup at parse time; the DataFrame API doesn't.

For the column-name path, the Python wrapper:

1. Aliases both sides internally with sentinel qualifiers (`_sd_join_left_` / `_sd_join_right_`).
2. Synthesizes `aliased_left[k] == aliased_right[k]` predicates and calls `join_on`.
3. Projects with fully qualified column refs to dedupe the key columns and strip the sentinel qualifiers from the output.

The unified join-key column:
- **inner / left**: sourced from the left side (always populated).
- **right**: sourced from the right side (left may be NULL for unmatched rows).
- **outer**: `COALESCE(left.k, right.k)` — picks the populated side for rows unmatched on either input.
- **left_semi / left_anti / right_semi / right_anti**: only one side's columns appear; projection is straightforward.

For the predicate path, none of this dedup machinery runs — the Exprs flow straight through to `DataFrame::join_on`.

## Implementation

| File | Change |
|---|---|
| `python/sedonadb/src/dataframe.rs` | New `InternalDataFrame::join_on(right, predicates, how)`. Thin wrapper over DataFusion's `DataFrame::join_on`. Maps the `how` string to `JoinType`; takes a `Vec<PyExpr>` of predicates. |
| `python/sedonadb/python/sedonadb/dataframe.py` | New `DataFrame.join(other, on, how)`. Routes the column-name path through the alias-and-project pipeline; passes Expr predicates straight through. |

## Test plan

20 tests in `tests/expr/test_dataframe_join.py`:

- **Positive (column-name path)**: single-key inner / left / right / outer; multi-key inner; left_semi; left_anti; right_semi; right_anti.
- **PySpark `how` aliases**: `semi` / `anti` / `full`.
- **Positive (predicate path)**: single Expr equi-join; list of Exprs combined with AND; non-equi predicate (`left.x < right.y`) as a spatial-join shape analogue.
- **Lazy return**: `isinstance(out, DataFrame)`.
- **Errors**: non-DataFrame `other`; bad `on` type; empty `on` list; mixed str / non-str (or str / Expr) in `on` list; invalid `how`; unknown column (caught pre-flight as `KeyError`).

All output assertions use exact `pd.testing.assert_frame_equal` after sorting.

Local: 20 unit + 24 doctests + 187 expr-dir tests + `ruff format` + `ruff check` + `cargo fmt --check` all clean.

## Known limitations (for follow-up)

- **Non-key column-name collisions** in the column-name path are not auto-suffixed (`_x` / `_y` like pandas). The duplicate names propagate and become ambiguous to reference. Deferred to a later PR per the design discussion.
- **Self-join** requires the user to alias one side explicitly. The internal sentinel aliasing handles the unaliased common case but doesn't disambiguate a self-join.