### PR TITLE
fix(c/sedona-gdal): replace gpkg temporary datasets with flatgeobuf in sedona-gdal tests

### DIFF
--- a/c/sedona-gdal/src/dataset.rs
+++ b/c/sedona-gdal/src/dataset.rs
@@ -363,7 +363,7 @@ mod tests {
     use crate::gdal_dyn_bindgen::{OGRwkbGeometryType, GDAL_OF_READONLY, GDAL_OF_VECTOR};
     use crate::global::with_global_gdal_api;
     use crate::vector::layer::Layer;
-    use crate::vsi::unlink_mem_file;
+    use crate::vsi::with_memfile;
 
     use super::{Dataset, LayerOptions};
 
@@ -435,24 +435,27 @@ mod tests {
     #[test]
     fn test_create_vector_layer() {
         with_global_gdal_api(|api| {
-            let path = "/vsimem/test_dataset_create_vector_layer.gpkg";
-            let driver = DriverManager::get_driver_by_name(api, "GPKG").unwrap();
-            let dataset = driver.create_vector_only(path).unwrap();
+            with_memfile(
+                api,
+                "/vsimem/test_dataset_create_vector_layer.fgb",
+                |path| {
+                    let driver = DriverManager::get_driver_by_name(api, "FlatGeobuf").unwrap();
+                    let dataset = driver.create_vector_only(path).unwrap();
 
-            let layer = dataset
-                .create_layer(LayerOptions {
-                    name: "points",
-                    srs: None,
-                    ty: OGRwkbGeometryType::wkbPoint,
-                    options: None,
-                })
-                .unwrap();
+                    let layer = dataset
+                        .create_layer(LayerOptions {
+                            name: "points",
+                            srs: None,
+                            ty: OGRwkbGeometryType::wkbPoint,
+                            options: None,
+                        })
+                        .unwrap();
 
-            assert_eq!(dataset.raster_count(), 0);
-            assert!(!layer.c_layer().is_null());
-            assert_eq!(layer.feature_count(true), 0);
-
-            unlink_mem_file(api, path).unwrap();
+                    assert_eq!(dataset.raster_count(), 0);
+                    assert!(!layer.c_layer().is_null());
+                    assert_eq!(layer.feature_count(true), 0);
+                },
+            );
         })
         .unwrap();
     }
@@ -460,41 +463,40 @@ mod tests {
     #[test]
     fn test_open_vector_dataset_with_open_ex() {
         with_global_gdal_api(|api| {
-            let path = "/vsimem/test_dataset_open_vector.gpkg";
-            let driver = DriverManager::get_driver_by_name(api, "GPKG").unwrap();
-            {
-                let dataset = driver.create_vector_only(path).unwrap();
+            with_memfile(api, "/vsimem/test_dataset_open_vector.fgb", |path| {
+                let driver = DriverManager::get_driver_by_name(api, "FlatGeobuf").unwrap();
+                {
+                    let dataset = driver.create_vector_only(path).unwrap();
 
-                dataset
-                    .create_layer(LayerOptions {
-                        name: "points",
-                        srs: None,
-                        ty: OGRwkbGeometryType::wkbPoint,
-                        options: None,
-                    })
-                    .unwrap();
-            }
+                    dataset
+                        .create_layer(LayerOptions {
+                            name: "points",
+                            srs: None,
+                            ty: OGRwkbGeometryType::wkbPoint,
+                            options: None,
+                        })
+                        .unwrap();
+                }
 
-            let reopened = Dataset::open_ex(
-                api,
-                path,
-                GDAL_OF_VECTOR | GDAL_OF_READONLY,
-                None,
-                None,
-                None,
-            )
-            .unwrap();
+                let reopened = Dataset::open_ex(
+                    api,
+                    path,
+                    GDAL_OF_VECTOR | GDAL_OF_READONLY,
+                    None,
+                    None,
+                    None,
+                )
+                .unwrap();
 
-            let layer_count = unsafe { GDALDatasetGetLayerCount(reopened.c_dataset()) };
-            assert_eq!(layer_count, 1);
+                let layer_count = unsafe { GDALDatasetGetLayerCount(reopened.c_dataset()) };
+                assert_eq!(layer_count, 1);
 
-            let c_layer = unsafe { GDALDatasetGetLayer(reopened.c_dataset(), 0) };
-            assert!(!c_layer.is_null());
+                let c_layer = unsafe { GDALDatasetGetLayer(reopened.c_dataset(), 0) };
+                assert!(!c_layer.is_null());
 
-            let reopened_layer = Layer::new(api, c_layer, &reopened);
-            assert_eq!(reopened_layer.feature_count(true), 0);
-
-            unlink_mem_file(api, path).unwrap();
+                let reopened_layer = Layer::new(api, c_layer, &reopened);
+                assert_eq!(reopened_layer.feature_count(true), 0);
+            });
         })
         .unwrap();
     }

--- a/c/sedona-gdal/src/raster/polygonize.rs
+++ b/c/sedona-gdal/src/raster/polygonize.rs
@@ -103,6 +103,7 @@ pub fn polygonize(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gdal_sys::GDALDatasetGetLayer;
 
     #[test]
     fn test_polygonizeoptions_as_ptr() {
@@ -137,10 +138,11 @@ mod tests {
         use crate::global::with_global_gdal_api;
         use crate::raster::types::Buffer;
         use crate::vector::feature::FieldDefn;
-        use crate::vsi::unlink_mem_file;
+        use crate::vsi::with_memfile;
 
         with_global_gdal_api(|api| {
             let mem_driver = DriverManager::get_driver_by_name(api, "MEM").unwrap();
+            let flatgeobuf_driver = DriverManager::get_driver_by_name(api, "FlatGeobuf").unwrap();
             let raster_ds = mem_driver.create("", 3, 3, 1).unwrap();
             let band = raster_ds.rasterband(1).unwrap();
 
@@ -151,65 +153,111 @@ mod tests {
             let mut data = Buffer::new((3, 3), vec![1u8, 0, 0, 0, 1, 0, 0, 0, 1]);
             band.write((0, 0), (3, 3), &mut data).unwrap();
 
-            let gpkg_path = "/vsimem/test_polygonize_connectivity.gpkg";
-            let gpkg_driver = DriverManager::get_driver_by_name(api, "GPKG").unwrap();
-            let vector_ds = gpkg_driver.create_vector_only(gpkg_path).unwrap();
+            with_memfile(
+                api,
+                "/vsimem/test_polygonize_connectivity_four.fgb",
+                |layer_4_path| {
+                    {
+                        let vector_ds_4 =
+                            flatgeobuf_driver.create_vector_only(layer_4_path).unwrap();
 
-            // 4-connected output
-            let mut layer_4 = vector_ds
-                .create_layer(LayerOptions {
-                    name: "four",
-                    srs: None,
-                    ty: OGRwkbGeometryType::wkbPolygon,
-                    options: None,
-                })
-                .unwrap();
-            let field_defn = FieldDefn::new(api, "val", OGRFieldType::OFTInteger).unwrap();
-            layer_4.create_field(&field_defn).unwrap();
+                        // 4-connected output
+                        let layer_4 = vector_ds_4
+                            .create_layer(LayerOptions {
+                                name: "four",
+                                srs: None,
+                                ty: OGRwkbGeometryType::wkbPolygon,
+                                options: None,
+                            })
+                            .unwrap();
+                        let field_defn =
+                            FieldDefn::new(api, "val", OGRFieldType::OFTInteger).unwrap();
+                        layer_4.create_field(&field_defn).unwrap();
 
-            polygonize(api, &band, None, &layer_4, 0, &PolygonizeOptions::default()).unwrap();
+                        polygonize(api, &band, None, &layer_4, 0, &PolygonizeOptions::default())
+                            .unwrap();
+                    }
 
-            let ones_4 = layer_4
-                .features()
-                .filter_map(|f| f.field_as_integer(0))
-                .filter(|v| *v == 1)
-                .count();
-            assert_eq!(ones_4, 3);
+                    let reopened_4 = crate::dataset::Dataset::open_ex(
+                        api,
+                        layer_4_path,
+                        crate::gdal_dyn_bindgen::GDAL_OF_VECTOR
+                            | crate::gdal_dyn_bindgen::GDAL_OF_READONLY,
+                        None,
+                        None,
+                        None,
+                    )
+                    .unwrap();
+                    let c_layer_4 = unsafe { GDALDatasetGetLayer(reopened_4.c_dataset(), 0) };
+                    assert!(!c_layer_4.is_null());
+                    let mut read_layer_4 =
+                        crate::vector::layer::Layer::new(api, c_layer_4, &reopened_4);
+                    let ones_4 = read_layer_4
+                        .features()
+                        .filter_map(|f| f.field_as_integer(0))
+                        .filter(|v| *v == 1)
+                        .count();
+                    assert_eq!(ones_4, 3);
+                },
+            );
 
             // 8-connected output
-            let mut layer_8 = vector_ds
-                .create_layer(LayerOptions {
-                    name: "eight",
-                    srs: None,
-                    ty: OGRwkbGeometryType::wkbPolygon,
-                    options: None,
-                })
-                .unwrap();
-            let field_defn = FieldDefn::new(api, "val", OGRFieldType::OFTInteger).unwrap();
-            layer_8.create_field(&field_defn).unwrap();
-
-            polygonize(
+            with_memfile(
                 api,
-                &band,
-                None,
-                &layer_8,
-                0,
-                &PolygonizeOptions {
-                    eight_connected: true,
-                    dataset_for_georef: None,
-                    commit_interval: None,
+                "/vsimem/test_polygonize_connectivity_eight.fgb",
+                |layer_8_path| {
+                    {
+                        let vector_ds_8 =
+                            flatgeobuf_driver.create_vector_only(layer_8_path).unwrap();
+                        let layer_8 = vector_ds_8
+                            .create_layer(LayerOptions {
+                                name: "eight",
+                                srs: None,
+                                ty: OGRwkbGeometryType::wkbPolygon,
+                                options: None,
+                            })
+                            .unwrap();
+                        let field_defn =
+                            FieldDefn::new(api, "val", OGRFieldType::OFTInteger).unwrap();
+                        layer_8.create_field(&field_defn).unwrap();
+
+                        polygonize(
+                            api,
+                            &band,
+                            None,
+                            &layer_8,
+                            0,
+                            &PolygonizeOptions {
+                                eight_connected: true,
+                                dataset_for_georef: None,
+                                commit_interval: None,
+                            },
+                        )
+                        .unwrap();
+                    }
+
+                    let reopened_8 = crate::dataset::Dataset::open_ex(
+                        api,
+                        layer_8_path,
+                        crate::gdal_dyn_bindgen::GDAL_OF_VECTOR
+                            | crate::gdal_dyn_bindgen::GDAL_OF_READONLY,
+                        None,
+                        None,
+                        None,
+                    )
+                    .unwrap();
+                    let c_layer_8 = unsafe { GDALDatasetGetLayer(reopened_8.c_dataset(), 0) };
+                    assert!(!c_layer_8.is_null());
+                    let mut read_layer_8 =
+                        crate::vector::layer::Layer::new(api, c_layer_8, &reopened_8);
+                    let ones_8 = read_layer_8
+                        .features()
+                        .filter_map(|f| f.field_as_integer(0))
+                        .filter(|v| *v == 1)
+                        .count();
+                    assert_eq!(ones_8, 1);
                 },
-            )
-            .unwrap();
-
-            let ones_8 = layer_8
-                .features()
-                .filter_map(|f| f.field_as_integer(0))
-                .filter(|v| *v == 1)
-                .count();
-            assert_eq!(ones_8, 1);
-
-            unlink_mem_file(api, gpkg_path).unwrap();
+            );
         })
         .unwrap();
     }
@@ -222,7 +270,7 @@ mod tests {
         use crate::global::with_global_gdal_api;
         use crate::raster::types::Buffer;
         use crate::vector::feature::FieldDefn;
-        use crate::vsi::unlink_mem_file;
+        use crate::vsi::with_memfile;
 
         with_global_gdal_api(|api| {
             let mem_driver = DriverManager::get_driver_by_name(api, "MEM").unwrap();
@@ -239,36 +287,51 @@ mod tests {
             let mut mask = Buffer::new((3, 3), vec![0u8, 0, 0, 0, 1, 0, 0, 0, 0]);
             mask_band.write((0, 0), (3, 3), &mut mask).unwrap();
 
-            let gpkg_path = "/vsimem/test_polygonize_mask.gpkg";
-            let gpkg_driver = DriverManager::get_driver_by_name(api, "GPKG").unwrap();
-            let vector_ds = gpkg_driver.create_vector_only(gpkg_path).unwrap();
+            with_memfile(api, "/vsimem/test_polygonize_mask.fgb", |fgb_path| {
+                let flatgeobuf_driver =
+                    DriverManager::get_driver_by_name(api, "FlatGeobuf").unwrap();
+                {
+                    let vector_ds = flatgeobuf_driver.create_vector_only(fgb_path).unwrap();
 
-            let mut layer = vector_ds
-                .create_layer(LayerOptions {
-                    name: "masked",
-                    srs: None,
-                    ty: OGRwkbGeometryType::wkbPolygon,
-                    options: None,
-                })
+                    let layer = vector_ds
+                        .create_layer(LayerOptions {
+                            name: "masked",
+                            srs: None,
+                            ty: OGRwkbGeometryType::wkbPolygon,
+                            options: None,
+                        })
+                        .unwrap();
+                    let field_defn = FieldDefn::new(api, "val", OGRFieldType::OFTInteger).unwrap();
+                    layer.create_field(&field_defn).unwrap();
+
+                    polygonize(
+                        api,
+                        &value_band,
+                        Some(&mask_band),
+                        &layer,
+                        0,
+                        &PolygonizeOptions::default(),
+                    )
+                    .unwrap();
+                }
+
+                let reopened = crate::dataset::Dataset::open_ex(
+                    api,
+                    fgb_path,
+                    crate::gdal_dyn_bindgen::GDAL_OF_VECTOR
+                        | crate::gdal_dyn_bindgen::GDAL_OF_READONLY,
+                    None,
+                    None,
+                    None,
+                )
                 .unwrap();
-            let field_defn = FieldDefn::new(api, "val", OGRFieldType::OFTInteger).unwrap();
-            layer.create_field(&field_defn).unwrap();
-
-            polygonize(
-                api,
-                &value_band,
-                Some(&mask_band),
-                &layer,
-                0,
-                &PolygonizeOptions::default(),
-            )
-            .unwrap();
-
-            assert_eq!(layer.feature_count(true), 1);
-            let only_val = layer.features().next().unwrap().field_as_integer(0);
-            assert_eq!(only_val, Some(7));
-
-            unlink_mem_file(api, gpkg_path).unwrap();
+                let c_layer = unsafe { GDALDatasetGetLayer(reopened.c_dataset(), 0) };
+                assert!(!c_layer.is_null());
+                let mut read_layer = crate::vector::layer::Layer::new(api, c_layer, &reopened);
+                assert_eq!(read_layer.feature_count(true), 1);
+                let only_val = read_layer.features().next().unwrap().field_as_integer(0);
+                assert_eq!(only_val, Some(7));
+            });
         })
         .unwrap();
     }

--- a/c/sedona-gdal/src/vector/layer.rs
+++ b/c/sedona-gdal/src/vector/layer.rs
@@ -132,77 +132,80 @@ mod tests {
     use crate::gdal_dyn_bindgen::OGRwkbGeometryType;
     use crate::global::with_global_gdal_api;
     use crate::vector::geometry::Geometry;
-    use crate::vsi::unlink_mem_file;
+    use crate::vsi::with_memfile;
 
     #[test]
     fn test_layer_iteration_and_reset() {
         with_global_gdal_api(|api| {
-            let path = "/vsimem/test_layer_iteration.gpkg";
-            let driver = DriverManager::get_driver_by_name(api, "GPKG").unwrap();
-            let dataset = driver.create_vector_only(path).unwrap();
+            with_memfile(api, "/vsimem/test_layer_iteration.fgb", |path| {
+                let driver = DriverManager::get_driver_by_name(api, "FlatGeobuf").unwrap();
+                {
+                    let dataset = driver.create_vector_only(path).unwrap();
 
-            let layer = dataset
-                .create_layer(LayerOptions {
-                    name: "features",
-                    srs: None,
-                    ty: OGRwkbGeometryType::wkbPoint,
-                    options: None,
-                })
+                    let layer = dataset
+                        .create_layer(LayerOptions {
+                            name: "features",
+                            srs: None,
+                            ty: OGRwkbGeometryType::wkbPoint,
+                            options: None,
+                        })
+                        .unwrap();
+
+                    let layer_defn = unsafe { OGR_L_GetLayerDefn(layer.c_layer()) };
+                    assert!(!layer_defn.is_null());
+
+                    for x in [1.0_f64, 2.0, 3.0] {
+                        let feature = unsafe { OGR_F_Create(layer_defn) };
+                        assert!(!feature.is_null());
+
+                        let geometry = Geometry::from_wkt(api, &format!("POINT ({x} 0)")).unwrap();
+                        let set_geometry_err =
+                            unsafe { OGR_F_SetGeometry(feature, geometry.c_geometry()) };
+                        assert_eq!(set_geometry_err, gdal_sys::OGRErr::OGRERR_NONE);
+
+                        let create_feature_err =
+                            unsafe { OGR_L_CreateFeature(layer.c_layer(), feature) };
+                        assert_eq!(create_feature_err, gdal_sys::OGRErr::OGRERR_NONE);
+
+                        unsafe { gdal_sys::OGR_F_Destroy(feature) };
+                    }
+
+                    let write_count = unsafe { GDALDatasetGetLayerCount(dataset.c_dataset()) };
+                    assert_eq!(write_count, 1);
+                }
+
+                let read_dataset = Dataset::open_ex(
+                    api,
+                    path,
+                    crate::gdal_dyn_bindgen::GDAL_OF_VECTOR
+                        | crate::gdal_dyn_bindgen::GDAL_OF_READONLY,
+                    None,
+                    None,
+                    None,
+                )
                 .unwrap();
 
-            let layer_defn = unsafe { OGR_L_GetLayerDefn(layer.c_layer()) };
-            assert!(!layer_defn.is_null());
+                let read_count = unsafe { GDALDatasetGetLayerCount(read_dataset.c_dataset()) };
+                assert_eq!(read_count, 1);
 
-            for x in [1.0_f64, 2.0, 3.0] {
-                let feature = unsafe { OGR_F_Create(layer_defn) };
-                assert!(!feature.is_null());
+                let c_layer = unsafe { GDALDatasetGetLayer(read_dataset.c_dataset(), 0) };
+                assert!(!c_layer.is_null());
+                let mut read_layer = Layer::new(api, c_layer, &read_dataset);
 
-                let geometry = Geometry::from_wkt(api, &format!("POINT ({x} 0)")).unwrap();
-                let set_geometry_err = unsafe { OGR_F_SetGeometry(feature, geometry.c_geometry()) };
-                assert_eq!(set_geometry_err, gdal_sys::OGRErr::OGRERR_NONE);
+                assert_eq!(read_layer.feature_count(true), 3);
 
-                let create_feature_err = unsafe { OGR_L_CreateFeature(layer.c_layer(), feature) };
-                assert_eq!(create_feature_err, gdal_sys::OGRErr::OGRERR_NONE);
+                let mut iter = read_layer.features();
+                assert!(iter.next().is_some());
+                assert!(iter.next().is_some());
+                assert!(iter.next().is_some());
+                assert!(iter.next().is_none());
 
-                unsafe { gdal_sys::OGR_F_Destroy(feature) };
-            }
+                read_layer.reset_reading();
+                assert!(read_layer.next_feature().is_some());
 
-            let write_count = unsafe { GDALDatasetGetLayerCount(dataset.c_dataset()) };
-            assert_eq!(write_count, 1);
-            drop(dataset);
-
-            let read_dataset = Dataset::open_ex(
-                api,
-                path,
-                crate::gdal_dyn_bindgen::GDAL_OF_VECTOR | crate::gdal_dyn_bindgen::GDAL_OF_READONLY,
-                None,
-                None,
-                None,
-            )
-            .unwrap();
-
-            let read_count = unsafe { GDALDatasetGetLayerCount(read_dataset.c_dataset()) };
-            assert_eq!(read_count, 1);
-
-            let c_layer = unsafe { GDALDatasetGetLayer(read_dataset.c_dataset(), 0) };
-            assert!(!c_layer.is_null());
-            let mut read_layer = Layer::new(api, c_layer, &read_dataset);
-
-            assert_eq!(read_layer.feature_count(true), 3);
-
-            let mut iter = read_layer.features();
-            assert!(iter.next().is_some());
-            assert!(iter.next().is_some());
-            assert!(iter.next().is_some());
-            assert!(iter.next().is_none());
-
-            read_layer.reset_reading();
-            assert!(read_layer.next_feature().is_some());
-
-            assert_eq!(read_layer.features().count(), 3);
-            assert_eq!(read_layer.features().count(), 3);
-
-            unlink_mem_file(api, path).unwrap();
+                assert_eq!(read_layer.features().count(), 3);
+                assert_eq!(read_layer.features().count(), 3);
+            });
         })
         .unwrap();
     }

--- a/c/sedona-gdal/src/vsi.rs
+++ b/c/sedona-gdal/src/vsi.rs
@@ -147,6 +147,17 @@ pub fn unlink_mem_file(api: &'static GdalApi, file_name: &str) -> Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
+pub(crate) fn with_memfile<T>(
+    api: &'static GdalApi,
+    file_name: &str,
+    f: impl FnOnce(&str) -> T,
+) -> T {
+    let ret = f(file_name);
+    unlink_mem_file(api, file_name).unwrap();
+    ret
+}
+
 /// Returns an owned GDAL-allocated buffer containing the bytes of the VSI in-memory
 /// file, taking ownership and freeing the GDAL memory on drop.
 pub fn get_vsi_mem_file_buffer_owned(api: &'static GdalApi, file_name: &str) -> Result<VSIBuffer> {


### PR DESCRIPTION
## Summary

Closes https://github.com/apache/sedona-db/issues/870.

- replace `sedona-gdal` `/vsimem` GeoPackage tests with FlatGeobuf fixtures
- add a test-only `with_memfile(...)` helper to keep `/vsimem` cleanup explicit
- keep the polygonize assertions by reopening the generated `.fgb` outputs after writer close

## Why
GitHub Actions runners currently use GDAL `3.8.4`, and the `GPKG` test path can crash during concurrent `GDALClose()` teardown through `libspatialite` and `libxml2` cleanup. Upstream fixed this in GDAL `3.9.3+`, but CI is still on the older path.

Switching these tests from GeoPackage to FlatGeobuf avoids the buggy GeoPackage/SpatiaLite teardown path while preserving the behavior the tests cover.

Upstream references:
- OSGeo/gdal#10685
- OSGeo/gdal#10687
- mainline fix: `e8eaa68094`
- 3.9 backport: `0e89c18606`

## Testing

Running the sedona-gdal test 1,000 times on GitHub runner using the following command:

```bash
cargo test -p sedona-gdal --lib --no-run
BIN=$(ls target/debug/deps/sedona_gdal-* | grep -v '\.d$' | head -n1)
for i in $(seq 1 1000); do
  echo "iteration $i"
  MALLOC_CHECK_=3 MALLOC_PERTURB_=$((i % 255 + 1)) \
  "$BIN" --test-threads=16 >>"/tmp/run_$i" 2>&1 || break
done
```
