### PR TITLE
perf(rust/sedona-functions): Improve performance of ST_Reverse()

### DIFF
--- a/rust/sedona-functions/src/st_reverse.rs
+++ b/rust/sedona-functions/src/st_reverse.rs
@@ -19,7 +19,7 @@ use std::io::Write;
 use std::sync::Arc;
 
 use arrow_array::builder::BinaryBuilder;
-use datafusion_common::{DataFusionError, Result};
+use datafusion_common::{exec_datafusion_err, Result};
 use datafusion_expr::ColumnarValue;
 use datafusion_expr::Volatility;
 use geo_traits::{
@@ -27,6 +27,7 @@ use geo_traits::{
     MultiPointTrait, MultiPolygonTrait, PointTrait, PolygonTrait,
 };
 use sedona_expr::item_crs::ItemCrsKernel;
+use sedona_geometry::error::SedonaGeometryError;
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_geometry::wkb_factory::{
     write_wkb_coord_trait, write_wkb_empty_point, write_wkb_geometrycollection_header,
@@ -83,7 +84,8 @@ impl SedonaScalarKernel for STReverse {
         executor.execute_wkb_void(|maybe_wkb| {
             match maybe_wkb {
                 Some(wkb) => {
-                    invoke_scalar(&wkb, &mut builder)?;
+                    invoke_scalar(&wkb, &mut builder)
+                        .map_err(|e| exec_datafusion_err!("ST_Reverse error: {e}"))?;
                     builder.append_value([]);
                 }
                 _ => builder.append_null(),
@@ -95,39 +97,36 @@ impl SedonaScalarKernel for STReverse {
     }
 }
 
-fn invoke_scalar(geom: &impl GeometryTrait<T = f64>, writer: &mut impl Write) -> Result<()> {
+fn invoke_scalar(
+    geom: &impl GeometryTrait<T = f64>,
+    writer: &mut impl Write,
+) -> Result<(), SedonaGeometryError> {
     let dims = geom.dim();
     match geom.as_type() {
         geo_traits::GeometryType::Point(pt) => {
             if pt.coord().is_some() {
-                write_wkb_point_header(writer, dims)
-                    .map_err(|e| DataFusionError::Execution(e.to_string()))?;
-                write_wkb_coord_trait(writer, &pt.coord().unwrap())
-                    .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+                write_wkb_point_header(writer, dims)?;
+                write_wkb_coord_trait(writer, &pt.coord().unwrap())?;
             } else {
-                write_wkb_empty_point(writer, dims)
-                    .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+                write_wkb_empty_point(writer, dims)?;
             }
         }
 
         geo_traits::GeometryType::MultiPoint(multi_point) => {
-            write_wkb_multipoint_header(writer, dims, multi_point.points().count())
-                .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+            write_wkb_multipoint_header(writer, dims, multi_point.points().count())?;
             for pt in multi_point.points() {
                 invoke_scalar(&pt, writer)?;
             }
         }
 
         geo_traits::GeometryType::LineString(ls) => {
-            write_wkb_linestring_header(writer, dims, ls.coords().count())
-                .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+            write_wkb_linestring_header(writer, dims, ls.coords().count())?;
             write_reversed_coords(writer, ls.coords())?;
         }
 
         geo_traits::GeometryType::Polygon(pgn) => {
             let num_rings = pgn.interiors().count() + pgn.exterior().is_some() as usize;
-            write_wkb_polygon_header(writer, dims, num_rings)
-                .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+            write_wkb_polygon_header(writer, dims, num_rings)?;
 
             if let Some(exterior) = pgn.exterior() {
                 write_reversed_ring(writer, exterior)?;
@@ -139,31 +138,28 @@ fn invoke_scalar(geom: &impl GeometryTrait<T = f64>, writer: &mut impl Write) ->
         }
 
         geo_traits::GeometryType::MultiLineString(mls) => {
-            write_wkb_multilinestring_header(writer, dims, mls.line_strings().count())
-                .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+            write_wkb_multilinestring_header(writer, dims, mls.line_strings().count())?;
             for ls in mls.line_strings() {
                 invoke_scalar(&ls, writer)?;
             }
         }
 
         geo_traits::GeometryType::MultiPolygon(mpgn) => {
-            write_wkb_multipolygon_header(writer, dims, mpgn.polygons().count())
-                .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+            write_wkb_multipolygon_header(writer, dims, mpgn.polygons().count())?;
             for pgn in mpgn.polygons() {
                 invoke_scalar(&pgn, writer)?;
             }
         }
 
         geo_traits::GeometryType::GeometryCollection(gcn) => {
-            write_wkb_geometrycollection_header(writer, dims, gcn.geometries().count())
-                .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+            write_wkb_geometrycollection_header(writer, dims, gcn.geometries().count())?;
             for geom in gcn.geometries() {
                 invoke_scalar(&geom, writer)?;
             }
         }
 
         _ => {
-            return Err(DataFusionError::Execution(
+            return Err(SedonaGeometryError::Invalid(
                 "Unsupported geometry type for reversal operation".to_string(),
             ));
         }
@@ -171,20 +167,22 @@ fn invoke_scalar(geom: &impl GeometryTrait<T = f64>, writer: &mut impl Write) ->
     Ok(())
 }
 
-fn write_reversed_ring(writer: &mut impl Write, ring: impl LineStringTrait<T = f64>) -> Result<()> {
-    write_wkb_polygon_ring_header(writer, ring.coords().count())
-        .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+fn write_reversed_ring(
+    writer: &mut impl Write,
+    ring: impl LineStringTrait<T = f64>,
+) -> Result<(), SedonaGeometryError> {
+    write_wkb_polygon_ring_header(writer, ring.coords().count())?;
     write_reversed_coords(writer, ring.coords())
 }
 
-fn write_reversed_coords<I>(writer: &mut impl Write, coords: I) -> Result<()>
+fn write_reversed_coords<I>(writer: &mut impl Write, coords: I) -> Result<(), SedonaGeometryError>
 where
     I: DoubleEndedIterator,
     I::Item: CoordTrait<T = f64>,
 {
-    coords.rev().try_for_each(|coord| {
-        write_wkb_coord_trait(writer, &coord).map_err(|e| DataFusionError::Execution(e.to_string()))
-    })
+    coords
+        .rev()
+        .try_for_each(|coord| write_wkb_coord_trait(writer, &coord))
 }
 
 #[cfg(test)]

--- a/rust/sedona-functions/src/st_reverse.rs
+++ b/rust/sedona-functions/src/st_reverse.rs
@@ -105,6 +105,8 @@ fn invoke_scalar(geom: &Wkb, writer: &mut impl Write) -> Result<(), SedonaGeomet
     let dims = geom.dim();
     match geom.as_type() {
         geo_traits::GeometryType::Point(_) | geo_traits::GeometryType::MultiPoint(_) => {
+            // Note: in the case of big endian input, this may result in mixed endian output.
+            // Mixed endian output should be handled by all readers but is probably not well tested.
             writer.write_all(geom.buf())?;
         }
 
@@ -117,21 +119,21 @@ fn invoke_scalar(geom: &Wkb, writer: &mut impl Write) -> Result<(), SedonaGeomet
         }
 
         geo_traits::GeometryType::MultiLineString(mls) => {
-            write_wkb_multilinestring_header(writer, dims, mls.line_strings().count())?;
+            write_wkb_multilinestring_header(writer, dims, mls.num_line_strings())?;
             for ls in mls.line_strings() {
                 write_reversed_linestring(writer, ls, dims)?;
             }
         }
 
         geo_traits::GeometryType::MultiPolygon(mpgn) => {
-            write_wkb_multipolygon_header(writer, dims, mpgn.polygons().count())?;
+            write_wkb_multipolygon_header(writer, dims, mpgn.num_polygons())?;
             for pgn in mpgn.polygons() {
                 write_reversed_polygon(writer, pgn, dims)?;
             }
         }
 
         geo_traits::GeometryType::GeometryCollection(gcn) => {
-            write_wkb_geometrycollection_header(writer, dims, gcn.geometries().count())?;
+            write_wkb_geometrycollection_header(writer, dims, gcn.num_geometries())?;
             for geom in gcn.geometries() {
                 invoke_scalar(geom, writer)?;
             }
@@ -151,7 +153,7 @@ fn write_reversed_linestring(
     ls: &wkb::reader::LineString,
     dims: Dimensions,
 ) -> Result<(), SedonaGeometryError> {
-    write_wkb_linestring_header(writer, dims, ls.coords().count())?;
+    write_wkb_linestring_header(writer, dims, ls.num_coords())?;
     write_reversed_coords(writer, ls.coords_slice(), dims.size(), ls.byte_order())?;
     Ok(())
 }
@@ -161,7 +163,7 @@ fn write_reversed_polygon(
     pgn: &wkb::reader::Polygon,
     dims: Dimensions,
 ) -> Result<(), SedonaGeometryError> {
-    let num_rings = pgn.interiors().count() + pgn.exterior().is_some() as usize;
+    let num_rings = pgn.num_interiors() + pgn.exterior().is_some() as usize;
     write_wkb_polygon_header(writer, dims, num_rings)?;
 
     if let Some(exterior) = pgn.exterior() {
@@ -180,7 +182,7 @@ fn write_reversed_ring(
     ring: &wkb::reader::LinearRing,
     dim_size: usize,
 ) -> Result<(), SedonaGeometryError> {
-    write_wkb_polygon_ring_header(writer, ring.coords().count())?;
+    write_wkb_polygon_ring_header(writer, ring.num_coords())?;
     write_reversed_coords(writer, ring.coords_slice(), dim_size, ring.byte_order())
 }
 
@@ -191,15 +193,10 @@ fn write_reversed_coords(
     endianness: Endianness,
 ) -> Result<(), SedonaGeometryError> {
     let coord_bytes = dim_size * size_of::<f64>();
-
-    #[cfg(target_endian = "little")]
     let needs_byteswap = matches!(endianness, Endianness::BigEndian);
 
-    #[cfg(target_endian = "big")]
-    let needs_byteswap = matches!(endianness, Endianness::LittleEndian);
-
     if needs_byteswap {
-        let mut ord_reversed = [0u8; 8];
+        let mut ord_reversed = [0u8; size_of::<f64>()];
         for coord in coords.rchunks_exact(coord_bytes) {
             for ord in coord.chunks_exact(size_of::<f64>()) {
                 ord_reversed.copy_from_slice(ord);

--- a/rust/sedona-functions/src/st_reverse.rs
+++ b/rust/sedona-functions/src/st_reverse.rs
@@ -22,13 +22,14 @@ use arrow_array::builder::BinaryBuilder;
 use datafusion_common::{exec_datafusion_err, Result};
 use datafusion_expr::ColumnarValue;
 use datafusion_expr::Volatility;
+use geo_traits::Dimensions;
 use geo_traits::{
     CoordTrait, GeometryCollectionTrait, GeometryTrait, LineStringTrait, MultiLineStringTrait,
     MultiPointTrait, MultiPolygonTrait, PointTrait, PolygonTrait,
 };
 use sedona_expr::item_crs::ItemCrsKernel;
-use sedona_geometry::error::SedonaGeometryError;
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
+use sedona_geometry::error::SedonaGeometryError;
 use sedona_geometry::wkb_factory::{
     write_wkb_coord_trait, write_wkb_empty_point, write_wkb_geometrycollection_header,
     write_wkb_linestring_header, write_wkb_multilinestring_header, write_wkb_multipoint_header,
@@ -39,6 +40,7 @@ use sedona_schema::{
     datatypes::{SedonaType, WKB_GEOGRAPHY, WKB_GEOMETRY},
     matchers::ArgMatcher,
 };
+use wkb::reader::Wkb;
 
 use crate::executor::WkbExecutor;
 
@@ -97,64 +99,39 @@ impl SedonaScalarKernel for STReverse {
     }
 }
 
-fn invoke_scalar(
-    geom: &impl GeometryTrait<T = f64>,
-    writer: &mut impl Write,
-) -> Result<(), SedonaGeometryError> {
+fn invoke_scalar(geom: &Wkb, writer: &mut impl Write) -> Result<(), SedonaGeometryError> {
     let dims = geom.dim();
     match geom.as_type() {
-        geo_traits::GeometryType::Point(pt) => {
-            if pt.coord().is_some() {
-                write_wkb_point_header(writer, dims)?;
-                write_wkb_coord_trait(writer, &pt.coord().unwrap())?;
-            } else {
-                write_wkb_empty_point(writer, dims)?;
-            }
-        }
-
-        geo_traits::GeometryType::MultiPoint(multi_point) => {
-            write_wkb_multipoint_header(writer, dims, multi_point.points().count())?;
-            for pt in multi_point.points() {
-                invoke_scalar(&pt, writer)?;
-            }
+        geo_traits::GeometryType::Point(_) | geo_traits::GeometryType::MultiPoint(_) => {
+            writer.write_all(geom.buf())?;
         }
 
         geo_traits::GeometryType::LineString(ls) => {
-            write_wkb_linestring_header(writer, dims, ls.coords().count())?;
-            write_reversed_coords(writer, ls.coords())?;
+            write_reversed_linestring(writer, ls, dims)?;
         }
 
         geo_traits::GeometryType::Polygon(pgn) => {
-            let num_rings = pgn.interiors().count() + pgn.exterior().is_some() as usize;
-            write_wkb_polygon_header(writer, dims, num_rings)?;
-
-            if let Some(exterior) = pgn.exterior() {
-                write_reversed_ring(writer, exterior)?;
-            }
-
-            for interior in pgn.interiors() {
-                write_reversed_ring(writer, interior)?;
-            }
+            write_reversed_polygon(writer, pgn, dims)?;
         }
 
         geo_traits::GeometryType::MultiLineString(mls) => {
             write_wkb_multilinestring_header(writer, dims, mls.line_strings().count())?;
             for ls in mls.line_strings() {
-                invoke_scalar(&ls, writer)?;
+                write_reversed_linestring(writer, ls, dims)?;
             }
         }
 
         geo_traits::GeometryType::MultiPolygon(mpgn) => {
             write_wkb_multipolygon_header(writer, dims, mpgn.polygons().count())?;
             for pgn in mpgn.polygons() {
-                invoke_scalar(&pgn, writer)?;
+                write_reversed_polygon(writer, pgn, dims)?;
             }
         }
 
         geo_traits::GeometryType::GeometryCollection(gcn) => {
             write_wkb_geometrycollection_header(writer, dims, gcn.geometries().count())?;
             for geom in gcn.geometries() {
-                invoke_scalar(&geom, writer)?;
+                invoke_scalar(geom, writer)?;
             }
         }
 
@@ -167,22 +144,54 @@ fn invoke_scalar(
     Ok(())
 }
 
-fn write_reversed_ring(
+fn write_reversed_linestring(
     writer: &mut impl Write,
-    ring: impl LineStringTrait<T = f64>,
+    ls: &wkb::reader::LineString,
+    dims: Dimensions,
 ) -> Result<(), SedonaGeometryError> {
-    write_wkb_polygon_ring_header(writer, ring.coords().count())?;
-    write_reversed_coords(writer, ring.coords())
+    write_wkb_linestring_header(writer, dims, ls.coords().count())?;
+    write_reversed_coords(writer, ls.coords_slice(), dims.size())?;
+    Ok(())
 }
 
-fn write_reversed_coords<I>(writer: &mut impl Write, coords: I) -> Result<(), SedonaGeometryError>
-where
-    I: DoubleEndedIterator,
-    I::Item: CoordTrait<T = f64>,
-{
-    coords
-        .rev()
-        .try_for_each(|coord| write_wkb_coord_trait(writer, &coord))
+fn write_reversed_polygon(
+    writer: &mut impl Write,
+    pgn: &wkb::reader::Polygon,
+    dims: Dimensions,
+) -> Result<(), SedonaGeometryError> {
+    let num_rings = pgn.interiors().count() + pgn.exterior().is_some() as usize;
+    write_wkb_polygon_header(writer, dims, num_rings)?;
+
+    if let Some(exterior) = pgn.exterior() {
+        write_reversed_ring(writer, exterior, dims)?;
+    }
+
+    for interior in pgn.interiors() {
+        write_reversed_ring(writer, interior, dims)?;
+    }
+
+    Ok(())
+}
+
+fn write_reversed_ring(
+    writer: &mut impl Write,
+    ring: &wkb::reader::LinearRing,
+    dims: Dimensions,
+) -> Result<(), SedonaGeometryError> {
+    write_wkb_polygon_ring_header(writer, ring.coords().count())?;
+    write_reversed_coords(writer, ring.coords_slice(), dims.size())
+}
+
+fn write_reversed_coords(
+    writer: &mut impl Write,
+    coords: &[u8],
+    dim_size: usize,
+) -> Result<(), SedonaGeometryError> {
+    let coord_bytes = dim_size * size_of::<f64>();
+    for coord in coords.chunks(coord_bytes).rev() {
+        writer.write_all(coord)?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/rust/sedona-functions/src/st_reverse.rs
+++ b/rust/sedona-functions/src/st_reverse.rs
@@ -42,6 +42,7 @@ use sedona_schema::{
     matchers::ArgMatcher,
 };
 use wkb::reader::Wkb;
+use wkb::Endianness;
 
 use crate::executor::WkbExecutor;
 
@@ -151,7 +152,7 @@ fn write_reversed_linestring(
     dims: Dimensions,
 ) -> Result<(), SedonaGeometryError> {
     write_wkb_linestring_header(writer, dims, ls.coords().count())?;
-    write_reversed_coords(writer, ls.coords_slice(), dims.size())?;
+    write_reversed_coords(writer, ls.coords_slice(), dims.size(), ls.byte_order())?;
     Ok(())
 }
 
@@ -164,11 +165,11 @@ fn write_reversed_polygon(
     write_wkb_polygon_header(writer, dims, num_rings)?;
 
     if let Some(exterior) = pgn.exterior() {
-        write_reversed_ring(writer, exterior, dims)?;
+        write_reversed_ring(writer, exterior, dims.size())?;
     }
 
     for interior in pgn.interiors() {
-        write_reversed_ring(writer, interior, dims)?;
+        write_reversed_ring(writer, interior, dims.size())?;
     }
 
     Ok(())
@@ -177,21 +178,41 @@ fn write_reversed_polygon(
 fn write_reversed_ring(
     writer: &mut impl Write,
     ring: &wkb::reader::LinearRing,
-    dims: Dimensions,
+    dim_size: usize,
 ) -> Result<(), SedonaGeometryError> {
     write_wkb_polygon_ring_header(writer, ring.coords().count())?;
-    write_reversed_coords(writer, ring.coords_slice(), dims.size())
+    write_reversed_coords(writer, ring.coords_slice(), dim_size, ring.byte_order())
 }
 
 fn write_reversed_coords(
     writer: &mut impl Write,
     coords: &[u8],
     dim_size: usize,
+    endianness: Endianness,
 ) -> Result<(), SedonaGeometryError> {
     let coord_bytes = dim_size * size_of::<f64>();
-    for coord in coords.chunks(coord_bytes).rev() {
-        writer.write_all(coord)?;
+
+    #[cfg(target_endian = "little")]
+    let needs_byteswap = matches!(endianness, Endianness::BigEndian);
+
+    #[cfg(target_endian = "big")]
+    let needs_byteswap = matches!(endianness, Endianness::LittleEndian);
+
+    if needs_byteswap {
+        let mut ord_reversed = [0u8; 8];
+        for coord in coords.rchunks_exact(coord_bytes) {
+            for ord in coord.chunks_exact(size_of::<f64>()) {
+                ord_reversed.copy_from_slice(ord);
+                ord_reversed.reverse();
+                writer.write_all(&ord_reversed)?;
+            }
+        }
+    } else {
+        for coord in coords.rchunks_exact(coord_bytes) {
+            writer.write_all(coord)?;
+        }
     }
+
     Ok(())
 }
 
@@ -442,6 +463,29 @@ mod tests {
         );
 
         assert_array_equal(&tester.invoke_wkb_array(input_wkt).unwrap(), &expected);
+    }
+
+    #[test]
+    fn udf_big_endian_linestring() {
+        // Big-endian WKB for LINESTRING (1 2, 3 4)
+        #[rustfmt::skip]
+        let big_endian_wkb: &[u8] = &[
+            0x00,                               // big-endian
+            0x00, 0x00, 0x00, 0x02,              // LINESTRING
+            0x00, 0x00, 0x00, 0x02,              // 2 points
+            0x3F, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // x=1.0
+            0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // y=2.0
+            0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // x=3.0
+            0x40, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // y=4.0
+        ];
+
+        let tester = ScalarUdfTester::new(st_reverse_udf().into(), vec![WKB_GEOMETRY.clone()]);
+        let input = Arc::new(arrow_array::BinaryArray::from_vec(vec![big_endian_wkb]));
+        let result = tester.invoke_array(input).unwrap();
+
+        // Result should be LINESTRING (3 4, 1 2) in little-endian WKB
+        let expected = create_array(&[Some("LINESTRING (3 4, 1 2)")], &WKB_GEOMETRY);
+        assert_array_equal(&result, &expected);
     }
 
     #[rstest]

--- a/rust/sedona-functions/src/st_reverse.rs
+++ b/rust/sedona-functions/src/st_reverse.rs
@@ -24,17 +24,18 @@ use datafusion_expr::ColumnarValue;
 use datafusion_expr::Volatility;
 use geo_traits::Dimensions;
 use geo_traits::{
-    CoordTrait, GeometryCollectionTrait, GeometryTrait, LineStringTrait, MultiLineStringTrait,
-    MultiPointTrait, MultiPolygonTrait, PointTrait, PolygonTrait,
+    GeometryCollectionTrait, GeometryTrait, LineStringTrait, MultiLineStringTrait,
+    MultiPolygonTrait, PolygonTrait,
 };
 use sedona_expr::item_crs::ItemCrsKernel;
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
-use sedona_geometry::error::SedonaGeometryError;
-use sedona_geometry::wkb_factory::{
-    write_wkb_coord_trait, write_wkb_empty_point, write_wkb_geometrycollection_header,
-    write_wkb_linestring_header, write_wkb_multilinestring_header, write_wkb_multipoint_header,
-    write_wkb_multipolygon_header, write_wkb_point_header, write_wkb_polygon_header,
-    write_wkb_polygon_ring_header, WKB_MIN_PROBABLE_BYTES,
+use sedona_geometry::{
+    error::SedonaGeometryError,
+    wkb_factory::{
+        write_wkb_geometrycollection_header, write_wkb_linestring_header,
+        write_wkb_multilinestring_header, write_wkb_multipolygon_header, write_wkb_polygon_header,
+        write_wkb_polygon_ring_header, WKB_MIN_PROBABLE_BYTES,
+    },
 };
 use sedona_schema::{
     datatypes::{SedonaType, WKB_GEOGRAPHY, WKB_GEOMETRY},


### PR DESCRIPTION
Not earth shattering, but does close out an open issue and is a better pattern to draw on for functions that are just shuffling input:

```
native-st_reverse-Array(Polygon(10))
                        time:   [8.3201 ms 8.3812 ms 8.4411 ms]
                        change: [−25.012% −24.416% −23.844%] (p = 0.00 < 0.05)
                        Performance has improved.

native-st_reverse-Array(MultiPoint(10))
                        time:   [3.2412 ms 3.2675 ms 3.2948 ms]
                        change: [−83.572% −83.426% −83.278%] (p = 0.00 < 0.05)
                        Performance has improved.
```

This is faster because it (1) only shuffles bytes (no decoding into f64) and (2) for multipoint/point, just copies bytes.

Closes #377.