### PR TITLE
refactor(raster): drop data()/contiguous_data() from Raster interface

### DIFF
--- a/rust/sedona-raster-functions/src/rs_ensure_loaded.rs
+++ b/rust/sedona-raster-functions/src/rs_ensure_loaded.rs
@@ -359,13 +359,13 @@ where
                     // boundary rejects non-identity views — but guard it loudly
                     // so that when views land this surfaces as the internal gap
                     // it is, not a confusing downstream error. Fixed alongside
-                    // the zero-copy view-preserving passthrough
-                    // (apache/sedona-db#894 + #897).
+                    // https://github.com/apache/sedona-db/pull/894
+                    // https://github.com/apache/sedona-db/pull/897
                     if !view_is_identity(&view_owned, &source_shape) {
                         return sedona_internal_err!(
                             "RS_EnsureLoaded: InDb band ({raster_idx},{band_idx}) has a \
                              non-identity view; view-preserving passthrough is not \
-                             implemented yet (apache/sedona-db#897)"
+                             implemented yet"
                         );
                     }
                     let bytes = band

--- a/rust/sedona-raster-functions/src/rs_ensure_loaded.rs
+++ b/rust/sedona-raster-functions/src/rs_ensure_loaded.rs
@@ -341,8 +341,8 @@ where
                 let outdb_format: Option<String> = band.outdb_format().map(|s| s.to_string());
                 // For InDb bands, copy bytes into an owned Buffer.
                 // `Buffer::from_vec` is zero-copy ownership transfer of
-                // the Vec; the per-row clone of `band.data()` itself is
-                // the one InDb copy we accept for sequential simplicity.
+                // the Vec; the per-row clone of the band's contiguous bytes
+                // is the one InDb copy we accept for sequential simplicity.
                 //
                 // This passthrough copy (and the equivalent re-copy of
                 // freshly-loaded OutDb bytes through the builder) goes
@@ -351,7 +351,34 @@ where
                 // as a `BinaryViewArray` row. Tracked in
                 // https://github.com/apache/sedona-db/issues/894.
                 let indb_bytes: Option<Buffer> = if band.is_indb() {
-                    Some(Buffer::from_vec(band.data().to_vec()))
+                    // A non-identity view can't be passed through yet: the
+                    // rebuild via `start_band_nd` below emits an identity band,
+                    // so the view would be silently dropped (and a contiguous
+                    // outer-slice would trip the source-byte-count check with a
+                    // misleading message). Unreachable today — the read
+                    // boundary rejects non-identity views — but guard it loudly
+                    // so that when views land this surfaces as the internal gap
+                    // it is, not a confusing downstream error. Fixed alongside
+                    // the zero-copy view-preserving passthrough
+                    // (apache/sedona-db#894 + #897).
+                    if !view_is_identity(&view_owned, &source_shape) {
+                        return sedona_internal_err!(
+                            "RS_EnsureLoaded: InDb band ({raster_idx},{band_idx}) has a \
+                             non-identity view; view-preserving passthrough is not \
+                             implemented yet (apache/sedona-db#897)"
+                        );
+                    }
+                    let bytes = band
+                        .nd_buffer()
+                        .and_then(|ndb| ndb.as_contiguous())
+                        .map(|b| b.to_vec())
+                        .map_err(|e| {
+                            sedona_internal_datafusion_err!(
+                                "RS_EnsureLoaded: InDb band ({raster_idx},{band_idx}) \
+                                 bytes unavailable: {e}"
+                            )
+                        })?;
+                    Some(Buffer::from_vec(bytes))
                 } else {
                     None
                 };
@@ -640,7 +667,10 @@ mod tests {
         let r = out_rasters.get(0).unwrap();
         let band = r.band(0).unwrap();
         // Loader filled 6 bytes (2 × 3 × UInt8) with the (i % 251) pattern.
-        assert_eq!(band.data(), &[0, 1, 2, 3, 4, 5]);
+        assert_eq!(
+            band.nd_buffer().unwrap().as_contiguous().unwrap(),
+            &[0, 1, 2, 3, 4, 5]
+        );
         // outdb_uri / outdb_format are preserved as provenance.
         assert_eq!(band.outdb_uri(), Some("file:///tmp/foo.tif"));
         assert_eq!(band.outdb_format(), Some("mock"));
@@ -671,7 +701,7 @@ mod tests {
         let out_rasters = RasterStructArray::new(out_struct);
         let r = out_rasters.get(0).unwrap();
         let band = r.band(0).unwrap();
-        assert_eq!(band.data(), &pixels);
+        assert_eq!(band.nd_buffer().unwrap().as_contiguous().unwrap(), &pixels);
 
         // Loader was never called.
         assert!(loader.seen.lock().unwrap().is_empty());

--- a/rust/sedona-raster-functions/src/rs_setsrid.rs
+++ b/rust/sedona-raster-functions/src/rs_setsrid.rs
@@ -543,7 +543,10 @@ mod tests {
             for band_idx in 0..orig_bands.len() {
                 let orig_band = orig_bands.band(band_idx + 1).unwrap();
                 let mod_band = mod_bands.band(band_idx + 1).unwrap();
-                assert_eq!(orig_band.data(), mod_band.data());
+                assert_eq!(
+                    orig_band.nd_buffer().unwrap().as_contiguous().unwrap(),
+                    mod_band.nd_buffer().unwrap().as_contiguous().unwrap()
+                );
                 assert_eq!(
                     orig_band.metadata().data_type().unwrap(),
                     mod_band.metadata().data_type().unwrap()

--- a/rust/sedona-raster-gdal/src/gdal_common.rs
+++ b/rust/sedona-raster-gdal/src/gdal_common.rs
@@ -243,8 +243,7 @@ pub unsafe fn raster_ref_to_gdal_mem<R: RasterRef + ?Sized>(
         // view); GDAL holds the pointer, so `raster` must outlive the dataset.
         let band_bytes = band
             .nd_buffer()
-            .and_then(|ndb| ndb.as_contiguous())
-            .map_err(|e| arrow_datafusion_err!(e))?;
+            .and_then(|ndb| ndb.as_contiguous())?;
         let data_ptr: *const u8 = band_bytes.as_ptr();
         unsafe {
             mem_ds_builder = mem_ds_builder.add_band(gdal_type, data_ptr as *mut u8);

--- a/rust/sedona-raster-gdal/src/gdal_common.rs
+++ b/rust/sedona-raster-gdal/src/gdal_common.rs
@@ -223,7 +223,7 @@ pub unsafe fn raster_ref_to_gdal_mem<R: RasterRef + ?Sized>(
             .band(src_band_index)
             .map_err(|e| arrow_datafusion_err!(e))?;
 
-        if !band.is_2d() {
+        if !band.is_spatial_2d() {
             return exec_err!(
                 "GDAL backend requires a 2-dim band; got dim_names={:?}",
                 band.dim_names()
@@ -239,8 +239,13 @@ pub unsafe fn raster_ref_to_gdal_mem<R: RasterRef + ?Sized>(
         let band_metadata = band.metadata();
         let band_type = band_metadata.data_type()?;
         let gdal_type = band_data_type_to_gdal(&band_type);
-        let band_data = band.data();
-        let data_ptr = band_data.as_ptr();
+        // `as_contiguous()` borrows the bytes zero-copy (erroring on a strided
+        // view); GDAL holds the pointer, so `raster` must outlive the dataset.
+        let band_bytes = band
+            .nd_buffer()
+            .and_then(|ndb| ndb.as_contiguous())
+            .map_err(|e| arrow_datafusion_err!(e))?;
+        let data_ptr: *const u8 = band_bytes.as_ptr();
         unsafe {
             mem_ds_builder = mem_ds_builder.add_band(gdal_type, data_ptr as *mut u8);
         }

--- a/rust/sedona-raster-gdal/src/gdal_common.rs
+++ b/rust/sedona-raster-gdal/src/gdal_common.rs
@@ -241,9 +241,7 @@ pub unsafe fn raster_ref_to_gdal_mem<R: RasterRef + ?Sized>(
         let gdal_type = band_data_type_to_gdal(&band_type);
         // `as_contiguous()` borrows the bytes zero-copy (erroring on a strided
         // view); GDAL holds the pointer, so `raster` must outlive the dataset.
-        let band_bytes = band
-            .nd_buffer()
-            .and_then(|ndb| ndb.as_contiguous())?;
+        let band_bytes = band.nd_buffer().and_then(|ndb| ndb.as_contiguous())?;
         let data_ptr: *const u8 = band_bytes.as_ptr();
         unsafe {
             mem_ds_builder = mem_ds_builder.add_band(gdal_type, data_ptr as *mut u8);

--- a/rust/sedona-raster-gdal/src/gdal_dataset_provider.rs
+++ b/rust/sedona-raster-gdal/src/gdal_dataset_provider.rs
@@ -261,7 +261,7 @@ impl GDALDatasetCache {
         for i in 1..=num_bands {
             let band = bands.band(i).map_err(|e| arrow_datafusion_err!(e))?;
 
-            if !band.is_2d() {
+            if !band.is_spatial_2d() {
                 return exec_err!(
                     "GDAL backend requires 2-dim bands; got dim_names={:?}",
                     band.dim_names()

--- a/rust/sedona-raster-gdal/src/utils.rs
+++ b/rust/sedona-raster-gdal/src/utils.rs
@@ -334,7 +334,10 @@ mod tests {
         assert_eq!(band.metadata().storage_type().unwrap(), StorageType::InDb);
         assert_eq!(band.metadata().data_type().unwrap(), BandDataType::UInt8);
         assert_eq!(band.metadata().nodata_value().unwrap(), [255u8]);
-        assert_eq!(band.data(), [1u8, 2, 3, 4, 5, 6]);
+        assert_eq!(
+            band.nd_buffer().unwrap().as_contiguous().unwrap(),
+            [1u8, 2, 3, 4, 5, 6]
+        );
     }
 
     #[test]
@@ -435,7 +438,10 @@ mod tests {
         );
 
         let pixels: Vec<u64> = band
-            .data()
+            .nd_buffer()
+            .unwrap()
+            .as_contiguous()
+            .unwrap()
             .chunks_exact(8)
             .map(|chunk| u64::from_le_bytes(chunk.try_into().unwrap()))
             .collect();
@@ -467,7 +473,10 @@ mod tests {
         );
 
         let pixels: Vec<i64> = band
-            .data()
+            .nd_buffer()
+            .unwrap()
+            .as_contiguous()
+            .unwrap()
             .chunks_exact(8)
             .map(|chunk| i64::from_le_bytes(chunk.try_into().unwrap()))
             .collect();
@@ -499,7 +508,10 @@ mod tests {
         );
 
         let pixels: Vec<u16> = band
-            .data()
+            .nd_buffer()
+            .unwrap()
+            .as_contiguous()
+            .unwrap()
             .chunks_exact(2)
             .map(|chunk| u16::from_le_bytes(chunk.try_into().unwrap()))
             .collect();
@@ -528,12 +540,18 @@ mod tests {
         assert_eq!(band1.metadata().storage_type().unwrap(), StorageType::InDb);
         assert_eq!(band1.metadata().data_type().unwrap(), BandDataType::UInt8);
         assert_eq!(band1.metadata().nodata_value().unwrap(), [255u8]);
-        assert_eq!(band1.data(), [10u8, 11, 12, 13]);
+        assert_eq!(
+            band1.nd_buffer().unwrap().as_contiguous().unwrap(),
+            [10u8, 11, 12, 13]
+        );
 
         assert_eq!(band2.metadata().storage_type().unwrap(), StorageType::InDb);
         assert_eq!(band2.metadata().data_type().unwrap(), BandDataType::UInt8);
         assert_eq!(band2.metadata().nodata_value().unwrap(), [255u8]);
-        assert_eq!(band2.data(), [100u8, 0, 200, 0]);
+        assert_eq!(
+            band2.nd_buffer().unwrap().as_contiguous().unwrap(),
+            [100u8, 0, 200, 0]
+        );
     }
 
     #[test]
@@ -553,12 +571,18 @@ mod tests {
         assert_eq!(band1.metadata().storage_type().unwrap(), StorageType::InDb);
         assert_eq!(band1.metadata().data_type().unwrap(), BandDataType::UInt8);
         assert_eq!(band1.metadata().nodata_value().unwrap(), [0u8]);
-        assert_eq!(band1.data(), [10u8, 11, 12, 13]);
+        assert_eq!(
+            band1.nd_buffer().unwrap().as_contiguous().unwrap(),
+            [10u8, 11, 12, 13]
+        );
 
         assert_eq!(band2.metadata().storage_type().unwrap(), StorageType::InDb);
         assert_eq!(band2.metadata().data_type().unwrap(), BandDataType::UInt8);
         assert_eq!(band2.metadata().nodata_value().unwrap(), [255u8]);
-        assert_eq!(band2.data(), [100u8, 0, 200, 0]);
+        assert_eq!(
+            band2.nd_buffer().unwrap().as_contiguous().unwrap(),
+            [100u8, 0, 200, 0]
+        );
     }
 
     #[test]

--- a/rust/sedona-raster/src/array.rs
+++ b/rust/sedona-raster/src/array.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::borrow::Cow;
-
 use arrow_array::{
     Array, BinaryArray, BinaryViewArray, Float64Array, Int64Array, ListArray, StringArray,
     StringViewArray, StructArray, UInt32Array, UInt64Array,
@@ -85,17 +83,6 @@ impl<'a> BandRef for BandRefImpl<'a> {
         self.data_type
     }
 
-    fn data(&self) -> &[u8] {
-        // Pre-N-D compatibility surface. Identity-view InDb bands → the
-        // row-major in-line buffer (zero-copy borrow into the StructArray),
-        // matching the pre-N-D behavior exactly. OutDb → `&[]` from the
-        // empty `data` column, no panic. Non-identity views never reach
-        // here — `RasterRefImpl::band()` rejects them upstream so the
-        // raw column bytes always equal the visible bytes for any band
-        // this reader produces.
-        self.data_array.value(self.band_row)
-    }
-
     fn nodata(&self) -> Option<&[u8]> {
         if self.nodata_array.is_null(self.band_row) {
             None
@@ -141,19 +128,6 @@ impl<'a> BandRef for BandRefImpl<'a> {
             offset: self.byte_offset,
             data_type: self.data_type,
         })
-    }
-
-    fn contiguous_data(&self) -> Result<Cow<'_, [u8]>, ArrowError> {
-        if !self.is_indb() {
-            return Err(ArrowError::NotYetImplemented(
-                "OutDb byte access via contiguous_data() is not yet implemented; \
-                 backend-specific OutDb resolvers are tracked separately"
-                    .to_string(),
-            ));
-        }
-        // Identity-view only today, so the data buffer is already row-major
-        // over the visible region.
-        Ok(Cow::Borrowed(self.data_array.value(self.band_row)))
     }
 }
 
@@ -678,8 +652,11 @@ mod tests {
 
         // Access band with 1-based band_number
         let band = bands.band(1).unwrap();
-        assert_eq!(band.data().len(), 100);
-        assert_eq!(band.data()[0], 1u8);
+        assert_eq!(
+            band.nd_buffer().unwrap().as_contiguous().unwrap().len(),
+            100
+        );
+        assert_eq!(band.nd_buffer().unwrap().as_contiguous().unwrap()[0], 1u8);
 
         let band_meta = band.metadata();
         assert_eq!(band_meta.storage_type().unwrap(), StorageType::InDb);
@@ -743,7 +720,13 @@ mod tests {
             // Access band with 1-based band_number
             let band = bands.band(i + 1).unwrap();
             let expected_value = i as u8;
-            assert!(band.data().iter().all(|&x| x == expected_value));
+            assert!(band
+                .nd_buffer()
+                .unwrap()
+                .as_contiguous()
+                .unwrap()
+                .iter()
+                .all(|&x| x == expected_value));
         }
 
         // Test array
@@ -752,8 +735,11 @@ mod tests {
             .enumerate()
             .map(|(i, band)| {
                 let band = band.unwrap();
-                assert_eq!(band.data()[0], i as u8);
-                band.data()[0]
+                assert_eq!(
+                    band.nd_buffer().unwrap().as_contiguous().unwrap()[0],
+                    i as u8
+                );
+                band.nd_buffer().unwrap().as_contiguous().unwrap()[0]
             })
             .collect();
 
@@ -1043,17 +1029,32 @@ mod tests {
         assert_eq!(r0.num_bands(), 3);
         assert_eq!(r0.band(0).unwrap().shape(), &[3]);
         assert_eq!(
-            &*r0.band(0).unwrap().contiguous_data().unwrap(),
+            r0.band(0)
+                .unwrap()
+                .nd_buffer()
+                .unwrap()
+                .as_contiguous()
+                .unwrap(),
             &[10u8, 20, 30]
         );
         assert_eq!(r0.band(1).unwrap().shape(), &[3]);
         assert_eq!(
-            &*r0.band(1).unwrap().contiguous_data().unwrap(),
+            r0.band(1)
+                .unwrap()
+                .nd_buffer()
+                .unwrap()
+                .as_contiguous()
+                .unwrap(),
             &[40u8, 50, 60]
         );
         assert_eq!(r0.band(2).unwrap().shape(), &[3]);
         assert_eq!(
-            &*r0.band(2).unwrap().contiguous_data().unwrap(),
+            r0.band(2)
+                .unwrap()
+                .nd_buffer()
+                .unwrap()
+                .as_contiguous()
+                .unwrap(),
             &[100u8, 101, 102]
         );
 
@@ -1061,12 +1062,22 @@ mod tests {
         assert_eq!(r1.num_bands(), 2);
         assert_eq!(r1.band(0).unwrap().shape(), &[4]);
         assert_eq!(
-            &*r1.band(0).unwrap().contiguous_data().unwrap(),
+            r1.band(0)
+                .unwrap()
+                .nd_buffer()
+                .unwrap()
+                .as_contiguous()
+                .unwrap(),
             &[42u8, 43, 44, 45]
         );
         assert_eq!(r1.band(1).unwrap().shape(), &[4]);
         assert_eq!(
-            &*r1.band(1).unwrap().contiguous_data().unwrap(),
+            r1.band(1)
+                .unwrap()
+                .nd_buffer()
+                .unwrap()
+                .as_contiguous()
+                .unwrap(),
             &[1u8, 2, 3, 4]
         );
 

--- a/rust/sedona-raster/src/builder.rs
+++ b/rust/sedona-raster/src/builder.rs
@@ -687,7 +687,6 @@ mod tests {
     use arrow_ipc::writer::StreamWriter;
     use arrow_schema::Schema;
     use sedona_schema::raster::StorageType;
-    use std::borrow::Cow;
     use std::io::Cursor;
 
     #[test]
@@ -747,8 +746,11 @@ mod tests {
 
         // Access band with 1-based band_number
         let band = bands.band(1).unwrap();
-        assert_eq!(band.data().len(), 100);
-        assert_eq!(band.data()[0], 1u8);
+        assert_eq!(
+            band.nd_buffer().unwrap().as_contiguous().unwrap().len(),
+            100
+        );
+        assert_eq!(band.nd_buffer().unwrap().as_contiguous().unwrap()[0], 1u8);
 
         let band_meta = band.metadata();
         assert_eq!(band_meta.storage_type().unwrap(), StorageType::InDb);
@@ -812,7 +814,13 @@ mod tests {
             // Access band with 1-based band_number
             let band = bands.band(i + 1).unwrap();
             let expected_value = i as u8;
-            assert!(band.data().iter().all(|&x| x == expected_value));
+            assert!(band
+                .nd_buffer()
+                .unwrap()
+                .as_contiguous()
+                .unwrap()
+                .iter()
+                .all(|&x| x == expected_value));
         }
 
         // Test iterator
@@ -821,8 +829,11 @@ mod tests {
             .enumerate()
             .map(|(i, band)| {
                 let band = band.unwrap();
-                assert_eq!(band.data()[0], i as u8);
-                band.data()[0]
+                assert_eq!(
+                    band.nd_buffer().unwrap().as_contiguous().unwrap()[0],
+                    i as u8
+                );
+                band.nd_buffer().unwrap().as_contiguous().unwrap()[0]
             })
             .collect();
 
@@ -913,7 +924,15 @@ mod tests {
         let target_band_meta = target_band.metadata();
         assert_eq!(target_band_meta.data_type().unwrap(), BandDataType::UInt16);
         assert!(target_band_meta.nodata_value().is_none());
-        assert_eq!(target_band.data().len(), 2016); // 1008 * 2 bytes per u16
+        assert_eq!(
+            target_band
+                .nd_buffer()
+                .unwrap()
+                .as_contiguous()
+                .unwrap()
+                .len(),
+            2016
+        ); // 1008 * 2 bytes per u16
 
         let result = target_raster.bands().band(0);
         assert!(result.is_err(), "Band number 0 should be invalid");
@@ -1112,7 +1131,7 @@ mod tests {
         assert_eq!(indb_metadata.data_type().unwrap(), BandDataType::UInt8);
         assert!(indb_metadata.outdb_url().is_none());
         assert!(indb_metadata.outdb_band_id().is_none());
-        assert_eq!(indb_band.data().len(), 100);
+        assert!(indb_band.is_indb());
 
         // Test OutDbRef band
         let outdb_band = bands.band(2).unwrap();
@@ -1127,7 +1146,7 @@ mod tests {
             "s3://mybucket/satellite_image.tif"
         );
         assert_eq!(outdb_metadata.outdb_band_id().unwrap(), 2);
-        assert_eq!(outdb_band.data().len(), 0); // Empty data for OutDbRef
+        assert!(!outdb_band.is_indb());
     }
 
     #[test]
@@ -1182,7 +1201,10 @@ mod tests {
         let result = bands.band(1);
         assert!(result.is_ok());
         let band = result.unwrap();
-        assert_eq!(band.data().len(), 100);
+        assert_eq!(
+            band.nd_buffer().unwrap().as_contiguous().unwrap().len(),
+            100
+        );
     }
 
     #[test]
@@ -1227,7 +1249,10 @@ mod tests {
         assert_eq!(band.shape(), &[20, 10]);
         assert_eq!(band.data_type(), BandDataType::UInt8);
         assert_eq!(band.nodata(), Some(&[255u8][..]));
-        assert_eq!(band.contiguous_data().unwrap().len(), 200);
+        assert_eq!(
+            band.nd_buffer().unwrap().as_contiguous().unwrap().len(),
+            200
+        );
     }
 
     #[test]
@@ -1478,7 +1503,7 @@ mod tests {
     }
 
     #[test]
-    fn test_contiguous_data_is_borrowed() {
+    fn test_as_contiguous_borrows_identity_view() {
         let mut builder = RasterBuilder::new(1);
         builder
             .start_raster_2d(4, 4, 0.0, 0.0, 1.0, -1.0, 0.0, 0.0, None)
@@ -1493,9 +1518,11 @@ mod tests {
         let r = rasters.get(0).unwrap();
         let band = r.band(0).unwrap();
 
-        let data = band.contiguous_data().unwrap();
-        // Identity-view bands are always contiguous, so should be Cow::Borrowed
-        assert!(matches!(data, Cow::Borrowed(_)));
+        let ndb = band.nd_buffer().unwrap();
+        // Identity-view bands are always contiguous, so as_contiguous borrows
+        // the underlying bytes zero-copy rather than erroring.
+        assert!(ndb.is_contiguous());
+        let data = ndb.as_contiguous().unwrap();
         assert_eq!(data.len(), 16);
     }
 
@@ -1734,7 +1761,7 @@ mod tests {
     }
 
     #[test]
-    fn test_contiguous_data_identity_via_start_band_is_borrowed() {
+    fn test_as_contiguous_identity_via_start_band_borrows() {
         // Canonical identity: the row's view list is null, and the read path
         // synthesises the identity view. Should still hand the underlying
         // bytes back without copying.
@@ -1771,10 +1798,8 @@ mod tests {
         let buf = band.nd_buffer().unwrap();
         assert_eq!(buf.strides, &[3, 1]);
         assert_eq!(buf.offset, 0);
-
-        let bytes = band.contiguous_data().unwrap();
-        assert!(matches!(bytes, Cow::Borrowed(_)));
-        assert_eq!(&*bytes, pixels.as_slice());
+        assert!(buf.is_contiguous());
+        assert_eq!(buf.as_contiguous().unwrap(), pixels.as_slice());
     }
 
     #[test]

--- a/rust/sedona-raster/src/traits.rs
+++ b/rust/sedona-raster/src/traits.rs
@@ -955,10 +955,6 @@ mod tests {
         }
     }
 
-    // `is_spatial_2d` is a shape/naming predicate — it inspects only
-    // `dim_names`, never the view. View/byte-layout concerns are covered by
-    // the `NdBuffer::is_contiguous` tests below.
-
     #[test]
     fn is_spatial_2d_yx_is_true() {
         let b = band(&["y", "x"], &[4, 5], &[ve(0, 0, 1, 4), ve(1, 0, 1, 5)]);

--- a/rust/sedona-raster/src/traits.rs
+++ b/rust/sedona-raster/src/traits.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::borrow::Cow;
-
 use arrow_schema::ArrowError;
 use sedona_schema::raster::BandDataType;
 
@@ -60,6 +58,64 @@ pub struct NdBuffer<'a> {
     pub strides: Vec<i64>,
     pub offset: u64,
     pub data_type: BandDataType,
+}
+
+impl<'a> NdBuffer<'a> {
+    /// True iff the visible region is packed in C-order (row-major) with no
+    /// gaps — the byte strides equal the canonical innermost-fastest layout
+    /// over `shape`. Offset-agnostic. A strided slice, broadcast, or
+    /// permutation is not contiguous.
+    pub fn is_contiguous(&self) -> bool {
+        if self.shape.len() != self.strides.len() {
+            return false;
+        }
+        // An empty visible region is trivially packed.
+        if self.shape.contains(&0) {
+            return true;
+        }
+        // Expected C-order byte strides, innermost first:
+        // stride[i] == byte_size × Π_{j>i} shape[j].
+        let mut expected = self.data_type.byte_size() as i64;
+        for (&dim, &stride) in self.shape.iter().zip(self.strides.iter()).rev() {
+            if stride != expected {
+                return false;
+            }
+            expected = expected.saturating_mul(dim as i64);
+        }
+        true
+    }
+
+    /// The visible bytes as a packed row-major slice, borrowed zero-copy
+    /// from `buffer`. `Ok` iff [`is_contiguous`](Self::is_contiguous);
+    /// otherwise an error directing the caller to materialize via
+    /// `RS_EnsureContiguous`
+    /// (<https://github.com/apache/sedona-db/issues/899>). Never copies or
+    /// allocates — a strided layout returns an error, it is not materialized
+    /// here.
+    pub fn as_contiguous(&self) -> Result<&'a [u8], ArrowError> {
+        if !self.is_contiguous() {
+            return Err(ArrowError::InvalidArgumentError(format!(
+                "band view is not contiguous (shape {:?}, strides {:?}); \
+                 materialize it with RS_EnsureContiguous before contiguous \
+                 byte access — see https://github.com/apache/sedona-db/issues/899",
+                self.shape, self.strides
+            )));
+        }
+        let elements: u64 = self.shape.iter().product();
+        let len = elements as usize * self.data_type.byte_size();
+        let start = self.offset as usize;
+        let buffer: &'a [u8] = self.buffer;
+        match start.checked_add(len) {
+            Some(end) if end <= buffer.len() => Ok(&buffer[start..end]),
+            _ => Err(ArrowError::ExternalError(Box::new(
+                sedona_common::sedona_internal_datafusion_err!(
+                    "contiguous region [{start}, {start}+{len}) is out of bounds \
+                     for buffer of length {}",
+                    buffer.len()
+                ),
+            ))),
+        }
+    }
 }
 
 /// One per-dimension entry of a band's logical view. Describes how a
@@ -525,31 +581,19 @@ pub trait BandRef {
         self.dim_names().iter().position(|n| *n == name)
     }
 
-    /// True iff this band is shaped exactly like a legacy 2-D raster band:
-    /// `dim_names` is a recognized spatial pair (`["y", "x"]`, `["lat",
-    /// "lon"]`, or `["latitude", "longitude"]`; see [`is_spatial_dim_pair`])
-    /// and the view is the identity over the band's `raw_source_shape` (no
-    /// slice, no broadcast, no permutation).
+    /// True iff this band has a recognized 2-D spatial *shape*: exactly two
+    /// dimensions named as a spatial pair (`["y", "x"]`, `["lat", "lon"]`, or
+    /// `["latitude", "longitude"]`; see [`is_spatial_dim_pair`]).
     ///
-    /// GDAL-backed SQL functions use this to refuse N-D bands cleanly while
-    /// they wait for an MDArray-aware port.
-    fn is_2d(&self) -> bool {
+    /// This is a shape/naming predicate only — it says nothing about the
+    /// band's view or byte layout. Callers that also need the bytes laid out
+    /// contiguously (e.g. the GDAL boundary, which hands GDAL a zero-copy
+    /// pointer) pair this with a contiguity check via `nd_buffer()?` +
+    /// [`NdBuffer::as_contiguous`], which borrows on a contiguous view and
+    /// errors otherwise (pointing the caller at `RS_EnsureContiguous`).
+    fn is_spatial_2d(&self) -> bool {
         let dims = self.dim_names();
-        if dims.len() != 2 || !is_spatial_dim_pair(dims[0], dims[1]) {
-            return false;
-        }
-        let view = self.view();
-        let source_shape = self.raw_source_shape();
-        if view.len() != 2 || source_shape.len() != 2 {
-            return false;
-        }
-        view.iter().enumerate().all(|(i, v)| {
-            v.source_axis as usize == i
-                && v.start == 0
-                && v.step == 1
-                && v.steps >= 0
-                && v.steps as u64 == source_shape[i]
-        })
+        dims.len() == 2 && is_spatial_dim_pair(dims[0], dims[1])
     }
 
     // -- Band metadata --
@@ -631,39 +675,6 @@ pub trait BandRef {
     /// natural C-order byte strides. Strides may be zero (broadcast) or
     /// negative (reverse iteration).
     fn nd_buffer(&self) -> Result<NdBuffer<'_>, ArrowError>;
-
-    /// Contiguous row-major bytes covering the *visible* region. Zero-copy
-    /// (`Cow::Borrowed`) when the view is full identity over a C-order
-    /// source buffer; copies into a new buffer when the view slices,
-    /// broadcasts, or permutes. Most RS_* functions use this.
-    fn contiguous_data(&self) -> Result<Cow<'_, [u8]>, ArrowError>;
-
-    /// Pre-N-D compatibility shim: raw row-major bytes for InDb,
-    /// identity-view bands. Panics on anything else (OutDb, non-identity
-    /// view, or a `contiguous_data` error) — corresponds to main's
-    /// infallible `BandRef::data() -> &[u8]` which only ever ran against
-    /// identity-view InDb bands.
-    fn data(&self) -> &[u8] {
-        // Compatibility shim: returns the same bytes pre-N-D callers expect
-        // from `BandRef::data() -> &[u8]`. Delegates to `contiguous_data()`
-        // so identity-view bands surface the borrowed in-line bytes,
-        // matching the pre-N-D behavior exactly. View-materialized
-        // (`Cow::Owned`) bands can't be returned through `&[u8]` because
-        // the owned `Vec` would die at the end of this call — implementers
-        // that need view-materialized bytes via `data()` must override and
-        // anchor the materialized buffer on `Self`; other consumers should
-        // reach for `contiguous_data()` directly.
-        match self
-            .contiguous_data()
-            .expect("BandRef::data() requires an in-db band with bytes")
-        {
-            Cow::Borrowed(b) => b,
-            Cow::Owned(_) => panic!(
-                "BandRef::data() can't return view-materialized bytes; \
-                 use contiguous_data() for sliced/permuted bands"
-            ),
-        }
-    }
 
     /// Nodata value interpreted as f64.
     ///
@@ -930,10 +941,7 @@ mod tests {
             None
         }
         fn nd_buffer(&self) -> Result<NdBuffer<'_>, ArrowError> {
-            unimplemented!("not used in is_2d tests")
-        }
-        fn contiguous_data(&self) -> Result<Cow<'_, [u8]>, ArrowError> {
-            unimplemented!("not used in is_2d tests")
+            unimplemented!("not used in is_spatial_2d tests")
         }
     }
 
@@ -947,90 +955,99 @@ mod tests {
         }
     }
 
+    // `is_spatial_2d` is a shape/naming predicate — it inspects only
+    // `dim_names`, never the view. View/byte-layout concerns are covered by
+    // the `NdBuffer::is_contiguous` tests below.
+
     #[test]
-    fn is_2d_identity_yx_is_true() {
+    fn is_spatial_2d_yx_is_true() {
         let b = band(&["y", "x"], &[4, 5], &[ve(0, 0, 1, 4), ve(1, 0, 1, 5)]);
-        assert!(b.is_2d());
+        assert!(b.is_spatial_2d());
     }
 
     #[test]
-    fn is_2d_identity_3d_is_false() {
-        let b = band(
-            &["time", "y", "x"],
-            &[3, 4, 5],
-            &[ve(0, 0, 1, 3), ve(1, 0, 1, 4), ve(2, 0, 1, 5)],
-        );
-        assert!(!b.is_2d());
-    }
-
-    #[test]
-    fn is_2d_identity_1d_is_false() {
-        let b = band(&["x"], &[5], &[ve(0, 0, 1, 5)]);
-        assert!(!b.is_2d());
-    }
-
-    #[test]
-    fn is_2d_yx_with_slice_view_is_false() {
-        // Same dim_names but the y-axis is sliced — view is not the identity.
-        let b = band(&["y", "x"], &[4, 5], &[ve(0, 1, 1, 2), ve(1, 0, 1, 5)]);
-        assert!(!b.is_2d());
-    }
-
-    #[test]
-    fn is_2d_yx_with_step_two_is_false() {
-        let b = band(&["y", "x"], &[4, 5], &[ve(0, 0, 2, 2), ve(1, 0, 1, 5)]);
-        assert!(!b.is_2d());
-    }
-
-    #[test]
-    fn is_2d_yx_with_broadcast_is_false() {
-        let b = band(&["y", "x"], &[4, 5], &[ve(0, 0, 0, 4), ve(1, 0, 1, 5)]);
-        assert!(!b.is_2d());
-    }
-
-    #[test]
-    fn is_2d_permuted_xy_is_false() {
-        // dim_names are swapped — not the legacy 2D shape, even though the
-        // view per-axis is the identity.
-        let b = band(&["x", "y"], &[5, 4], &[ve(0, 0, 1, 5), ve(1, 0, 1, 4)]);
-        assert!(!b.is_2d());
-    }
-
-    #[test]
-    fn is_2d_yx_with_transposed_source_axes_is_false() {
-        // dim_names are ["y","x"] but the view permutes the source axes,
-        // so the band exposes y-then-x out of an x-then-y source.
-        let b = band(&["y", "x"], &[5, 4], &[ve(1, 0, 1, 4), ve(0, 0, 1, 5)]);
-        assert!(!b.is_2d());
-    }
-
-    #[test]
-    fn is_2d_identity_latlon_is_true() {
-        // CF-style lat/lon is a recognized spatial pair, so an identity-view
-        // band shaped [lat, lon] is a legacy 2-D raster.
+    fn is_spatial_2d_latlon_is_true() {
         let b = band(&["lat", "lon"], &[4, 5], &[ve(0, 0, 1, 4), ve(1, 0, 1, 5)]);
-        assert!(b.is_2d());
+        assert!(b.is_spatial_2d());
     }
 
     #[test]
-    fn is_2d_identity_latitude_longitude_is_true() {
+    fn is_spatial_2d_latitude_longitude_is_true() {
         let b = band(
             &["latitude", "longitude"],
             &[4, 5],
             &[ve(0, 0, 1, 4), ve(1, 0, 1, 5)],
         );
-        assert!(b.is_2d());
+        assert!(b.is_spatial_2d());
     }
 
     #[test]
-    fn is_2d_unrecognized_dim_names_is_false() {
-        // Names outside the recognized spatial pairs are not legacy 2-D,
-        // even with an identity view.
+    fn is_spatial_2d_3d_is_false() {
+        let b = band(
+            &["time", "y", "x"],
+            &[3, 4, 5],
+            &[ve(0, 0, 1, 3), ve(1, 0, 1, 4), ve(2, 0, 1, 5)],
+        );
+        assert!(!b.is_spatial_2d());
+    }
+
+    #[test]
+    fn is_spatial_2d_1d_is_false() {
+        let b = band(&["x"], &[5], &[ve(0, 0, 1, 5)]);
+        assert!(!b.is_spatial_2d());
+    }
+
+    #[test]
+    fn is_spatial_2d_permuted_xy_is_false() {
+        // ["x","y"] is not a recognized (y-like, x-like) pair.
+        let b = band(&["x", "y"], &[5, 4], &[ve(0, 0, 1, 5), ve(1, 0, 1, 4)]);
+        assert!(!b.is_spatial_2d());
+    }
+
+    #[test]
+    fn is_spatial_2d_unrecognized_dim_names_is_false() {
         let b = band(
             &["northing", "easting"],
             &[4, 5],
             &[ve(0, 0, 1, 4), ve(1, 0, 1, 5)],
         );
-        assert!(!b.is_2d());
+        assert!(!b.is_spatial_2d());
+    }
+
+    /// Build a bufferless `NdBuffer` for contiguity checks — `is_contiguous`
+    /// inspects only shape/strides/data_type, never the bytes.
+    fn ndbuf(shape: &[u64], strides: &[i64], offset: u64) -> NdBuffer<'static> {
+        NdBuffer {
+            buffer: &[],
+            shape: shape.to_vec(),
+            strides: strides.to_vec(),
+            offset,
+            data_type: BandDataType::UInt8,
+        }
+    }
+
+    #[test]
+    fn is_contiguous_packed_identity() {
+        // C-order packed strides for shape [2, 3], byte_size 1.
+        assert!(ndbuf(&[2, 3], &[3, 1], 0).is_contiguous());
+    }
+
+    #[test]
+    fn is_contiguous_packed_with_offset() {
+        // Offset is irrelevant to contiguity — a packed sub-window still
+        // counts (this is the relaxation the GDAL gate relies on).
+        assert!(ndbuf(&[2, 3], &[3, 1], 12).is_contiguous());
+    }
+
+    #[test]
+    fn is_contiguous_strided_is_false() {
+        // Inner stride 2 != byte_size 1 — gaps between elements.
+        assert!(!ndbuf(&[2, 3], &[6, 2], 0).is_contiguous());
+    }
+
+    #[test]
+    fn is_contiguous_broadcast_is_false() {
+        // Zero stride (broadcast) is not packed.
+        assert!(!ndbuf(&[2, 3], &[0, 1], 0).is_contiguous());
     }
 }

--- a/rust/sedona-testing/src/rasters.rs
+++ b/rust/sedona-testing/src/rasters.rs
@@ -475,7 +475,17 @@ pub fn assert_raster_equal(raster1: &impl RasterRef, raster2: &impl RasterRef) {
             "Band outdb band IDs do not match"
         );
 
-        assert_eq!(band1.data(), band2.data(), "Band data does not match");
+        assert_eq!(
+            band1.is_indb(),
+            band2.is_indb(),
+            "Band storage (in/out-db) does not match"
+        );
+        if band1.is_indb() {
+            // Identity-view InDb fixtures: compare the packed visible bytes.
+            let b1 = band1.nd_buffer().unwrap().as_contiguous().unwrap();
+            let b2 = band2.nd_buffer().unwrap().as_contiguous().unwrap();
+            assert_eq!(b1, b2, "Band data does not match");
+        }
     }
 }
 
@@ -513,7 +523,7 @@ mod tests {
             assert_eq!(band_metadata.outdb_url(), None);
             assert_eq!(band_metadata.outdb_band_id(), None);
 
-            let band_data = band.data();
+            let band_data = band.nd_buffer().unwrap().as_contiguous().unwrap();
             let expected_pixel_count = (i + 1) * (i + 2); // width * height
 
             // Convert raw bytes back to u16 values for comparison
@@ -550,7 +560,7 @@ mod tests {
                 let band_metadata = band.metadata();
                 assert_eq!(band_metadata.data_type().unwrap(), BandDataType::UInt8);
                 assert_eq!(band_metadata.storage_type().unwrap(), StorageType::InDb);
-                let band_data = band.data();
+                let band_data = band.nd_buffer().unwrap().as_contiguous().unwrap();
                 assert_eq!(band_data.len(), 64 * 64); // 4096 pixels
             }
         }
@@ -619,7 +629,10 @@ mod tests {
         let b1 = bands.band(1).unwrap();
         assert_eq!(b1.metadata().data_type().unwrap(), BandDataType::UInt8);
         assert_eq!(b1.metadata().nodata_value(), Some(&[255u8][..]));
-        assert_eq!(b1.data(), &[1u8, 2, 3, 4]);
+        assert_eq!(
+            b1.nd_buffer().unwrap().as_contiguous().unwrap(),
+            &[1u8, 2, 3, 4]
+        );
 
         // Band 2: UInt16, nodata=0
         let b2 = bands.band(2).unwrap();


### PR DESCRIPTION
After some discussions with @paleolimbot in some recent raster PRs, we reached the conclusion that we don't want the raster type to do transparent allocations. 

Given this I'm simplifying the raster byte access patterns with this PR to be just the `nd_buffer` method, and eliminating the `data` and `contiguous_data` methods. Instead we added two methods to the NDBuffer trait:

* `is_contiguous`: whether or not the data exported byte the buffer is all contiguous in memory
* `as_contiguous`: returns that buffer as a `Result<&'a [u8], ArrowError>`, throwing an error if the data is not contiguous.

This avoids any transparent allocations. We also expose a `try_contiguous_data` method 

## Drive-by: split `is_2d` into `is_spatial_2d` + a contiguity check

While moving the GDAL boundary off `data()`, I noticed `BandRef::is_2d()` was conflating two unrelated things: whether a band is a 2-D spatial raster (dim count + recognized `y/x`, `lat/lon`, … names) *and* whether its view is the identity (a byte-layout question). The name only advertised the first.

So I split it:

* `is_spatial_2d()` — a pure shape/naming predicate (dims only).
* contiguity is now its own question, answered by `NdBuffer::is_contiguous()` / `try_contiguous_data()`.

The GDAL gate now uses `is_spatial_2d()` for dimensionality and lets `try_contiguous_data()` enforce the byte layout where the bytes are actually read (it errors on a strided view). This also relaxes the old strict-identity requirement to plain contiguity — `is_contiguous()` is offset-agnostic, so a contiguous outer-axis slice is acceptable rather than rejected. Behavior-preserving today, since the read boundary still rejects non-identity views.
