### PR TITLE
refactor(rust/sedona-raster,rust/sedona-schema): source_shape i64 end-to-end (in-memory + Arrow column)

### DIFF
--- a/rust/sedona-raster-functions/src/rs_ensure_loaded.rs
+++ b/rust/sedona-raster-functions/src/rs_ensure_loaded.rs
@@ -133,14 +133,14 @@ fn lookup_loader(
 /// axis maps to the same source axis, full extent, unit step). An empty view
 /// is treated as identity. Used to detect whether a loader returned an
 /// already-resolved (identity) layout we can build directly.
-fn view_is_identity(view: &[ViewEntry], source_shape: &[u64]) -> bool {
+fn view_is_identity(view: &[ViewEntry], source_shape: &[i64]) -> bool {
     view.is_empty()
         || (view.len() == source_shape.len()
             && view.iter().enumerate().all(|(i, v)| {
                 v.source_axis == i as i64
                     && v.start == 0
                     && v.step == 1
-                    && v.steps == source_shape[i] as i64
+                    && v.steps == source_shape[i]
             }))
 }
 
@@ -333,7 +333,7 @@ where
                 })?;
                 let dim_names_owned: Vec<String> =
                     band.dim_names().iter().map(|s| s.to_string()).collect();
-                let source_shape: Vec<u64> = band.raw_source_shape().to_vec();
+                let source_shape: Vec<i64> = band.raw_source_shape().to_vec();
                 // Passed to the loader so it can (eventually) prune I/O; today
                 // every loader ignores it and returns the full source.
                 let view_owned: Vec<ViewEntry> = band.view().to_vec();
@@ -446,16 +446,16 @@ where
                 // surfaces here, not as garbage bytes downstream.
                 let expected_bytes = source_shape
                     .iter()
-                    .try_fold(1u64, |acc, &d| acc.checked_mul(d))
-                    .and_then(|elems| elems.checked_mul(data_type.byte_size() as u64))
+                    .try_fold(1i64, |acc, &d| acc.checked_mul(d))
+                    .and_then(|elems| elems.checked_mul(data_type.byte_size() as i64))
                     .ok_or_else(|| {
                         sedona_internal_datafusion_err!(
                             "RS_EnsureLoaded: band ({raster_idx},{band_idx}) byte count \
-                             overflows u64"
+                             overflows i64"
                         )
                     })?;
                 let got = result.bytes.len();
-                if got as u64 != expected_bytes {
+                if got as i64 != expected_bytes {
                     return sedona_internal_err!(
                         "RS_EnsureLoaded: band ({raster_idx},{band_idx}) expected \
                          {expected_bytes} bytes but loader returned {got}"
@@ -506,7 +506,7 @@ mod tests {
     /// Records load requests and returns a deterministic byte pattern.
     #[derive(Debug, Default)]
     struct RecordingLoader {
-        seen: Mutex<Vec<(String, Vec<u64>, BandDataType)>>,
+        seen: Mutex<Vec<(String, Vec<i64>, BandDataType)>>,
     }
 
     #[async_trait]
@@ -526,7 +526,7 @@ mod tests {
                 req.source_shape.to_vec(),
                 req.data_type,
             ));
-            let elements: u64 = req.source_shape.iter().copied().product();
+            let elements: i64 = req.source_shape.iter().copied().product();
             let len = elements as usize * req.data_type.byte_size();
             // Fill with a recognisable pattern: byte i = (i % 251) as u8.
             let bytes: Vec<u8> = (0..len).map(|i| (i % 251) as u8).collect();
@@ -536,12 +536,12 @@ mod tests {
 
     /// Build a 1-row raster with one OutDb band ready for the loader to
     /// materialise.
-    fn build_outdb_input(uri: &str, format: &str, source_shape: &[u64]) -> StructArray {
+    fn build_outdb_input(uri: &str, format: &str, source_shape: &[i64]) -> StructArray {
         let mut b = RasterBuilder::new(1);
         b.start_raster_nd(
             &[0.0, 1.0, 0.0, 0.0, 0.0, -1.0],
             &["y", "x"],
-            &source_shape.iter().map(|&v| v as i64).collect::<Vec<_>>(),
+            source_shape,
             None,
         )
         .unwrap();
@@ -564,12 +564,12 @@ mod tests {
 
     /// Build a 1-row raster with one InDb band — bytes are inline,
     /// `outdb_uri`/`outdb_format` are null.
-    fn build_indb_input(source_shape: &[u64], data: &[u8]) -> StructArray {
+    fn build_indb_input(source_shape: &[i64], data: &[u8]) -> StructArray {
         let mut b = RasterBuilder::new(1);
         b.start_raster_nd(
             &[0.0, 1.0, 0.0, 0.0, 0.0, -1.0],
             &["y", "x"],
-            &source_shape.iter().map(|&v| v as i64).collect::<Vec<_>>(),
+            source_shape,
             None,
         )
         .unwrap();
@@ -874,7 +874,7 @@ mod tests {
                 &self,
                 req: &RasterLoadRequest<'_>,
             ) -> Result<RasterLoadResult, arrow_schema::ArrowError> {
-                let elements: u64 = req.source_shape.iter().product();
+                let elements: i64 = req.source_shape.iter().product();
                 let len = elements as usize * req.data_type.byte_size();
                 Ok(RasterLoadResult {
                     bytes: Buffer::from_vec(vec![0u8; len]),

--- a/rust/sedona-raster-gdal/src/raster_loader.rs
+++ b/rust/sedona-raster-gdal/src/raster_loader.rs
@@ -166,8 +166,8 @@ impl AsyncRasterLoader for GdalLoader {
         // Byte-cap validation: compute Π source_shape × byte_size in u64
         // with checked arithmetic so a hostile request can't wrap to a
         // small accept-value. Reject before allocating.
-        let expected_bytes_u64 = (req.source_shape[0])
-            .checked_mul(req.source_shape[1])
+        let expected_bytes_u64 = (req.source_shape[0] as u64)
+            .checked_mul(req.source_shape[1] as u64)
             .and_then(|elems| elems.checked_mul(byte_size as u64))
             .ok_or_else(|| {
                 ArrowError::InvalidArgumentError(format!(

--- a/rust/sedona-raster-zarr/src/loader.rs
+++ b/rust/sedona-raster-zarr/src/loader.rs
@@ -174,10 +174,11 @@ impl ZarrChunkReader {
             // discriminator; this reader always emits empty `data` and
             // defers pixel-byte resolution to the raster byte loader.
             let anchor = build_chunk_anchor(&self.group_uri, &info.path, &self.chunk_indices);
+            let source_shape: Vec<i64> = info.chunk_shape.iter().map(|&n| n as i64).collect();
             builder.start_band_nd(
                 Some(info.path.as_str()),
                 &dim_names_ref,
-                &info.chunk_shape,
+                &source_shape,
                 info.data_type,
                 nodata_ref,
                 Some(anchor.as_str()),

--- a/rust/sedona-raster/src/array.rs
+++ b/rust/sedona-raster/src/array.rs
@@ -17,7 +17,7 @@
 
 use arrow_array::{
     Array, BinaryArray, BinaryViewArray, Float64Array, Int64Array, ListArray, StringArray,
-    StringViewArray, StructArray, UInt32Array, UInt64Array,
+    StringViewArray, StructArray, UInt32Array,
 };
 use arrow_schema::ArrowError;
 
@@ -33,7 +33,7 @@ struct BandRefImpl<'a> {
     dim_names_list: &'a ListArray,
     dim_names_values: &'a StringArray,
     source_shape_list: &'a ListArray,
-    source_shape_values: &'a UInt64Array,
+    source_shape_values: &'a Int64Array,
     nodata_array: &'a BinaryArray,
     outdb_uri_array: &'a StringArray,
     outdb_format_array: &'a StringViewArray,
@@ -45,7 +45,7 @@ struct BandRefImpl<'a> {
     /// Per-visible-axis view, length = ndim. Always identity today.
     view_entries: Vec<ViewEntry>,
     /// Visible shape, length = ndim. Equals `source_shape` today.
-    visible_shape: Vec<u64>,
+    visible_shape: Vec<i64>,
     /// Byte strides per visible axis. C-order over `source_shape` today.
     byte_strides: Vec<i64>,
     /// Byte offset into `data` of the visible region's `[0,...,0]` element.
@@ -65,11 +65,11 @@ impl<'a> BandRef for BandRefImpl<'a> {
             .collect()
     }
 
-    fn shape(&self) -> &[u64] {
+    fn shape(&self) -> &[i64] {
         &self.visible_shape
     }
 
-    fn raw_source_shape(&self) -> &[u64] {
+    fn raw_source_shape(&self) -> &[i64] {
         let start = self.source_shape_list.value_offsets()[self.band_row] as usize;
         let end = self.source_shape_list.value_offsets()[self.band_row + 1] as usize;
         &self.source_shape_values.values()[start..end]
@@ -151,7 +151,7 @@ pub struct RasterRefImpl<'a> {
     band_dim_names_list: &'a ListArray,
     band_dim_names_values: &'a StringArray,
     band_source_shape_list: &'a ListArray,
-    band_source_shape_values: &'a UInt64Array,
+    band_source_shape_values: &'a Int64Array,
     band_datatype_array: &'a UInt32Array,
     band_nodata_array: &'a BinaryArray,
     band_view_list: &'a ListArray,
@@ -194,7 +194,7 @@ impl<'a> RasterRef for RasterRefImpl<'a> {
         // Read source shape slice.
         let ss_start = self.band_source_shape_list.value_offsets()[band_row] as usize;
         let ss_end = self.band_source_shape_list.value_offsets()[band_row + 1] as usize;
-        let source_shape: &[u64] = &self.band_source_shape_values.values()[ss_start..ss_end];
+        let source_shape: &[i64] = &self.band_source_shape_values.values()[ss_start..ss_end];
 
         // Reject 0-D bands at the read boundary. Schema doesn't forbid them
         // outright but every consumer assumes ndim >= 1.
@@ -241,17 +241,17 @@ impl<'a> RasterRef for RasterRefImpl<'a> {
                 source_axis: i as i64,
                 start: 0,
                 step: 1,
-                steps: s as i64,
+                steps: s,
             })
             .collect();
 
-        let visible_shape: Vec<u64> = source_shape.to_vec();
+        let visible_shape: Vec<i64> = source_shape.to_vec();
 
         let dtype_size = data_type.byte_size() as i64;
         let mut byte_strides = vec![0i64; source_shape.len()];
         byte_strides[source_shape.len() - 1] = dtype_size;
         for k in (0..source_shape.len() - 1).rev() {
-            byte_strides[k] = byte_strides[k + 1] * (source_shape[k + 1] as i64);
+            byte_strides[k] = byte_strides[k + 1] * source_shape[k + 1];
         }
 
         Ok(Box::new(BandRefImpl {
@@ -386,7 +386,7 @@ pub struct RasterStructArray<'a> {
     band_dim_names_list: &'a ListArray,
     band_dim_names_values: &'a StringArray,
     band_source_shape_list: &'a ListArray,
-    band_source_shape_values: &'a UInt64Array,
+    band_source_shape_values: &'a Int64Array,
     band_datatype_array: &'a UInt32Array,
     band_nodata_array: &'a BinaryArray,
     band_view_list: &'a ListArray,
@@ -472,7 +472,7 @@ impl<'a> RasterStructArray<'a> {
         let band_source_shape_values = band_source_shape_list
             .values()
             .as_any()
-            .downcast_ref::<UInt64Array>()
+            .downcast_ref::<Int64Array>()
             .unwrap();
         let band_datatype_array = bands_struct
             .column(band_indices::DATA_TYPE)
@@ -601,7 +601,7 @@ mod tests {
     use super::*;
     use crate::builder::RasterBuilder;
     use crate::traits::{BandMetadata, RasterMetadata};
-    use arrow_array::{ArrayRef, ListArray, StructArray, UInt32Array, UInt64Array};
+    use arrow_array::{ArrayRef, ListArray, StructArray, UInt32Array};
     use arrow_buffer::{OffsetBuffer, ScalarBuffer};
     use arrow_schema::{DataType, Fields};
     use sedona_schema::raster::{
@@ -871,7 +871,7 @@ mod tests {
         let empty_source_shape = ListArray::new(
             ss_field,
             OffsetBuffer::new(ScalarBuffer::from(vec![0i32, 0])),
-            Arc::new(UInt64Array::from(Vec::<u64>::new())),
+            Arc::new(Int64Array::from(Vec::<i64>::new())),
             None,
         );
         let mutated = replace_band_column(

--- a/rust/sedona-raster/src/builder.rs
+++ b/rust/sedona-raster/src/builder.rs
@@ -18,7 +18,7 @@
 use arrow_array::{
     builder::{
         ArrayBuilder, BinaryBuilder, BinaryViewBuilder, BooleanBuilder, Float64Builder,
-        Int64Builder, StringBuilder, StringViewBuilder, UInt32Builder, UInt64Builder,
+        Int64Builder, StringBuilder, StringViewBuilder, UInt32Builder,
     },
     Array, ArrayRef, BinaryViewArray, ListArray, StructArray,
 };
@@ -98,7 +98,7 @@ pub struct RasterBuilder {
     band_name: StringBuilder,
     band_dim_names_values: StringBuilder,
     band_dim_names_offsets: Vec<i32>,
-    band_shape_values: UInt64Builder,
+    band_shape_values: Int64Builder,
     band_shape_offsets: Vec<i32>,
     band_datatype: UInt32Builder,
     band_nodata: BinaryBuilder,
@@ -130,7 +130,7 @@ pub struct RasterBuilder {
     // finish_raster can check every band matches the top-level spatial grid.
     current_spatial_dims: Vec<String>,
     current_spatial_shape: Vec<i64>,
-    current_raster_bands: Vec<(Vec<String>, Vec<u64>)>,
+    current_raster_bands: Vec<(Vec<String>, Vec<i64>)>,
 
     // Track band_data count at the start of each band for finish_band validation
     band_data_count_at_start: usize,
@@ -159,7 +159,7 @@ impl RasterBuilder {
             band_name: StringBuilder::with_capacity(capacity, capacity),
             band_dim_names_values: StringBuilder::with_capacity(capacity * 2, capacity * 4),
             band_dim_names_offsets: vec![0],
-            band_shape_values: UInt64Builder::with_capacity(capacity * 2),
+            band_shape_values: Int64Builder::with_capacity(capacity * 2),
             band_shape_offsets: vec![0],
             band_datatype: UInt32Builder::with_capacity(capacity),
             band_nodata: BinaryBuilder::with_capacity(capacity, capacity),
@@ -310,7 +310,7 @@ impl RasterBuilder {
         &mut self,
         name: Option<&str>,
         dim_names: &[&str],
-        shape: &[u64],
+        shape: &[i64],
         data_type: BandDataType,
         nodata: Option<&[u8]>,
         outdb_uri: Option<&str>,
@@ -404,7 +404,7 @@ impl RasterBuilder {
         self.start_band_nd(
             None,
             &["y", "x"],
-            &[self.current_height, self.current_width],
+            &[self.current_height as i64, self.current_width as i64],
             data_type,
             nodata,
             None,
@@ -431,7 +431,7 @@ impl RasterBuilder {
         self.start_band_nd(
             None,
             &["y", "x"],
-            &[self.current_height, self.current_width],
+            &[self.current_height as i64, self.current_width as i64],
             metadata.datatype,
             metadata.nodata_value.as_deref(),
             outdb_uri.as_deref(),
@@ -553,7 +553,7 @@ impl RasterBuilder {
                         ))
                     })?;
                 let expected = self.current_spatial_shape[spatial_idx];
-                let actual = band_shape[pos] as i64;
+                let actual = band_shape[pos];
                 if actual != expected {
                     return Err(ArrowError::InvalidArgumentError(format!(
                         "Band {band_idx} dimension {spatial_dim:?} has size {actual}, \

--- a/rust/sedona-raster/src/raster_loader.rs
+++ b/rust/sedona-raster/src/raster_loader.rs
@@ -65,7 +65,7 @@ pub struct RasterLoadRequest<'a> {
     /// Raw source shape in `dim_names` order. A loader that returns the full
     /// source produces a `Buffer` of `Π source_shape × byte_size` bytes in
     /// C-order over `dim_names`.
-    pub source_shape: &'a [u64],
+    pub source_shape: &'a [i64],
     /// The band's view over `source_shape` (the visible region). A loader
     /// may ignore it and return the full source (reporting the view
     /// unresolved), or honor it and return only the visible region; the
@@ -91,7 +91,7 @@ pub struct RasterLoadResult {
     /// `Π source_shape × data_type.byte_size()`.
     pub bytes: Buffer,
     /// The shape `bytes` are laid out in.
-    pub source_shape: Vec<u64>,
+    pub source_shape: Vec<i64>,
     /// View to apply to `bytes` to obtain the visible region (identity when
     /// the loader already resolved the crop).
     pub view: Vec<ViewEntry>,
@@ -397,7 +397,7 @@ mod tests {
     struct MockLoader {
         name: String,
         formats: Vec<String>,
-        seen: Mutex<Vec<(String, Vec<u64>)>>,
+        seen: Mutex<Vec<(String, Vec<i64>)>>,
     }
 
     impl MockLoader {
@@ -425,7 +425,7 @@ mod tests {
                 .lock()
                 .unwrap()
                 .push((req.uri.to_string(), req.source_shape.to_vec()));
-            let elements: u64 = req.source_shape.iter().copied().product();
+            let elements: i64 = req.source_shape.iter().copied().product();
             let len = elements as usize * req.data_type.byte_size();
             Ok(RasterLoadResult::unresolved(
                 Buffer::from_vec(vec![0u8; len]),

--- a/rust/sedona-raster/src/traits.rs
+++ b/rust/sedona-raster/src/traits.rs
@@ -54,7 +54,7 @@ pub fn is_spatial_dim_pair(y_like: &str, x_like: &str) -> bool {
 #[derive(Debug)]
 pub struct NdBuffer<'a> {
     pub buffer: &'a [u8],
-    pub shape: Vec<u64>,
+    pub shape: Vec<i64>,
     pub strides: Vec<i64>,
     pub offset: u64,
     pub data_type: BandDataType,
@@ -80,7 +80,7 @@ impl<'a> NdBuffer<'a> {
             if stride != expected {
                 return false;
             }
-            expected = expected.saturating_mul(dim as i64);
+            expected = expected.saturating_mul(dim);
         }
         true
     }
@@ -101,7 +101,7 @@ impl<'a> NdBuffer<'a> {
                 self.shape, self.strides
             )));
         }
-        let elements: u64 = self.shape.iter().product();
+        let elements: i64 = self.shape.iter().product();
         let len = elements as usize * self.data_type.byte_size();
         let start = self.offset as usize;
         let buffer: &'a [u8] = self.buffer;
@@ -550,7 +550,7 @@ pub trait BandRef {
     /// `dim_names` order. Derived from `view`: `[v.steps for v in view]`.
     /// This is what almost all consumers want; use `raw_source_shape()` only
     /// when you need to address into the raw `data` buffer (e.g. FFI).
-    fn shape(&self) -> &[u64];
+    fn shape(&self) -> &[i64];
 
     /// **Internal/FFI-only.** Natural C-order extent of the band's
     /// underlying `data` buffer, indexed by *source* axis (not visible
@@ -563,7 +563,7 @@ pub trait BandRef {
     /// Use this only when you need to index directly into the raw `data`
     /// bytes (e.g. Arrow C Data Interface, numpy zero-copy views) and you
     /// also handle `view()` and the byte-stride layout from `nd_buffer()`.
-    fn raw_source_shape(&self) -> &[u64];
+    fn raw_source_shape(&self) -> &[i64];
 
     /// Per-visible-dimension view entries describing how the band's
     /// visible axes map onto its `source_shape`. `view().len() == ndim()`.
@@ -571,7 +571,7 @@ pub trait BandRef {
     fn view(&self) -> &[ViewEntry];
 
     /// Size of a named dimension (None if doesn't exist)
-    fn dim_size(&self, name: &str) -> Option<u64> {
+    fn dim_size(&self, name: &str) -> Option<i64> {
         let idx = self.dim_index(name)?;
         Some(self.shape()[idx])
     }
@@ -913,8 +913,8 @@ mod tests {
     /// every other method returns a placeholder we never read.
     struct StubBand {
         dim_names: Vec<String>,
-        source_shape: Vec<u64>,
-        shape: Vec<u64>,
+        source_shape: Vec<i64>,
+        shape: Vec<i64>,
         view: Vec<ViewEntry>,
     }
 
@@ -925,10 +925,10 @@ mod tests {
         fn dim_names(&self) -> Vec<&str> {
             self.dim_names.iter().map(String::as_str).collect()
         }
-        fn shape(&self) -> &[u64] {
+        fn shape(&self) -> &[i64] {
             &self.shape
         }
-        fn raw_source_shape(&self) -> &[u64] {
+        fn raw_source_shape(&self) -> &[i64] {
             &self.source_shape
         }
         fn view(&self) -> &[ViewEntry] {
@@ -945,8 +945,8 @@ mod tests {
         }
     }
 
-    fn band(dims: &[&str], source_shape: &[u64], view: &[ViewEntry]) -> StubBand {
-        let shape = view.iter().map(|v| v.steps as u64).collect();
+    fn band(dims: &[&str], source_shape: &[i64], view: &[ViewEntry]) -> StubBand {
+        let shape = view.iter().map(|v| v.steps).collect();
         StubBand {
             dim_names: dims.iter().map(|s| (*s).to_string()).collect(),
             source_shape: source_shape.to_vec(),
@@ -1012,7 +1012,7 @@ mod tests {
 
     /// Build a bufferless `NdBuffer` for contiguity checks — `is_contiguous`
     /// inspects only shape/strides/data_type, never the bytes.
-    fn ndbuf(shape: &[u64], strides: &[i64], offset: u64) -> NdBuffer<'static> {
+    fn ndbuf(shape: &[i64], strides: &[i64], offset: u64) -> NdBuffer<'static> {
         NdBuffer {
             buffer: &[],
             shape: shape.to_vec(),

--- a/rust/sedona-schema/src/raster.rs
+++ b/rust/sedona-schema/src/raster.rs
@@ -107,7 +107,7 @@ impl RasterSchema {
     /// shape exposed to consumers is derived from `view`:
     /// `[entry.steps for entry in view]`.
     pub fn source_shape_type() -> DataType {
-        DataType::List(FieldRef::new(Field::new("item", DataType::UInt64, false)))
+        DataType::List(FieldRef::new(Field::new("item", DataType::Int64, false)))
     }
 
     /// View list type — one entry per dimension in the band's *visible*


### PR DESCRIPTION
Converts the raster band `source_shape` / visible-shape surface from `u64` to `i64` — both the in-memory representation and the Arrow `source_shape` column (`List<UInt64>` → `List<Int64>`).

### Why

The view/stride machinery (`ViewEntry`, byte strides) is already `i64` (signed, for negative-step / reverse views). Keeping `source_shape` as `u64` forces mixed signed/unsigned arithmetic at every shape↔stride boundary; making the shape `i64` end-to-end removes those casts and lets view composition use uniform signed math.

This is an **Arrow schema change** to the raster type (`source_shape` column element type `UInt64` → `Int64`), landed before the format stabilizes so we don't ship `u64` and break it later.

