### PR TITLE
fix(rust/sedona-raster): classify 0-element bands as InDb; make is_indb required

### DIFF
--- a/rust/sedona-raster/src/array.rs
+++ b/rust/sedona-raster/src/array.rs
@@ -108,7 +108,11 @@ impl<'a> BandRef for BandRefImpl<'a> {
     }
 
     fn is_indb(&self) -> bool {
-        !self.data_array.value(self.band_row).is_empty()
+        // A 0-element visible region (any visible dim is 0) holds no readable
+        // bytes — trivially fully in-RAM — so it's InDb, not the OutDb
+        // empty-`data` sentinel. Otherwise the discriminator is buffer presence.
+        self.shape().iter().product::<u64>() == 0
+            || !self.data_array.value(self.band_row).is_empty()
     }
 
     fn nd_buffer(&self) -> Result<NdBuffer<'_>, ArrowError> {
@@ -1151,5 +1155,40 @@ mod tests {
         assert!(r1.band_outdb_uri(0).is_none());
         assert!(r1.band_outdb_format(0).is_none());
         assert!(r1.band_nodata(0).is_none());
+    }
+
+    #[test]
+    fn zero_element_indb_band_classifies_as_indb() {
+        // A band with a 0-size dim (here `time = 0`) legitimately holds 0 bytes.
+        // Its empty `data` column must NOT be mistaken for the OutDb sentinel:
+        // a 0-element band has nothing to load, so it's InDb.
+        let mut builder = RasterBuilder::new(1);
+        builder
+            .start_raster_2d(2, 2, 0.0, 2.0, 1.0, -1.0, 0.0, 0.0, None)
+            .unwrap();
+        builder
+            .start_band_nd(
+                Some("empty_time"),
+                &["time", "y", "x"],
+                &[0, 2, 2],
+                BandDataType::UInt8,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        builder.band_data_writer().append_value([]); // 0 bytes, legitimately
+        builder.finish_band().unwrap();
+        builder.finish_raster().unwrap();
+        let arr = builder.finish().unwrap();
+
+        let rasters = RasterStructArray::new(&arr);
+        let r = rasters.get(0).unwrap();
+        let band = r.band(0).unwrap();
+        assert!(
+            band.is_indb(),
+            "a 0-element band holds 0 bytes legitimately and must be InDb"
+        );
+        assert_eq!(band.metadata().storage_type().unwrap(), StorageType::InDb);
     }
 }

--- a/rust/sedona-raster/src/traits.rs
+++ b/rust/sedona-raster/src/traits.rs
@@ -625,11 +625,15 @@ pub trait BandRef {
     /// The discriminator is whether the `data` buffer is non-empty —
     /// `outdb_uri` and `outdb_format` are orthogonal location/format hints
     /// that may be set on either kind of band.
-    fn is_indb(&self) -> bool {
-        // Default: materialize via nd_buffer and check buffer emptiness.
-        // Concrete impls should override with a direct buffer check.
-        self.nd_buffer().is_ok_and(|b| !b.buffer.is_empty())
-    }
+    /// A band whose visible region is empty (`Π shape() == 0`) holds no
+    /// readable bytes and is always InDb — there is nothing to load. This is
+    /// what separates a legitimately-empty InDb band from the OutDb empty-`data`
+    /// sentinel.
+    ///
+    /// Required (no default): a band's storage location is a primitive fact each
+    /// impl answers directly. `nd_buffer()` depends on `is_indb()`, so any
+    /// `nd_buffer`-based default would recurse.
+    fn is_indb(&self) -> bool;
 
     /// Eagerly-computed concrete band metadata. Mirrors the pre-N-D
     /// `BandRef::metadata()` accessor.
@@ -941,6 +945,9 @@ mod tests {
             None
         }
         fn nd_buffer(&self) -> Result<NdBuffer<'_>, ArrowError> {
+            unimplemented!("not used in is_spatial_2d tests")
+        }
+        fn is_indb(&self) -> bool {
             unimplemented!("not used in is_spatial_2d tests")
         }
     }


### PR DESCRIPTION
This was an outstanding issue where a band of 0 bytes could never return true from is_indb. Probably not a common case but I wanted to make sure it works in the cases where it arises instead of failing the whole pipeline for one row.

<details>
<summary>AI generated description</summary>

The InDb/OutDb discriminator was `!data.is_empty()`. That conflated two different 0-byte cases:
- an **InDb** band with an empty visible region (e.g. a `time = 0` dim) — genuinely 0 bytes, but in-database, and
- an **OutDb** band — 0 bytes because the pixels live elsewhere.

So a legitimately-empty InDb band was misclassified as OutDb (and `nd_buffer()`/`as_contiguous()` would error on it), failing a whole pipeline over one such row.

### Fix

A `data` column is empty for an InDb band **only** when the band has zero visible pixels, and `Π(shape) == 0` detects exactly that — so the discriminator becomes total without any schema change:

```rust
fn is_indb(&self) -> bool {
    self.shape().iter().product::<u64>() == 0       // 0-element band → nothing to load → InDb
        || !self.data_array.value(self.band_row).is_empty()
}
```

- `Π(shape) == 0` → InDb (a 0-element band holds 0 bytes legitimately; there's nothing to fetch).
- `Π(shape) > 0` + empty data → OutDb; + non-empty data → InDb.

Uses the **visible** `shape()` rather than the raw source shape on purpose: `is_indb` answers "can reads be satisfied from RAM without a loader?", and an empty visible region needs no load. (Moot today — identity views mean visible == source — but it's the cleaner semantics and avoids a pointless fetch for a future sliced-to-empty OutDb band.)

### Also

Made `is_indb` a **required** trait method, dropping the old `nd_buffer`-based default. That default was a recursion footgun (`nd_buffer()` itself depends on `is_indb()`) that every real impl had to override anyway; a band's storage location is a primitive each impl answers directly.

### Not a schema change

This resolves the ambiguity locally — no `data`-column nullability flip and no on-disk format change (which the original issue had proposed). Test: a 0-element InDb band now classifies as InDb and its `storage_type` follows.

</details>
