### PR TITLE
refactor(rust/sedona-raster-functions): width/height and RS_Width/RS_Height return i64

### DIFF
--- a/rust/sedona-raster-functions/src/executor.rs
+++ b/rust/sedona-raster-functions/src/executor.rs
@@ -697,8 +697,8 @@ impl<'a, 'b> RasterExecutor<'a, 'b> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_array::builder::UInt64Builder;
-    use arrow_array::UInt64Array;
+    use arrow_array::builder::Int64Builder;
+    use arrow_array::Int64Array;
     use arrow_schema::Field;
     use sedona_raster::traits::RasterRef;
     use sedona_schema::crs::{deserialize_crs, lnglat};
@@ -718,7 +718,7 @@ mod tests {
         let executor = RasterExecutor::new(&arg_types, &args);
         assert_eq!(executor.num_iterations(), 3);
 
-        let mut builder = UInt64Builder::with_capacity(executor.num_iterations());
+        let mut builder = Int64Builder::with_capacity(executor.num_iterations());
         executor
             .execute_raster_void(|_i, raster_opt| {
                 match raster_opt {
@@ -737,8 +737,8 @@ mod tests {
         let width_array = match &result {
             ColumnarValue::Array(array) => array
                 .as_any()
-                .downcast_ref::<UInt64Array>()
-                .expect("Expected UInt64Array"),
+                .downcast_ref::<Int64Array>()
+                .expect("Expected Int64Array"),
             ColumnarValue::Scalar(_) => panic!("Expected array, got scalar"),
         };
 
@@ -760,7 +760,7 @@ mod tests {
         let executor = RasterExecutor::new(&arg_types, &args);
         assert_eq!(executor.num_iterations(), 1);
 
-        let mut builder = UInt64Builder::with_capacity(executor.num_iterations());
+        let mut builder = Int64Builder::with_capacity(executor.num_iterations());
         executor
             .execute_raster_void(|_i, raster_opt| {
                 match raster_opt {
@@ -783,8 +783,8 @@ mod tests {
         };
 
         match width_scalar {
-            ScalarValue::UInt64(Some(width)) => assert_eq!(*width, 1),
-            _ => panic!("Expected UInt64 scalar"),
+            ScalarValue::Int64(Some(width)) => assert_eq!(*width, 1),
+            _ => panic!("Expected Int64 scalar"),
         }
     }
 
@@ -797,7 +797,7 @@ mod tests {
         let executor = RasterExecutor::new(&arg_types, &args);
         assert_eq!(executor.num_iterations(), 1);
 
-        let mut builder = UInt64Builder::with_capacity(executor.num_iterations());
+        let mut builder = Int64Builder::with_capacity(executor.num_iterations());
         executor
             .execute_raster_void(|_i, raster_opt| {
                 match raster_opt {
@@ -819,7 +819,7 @@ mod tests {
             ColumnarValue::Array(_) => panic!("Expected scalar, got array"),
         };
 
-        assert_eq!(width_scalar, &ScalarValue::UInt64(None));
+        assert_eq!(width_scalar, &ScalarValue::Int64(None));
     }
 
     #[test]

--- a/rust/sedona-raster-functions/src/rs_convexhull.rs
+++ b/rust/sedona-raster-functions/src/rs_convexhull.rs
@@ -107,8 +107,8 @@ impl SedonaScalarKernel for RsConvexHull {
 /// of the raster in world coordinates. Due to skew/rotation in the affine
 /// transformation, each corner must be computed individually.
 fn write_convexhull_wkb(raster: &dyn RasterRef, out: &mut impl std::io::Write) -> Result<()> {
-    let width = raster.metadata().width() as i64;
-    let height = raster.metadata().height() as i64;
+    let width = raster.metadata().width();
+    let height = raster.metadata().height();
 
     // Compute the four corners in pixel coordinates:
     // Upper-left (0, 0), Upper-right (width, 0), Lower-right (width, height), Lower-left (0, height)

--- a/rust/sedona-raster-functions/src/rs_envelope.rs
+++ b/rust/sedona-raster-functions/src/rs_envelope.rs
@@ -105,8 +105,8 @@ impl SedonaScalarKernel for RsEnvelope {
 /// derives the min/max X and Y to produce an axis-aligned bounding box.
 /// For skewed/rotated rasters, this differs from the convex hull.
 fn write_envelope_wkb(raster: &dyn RasterRef, out: &mut impl std::io::Write) -> Result<()> {
-    let width = raster.metadata().width() as i64;
-    let height = raster.metadata().height() as i64;
+    let width = raster.metadata().width();
+    let height = raster.metadata().height();
 
     // Compute the four corners in world coordinates
     let (ulx, uly) = to_world_coordinate(raster, 0, 0);

--- a/rust/sedona-raster-functions/src/rs_size.rs
+++ b/rust/sedona-raster-functions/src/rs_size.rs
@@ -17,7 +17,7 @@
 use std::{sync::Arc, vec};
 
 use crate::executor::RasterExecutor;
-use arrow_array::builder::UInt64Builder;
+use arrow_array::builder::Int64Builder;
 use arrow_schema::DataType;
 use datafusion_common::error::Result;
 use datafusion_expr::{ColumnarValue, Volatility};
@@ -66,7 +66,7 @@ impl SedonaScalarKernel for RsSize {
     fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
         let matcher = ArgMatcher::new(
             vec![ArgMatcher::is_raster()],
-            SedonaType::Arrow(DataType::UInt64),
+            SedonaType::Arrow(DataType::Int64),
         );
 
         matcher.match_args(args)
@@ -78,7 +78,7 @@ impl SedonaScalarKernel for RsSize {
         args: &[ColumnarValue],
     ) -> Result<ColumnarValue> {
         let executor = RasterExecutor::new(arg_types, args);
-        let mut builder = UInt64Builder::with_capacity(executor.num_iterations());
+        let mut builder = Int64Builder::with_capacity(executor.num_iterations());
 
         executor.execute_raster_void(|_i, raster_opt| {
             match raster_opt {
@@ -104,7 +104,7 @@ impl SedonaScalarKernel for RsSize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_array::UInt64Array;
+    use arrow_array::Int64Array;
     use datafusion_expr::ScalarUDF;
     use rstest::rstest;
     use sedona_schema::datatypes::RASTER;
@@ -134,7 +134,7 @@ mod tests {
             SizeType::Height => vec![Some(2), None, Some(4)],
             SizeType::Width => vec![Some(1), None, Some(3)],
         };
-        let expected: Arc<dyn arrow_array::Array> = Arc::new(UInt64Array::from(expected_values));
+        let expected: Arc<dyn arrow_array::Array> = Arc::new(Int64Array::from(expected_values));
 
         // Check scalars
         let result = tester.invoke_array(Arc::new(rasters)).unwrap();

--- a/rust/sedona-raster-functions/src/rs_spatial_predicates.rs
+++ b/rust/sedona-raster-functions/src/rs_spatial_predicates.rs
@@ -377,8 +377,8 @@ const CONVEXHULL_WKB_SIZE: usize = 93;
 
 /// Create WKB for a convex hull polygon for the raster
 fn write_convexhull_wkb(raster: &dyn RasterRef, out: &mut impl std::io::Write) -> Result<()> {
-    let width = raster.metadata().width() as i64;
-    let height = raster.metadata().height() as i64;
+    let width = raster.metadata().width();
+    let height = raster.metadata().height();
 
     let (ulx, uly) = to_world_coordinate(raster, 0, 0);
     let (urx, ury) = to_world_coordinate(raster, width, 0);

--- a/rust/sedona-raster-gdal/src/gdal_common.rs
+++ b/rust/sedona-raster-gdal/src/gdal_common.rs
@@ -359,7 +359,7 @@ pub struct GdalBandPlan {
     /// Full dim-name list, e.g. `["time", "y", "x"]`.
     pub dim_names: Vec<String>,
     /// Sizes of the non-spatial (leading) axes; empty for a plain 2-D band.
-    pub nonspatial_shape: Vec<u64>,
+    pub nonspatial_shape: Vec<i64>,
     /// Number of 2-D planes (`Π nonspatial_shape`, `1` for a 2-D band) — the
     /// count of consecutive GDAL bands this source band owns.
     pub plane_count: usize,
@@ -384,8 +384,8 @@ impl GdalBandLayout {
                      spatial (y, x) pair; got dim_names={dim_names:?}"
                 );
             }
-            let nonspatial_shape: Vec<u64> = band.shape()[..ndim - 2].to_vec();
-            let plane_count = nonspatial_shape.iter().product::<u64>() as usize;
+            let nonspatial_shape: Vec<i64> = band.shape()[..ndim - 2].to_vec();
+            let plane_count = nonspatial_shape.iter().product::<i64>() as usize;
             plans.push(GdalBandPlan {
                 // `band_indices` are 1-based (the `Bands` wrapper convention used
                 // by `raster_ref_to_gdal_mem`), but `band_name` is 0-based.

--- a/rust/sedona-raster-gdal/src/gdal_common.rs
+++ b/rust/sedona-raster-gdal/src/gdal_common.rs
@@ -73,8 +73,8 @@ pub(crate) trait RasterMetadataFromGdalGeoTransform {
 impl RasterMetadataFromGdalGeoTransform for GeoTransform {
     fn to_raster_metadata(&self, width: usize, height: usize) -> RasterMetadata {
         RasterMetadata {
-            width: width as u64,
-            height: height as u64,
+            width: width as i64,
+            height: height as i64,
             upperleft_x: self[0],
             upperleft_y: self[3],
             scale_x: self[1],

--- a/rust/sedona-raster-gdal/src/gdal_dataset_provider.rs
+++ b/rust/sedona-raster-gdal/src/gdal_dataset_provider.rs
@@ -472,8 +472,8 @@ struct VrtBandKey {
 
 #[derive(Hash, Eq, PartialEq)]
 struct VrtKey {
-    width: u64,
-    height: u64,
+    width: i64,
+    height: i64,
     geotransform_bits: [u64; 6],
     crs: Option<String>,
     bands: Vec<VrtBandKey>,

--- a/rust/sedona-raster-gdal/src/rs_frompath.rs
+++ b/rust/sedona-raster-gdal/src/rs_frompath.rs
@@ -111,14 +111,14 @@ mod tests {
     fn assert_raster_dimensions(
         result: &ColumnarValue,
         expected_len: usize,
-        width: u64,
-        height: u64,
+        width: i64,
+        height: i64,
     ) {
         fn assert_struct_array_dimensions(
             struct_arr: &StructArray,
             expected_len: usize,
-            width: u64,
-            height: u64,
+            width: i64,
+            height: i64,
         ) {
             let raster_array = RasterStructArray::new(struct_arr);
             assert_eq!(raster_array.len(), expected_len);

--- a/rust/sedona-raster-gdal/src/utils.rs
+++ b/rust/sedona-raster-gdal/src/utils.rs
@@ -219,8 +219,8 @@ pub fn append_nd_from_dataset(
         let dim_names: Vec<&str> = plan.dim_names.iter().map(String::as_str).collect();
         // shape = [non-spatial..., height, width] — spatial from the dataset.
         let mut shape = plan.nonspatial_shape.clone();
-        shape.push(height as u64);
-        shape.push(width as u64);
+        shape.push(height as i64);
+        shape.push(width as i64);
 
         builder
             .start_band_nd(

--- a/rust/sedona-raster/src/builder.rs
+++ b/rust/sedona-raster/src/builder.rs
@@ -123,8 +123,8 @@ pub struct RasterBuilder {
     current_band_count: i32, // Track bands in current raster
 
     // Current raster state (needed for start_band_2d)
-    current_width: u64,
-    current_height: u64,
+    current_width: i64,
+    current_height: i64,
 
     // Per-raster validation state: spatial dims/shape and recorded bands so
     // finish_raster can check every band matches the top-level spatial grid.
@@ -260,8 +260,8 @@ impl RasterBuilder {
     #[allow(clippy::too_many_arguments)]
     pub fn start_raster_2d(
         &mut self,
-        width: u64,
-        height: u64,
+        width: i64,
+        height: i64,
         origin_x: f64,
         origin_y: f64,
         scale_x: f64,
@@ -271,7 +271,7 @@ impl RasterBuilder {
         crs: Option<&str>,
     ) -> Result<(), ArrowError> {
         let transform = [origin_x, scale_x, skew_x, origin_y, skew_y, scale_y];
-        self.start_raster_nd(&transform, &["x", "y"], &[width as i64, height as i64], crs)?;
+        self.start_raster_nd(&transform, &["x", "y"], &[width, height], crs)?;
         self.current_width = width;
         self.current_height = height;
         Ok(())
@@ -404,7 +404,7 @@ impl RasterBuilder {
         self.start_band_nd(
             None,
             &["y", "x"],
-            &[self.current_height as i64, self.current_width as i64],
+            &[self.current_height, self.current_width],
             data_type,
             nodata,
             None,
@@ -431,7 +431,7 @@ impl RasterBuilder {
         self.start_band_nd(
             None,
             &["y", "x"],
-            &[self.current_height as i64, self.current_width as i64],
+            &[self.current_height, self.current_width],
             metadata.datatype,
             metadata.nodata_value.as_deref(),
             outdb_uri.as_deref(),

--- a/rust/sedona-raster/src/display.rs
+++ b/rust/sedona-raster/src/display.rs
@@ -66,8 +66,8 @@ impl fmt::Display for RasterDisplay<'_> {
 
         // Compute axis-aligned bounding box from 4 corners in world coordinates.
         // This handles both skewed and non-skewed rasters correctly.
-        let w = width as i64;
-        let h = height as i64;
+        let w = width;
+        let h = height;
         let (ulx, uly) = to_world_coordinate(raster, 0, 0);
         let (urx, ury) = to_world_coordinate(raster, w, 0);
         let (lrx, lry) = to_world_coordinate(raster, w, h);

--- a/rust/sedona-raster/src/traits.rs
+++ b/rust/sedona-raster/src/traits.rs
@@ -150,8 +150,8 @@ pub struct ViewEntry {
 /// methods directly; the metadata accessor is the convenience surface.
 #[derive(Debug, Clone)]
 pub struct RasterMetadata {
-    pub width: u64,
-    pub height: u64,
+    pub width: i64,
+    pub height: i64,
     pub upperleft_x: f64,
     pub upperleft_y: f64,
     pub scale_x: f64,
@@ -166,9 +166,9 @@ pub struct RasterMetadata {
 /// should reach for `RasterRef::width()? / height()?` instead.
 pub trait MetadataRef {
     /// Width of the raster in pixels
-    fn width(&self) -> u64;
+    fn width(&self) -> i64;
     /// Height of the raster in pixels
-    fn height(&self) -> u64;
+    fn height(&self) -> i64;
     /// X coordinate of the upper-left corner
     fn upper_left_x(&self) -> f64;
     /// Y coordinate of the upper-left corner
@@ -184,10 +184,10 @@ pub trait MetadataRef {
 }
 
 impl MetadataRef for RasterMetadata {
-    fn width(&self) -> u64 {
+    fn width(&self) -> i64 {
         self.width
     }
-    fn height(&self) -> u64 {
+    fn height(&self) -> i64 {
         self.height
     }
     fn upper_left_x(&self) -> f64 {
@@ -211,10 +211,10 @@ impl MetadataRef for RasterMetadata {
 }
 
 impl RasterMetadata {
-    pub fn width(&self) -> u64 {
+    pub fn width(&self) -> i64 {
         self.width
     }
-    pub fn height(&self) -> u64 {
+    pub fn height(&self) -> i64 {
         self.height
     }
     pub fn upper_left_x(&self) -> f64 {
@@ -480,41 +480,27 @@ pub trait RasterRef {
     }
 
     /// Width in pixels — size of the X spatial dimension from the top-level
-    /// `spatial_shape`. Errors if `spatial_shape` is empty or the X size is
-    /// negative; both are invariant violations rather than legitimate "no
-    /// value" states.
-    fn width(&self) -> Result<u64, ArrowError> {
+    /// `spatial_shape`. Errors if `spatial_shape` is empty, which is an
+    /// invariant violation rather than a legitimate "no value" state.
+    fn width(&self) -> Result<i64, ArrowError> {
         let shape = self.spatial_shape();
-        let Some(&v) = shape.first() else {
-            return Err(ArrowError::InvalidArgumentError(
+        shape.first().copied().ok_or_else(|| {
+            ArrowError::InvalidArgumentError(
                 "raster has no width (spatial_shape is empty)".to_string(),
-            ));
-        };
-        if v < 0 {
-            return Err(ArrowError::InvalidArgumentError(format!(
-                "raster width must be non-negative, got {v}"
-            )));
-        }
-        Ok(v as u64)
+            )
+        })
     }
 
     /// Height in pixels — size of the Y spatial dimension from the top-level
-    /// `spatial_shape`. Errors if `spatial_shape` has fewer than two entries
-    /// or the Y size is negative.
-    fn height(&self) -> Result<u64, ArrowError> {
+    /// `spatial_shape`. Errors if `spatial_shape` has fewer than two entries.
+    fn height(&self) -> Result<i64, ArrowError> {
         let shape = self.spatial_shape();
-        let Some(&v) = shape.get(1) else {
-            return Err(ArrowError::InvalidArgumentError(format!(
+        shape.get(1).copied().ok_or_else(|| {
+            ArrowError::InvalidArgumentError(format!(
                 "raster has no height (spatial_shape has {} entries, need >= 2)",
                 shape.len()
-            )));
-        };
-        if v < 0 {
-            return Err(ArrowError::InvalidArgumentError(format!(
-                "raster height must be non-negative, got {v}"
-            )));
-        }
-        Ok(v as u64)
+            ))
+        })
     }
 
     /// Look up a band by name. Returns an error if no band has that

--- a/rust/sedona-testing/src/rasters.rs
+++ b/rust/sedona-testing/src/rasters.rs
@@ -47,8 +47,8 @@ pub fn generate_test_rasters(
         }
 
         let raster_metadata = RasterMetadata {
-            width: i as u64 + 1,
-            height: i as u64 + 2,
+            width: i as i64 + 1,
+            height: i as i64 + 2,
             upperleft_x: i as f64 + 1.0,
             upperleft_y: i as f64 + 2.0,
             scale_x: i.max(1) as f64 * 0.1,
@@ -106,8 +106,8 @@ pub fn generate_tiled_rasters(
             let origin_y = (tile_y * tile_height) as f64;
 
             let raster_metadata = RasterMetadata {
-                width: tile_width as u64,
-                height: tile_height as u64,
+                width: tile_width as i64,
+                height: tile_height as i64,
                 upperleft_x: origin_x,
                 upperleft_y: origin_y,
                 scale_x: 1.0,
@@ -225,8 +225,8 @@ pub fn raster_from_single_band(
     crs: Option<&str>,
 ) -> StructArray {
     let metadata = RasterMetadata {
-        width: width as u64,
-        height: height as u64,
+        width: width as i64,
+        height: height as i64,
         upperleft_x: 0.0,
         upperleft_y: 0.0,
         scale_x: 1.0,
@@ -505,8 +505,8 @@ mod tests {
         for i in 0..count {
             let raster = raster_array.get(i).unwrap();
             let metadata = raster.metadata();
-            assert_eq!(metadata.width(), i as u64 + 1);
-            assert_eq!(metadata.height(), i as u64 + 2);
+            assert_eq!(metadata.width(), i as i64 + 1);
+            assert_eq!(metadata.height(), i as i64 + 2);
             assert_eq!(metadata.upper_left_x(), i as f64 + 1.0);
             assert_eq!(metadata.upper_left_y(), i as f64 + 2.0);
             assert_eq!(metadata.scale_x(), (i.max(1) as f64) * 0.1);


### PR DESCRIPTION
Follow up to https://github.com/apache/sedona-db/pull/927

trying to eliminate a bunch of the casting between u64 and i64. This is something of a breaking change as it changes the return type of these RS functions

### Drive By
`main` was broken by a semantic conflict between #927 and #928. This PR fixes that issue with its second commit

<details>
<summary>AI generated description</summary>

`RS_Width` / `RS_Height` and the underlying `width()` / `height()` accessors returned `u64`. This switches them to `i64`, matching the signed `spatial_shape` (and band `shape`) from the source_shape work and the `Int64` Arrow type used for dimension sizes elsewhere — so values stop being round-tripped through `u64` at the boundary.

### What changed

- `RasterRef::width()` / `height()` now return `Result<i64, ArrowError>`. Since `spatial_shape()` is already `i64`, the value is returned directly; the old non-negative guard and `as u64` cast are gone. The only remaining error is an empty / too-short `spatial_shape`, which is an invariant violation rather than a "no value" state.
- `RasterMetadata`'s `width` / `height` fields, the `MetadataRef` trait, and the inherent accessors are all `i64`.
- `RS_Width` / `RS_Height` now produce an `Int64` column (`Int64Builder`).
- The construction surface follows so no casts are reintroduced: `RasterBuilder::start_raster_2d` parameters and the builder's `current_width` / `current_height`, plus the `VrtKey` GDAL cache key.
- Call sites updated to match: the `Display` impl, the envelope / convex-hull / spatial-predicate corner math, and the test helpers.

### Also repairs `main`

#927 (source_shape → `i64`) and #928 (GDAL plane stacking) each merged green against a `main` that lacked the other, so their combination left `sedona-raster-gdal` not compiling: the plane-stacking path still did `Vec<u64> = band.shape()…` and `product::<u64>()` over a now-`i64` `shape()`. This flips `GdalBandPlan::nonspatial_shape` to `Vec<i64>` and the regroup path to push `i64` extents, restoring the build.

</details>
