### PR TITLE
feat(python/sedonadb): Ensure dataframes have meaningful default alias

### DIFF
--- a/python/sedonadb/python/sedonadb/context.py
+++ b/python/sedonadb/python/sedonadb/context.py
@@ -276,7 +276,9 @@ class SedonaContext:
             <sedonadb.dataframe.DataFrame object at ...>
         """
         if isinstance(table_paths, (str, Path)):
-            table_paths = [table_paths]
+            table_paths_list = [str(table_paths)]
+        else:
+            table_paths_list = [str(path) for path in table_paths]
 
         if options is None:
             options = {}
@@ -290,13 +292,13 @@ class SedonaContext:
         return DataFrame(
             self,
             self._impl.read_parquet(
-                [str(path) for path in table_paths],
+                table_paths_list,
                 options,
                 geometry_columns,
                 validate,
                 None if partitioning is None else list(partitioning),
             ),
-        )
+        )._ensure_aliased(table_paths)
 
     def read_pyogrio(
         self,
@@ -365,7 +367,9 @@ class SedonaContext:
         from sedonadb.datasource import PyogrioFormatSpec
 
         if isinstance(table_paths, (str, Path)):
-            table_paths = [table_paths]
+            table_paths_list = [str(table_paths)]
+        else:
+            table_paths_list = [str(path) for path in table_paths]
 
         spec = PyogrioFormatSpec(extension)
         if options is not None:
@@ -378,11 +382,11 @@ class SedonaContext:
             self,
             self._impl.read_external_format(
                 spec,
-                [str(path) for path in table_paths],
+                table_paths_list,
                 False,
                 None if partitioning is None else list(partitioning),
             ),
-        )
+        )._ensure_aliased(table_paths)
 
     def read_format(
         self,
@@ -426,7 +430,9 @@ class SedonaContext:
             >>> sd.read_format(spec, "file:///path/to/foo.zarr").show()  # doctest: +SKIP
         """
         if isinstance(table_paths, (str, Path)):
-            table_paths = [table_paths]
+            table_paths = [str(table_paths)]
+        else:
+            table_paths_list = [str(path) for path in table_paths]
 
         if isinstance(partitioning, str):
             partitioning = [partitioning]
@@ -435,11 +441,11 @@ class SedonaContext:
             self,
             self._impl.read_external_format(
                 spec,
-                [str(path) for path in table_paths],
+                table_paths_list,
                 check_extension,
                 None if partitioning is None else list(partitioning),
             ),
-        )
+        )._ensure_aliased(table_paths)
 
     def sql(
         self, sql: str, *, params: Union[List, Tuple, Dict, None] = None
@@ -484,7 +490,7 @@ class SedonaContext:
             └────────────┘
 
         """
-        df = DataFrame(self, self._impl.sql(sql))
+        df = DataFrame(self, self._impl.sql(sql))._ensure_aliased(f"sql_{id(sql)}")
 
         if params is not None:
             if isinstance(params, (tuple, list)):

--- a/python/sedonadb/python/sedonadb/context.py
+++ b/python/sedonadb/python/sedonadb/context.py
@@ -278,6 +278,7 @@ class SedonaContext:
         if isinstance(table_paths, (str, Path)):
             table_paths_list = [str(table_paths)]
         else:
+            table_paths = list(table_paths)
             table_paths_list = [str(path) for path in table_paths]
 
         if options is None:
@@ -369,6 +370,7 @@ class SedonaContext:
         if isinstance(table_paths, (str, Path)):
             table_paths_list = [str(table_paths)]
         else:
+            table_paths = list(table_paths)
             table_paths_list = [str(path) for path in table_paths]
 
         spec = PyogrioFormatSpec(extension)
@@ -430,8 +432,9 @@ class SedonaContext:
             >>> sd.read_format(spec, "file:///path/to/foo.zarr").show()  # doctest: +SKIP
         """
         if isinstance(table_paths, (str, Path)):
-            table_paths = [str(table_paths)]
+            table_paths_list = [str(table_paths)]
         else:
+            table_paths = list(table_paths)
             table_paths_list = [str(path) for path in table_paths]
 
         if isinstance(partitioning, str):

--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -1384,8 +1384,7 @@ class DataFrame:
 
         Examples:
 
-            >>> import sedonadb
-            >>> con = sedonadb.connect()
+            >>> con = sedona.db.connect()
             >>> df = con.sql("SELECT 1 as one")
             >>> df.explain().show()
             ┌───────────────┬─────────────────────────────────┐
@@ -1400,7 +1399,7 @@ class DataFrame:
             │               ┆                                 │
             └───────────────┴─────────────────────────────────┘
         """
-        return DataFrame(self._ctx, self._impl.explain(type, format))
+        return DataFrame(self._ctx, self._impl.unwrap_alias().explain(type, format))
 
     def __repr__(self) -> str:
         if self._ctx.options.interactive:

--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -1434,12 +1434,23 @@ class DataFrame:
 
 
 def _default_alias_for_obj(obj: Any) -> str:
+    hex_id = f"{id(obj):x}"
     if isinstance(obj, str):
-        return obj
+        try:
+            basename = Path(obj).name
+            if basename:
+                return f"{basename}_{hex_id}"
+        except Exception:
+            pass
+        return f"{obj}_{hex_id}"
     elif isinstance(obj, Path):
-        return str(obj)
+        try:
+            if obj.name:
+                return f"{obj.name}_{hex_id}"
+        except Exception:
+            pass
 
-    return f"{type(obj).__name__}_{id(obj)}"
+    return f"{type(obj).__name__.lower()}_{hex_id}"
 
 
 def _create_data_frame(ctx, obj, schema) -> DataFrame:

--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -1471,7 +1471,7 @@ def _create_data_frame(ctx, obj, schema) -> DataFrame:
     # This includes geopandas/pandas DataFrames, pyarrow tables, and Polars tables.
     type_name = _qualified_type_name(obj)
     if type_name in SPECIAL_CASED_SCANS:
-        return SPECIAL_CASED_SCANS[type_name](ctx, obj, schema)
+        return SPECIAL_CASED_SCANS[type_name](ctx, obj, schema)._ensure_aliased(obj)
 
     # The default implementation handles objects that implement
     # __datafusion_table_provider__ or __arrow_c_stream__. For objects implementing

--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -1429,6 +1429,18 @@ class DataFrame:
 
         return width
 
+    def _ensure_aliased(self, src: Any) -> "DataFrame":
+        return self.alias(_default_alias_for_obj(src))
+
+
+def _default_alias_for_obj(obj: Any) -> str:
+    if isinstance(obj, str):
+        return obj
+    elif isinstance(obj, Path):
+        return str(obj)
+
+    return f"{type(obj).__name__}_{id(obj)}"
+
 
 def _create_data_frame(ctx, obj, schema) -> DataFrame:
     """Create a DataFrame (internal)
@@ -1455,7 +1467,7 @@ def _create_data_frame(ctx, obj, schema) -> DataFrame:
     # __datafusion_table_provider__ or __arrow_c_stream__. For objects implementing
     # __arrow_c_stream__, this currently will only work for a single scan (i.e.,
     # the returned data frame can't be previewed before the query is computed).
-    return _scan_default(ctx, obj, schema)
+    return _scan_default(ctx, obj, schema)._ensure_aliased(obj)
 
 
 def _scan_default(ctx, obj, schema):

--- a/python/sedonadb/src/dataframe.rs
+++ b/python/sedonadb/src/dataframe.rs
@@ -157,6 +157,22 @@ impl InternalDataFrame {
         }
     }
 
+    fn unwrap_alias(&self) -> Result<InternalDataFrame, PySedonaError> {
+        let (state, plan) = self.inner.clone().into_parts();
+
+        if let LogicalPlan::SubqueryAlias(sqa) = plan {
+            Ok(InternalDataFrame::new(
+                DataFrame::new(state, Arc::unwrap_or_clone(sqa.input)),
+                self.runtime.clone(),
+            ))
+        } else {
+            Ok(InternalDataFrame::new(
+                DataFrame::new(state, plan),
+                self.runtime.clone(),
+            ))
+        }
+    }
+
     fn limit(
         &self,
         limit: Option<usize>,

--- a/python/sedonadb/src/dataframe.rs
+++ b/python/sedonadb/src/dataframe.rs
@@ -28,7 +28,9 @@ use datafusion::logical_expr::SortExpr;
 use datafusion::prelude::{DataFrame, SessionContext};
 use datafusion_common::{Column, DataFusionError, ParamValues};
 use datafusion_execution::TaskContextProvider;
-use datafusion_expr::{ExplainFormat, ExplainOption, Expr, JoinType, LogicalPlanBuilder};
+use datafusion_expr::{
+    ExplainFormat, ExplainOption, Expr, JoinType, LogicalPlan, LogicalPlanBuilder,
+};
 use datafusion_ffi::table_provider::FFI_TableProvider;
 use futures::lock::Mutex;
 use futures::TryStreamExt;
@@ -140,8 +142,19 @@ impl InternalDataFrame {
     }
 
     fn alias(&self, alias: &str) -> Result<InternalDataFrame, PySedonaError> {
-        let inner = self.inner.clone().alias(alias)?;
-        Ok(InternalDataFrame::new(inner, self.runtime.clone()))
+        let inner_clone = self.inner.clone();
+
+        // Don't alias an explain plan because if we do it won't execute.
+        // If we don't special case this here, sd.sql("EXPLAIN ...") doesn't
+        // work and we need to special case it in Python instead.
+        if matches!(inner_clone.logical_plan(), LogicalPlan::Explain(_)) {
+            Ok(InternalDataFrame::new(inner_clone, self.runtime.clone()))
+        } else {
+            Ok(InternalDataFrame::new(
+                inner_clone.alias(alias)?,
+                self.runtime.clone(),
+            ))
+        }
     }
 
     fn limit(

--- a/python/sedonadb/tests/io/test_parquet.py
+++ b/python/sedonadb/tests/io/test_parquet.py
@@ -32,6 +32,28 @@ from sedonadb._lib import SedonaError
 from sedonadb.testing import DuckDB, SedonaDB, geom_or_null, skip_if_not_exists
 
 
+def test_read_parquet(con, geoarrow_data):
+    # Check one file
+    df = con.read_parquet(
+        geoarrow_data / "quadrangles/files/quadrangles_100k_geo.parquet"
+    )
+
+    # Ensure the alias reflects the filename
+    assert "quadrangles_100k" in repr(df.geometry)
+
+    tab = df.to_arrow_table()
+    assert tab["geometry"].type.extension_name == "geoarrow.wkb"
+
+    # Check many files
+    df = con.read_parquet(geoarrow_data.glob("example/files/*_geo.parquet"))
+    tab = df.to_arrow_table()
+    assert tab["geometry"].type.extension_name == "geoarrow.wkb"
+    assert len(tab) == 244
+
+    # Check that we still have an alias based on the input object
+    assert "map_" in repr(df.geometry)
+
+
 @pytest.mark.parametrize("name", ["water-junc", "water-point"])
 def test_read_whole_geoparquet(geoarrow_data, name):
     # Checks a read of some non-trivial files and ensures we match a GeoPandas read

--- a/python/sedonadb/tests/io/test_parquet.py
+++ b/python/sedonadb/tests/io/test_parquet.py
@@ -51,7 +51,7 @@ def test_read_parquet(con, geoarrow_data):
     assert len(tab) == 244
 
     # Check that we still have an alias based on the input object
-    assert "map_" in repr(df.geometry)
+    assert "list_" in repr(df.geometry)
 
 
 @pytest.mark.parametrize("name", ["water-junc", "water-point"])

--- a/python/sedonadb/tests/io/test_pyogrio.py
+++ b/python/sedonadb/tests/io/test_pyogrio.py
@@ -42,7 +42,11 @@ def test_read_ogr_projection(con):
     with tempfile.TemporaryDirectory() as td:
         temp_fgb_path = f"{td}/temp.fgb"
         gdf.to_file(temp_fgb_path)
-        con.read_pyogrio(temp_fgb_path).to_view("test_fgb", overwrite=True)
+        df = con.read_pyogrio(temp_fgb_path)
+        df.to_view("test_fgb", overwrite=True)
+
+        # Ensure we get a meaningful alias when reading a path
+        assert "temp.fgb" in repr(df.wkb_geometry)
 
         # With no projection
         geopandas.testing.assert_geodataframe_equal(

--- a/python/sedonadb/tests/test_context.py
+++ b/python/sedonadb/tests/test_context.py
@@ -55,21 +55,6 @@ def test_options():
     assert "DataFrame object at" not in repr(sd.sql("SELECT 1 as one"))
 
 
-def test_read_parquet(con, geoarrow_data):
-    # Check one file
-    tab = con.read_parquet(
-        geoarrow_data / "quadrangles/files/quadrangles_100k_geo.parquet"
-    ).to_arrow_table()
-    assert tab["geometry"].type.extension_name == "geoarrow.wkb"
-
-    # Check many files
-    tab = con.read_parquet(
-        geoarrow_data.glob("example/files/*_geo.parquet")
-    ).to_arrow_table()
-    assert tab["geometry"].type.extension_name == "geoarrow.wkb"
-    assert len(tab) == 244
-
-
 def test_read_parquet_local_glob(con, geoarrow_data):
     # The above test uses .glob() method, this test uses the raw string
     tab = con.read_parquet(

--- a/python/sedonadb/tests/test_dataframe.py
+++ b/python/sedonadb/tests/test_dataframe.py
@@ -600,3 +600,43 @@ def test_len_error(con):
         ValueError, match=r"Can't compute len\(\) of a lazy SedonaDB DataFrame"
     ):
         len(con.sql("SELECT 1 as one"))
+
+
+def test_default_alias_for_obj():
+    from sedonadb.dataframe import _default_alias_for_obj
+
+    # String with path - extracts basename + hex id suffix
+    s = "/path/to/file.parquet"
+    assert _default_alias_for_obj(s) == f"file.parquet_{id(s):x}"
+
+    s = "s3://bucket/data.parquet"
+    assert _default_alias_for_obj(s) == f"data.parquet_{id(s):x}"
+
+    s = "relative/path/data.csv"
+    assert _default_alias_for_obj(s) == f"data.csv_{id(s):x}"
+
+    # String without path component - returns original + hex id suffix
+    s = "simple_name"
+    assert _default_alias_for_obj(s) == f"simple_name_{id(s):x}"
+
+    s = ""
+    alias = _default_alias_for_obj(s)
+    # Empty basename, falls back to original (empty) + hex id
+    assert alias == f"_{id(s):x}"
+
+    # Path object - extracts name + hex id suffix
+    p = Path("/path/to/file.parquet")
+    assert _default_alias_for_obj(p) == f"file.parquet_{id(p):x}"
+
+    p = Path("relative/data.csv")
+    assert _default_alias_for_obj(p) == f"data.csv_{id(p):x}"
+
+    # Path with empty name (root path) - falls back to type-based
+    root_path = Path("/")
+    alias = _default_alias_for_obj(root_path)
+    assert alias == f"posixpath_{id(root_path):x}"
+
+    # Other types - returns lowercase type name + hex id
+    obj = [1, 2, 3]
+    alias = _default_alias_for_obj(obj)
+    assert alias == f"list_{id(obj):x}"

--- a/python/sedonadb/tests/test_dataframe.py
+++ b/python/sedonadb/tests/test_dataframe.py
@@ -67,7 +67,7 @@ def test_dataframe_from_table(con):
     assert df.to_arrow_table() == tab
 
     # Should be aliased with 'table'
-    assert 'table_' in repr(df.geom)
+    assert "table_" in repr(df.geom)
 
 
 def test_dataframe_from_pandas(con):
@@ -82,7 +82,7 @@ def test_dataframe_from_pandas(con):
     pd.testing.assert_frame_equal(df.to_pandas(), pd_df)
 
     # Should be aliased with 'dataframe'
-    assert 'dataframe_' in repr(df.col1)
+    assert "dataframe_" in repr(df.col1)
 
 
 def test_dataframe_from_geopandas(con):

--- a/python/sedonadb/tests/test_dataframe.py
+++ b/python/sedonadb/tests/test_dataframe.py
@@ -66,6 +66,9 @@ def test_dataframe_from_table(con):
     # ...and ensure we can collect again
     assert df.to_arrow_table() == tab
 
+    # Should be aliased with 'table'
+    assert 'table_' in repr(df.geom)
+
 
 def test_dataframe_from_pandas(con):
     pd_df = pd.DataFrame({"col1": [1, 2, 3]})
@@ -77,6 +80,9 @@ def test_dataframe_from_pandas(con):
 
     # ...and ensure we can collect again
     pd.testing.assert_frame_equal(df.to_pandas(), pd_df)
+
+    # Should be aliased with 'dataframe'
+    assert 'dataframe_' in repr(df.col1)
 
 
 def test_dataframe_from_geopandas(con):

--- a/python/sedonadb/tests/test_dataframe.py
+++ b/python/sedonadb/tests/test_dataframe.py
@@ -545,20 +545,7 @@ def test_show_explained(con, capsys):
 
 def test_explain(con, capsys):
     con.sql("SELECT 1 as one").explain().show()
-    expected = """
-┌───────────────┬─────────────────────────────────┐
-│   plan_type   ┆               plan              │
-│      utf8     ┆               utf8              │
-╞═══════════════╪═════════════════════════════════╡
-│ logical_plan  ┆ Projection: Int64(1) AS one     │
-│               ┆   EmptyRelation: rows=1         │
-├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
-│ physical_plan ┆ ProjectionExec: expr=[1 as one] │
-│               ┆   PlaceholderRowExec            │
-│               ┆                                 │
-└───────────────┴─────────────────────────────────┘
-    """.strip()
-    assert capsys.readouterr().out.strip() == expected
+    assert "Projection: Int64(1) AS one" in capsys.readouterr().out.strip()
 
     con.sql("SELECT 1 as one").explain(format="tree").show()
     expected = """

--- a/python/sedonadb/tests/test_dataframe.py
+++ b/python/sedonadb/tests/test_dataframe.py
@@ -32,7 +32,11 @@ def test_dataframe_from_dataframe(con):
     # DataFrame from DataFrame on the same context with no schema
     # should be just a Python reference
     df = con.sql("SELECT ST_Point(0, 1) as geom")
-    assert con.create_data_frame(df) is df
+    new_df = con.create_data_frame(df)
+    assert new_df is df
+
+    # Alias should not change
+    assert repr(df.geom) == repr(new_df.geom)
 
     # On a separate context the table should still be collected the same
     # but should be a separate Python reference. This also has the effect
@@ -41,6 +45,9 @@ def test_dataframe_from_dataframe(con):
     new_df = new_con.create_data_frame(df)
     assert new_df is not df
     pd.testing.assert_frame_equal(df.to_pandas(), new_df.to_pandas())
+
+    # Alias changes
+    assert repr(new_df.geom) != repr(df.geom)
 
 
 def test_dataframe_from_table(con):


### PR DESCRIPTION
This PR ensures all dataframes when created have a default alias that is probably unique and mostly meaningful (e.g., the filename being read). This ensures that joins don't require manual aliasing in most cases.

Motivating use case:

```python
import sedona.db

sd = sedona.db.connect()

pts = sd.read_parquet(
    "https://github.com/geoarrow/geoarrow-data/releases/download/v0.2.0/ns-water_water-point.parquet"
)
ply = sd.read_parquet(
    "https://github.com/geoarrow/geoarrow-data/releases/download/v0.2.0/ns-water_water-poly.parquet"
)
pts.join(ply, on=sd.funcs.st_intersects(pts.geometry, ply.geometry)).select(
    pt_hid=pts.HID, pl_hid=ply.HID, geometry=pts.geometry
).show(5)
# ┌────────────────────────────────┬────────────────────────────────┬────────────────────────────────┐
# │             pt_hid             ┆             pl_hid             ┆            geometry            │
# │              utf8              ┆              utf8              ┆            geometry            │
# ╞════════════════════════════════╪════════════════════════════════╪════════════════════════════════╡
# │ FC9A29123BEF4A6588A2FD777B81A… ┆ 63E9CC5AE7144EEABEBEC2C95C91F… ┆ POINT Z(258498.62729999982 48… │
# ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
# │ 28E47E22D71549ED91472AD59A9D8… ┆ 63E9CC5AE7144EEABEBEC2C95C91F… ┆ POINT Z(258498.32830000017 48… │
# ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
# │ B10B26FA32FB4438925D86CD612BA… ┆ 63E9CC5AE7144EEABEBEC2C95C91F… ┆ POINT Z(258502.0273000002 481… │
# ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
# │ 6ACD71128B6B492C8177B11A5C2D2… ┆ 63E9CC5AE7144EEABEBEC2C95C91F… ┆ POINT Z(258498.92729999963 48… │
# ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
# │ 0A4BE2AB03D8459B8279FCC4BDE55… ┆ 63E9CC5AE7144EEABEBEC2C95C91F… ┆ POINT Z(258526.62729999982 48… │
# └────────────────────────────────┴────────────────────────────────┴────────────────────────────────┘
```

A downside here is that the explain plans get more verbose because they always print out the qualifier.

Closes #926.