### PR TITLE
chore(ci): build, test, and publish sedonadb-zarr wheels

### DIFF
--- a/.github/actions/setup-wheel-build/action.yml
+++ b/.github/actions/setup-wheel-build/action.yml
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: "Set up wheel build"
+description: >
+  Shared setup for cibuildwheel jobs: Python, cibuildwheel, an optional Rust
+  cache, and the SedonaDB dev version. Run after actions/checkout.
+
+inputs:
+  rust-cache-key:
+    description: >
+      Swatinem/rust-cache prefix-key. Leave empty to skip the cache (e.g.
+      Linux container builds, where the host cache doesn't apply).
+    required: false
+    default: ""
+  cache-bin:
+    description: "Passed through to rust-cache's cache-bin."
+    required: false
+    default: "true"
+  delvewheel:
+    description: "Also install delvewheel (Windows wheel repair)."
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-python@v6
+      with:
+        python-version: "3.13"
+
+    - name: Install cibuildwheel
+      shell: bash
+      run: |
+        python -m pip install cibuildwheel==3.1.4
+        if [ "${{ inputs.delvewheel }}" = "true" ]; then
+          python -m pip install delvewheel
+        fi
+
+    - uses: Swatinem/rust-cache@v2
+      if: inputs.rust-cache-key != ''
+      with:
+        prefix-key: ${{ inputs.rust-cache-key }}
+        # Don't cache ~/.cargo/bin -- caching it across runner-image
+        # generations leaves cargo on PATH as a stale rustup-init that
+        # rejects normal subcommands. See sedona-db#837.
+        cache-bin: ${{ inputs.cache-bin }}
+
+    - name: Set SedonaDB dev version
+      shell: bash
+      run: |
+        # Set the unique development version anywhere except a release branch
+        if [[ "${GITHUB_REF##*/}" =~ ^branch-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          version="${GITHUB_REF##*/branch-}"
+          echo "${version}"
+        else
+          python ci/scripts/set_dev_version.py
+        fi

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -23,6 +23,8 @@ on:
     paths:
       - 'ci/scripts/wheels-*'
       - '.github/workflows/python-wheels.yml'
+      - '.github/workflows/wheels-zarr.yml'
+      - '.github/actions/setup-wheel-build/**'
   push:
     branches:
       - main
@@ -50,17 +52,10 @@ jobs:
           submodules: 'true'
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - uses: ./.github/actions/setup-wheel-build
         with:
-          python-version: "3.13"
-
-      - name: Install cibuildwheel and delvewheel
-        run: python -m pip install cibuildwheel==3.1.4 delvewheel
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          # Update this key to force a new cache
-          prefix-key: "python-wheel-windows-latest-v3"
+          rust-cache-key: "python-wheel-windows-latest-v3"
+          delvewheel: "true"
 
       - name: Clone vcpkg
         uses: actions/checkout@v6
@@ -68,17 +63,6 @@ jobs:
           repository: microsoft/vcpkg
           ref: ${{ env.VCPKG_REF }}
           path: vcpkg
-
-      - name: Set SedonaDB dev version
-        shell: bash
-        run: |
-          # Set the unique development version anywhere except a release branch
-          if [[ "${GITHUB_REF##*/}" =~ ^branch-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            version="${GITHUB_REF##*/branch-}"
-            echo "${version}"
-          else
-            python ci/scripts/set_dev_version.py
-          fi
 
       - name: Build and test wheels (sedonadb)
         run: |
@@ -106,21 +90,10 @@ jobs:
           submodules: 'true'
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - uses: ./.github/actions/setup-wheel-build
         with:
-          python-version: "3.13"
-
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==3.1.4
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          # Update this key to force a new cache
-          prefix-key: "python-wheel-macOS-latest-v2"
-          # Don't cache ~/.cargo/bin -- caching it across runner-image
-          # generations leaves cargo on PATH as a stale rustup-init that
-          # rejects normal subcommands. See sedona-db#837.
-          cache-bin: false
+          rust-cache-key: "python-wheel-macOS-latest-v2"
+          cache-bin: "false"
 
       - name: Clone vcpkg
         uses: actions/checkout@v6
@@ -128,17 +101,6 @@ jobs:
           repository: microsoft/vcpkg
           ref: ${{ env.VCPKG_REF }}
           path: vcpkg
-
-      - name: Set SedonaDB dev version
-        shell: bash
-        run: |
-          # Set the unique development version anywhere except a release branch
-          if [[ "${GITHUB_REF##*/}" =~ ^branch-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            version="${GITHUB_REF##*/branch-}"
-            echo "${version}"
-          else
-            python ci/scripts/set_dev_version.py
-          fi
 
       - name: Build and test wheels (sedonadb)
         run: |
@@ -163,21 +125,10 @@ jobs:
           submodules: 'true'
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - uses: ./.github/actions/setup-wheel-build
         with:
-          python-version: "3.13"
-
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==3.1.4
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          # Update this key to force a new cache
-          prefix-key: "python-wheel-macOS-latest-v2"
-          # Don't cache ~/.cargo/bin -- caching it across runner-image
-          # generations leaves cargo on PATH as a stale rustup-init that
-          # rejects normal subcommands. See sedona-db#837.
-          cache-bin: false
+          rust-cache-key: "python-wheel-macOS-latest-v2"
+          cache-bin: "false"
 
       - name: Clone vcpkg
         uses: actions/checkout@v6
@@ -185,17 +136,6 @@ jobs:
           repository: microsoft/vcpkg
           ref: ${{ env.VCPKG_REF }}
           path: vcpkg
-
-      - name: Set SedonaDB dev version
-        shell: bash
-        run: |
-          # Set the unique development version anywhere except a release branch
-          if [[ "${GITHUB_REF##*/}" =~ ^branch-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            version="${GITHUB_REF##*/branch-}"
-            echo "${version}"
-          else
-            python ci/scripts/set_dev_version.py
-          fi
 
       - name: Build and test wheels (sedonadb)
         run: |
@@ -227,23 +167,7 @@ jobs:
           submodules: 'true'
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==3.1.4
-
-      - name: Set SedonaDB dev version
-        shell: bash
-        run: |
-          # Set the unique development version anywhere except a release branch
-          if [[ "${GITHUB_REF##*/}" =~ ^branch-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            version="${GITHUB_REF##*/branch-}"
-            echo "${version}"
-          else
-            python ci/scripts/set_dev_version.py
-          fi
+      - uses: ./.github/actions/setup-wheel-build
 
       - name: Build and test wheels (sedonadb)
         run: |
@@ -259,6 +183,15 @@ jobs:
           name: release-wheels-${{ matrix.config.label }}
           path: python/sedonadb/dist/*.whl
 
+  # Extension wheels build in their own reusable workflow, gated on the
+  # sedonadb jobs (so they run in the same run and can download those wheels
+  # to test against) but isolated so an extension failure can't block the
+  # core package's nightly. Future extensions follow the same shape.
+  zarr:
+    needs: ["windows-x86_64", "macOS-arm64", "macOS-amd64", "wheels-linux"]
+    uses: ./.github/workflows/wheels-zarr.yml
+    secrets: inherit
+
   upload_nightly:
     needs: ["wheels-linux", "macOS-arm64", "macOS-amd64", "windows-x86_64"]
     name: Upload nightly packages
@@ -266,7 +199,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v8
         with:
-          pattern: release-*
+          pattern: release-wheels-*
           merge-multiple: true
           path: dist
 

--- a/.github/workflows/wheels-zarr.yml
+++ b/.github/workflows/wheels-zarr.yml
@@ -64,7 +64,7 @@ jobs:
           # version is a prerelease), then its dependencies without --pre so
           # transitive deps can't resolve to prereleases.
           CIBW_BEFORE_TEST: pip install --no-deps --pre --find-links {package}/prebuilt sedonadb && pip install --find-links {package}/prebuilt sedonadb
-          CIBW_TEST_REQUIRES: pytest zarr numpy
+          CIBW_TEST_REQUIRES: pytest zarr numpy geoarrow-pyarrow
           CIBW_TEST_COMMAND: pytest {package}/tests -vv
 
       - uses: actions/upload-artifact@v7
@@ -97,7 +97,7 @@ jobs:
           ./wheels-build-zarr-macos.sh
         env:
           CIBW_BEFORE_TEST: pip install --no-deps --pre --find-links {package}/prebuilt sedonadb && pip install --find-links {package}/prebuilt sedonadb
-          CIBW_TEST_REQUIRES: pytest zarr numpy
+          CIBW_TEST_REQUIRES: pytest zarr numpy geoarrow-pyarrow
           CIBW_TEST_COMMAND: pytest {package}/tests -vv
 
       - uses: actions/upload-artifact@v7
@@ -130,7 +130,7 @@ jobs:
           ./wheels-build-zarr-macos.sh
         env:
           CIBW_BEFORE_TEST: pip install --no-deps --pre --find-links {package}/prebuilt sedonadb && pip install --find-links {package}/prebuilt sedonadb
-          CIBW_TEST_REQUIRES: pytest zarr numpy
+          CIBW_TEST_REQUIRES: pytest zarr numpy geoarrow-pyarrow
           CIBW_TEST_COMMAND: pytest {package}/tests -vv
           SEDONADB_MACOS_ARCH: x86_64
 
@@ -169,7 +169,7 @@ jobs:
         env:
           CIBW_SKIP: "*musllinux*"
           CIBW_BEFORE_TEST: pip install --no-deps --pre --find-links {package}/prebuilt sedonadb && pip install --find-links {package}/prebuilt sedonadb
-          CIBW_TEST_REQUIRES: pytest zarr numpy
+          CIBW_TEST_REQUIRES: pytest zarr numpy geoarrow-pyarrow
           CIBW_TEST_COMMAND: pytest {package}/tests -vv
 
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/wheels-zarr.yml
+++ b/.github/workflows/wheels-zarr.yml
@@ -59,10 +59,11 @@ jobs:
           .\wheels-build-zarr-windows.ps1
         env:
           CIBW_BUILD: "*-win_amd64"
-          # The sedonadb wheel was downloaded into the package dir above; --pre
-          # lets pip prefer the local dev prerelease over a PyPI stable release
-          # (transitive deps still resolve from PyPI).
-          CIBW_BEFORE_TEST: pip install --pre --find-links {package}/prebuilt sedonadb
+          # Install the sedonadb dev wheel downloaded into the package dir
+          # above: first sedonadb itself (--no-deps --pre, since the dev
+          # version is a prerelease), then its dependencies without --pre so
+          # transitive deps can't resolve to prereleases.
+          CIBW_BEFORE_TEST: pip install --no-deps --pre --find-links {package}/prebuilt sedonadb && pip install --find-links {package}/prebuilt sedonadb
           CIBW_TEST_REQUIRES: pytest zarr numpy
           CIBW_TEST_COMMAND: pytest {package}/tests -vv
 
@@ -95,7 +96,7 @@ jobs:
           cd ci/scripts
           ./wheels-build-zarr-macos.sh
         env:
-          CIBW_BEFORE_TEST: pip install --pre --find-links {package}/prebuilt sedonadb
+          CIBW_BEFORE_TEST: pip install --no-deps --pre --find-links {package}/prebuilt sedonadb && pip install --find-links {package}/prebuilt sedonadb
           CIBW_TEST_REQUIRES: pytest zarr numpy
           CIBW_TEST_COMMAND: pytest {package}/tests -vv
 
@@ -128,7 +129,7 @@ jobs:
           cd ci/scripts
           ./wheels-build-zarr-macos.sh
         env:
-          CIBW_BEFORE_TEST: pip install --pre --find-links {package}/prebuilt sedonadb
+          CIBW_BEFORE_TEST: pip install --no-deps --pre --find-links {package}/prebuilt sedonadb && pip install --find-links {package}/prebuilt sedonadb
           CIBW_TEST_REQUIRES: pytest zarr numpy
           CIBW_TEST_COMMAND: pytest {package}/tests -vv
           SEDONADB_MACOS_ARCH: x86_64
@@ -167,7 +168,7 @@ jobs:
           ./wheels-build-zarr-linux.sh ${{ matrix.config.arch }}
         env:
           CIBW_SKIP: "*musllinux*"
-          CIBW_BEFORE_TEST: pip install --pre --find-links {package}/prebuilt sedonadb
+          CIBW_BEFORE_TEST: pip install --no-deps --pre --find-links {package}/prebuilt sedonadb && pip install --find-links {package}/prebuilt sedonadb
           CIBW_TEST_REQUIRES: pytest zarr numpy
           CIBW_TEST_COMMAND: pytest {package}/tests -vv
 
@@ -180,6 +181,9 @@ jobs:
     needs: ["zarr-linux", "zarr-macOS-arm64", "zarr-macOS-amd64", "zarr-windows-x86_64"]
     name: Upload nightly packages (sedonadb-zarr)
     runs-on: "macos-latest"
+    # Only the nightly publish needs this job; skip it entirely (rather than
+    # just the push step) on PRs so it doesn't burn a runner.
+    if: github.repository == 'apache/sedona-db' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -194,7 +198,6 @@ jobs:
           fury --version
 
       - name: Upload packages to Gemfury
-        if: github.repository == 'apache/sedona-db' && github.ref == 'refs/heads/main'
         shell: bash
         run: |
           fury push \

--- a/.github/workflows/wheels-zarr.yml
+++ b/.github/workflows/wheels-zarr.yml
@@ -1,0 +1,205 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+name: wheels-zarr
+
+# Reusable workflow that builds, tests, and publishes the sedonadb-zarr
+# extension wheels. Invoked by python-wheels.yml after the sedonadb jobs so
+# this runs in the same run and can download their wheels for testing.
+#
+# Kept separate from the core wheel jobs so an extension build failure can't
+# block the core package from publishing. Future extensions (e.g. point cloud)
+# get their own reusable workflow following this same shape.
+#
+# sedonadb-zarr wheels are pure Rust + pyo3, but the tests `import sedonadb`,
+# so each job downloads the matching sedonadb wheel (built by the caller) and
+# installs it via CIBW_BEFORE_TEST before running the tests.
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  zarr-windows-x86_64:
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: 'true'
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-wheel-build
+        with:
+          rust-cache-key: "python-wheel-zarr-windows-v1"
+          delvewheel: "true"
+
+      - name: Download sedonadb wheel for the test environment
+        uses: actions/download-artifact@v8
+        with:
+          name: release-wheels-windows-x86_64
+          path: python/sedonadb-zarr/prebuilt
+
+      - name: Build and test wheels (sedonadb-zarr)
+        run: |
+          cd ci/scripts
+          .\wheels-build-zarr-windows.ps1
+        env:
+          CIBW_BUILD: "*-win_amd64"
+          # The sedonadb wheel was downloaded into the package dir above; --pre
+          # lets pip prefer the local dev prerelease over a PyPI stable release
+          # (transitive deps still resolve from PyPI).
+          CIBW_BEFORE_TEST: pip install --pre --find-links {package}/prebuilt sedonadb
+          CIBW_TEST_REQUIRES: pytest zarr numpy
+          CIBW_TEST_COMMAND: pytest {package}/tests -vv
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: release-zarr-wheels-windows-x86_64
+          path: python/sedonadb-zarr/dist/*.whl
+
+  zarr-macOS-arm64:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: 'true'
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-wheel-build
+        with:
+          rust-cache-key: "python-wheel-zarr-macOS-v1"
+          cache-bin: "false"
+
+      - name: Download sedonadb wheel for the test environment
+        uses: actions/download-artifact@v8
+        with:
+          name: release-wheels-macOS-arm64
+          path: python/sedonadb-zarr/prebuilt
+
+      - name: Build and test wheels (sedonadb-zarr)
+        run: |
+          cd ci/scripts
+          ./wheels-build-zarr-macos.sh
+        env:
+          CIBW_BEFORE_TEST: pip install --pre --find-links {package}/prebuilt sedonadb
+          CIBW_TEST_REQUIRES: pytest zarr numpy
+          CIBW_TEST_COMMAND: pytest {package}/tests -vv
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: release-zarr-wheels-macOS-arm64
+          path: python/sedonadb-zarr/dist/*.whl
+
+  zarr-macOS-amd64:
+    runs-on: macos-15-intel
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: 'true'
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-wheel-build
+        with:
+          rust-cache-key: "python-wheel-zarr-macOS-v1"
+          cache-bin: "false"
+
+      - name: Download sedonadb wheel for the test environment
+        uses: actions/download-artifact@v8
+        with:
+          name: release-wheels-macOS-amd64
+          path: python/sedonadb-zarr/prebuilt
+
+      - name: Build and test wheels (sedonadb-zarr)
+        run: |
+          cd ci/scripts
+          ./wheels-build-zarr-macos.sh
+        env:
+          CIBW_BEFORE_TEST: pip install --pre --find-links {package}/prebuilt sedonadb
+          CIBW_TEST_REQUIRES: pytest zarr numpy
+          CIBW_TEST_COMMAND: pytest {package}/tests -vv
+          SEDONADB_MACOS_ARCH: x86_64
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: release-zarr-wheels-macOS-amd64
+          path: python/sedonadb-zarr/dist/*.whl
+
+  zarr-linux:
+    name: zarr-${{ matrix.config.label }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      matrix:
+        config:
+          - {os: "ubuntu-latest", label: "linux-x86_64", arch: "x86_64"}
+          - {os: "ubuntu-24.04-arm", label: "linux-arm64", arch: "aarch64"}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: 'true'
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-wheel-build
+
+      - name: Download sedonadb wheel for the test environment
+        uses: actions/download-artifact@v8
+        with:
+          name: release-wheels-${{ matrix.config.label }}
+          path: python/sedonadb-zarr/prebuilt
+
+      - name: Build and test wheels (sedonadb-zarr)
+        run: |
+          cd ci/scripts
+          ./wheels-build-zarr-linux.sh ${{ matrix.config.arch }}
+        env:
+          CIBW_SKIP: "*musllinux*"
+          CIBW_BEFORE_TEST: pip install --pre --find-links {package}/prebuilt sedonadb
+          CIBW_TEST_REQUIRES: pytest zarr numpy
+          CIBW_TEST_COMMAND: pytest {package}/tests -vv
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: release-zarr-wheels-${{ matrix.config.label }}
+          path: python/sedonadb-zarr/dist/*.whl
+
+  upload_nightly:
+    needs: ["zarr-linux", "zarr-macOS-arm64", "zarr-macOS-amd64", "zarr-windows-x86_64"]
+    name: Upload nightly packages (sedonadb-zarr)
+    runs-on: "macos-latest"
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: release-zarr-wheels-*
+          merge-multiple: true
+          path: dist
+
+      - name: Install gemfury client
+        run: |
+          brew tap gemfury/tap
+          brew install fury-cli
+          fury --version
+
+      - name: Upload packages to Gemfury
+        if: github.repository == 'apache/sedona-db' && github.ref == 'refs/heads/main'
+        shell: bash
+        run: |
+          fury push \
+            --api-token=${GEMFURY_PUSH_TOKEN} \
+            --as="sedona-nightlies" \
+            dist/*
+        env:
+          GEMFURY_PUSH_TOKEN: ${{ secrets.GEMFURY_PUSH_TOKEN }}

--- a/ci/scripts/wheels-build-zarr-linux.sh
+++ b/ci/scripts/wheels-build-zarr-linux.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Build Linux wheels for sedonadb-zarr.
+#
+# sedonadb-zarr is pure Rust + pyo3 with no vcpkg-managed native dependencies
+# and no sedonadb-only cargo features, so this is just cibuildwheel over the
+# Rust build. The manylinux image needs cmake (builds c-blosc via blosc-src
+# and aws-lc-sys) plus clang/perl (back ring and aws-lc-sys).
+#
+# This build profile is specific to sedonadb-zarr. Other extensions may have
+# different native build requirements and should get their own script rather
+# than reusing this one.
+#
+# Builds one arch at a time; musllinux must be skipped via CIBW_BUILD/CIBW_SKIP.
+#
+# Local usage:
+# CIBW_BUILD=cp313-manylinux_x86_64 ./wheels-build-zarr-linux.sh x86_64
+
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+SEDONADB_DIR="$(cd "${SOURCE_DIR}/../.." && pwd)"
+
+ARCH="$1"
+
+export CIBW_BEFORE_ALL="yum install -y clang perl cmake"
+
+pushd "${SEDONADB_DIR}"
+python -m cibuildwheel --platform linux --archs ${ARCH} --output-dir python/sedonadb-zarr/dist python/sedonadb-zarr

--- a/ci/scripts/wheels-build-zarr-linux.sh
+++ b/ci/scripts/wheels-build-zarr-linux.sh
@@ -17,18 +17,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Build Linux wheels for sedonadb-zarr.
-#
-# sedonadb-zarr is pure Rust + pyo3 with no vcpkg-managed native dependencies
-# and no sedonadb-only cargo features, so this is just cibuildwheel over the
-# Rust build. The manylinux image needs cmake (builds c-blosc via blosc-src
-# and aws-lc-sys) plus clang/perl (back ring and aws-lc-sys).
-#
-# This build profile is specific to sedonadb-zarr. Other extensions may have
-# different native build requirements and should get their own script rather
-# than reusing this one.
-#
-# Builds one arch at a time; musllinux must be skipped via CIBW_BUILD/CIBW_SKIP.
+# Build Linux wheels for sedonadb-zarr: pure Rust + pyo3, no vcpkg. cmake
+# builds c-blosc + aws-lc-sys; clang/perl back ring/aws-lc-sys. One arch per
+# invocation; skip musllinux via CIBW_BUILD/CIBW_SKIP.
 #
 # Local usage:
 # CIBW_BUILD=cp313-manylinux_x86_64 ./wheels-build-zarr-linux.sh x86_64

--- a/ci/scripts/wheels-build-zarr-linux.sh
+++ b/ci/scripts/wheels-build-zarr-linux.sh
@@ -33,6 +33,13 @@
 # Local usage:
 # CIBW_BUILD=cp313-manylinux_x86_64 ./wheels-build-zarr-linux.sh x86_64
 
+set -e
+set -o pipefail
+
+if [ ${VERBOSE:-0} -gt 0 ]; then
+  set -x
+fi
+
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 SEDONADB_DIR="$(cd "${SOURCE_DIR}/../.." && pwd)"
 
@@ -41,4 +48,4 @@ ARCH="$1"
 export CIBW_BEFORE_ALL="yum install -y clang perl cmake"
 
 pushd "${SEDONADB_DIR}"
-python -m cibuildwheel --platform linux --archs ${ARCH} --output-dir python/sedonadb-zarr/dist python/sedonadb-zarr
+python -m cibuildwheel --platform linux --archs "${ARCH}" --output-dir python/sedonadb-zarr/dist python/sedonadb-zarr

--- a/ci/scripts/wheels-build-zarr-macos.sh
+++ b/ci/scripts/wheels-build-zarr-macos.sh
@@ -17,19 +17,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Build macOS wheels for sedonadb-zarr.
-#
-# sedonadb-zarr is pure Rust + pyo3 with no vcpkg-managed native dependencies
-# and no sedonadb-only cargo features, so this is just cibuildwheel over the
-# Rust build. cmake (preinstalled on the runners) backs c-blosc and
-# aws-lc-sys, and the default delocate repair suffices because there are no
-# vcpkg @rpath libs to vendor.
-#
-# This build profile is specific to sedonadb-zarr. Other extensions may have
-# different native build requirements and should get their own script rather
-# than reusing this one.
-#
-# Set SEDONADB_MACOS_ARCH=x86_64 to cross-build for Intel (defaults to arm64).
+# Build macOS wheels for sedonadb-zarr: pure Rust + pyo3, no vcpkg. cmake
+# (preinstalled) builds c-blosc + aws-lc-sys; default delocate repair
+# suffices. Set SEDONADB_MACOS_ARCH=x86_64 to cross-build for Intel.
 #
 # Local usage:
 # CIBW_BUILD='cp313*' ./wheels-build-zarr-macos.sh

--- a/ci/scripts/wheels-build-zarr-macos.sh
+++ b/ci/scripts/wheels-build-zarr-macos.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Build macOS wheels for sedonadb-zarr.
+#
+# sedonadb-zarr is pure Rust + pyo3 with no vcpkg-managed native dependencies
+# and no sedonadb-only cargo features, so this is just cibuildwheel over the
+# Rust build. cmake (preinstalled on the runners) backs c-blosc and
+# aws-lc-sys, and the default delocate repair suffices because there are no
+# vcpkg @rpath libs to vendor.
+#
+# This build profile is specific to sedonadb-zarr. Other extensions may have
+# different native build requirements and should get their own script rather
+# than reusing this one.
+#
+# Set SEDONADB_MACOS_ARCH=x86_64 to cross-build for Intel (defaults to arm64).
+#
+# Local usage:
+# CIBW_BUILD='cp313*' ./wheels-build-zarr-macos.sh
+
+set -e
+set -o pipefail
+
+if [ ${VERBOSE:-0} -gt 0 ]; then
+  set -x
+fi
+
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+SEDONADB_DIR="$(cd "${SOURCE_DIR}/../.." && pwd)"
+
+# Default to arm64 but allow override to x86_64
+SEDONADB_MACOS_ARCH=${SEDONADB_MACOS_ARCH:-arm64}
+
+# Match the deployment target the main package uses so the wheel platform tag
+# lines up across both packages.
+export CIBW_ENVIRONMENT_MACOS="$CIBW_ENVIRONMENT_MACOS _PYTHON_HOST_PLATFORM=macosx-12.0-${SEDONADB_MACOS_ARCH} MACOSX_DEPLOYMENT_TARGET=12.0"
+
+pushd "${SEDONADB_DIR}"
+python -m cibuildwheel --output-dir python/sedonadb-zarr/dist python/sedonadb-zarr

--- a/ci/scripts/wheels-build-zarr-windows.ps1
+++ b/ci/scripts/wheels-build-zarr-windows.ps1
@@ -15,17 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Build Windows wheels for sedonadb-zarr.
-#
-# sedonadb-zarr is pure Rust + pyo3 with no vcpkg-managed native dependencies
-# (GEOS / s2geometry / OpenSSL), no geos-config shim, and no sedonadb-only
-# cargo features, so this is just cibuildwheel over the Rust build. NASM is
-# still required for aws-lc-sys assembly; cmake (preinstalled on the runners)
-# backs c-blosc and aws-lc-sys.
-#
-# This build profile is specific to sedonadb-zarr. Other extensions may have
-# different native build requirements and should get their own script rather
-# than reusing this one.
+# Build Windows wheels for sedonadb-zarr: pure Rust + pyo3, no vcpkg. NASM is
+# required for aws-lc-sys assembly; cmake (preinstalled) builds c-blosc +
+# aws-lc-sys.
 #
 # Local usage:
 # $env:CIBW_BUILD="cp313-win_amd64"; .\wheels-build-zarr-windows.ps1
@@ -33,36 +25,22 @@
 $originalDirectory = Get-Location
 $scriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
 
-# Download and extract NASM if it doesn't exist
-# On Windows, NASM is required for AWS Rust dependencies (aws-lc-sys)
+# Fetch NASM (required for aws-lc-sys assembly) if not already present.
 $NASM_URL = "https://www.nasm.us/pub/nasm/releasebuilds/2.16.03/win64/nasm-2.16.03-win64.zip"
 $NASM_DIR = "$scriptDirectory\nasm-2.16.03"
 $NASM_ZIP = "$scriptDirectory\nasm.zip"
 
 if (-not (Test-Path $NASM_DIR)) {
-	Write-Host "Downloading NASM to $NASM_DIR..."
 	New-Item -Path $NASM_DIR -ItemType Directory -Force | Out-Null
-
-	# Download the NASM zip file
 	Invoke-WebRequest -Uri $NASM_URL -OutFile $NASM_ZIP
-
-	# Extract the zip file
 	Expand-Archive -Path $NASM_ZIP -DestinationPath $scriptDirectory -Force
-
-	# Clean up the zip file
 	Remove-Item -Path $NASM_ZIP -Force
-
-	Write-Host "NASM downloaded and extracted to $NASM_DIR"
-} else {
-	Write-Host "NASM directory already exists at $NASM_DIR"
 }
 
 # Add NASM to PATH
 $env:PATH += ";$NASM_DIR"
 
-# Vendor any runtime DLLs into the wheel. sedonadb-zarr links Rust statically, so
-# this is typically a no-op, but it keeps the wheel self-contained if a
-# dependency does pull a DLL.
+# Vendor any runtime DLLs into the wheel (typically a no-op; Rust links static).
 $env:CIBW_REPAIR_WHEEL_COMMAND_WINDOWS="delvewheel repair -v --exclude=combase.dll --wheel-dir={dest_dir} {wheel}"
 
 # Quality of life: don't change the working directory of the calling script even when it fails

--- a/ci/scripts/wheels-build-zarr-windows.ps1
+++ b/ci/scripts/wheels-build-zarr-windows.ps1
@@ -1,0 +1,78 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Build Windows wheels for sedonadb-zarr.
+#
+# sedonadb-zarr is pure Rust + pyo3 with no vcpkg-managed native dependencies
+# (GEOS / s2geometry / OpenSSL), no geos-config shim, and no sedonadb-only
+# cargo features, so this is just cibuildwheel over the Rust build. NASM is
+# still required for aws-lc-sys assembly; cmake (preinstalled on the runners)
+# backs c-blosc and aws-lc-sys.
+#
+# This build profile is specific to sedonadb-zarr. Other extensions may have
+# different native build requirements and should get their own script rather
+# than reusing this one.
+#
+# Local usage:
+# $env:CIBW_BUILD="cp313-win_amd64"; .\wheels-build-zarr-windows.ps1
+
+$originalDirectory = Get-Location
+$scriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+# Download and extract NASM if it doesn't exist
+# On Windows, NASM is required for AWS Rust dependencies (aws-lc-sys)
+$NASM_URL = "https://www.nasm.us/pub/nasm/releasebuilds/2.16.03/win64/nasm-2.16.03-win64.zip"
+$NASM_DIR = "$scriptDirectory\nasm-2.16.03"
+$NASM_ZIP = "$scriptDirectory\nasm.zip"
+
+if (-not (Test-Path $NASM_DIR)) {
+	Write-Host "Downloading NASM to $NASM_DIR..."
+	New-Item -Path $NASM_DIR -ItemType Directory -Force | Out-Null
+
+	# Download the NASM zip file
+	Invoke-WebRequest -Uri $NASM_URL -OutFile $NASM_ZIP
+
+	# Extract the zip file
+	Expand-Archive -Path $NASM_ZIP -DestinationPath $scriptDirectory -Force
+
+	# Clean up the zip file
+	Remove-Item -Path $NASM_ZIP -Force
+
+	Write-Host "NASM downloaded and extracted to $NASM_DIR"
+} else {
+	Write-Host "NASM directory already exists at $NASM_DIR"
+}
+
+# Add NASM to PATH
+$env:PATH += ";$NASM_DIR"
+
+# Vendor any runtime DLLs into the wheel. sedonadb-zarr links Rust statically, so
+# this is typically a no-op, but it keeps the wheel self-contained if a
+# dependency does pull a DLL.
+$env:CIBW_REPAIR_WHEEL_COMMAND_WINDOWS="delvewheel repair -v --exclude=combase.dll --wheel-dir={dest_dir} {wheel}"
+
+# Quality of life: don't change the working directory of the calling script even when it fails
+$parentDirectory = Split-Path -Parent (Split-Path -Parent $scriptDirectory)
+try {
+	Push-Location "$parentDirectory"
+	python -m cibuildwheel --output-dir python\sedonadb-zarr\dist python\sedonadb-zarr
+	Pop-Location
+}
+finally {
+	# Restore the original working directory
+	Set-Location -Path $originalDirectory
+}

--- a/python/sedonadb-zarr/.gitignore
+++ b/python/sedonadb-zarr/.gitignore
@@ -32,6 +32,8 @@ bin/
 build/
 develop-eggs/
 dist/
+# CI downloads the sedonadb wheel here to test the plugin against it.
+prebuilt/
 eggs/
 lib/
 lib64/

--- a/python/sedonadb-zarr/pyproject.toml
+++ b/python/sedonadb-zarr/pyproject.toml
@@ -30,8 +30,12 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    # `ExternalFormatSpec` + `list_single_object` landed in 0.4.0.
-    "sedonadb>=0.4.0",
+    # `ExternalFormatSpec` + `list_single_object` landed in 0.4.0. The floor is
+    # an explicit prerelease (`0.4.0a0`) so dev/nightly builds — which version
+    # as `0.4.0aN` and are PEP 440-*less* than `0.4.0` — satisfy it; a plain
+    # `>=0.4.0` would reject the matching nightly sedonadb wheel (and break
+    # `pip install` of the nightly for users, not just CI).
+    "sedonadb>=0.4.0a0",
 ]
 
 [project.optional-dependencies]

--- a/python/sedonadb-zarr/tests/test_zarr.py
+++ b/python/sedonadb-zarr/tests/test_zarr.py
@@ -32,7 +32,10 @@ import sedonadb_zarr
 @pytest.fixture
 def zarr_group(tmp_path):
     """Build a tiny 2x2 UInt8 Zarr v3 group with two chunks."""
-    zarr = pytest.importorskip("zarr")
+    # The fixture uses the zarr-python 3.x API (create_array,
+    # dimension_names); zarr 2.x (the newest available on Python < 3.11)
+    # can't write these fixtures.
+    zarr = pytest.importorskip("zarr", minversion="3.0")
     root = zarr.open_group(str(tmp_path), mode="w")
     arr = root.create_array(
         "temperature",
@@ -100,7 +103,7 @@ def test_format_spec_class_invariants():
     ],
 )
 def test_dtype_mapping_roundtrips(tmp_path, numpy_dtype):
-    zarr = pytest.importorskip("zarr")
+    zarr = pytest.importorskip("zarr", minversion="3.0")
     root = zarr.open_group(str(tmp_path), mode="w")
     arr = root.create_array(
         "temperature",


### PR DESCRIPTION
Build the wheels and run tests for sedona-zarr. This parallels the build for sedona db but is simpler because theres no native code dependencies here. 

I also refactored out a common action that is shared between sedona db and the zarr extension. 