### PR TITLE
feat(python/sedonadb): add Python aggregate UDF decorator

### DIFF
--- a/python/sedonadb/python/sedonadb/udf.py
+++ b/python/sedonadb/python/sedonadb/udf.py
@@ -16,9 +16,10 @@
 # under the License.
 
 import inspect
+import re
 from typing import Any, List, Literal, Optional, Union
 
-from sedonadb._lib import sedona_scalar_udf
+from sedonadb._lib import sedona_aggregate_udf, sedona_scalar_udf
 from sedonadb.utility import sedona  # noqa: F401
 
 
@@ -314,3 +315,221 @@ def _callable_kwarg_only_names(f):
     return [
         k for k, p in sig.parameters.items() if p.kind == inspect.Parameter.KEYWORD_ONLY
     ]
+
+
+def _camel_to_snake(name: str) -> str:
+    """Convert a `CamelCase` identifier to `snake_case`.
+
+    `MyMean` -> `my_mean`, `STMean` -> `st_mean`, `my_mean` -> `my_mean`.
+    """
+    s = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", name)
+    s = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s)
+    return s.lower()
+
+
+def arrow_aggregate_udf(
+    return_type: Any,
+    input_types: List[Union[TypeMatcher, Any]],
+    state_types: List[Any],
+    *,
+    volatility: Literal["immutable", "stable", "volatile"] = "immutable",
+    name: Optional[str] = None,
+):
+    """Decorator for Python-implemented aggregate UDFs.
+
+    Decorates a class whose instances act as a stateful accumulator. Each
+    grouped/global aggregation builds one instance per partial-state slot
+    and then merges them.
+
+    !!! warning
+        SedonaDB Python UDFs are experimental and this interface may change
+        based on user feedback.
+
+    The decorated class must define:
+
+    - `__init__(self)`: build a fresh accumulator (no arguments).
+    - `update(self, *arrays)`: receives one `pa.Array` per declared input
+      column, splatted positionally (single input today; the array can
+      contain nulls).
+    - `state(self) -> tuple`: serialize the accumulator into a tuple of
+      Python values matching `state_types` in order.
+    - `merge(self, *arrays)`: receives one `pa.Array` per element of
+      `state_types`, splatted positionally. Each array has N rows for N
+      partial states being merged in.
+    - `evaluate(self)`: return the final scalar Python value (or `None`
+      for SQL NULL) matching `return_type`.
+
+    Args:
+        return_type: A pyarrow data type for the final aggregate result.
+            Must be a concrete pyarrow type — `TypeMatcher` constants are
+            not accepted here.
+        input_types: One or more types describing the columns the
+            aggregate consumes. Each entry is either a `TypeMatcher`
+            constant (`udf.NUMERIC`, `udf.GEOMETRY`, …) or a concrete
+            pyarrow type.
+        state_types: A list of concrete pyarrow types describing the
+            serialized state. The length must match the tuple returned by
+            `state()`.
+        volatility: `"immutable"` (default), `"stable"`, or `"volatile"`.
+        name: SQL-visible name. Defaults to the decorated class name
+            converted from `CamelCase` to `snake_case` (so a `MyMean`
+            class is callable as `my_mean`).
+
+    Examples:
+
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> import sedonadb
+        >>> from sedonadb import udf
+        >>> sd = sedonadb.connect()
+        >>>
+        >>> @udf.arrow_aggregate_udf(
+        ...     return_type=pa.float64(),
+        ...     input_types=[udf.NUMERIC],
+        ...     state_types=[pa.float64(), pa.int64()],
+        ... )
+        ... class my_mean:
+        ...     def __init__(self):
+        ...         self.total = 0.0
+        ...         self.count = 0
+        ...     def update(self, batch):
+        ...         for v in batch:
+        ...             if v.is_valid:
+        ...                 self.total += float(v.as_py())
+        ...                 self.count += 1
+        ...     def state(self):
+        ...         return (self.total, self.count)
+        ...     def merge(self, totals, counts):
+        ...         for i in range(len(totals)):
+        ...             self.total += totals[i].as_py()
+        ...             self.count += counts[i].as_py()
+        ...     def evaluate(self):
+        ...         return None if self.count == 0 else self.total / self.count
+        ...
+        >>> sd.register_udf(my_mean)
+        >>> sd.create_data_frame(
+        ...     pd.DataFrame({"k": ["a", "a", "b"], "v": [1.0, 3.0, 7.0]})
+        ... ).to_view("t", overwrite=True)
+        >>> sd.sql("SELECT k, my_mean(v) AS m FROM t GROUP BY k ORDER BY k").show()
+        ┌──────┬─────────┐
+        │   k  ┆    m    │
+        │ utf8 ┆ float64 │
+        ╞══════╪═════════╡
+        │ a    ┆     2.0 │
+        ├╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
+        │ b    ┆     7.0 │
+        └──────┴─────────┘
+    """
+
+    def decorator(cls):
+        return AggregateUdfImpl(
+            cls, return_type, input_types, state_types, volatility, name
+        )
+
+    return decorator
+
+
+class AggregateUdfImpl:
+    """Aggregate user-defined function wrapper.
+
+    Returned by [`arrow_aggregate_udf`][sedonadb.udf.arrow_aggregate_udf].
+    Holds the user's class plus the type schemas; on registration, builds
+    a factory that produces a per-accumulator `_AccumulatorWrapper`
+    bridging the user's class to the Rust `Accumulator` trait.
+    """
+
+    def __init__(
+        self,
+        user_cls,
+        return_type,
+        input_types,
+        state_types,
+        volatility: Literal["immutable", "stable", "volatile"] = "immutable",
+        name: Optional[str] = None,
+    ):
+        self._user_cls = user_cls
+        self._return_type = return_type
+        self._input_types = input_types
+        self._state_types = state_types
+        self._volatility = volatility
+        if name is None and hasattr(user_cls, "__name__"):
+            # Linters push users toward CamelCase class names, but function
+            # lookups (con.funcs.<name> and SQL) resolve against a lowercased
+            # name. Derive a snake_case default so `MyMean` is callable as
+            # `my_mean`.
+            self._name = _camel_to_snake(user_cls.__name__)
+        else:
+            self._name = name
+
+    def __sedona_internal_udf__(self):
+        # The factory closure is invoked by the Rust kernel once per
+        # accumulator instance; it captures `self` (which only holds the
+        # user class and small type lists).
+        def factory():
+            return _AccumulatorWrapper(
+                self._user_cls(), self._return_type, self._state_types
+            )
+
+        return sedona_aggregate_udf(
+            factory,
+            self._return_type,
+            self._input_types,
+            self._state_types,
+            self._volatility,
+            self._name,
+        )
+
+
+class _AccumulatorWrapper:
+    """Bridges a user accumulator class to the Rust `Accumulator` calls.
+
+    Translates each Rust → Python crossing:
+
+    - `update(args)` / `merge(args)`: `args` is a tuple of zero-copy
+      Arrow-array handles (PySedonaValue); we convert each to a real
+      `pa.Array` and splat them positionally into the user's method.
+    - `evaluate()`: wraps the user's scalar return value as a 1-element
+      `pa.Array` of `return_type` so the Rust side can extract a
+      `ScalarValue` via the C-data interface.
+    - `state()`: wraps each scalar in the user's tuple as a 1-element
+      `pa.Array` of the matching `state_types[i]`.
+    """
+
+    def __init__(self, user_instance, return_type, state_types):
+        self._user = user_instance
+        self._return_type = return_type
+        self._state_types = state_types
+
+    @staticmethod
+    def _to_arrays(args):
+        import pyarrow as pa
+
+        # `.to_array()` forces the Array variant before the C-data import,
+        # matching the conversion the scalar-UDF examples use.
+        return [pa.array(a.to_array()) for a in args]
+
+    @staticmethod
+    def _wrap_scalar(value, pa_type):
+        import pyarrow as pa
+
+        return pa.array([value], type=pa_type)
+
+    def update(self, args):
+        self._user.update(*self._to_arrays(args))
+
+    def merge(self, args):
+        self._user.merge(*self._to_arrays(args))
+
+    def evaluate(self):
+        return self._wrap_scalar(self._user.evaluate(), self._return_type)
+
+    def state(self):
+        values = self._user.state()
+        if not isinstance(values, (tuple, list)):
+            values = (values,)
+        if len(values) != len(self._state_types):
+            raise ValueError(
+                f"Aggregate UDF state() returned {len(values)} elements, "
+                f"expected {len(self._state_types)} per state_types"
+            )
+        return tuple(self._wrap_scalar(v, t) for v, t in zip(values, self._state_types))

--- a/python/sedonadb/src/context.rs
+++ b/python/sedonadb/src/context.rs
@@ -17,7 +17,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use arrow_schema::DataType;
-use datafusion_expr::ScalarUDFImpl;
+use datafusion_expr::{AggregateUDFImpl, ScalarUDFImpl};
 use pyo3::prelude::*;
 use sedona::context::SedonaContext;
 use sedona::context_builder::SedonaContextBuilder;
@@ -29,7 +29,7 @@ use crate::{
     error::PySedonaError,
     import_from::{import_ffi_scalar_udf, import_table_provider_from_any},
     runtime::wait_for_future,
-    udf::{PyAggregateUdf, PyScalarUdf, PySedonaScalarUdf},
+    udf::{PyAggregateUdf, PyScalarUdf, PySedonaAggregateUdf, PySedonaScalarUdf},
 };
 
 #[pyclass]
@@ -259,23 +259,42 @@ impl InternalContext {
 
     pub fn register_udf(&mut self, udf: Bound<PyAny>) -> Result<(), PySedonaError> {
         if udf.hasattr("__sedona_internal_udf__")? {
-            let py_scalar_udf = udf
-                .getattr("__sedona_internal_udf__")?
-                .call0()?
-                .extract::<PySedonaScalarUdf>()?;
-            let name = py_scalar_udf.inner.name();
-            self.inner
-                .functions
-                .insert_scalar_udf(py_scalar_udf.inner.clone());
-            self.inner.ctx.register_udf(
+            let internal = udf.getattr("__sedona_internal_udf__")?.call0()?;
+            if let Ok(py_scalar_udf) = internal.extract::<PySedonaScalarUdf>() {
+                let name = py_scalar_udf.inner.name();
                 self.inner
                     .functions
-                    .scalar_udf(name)
-                    .unwrap()
-                    .clone()
-                    .into(),
-            );
-            return Ok(());
+                    .insert_scalar_udf(py_scalar_udf.inner.clone());
+                self.inner.ctx.register_udf(
+                    self.inner
+                        .functions
+                        .scalar_udf(name)
+                        .unwrap()
+                        .clone()
+                        .into(),
+                );
+                return Ok(());
+            }
+            if let Ok(py_agg_udf) = internal.extract::<PySedonaAggregateUdf>() {
+                let name = py_agg_udf.inner.name();
+                self.inner
+                    .functions
+                    .insert_aggregate_udf(py_agg_udf.inner.clone());
+                self.inner.ctx.register_udaf(
+                    self.inner
+                        .functions
+                        .aggregate_udf(name)
+                        .unwrap()
+                        .clone()
+                        .into(),
+                );
+                return Ok(());
+            }
+            return Err(PySedonaError::SedonaPython(
+                "__sedona_internal_udf__ returned an unrecognized UDF type \
+                 (expected scalar or aggregate)"
+                    .to_string(),
+            ));
         } else if udf.hasattr("__datafusion_scalar_udf__")? {
             let scalar_udf = import_ffi_scalar_udf(&udf)?;
             self.inner.ctx.register_udf(scalar_udf);

--- a/python/sedonadb/src/lib.rs
+++ b/python/sedonadb/src/lib.rs
@@ -15,7 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{error::PySedonaError, udf::sedona_scalar_udf};
+use crate::{
+    error::PySedonaError,
+    udf::{sedona_aggregate_udf, sedona_scalar_udf},
+};
 use pyo3::{ffi::Py_uintptr_t, prelude::*};
 use sedona_adbc::AdbcSedonadbDriverInit;
 use sedona_gdal::global::{configure_global_gdal_api, with_global_gdal, GdalApiBuilder};
@@ -125,6 +128,7 @@ fn _lib(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(sedona_python_version, m)?)?;
     m.add_function(wrap_pyfunction!(sedona_python_features, m)?)?;
     m.add_function(wrap_pyfunction!(sedona_scalar_udf, m)?)?;
+    m.add_function(wrap_pyfunction!(sedona_aggregate_udf, m)?)?;
     m.add_function(wrap_pyfunction!(expr::expr_col, m)?)?;
     m.add_function(wrap_pyfunction!(expr::expr_lit, m)?)?;
     m.add_function(wrap_pyfunction!(expr::expr_binary, m)?)?;

--- a/python/sedonadb/src/udf.rs
+++ b/python/sedonadb/src/udf.rs
@@ -21,16 +21,20 @@ use arrow_array::{
     ffi::{FFI_ArrowArray, FFI_ArrowSchema},
     ArrayRef,
 };
-use arrow_schema::Field;
+use arrow_schema::{Field, FieldRef};
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::{Result, ScalarValue};
-use datafusion_expr::{AggregateUDF, ColumnarValue, ScalarUDF, ScalarUDFImpl, Volatility};
+use datafusion_expr::{
+    Accumulator, AggregateUDF, AggregateUDFImpl, ColumnarValue, ScalarUDF, ScalarUDFImpl,
+    Volatility,
+};
 use datafusion_ffi::udf::FFI_ScalarUDF;
 use pyo3::{
     pyclass, pyfunction, pymethods,
-    types::{PyAnyMethods, PyCapsule, PyTuple},
+    types::{PyAnyMethods, PyCapsule, PyTuple, PyTupleMethods},
     Bound, PyObject, Python,
 };
+use sedona_expr::aggregate_udf::{SedonaAccumulator, SedonaAccumulatorRef, SedonaAggregateUDF};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
 
@@ -148,6 +152,36 @@ impl PySedonaScalarUdf {
     }
 }
 
+/// Parse a Python-supplied volatility string into a [Volatility].
+fn parse_volatility(volatility: &str) -> Result<Volatility, PySedonaError> {
+    match volatility {
+        "immutable" => Ok(Volatility::Immutable),
+        "stable" => Ok(Volatility::Stable),
+        "volatile" => Ok(Volatility::Volatile),
+        v => Err(PySedonaError::SedonaPython(format!(
+            "Expected one of 'immutable', 'stable', or 'volatile' but got '{v}'"
+        ))),
+    }
+}
+
+/// Validate that an array imported from a Python UDF has the expected logical
+/// type, accepting either the exact [SedonaType] or its bare storage type.
+fn validate_imported_type(
+    expected: &SedonaType,
+    actual: &SedonaType,
+    context: &str,
+) -> Result<(), PySedonaError> {
+    if expected != actual {
+        let expected_storage = SedonaType::Arrow(expected.storage_type().clone());
+        if &expected_storage != actual {
+            return Err(PySedonaError::SedonaPython(format!(
+                "Expected {context} to return array of type {expected} or its storage but got {actual}"
+            )));
+        }
+    }
+    Ok(())
+}
+
 #[pyfunction]
 pub fn sedona_scalar_udf<'py>(
     py: Python<'py>,
@@ -157,16 +191,7 @@ pub fn sedona_scalar_udf<'py>(
     volatility: &str,
     name: &str,
 ) -> Result<PySedonaScalarUdf, PySedonaError> {
-    let volatility = match volatility {
-        "immutable" => Volatility::Immutable,
-        "stable" => Volatility::Stable,
-        "volatile" => Volatility::Volatile,
-        v => {
-            return Err(PySedonaError::SedonaPython(format!(
-                "Expected one of 'immutable', 'stable', or 'volatile' but got '{v}'"
-            )));
-        }
-    };
+    let volatility = parse_volatility(volatility)?;
 
     let scalar_kernel = sedona_scalar_kernel(py, py_input_types, py_return_type, py_invoke_batch)?;
     let sedona_scalar_udf = SedonaScalarUDF::new(name, vec![Arc::new(scalar_kernel)], volatility);
@@ -296,14 +321,11 @@ impl SedonaScalarKernel for PySedonaScalarKernel {
             let (result_field, result_array) = import_arrow_array(result_bound)?;
             let result_sedona_type = SedonaType::from_storage_field(&result_field)?;
 
-            if return_type != &result_sedona_type {
-                let return_type_storage = SedonaType::Arrow(return_type.storage_type().clone());
-                if return_type_storage != result_sedona_type {
-                    return Err(PySedonaError::SedonaPython(format!(
-                        "Expected result of user-defined function to return array of type {return_type} or its storage but got {result_sedona_type}"
-                    )));
-                }
-            }
+            validate_imported_type(
+                return_type,
+                &result_sedona_type,
+                "result of user-defined function",
+            )?;
 
             if result_array.len() != num_rows {
                 return Err(PySedonaError::SedonaPython(format!(
@@ -427,5 +449,237 @@ impl PySedonaValue {
             "PySedonaValue {label} {}[{}]",
             self.sedona_type.inner, self.num_rows
         )
+    }
+}
+
+/// SedonaAggregateUdf wrapper for Python-implemented aggregate UDFs.
+///
+/// Parallel to [PySedonaScalarUdf]: holds a SedonaAggregateUDF that wraps a
+/// Python class which produces accumulator instances. Registration goes
+/// through `__sedona_internal_udf__()` on the Python side; `InternalContext`
+/// recognizes the capsule and routes to `insert_aggregate_udf`.
+#[pyclass]
+#[derive(Clone)]
+pub struct PySedonaAggregateUdf {
+    pub inner: SedonaAggregateUDF,
+}
+
+#[pymethods]
+impl PySedonaAggregateUdf {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn __repr__(&self) -> String {
+        self.inner.name().to_string()
+    }
+
+    fn call(&self, args: Vec<PyExpr>) -> Result<PyExpr, PySedonaError> {
+        let expr_args = args.iter().map(|arg| arg.inner.clone()).collect();
+        let aggregate_udf: AggregateUDF = self.inner.clone().into();
+        let result = aggregate_udf.call(expr_args);
+        Ok(PyExpr::new(result))
+    }
+}
+
+#[pyfunction]
+pub fn sedona_aggregate_udf<'py>(
+    py: Python<'py>,
+    py_factory: PyObject,
+    py_return_type: PyObject,
+    py_input_types: Vec<PyObject>,
+    py_state_types: Vec<PyObject>,
+    volatility: &str,
+    name: &str,
+) -> Result<PySedonaAggregateUdf, PySedonaError> {
+    let volatility = parse_volatility(volatility)?;
+
+    let arg_matchers = py_input_types
+        .iter()
+        .map(|obj| import_arg_matcher(obj.bind(py)))
+        .collect::<Result<Vec<_>, _>>()?;
+    let return_type = import_sedona_type(py_return_type.bind(py))?;
+    let matcher = ArgMatcher::new(arg_matchers, return_type);
+
+    let state_types = py_state_types
+        .iter()
+        .map(|obj| import_sedona_type(obj.bind(py)))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let kernel = PySedonaAggregateKernel {
+        matcher,
+        state_types,
+        py_factory,
+    };
+    let kernel_ref: SedonaAccumulatorRef = Arc::new(kernel);
+    let sedona_aggregate_udf = SedonaAggregateUDF::new(name, vec![kernel_ref], volatility);
+
+    Ok(PySedonaAggregateUdf {
+        inner: sedona_aggregate_udf,
+    })
+}
+
+#[derive(Debug)]
+struct PySedonaAggregateKernel {
+    matcher: ArgMatcher,
+    state_types: Vec<SedonaType>,
+    py_factory: PyObject,
+}
+
+impl SedonaAccumulator for PySedonaAggregateKernel {
+    fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
+        self.matcher.match_args(args)
+    }
+
+    fn accumulator(
+        &self,
+        args: &[SedonaType],
+        output_type: &SedonaType,
+    ) -> Result<Box<dyn Accumulator>> {
+        let instance = Python::with_gil(|py| -> Result<PyObject, PySedonaError> {
+            Ok(self.py_factory.call0(py)?)
+        })?;
+        Ok(Box::new(PySedonaAccumulator {
+            instance,
+            input_types: args.to_vec(),
+            state_types: self.state_types.clone(),
+            output_type: output_type.clone(),
+        }))
+    }
+
+    fn state_fields(&self, _args: &[SedonaType]) -> Result<Vec<FieldRef>> {
+        self.state_types
+            .iter()
+            .enumerate()
+            .map(|(i, t)| Ok(Arc::new(t.to_storage_field(&format!("state_{i}"), true)?)))
+            .collect()
+    }
+}
+
+#[derive(Debug)]
+struct PySedonaAccumulator {
+    instance: PyObject,
+    input_types: Vec<SedonaType>,
+    state_types: Vec<SedonaType>,
+    output_type: SedonaType,
+}
+
+impl PySedonaAccumulator {
+    /// Build a tuple of PySedonaValue (Array variant) from raw Arrow arrays
+    /// for handoff into a Python method call.
+    fn arrays_to_py_values<'py>(
+        py: Python<'py>,
+        types: &[SedonaType],
+        arrays: &[ArrayRef],
+    ) -> Result<Bound<'py, PyTuple>, PySedonaError> {
+        if types.len() != arrays.len() {
+            return Err(PySedonaError::SedonaPython(format!(
+                "Internal aggregate UDF bridge: expected {} arrays, got {}",
+                types.len(),
+                arrays.len()
+            )));
+        }
+        let values: Vec<_> = zip(types, arrays)
+            .map(|(t, a)| PySedonaValue {
+                sedona_type: PySedonaType::new(t.clone()),
+                value: ColumnarValue::Array(a.clone()),
+                num_rows: a.len(),
+            })
+            .collect();
+        Ok(PyTuple::new(py, values)?)
+    }
+
+    /// Pull a ScalarValue out of a Python return value that implements
+    /// `__arrow_c_array__()` (a one-element Arrow array). The expected
+    /// SedonaType is used to validate the array's logical type.
+    fn import_scalar(
+        py: Python<'_>,
+        result: PyObject,
+        expected: &SedonaType,
+        context: &str,
+    ) -> Result<ScalarValue, PySedonaError> {
+        let result_bound = result.bind(py);
+        if !result_bound.hasattr("__arrow_c_array__")? {
+            return Err(PySedonaError::SedonaPython(format!(
+                "Expected {context} to return an object implementing __arrow_c_array__()"
+            )));
+        }
+        let (field, array) = import_arrow_array(result_bound)?;
+        let actual = SedonaType::from_storage_field(&field)?;
+        validate_imported_type(expected, &actual, context)?;
+        if array.len() != 1 {
+            return Err(PySedonaError::SedonaPython(format!(
+                "Expected {context} to be a 1-element array; got length {}",
+                array.len()
+            )));
+        }
+        Ok(ScalarValue::try_from_array(&array, 0)?)
+    }
+}
+
+impl Accumulator for PySedonaAccumulator {
+    fn update_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
+        Python::with_gil(|py| -> Result<(), PySedonaError> {
+            let args = Self::arrays_to_py_values(py, &self.input_types, values)?;
+            self.instance.call_method1(py, "update", (args,))?;
+            Ok(())
+        })?;
+        Ok(())
+    }
+
+    fn evaluate(&mut self) -> Result<ScalarValue> {
+        let scalar = Python::with_gil(|py| -> Result<ScalarValue, PySedonaError> {
+            let result = self.instance.call_method0(py, "evaluate")?;
+            Self::import_scalar(py, result, &self.output_type, "aggregate UDF evaluate()")
+        })?;
+        Ok(scalar)
+    }
+
+    fn state(&mut self) -> Result<Vec<ScalarValue>> {
+        let scalars = Python::with_gil(|py| -> Result<Vec<ScalarValue>, PySedonaError> {
+            let result = self.instance.call_method0(py, "state")?;
+            let result_bound = result.bind(py);
+            let tuple = result_bound.downcast::<PyTuple>().map_err(|_| {
+                PySedonaError::SedonaPython(
+                    "Expected aggregate UDF state() to return a tuple".to_string(),
+                )
+            })?;
+            if tuple.len() != self.state_types.len() {
+                return Err(PySedonaError::SedonaPython(format!(
+                    "Expected aggregate UDF state() to return {} elements; got {}",
+                    self.state_types.len(),
+                    tuple.len()
+                )));
+            }
+            let mut out = Vec::with_capacity(tuple.len());
+            for (i, item) in tuple.iter().enumerate() {
+                let scalar = Self::import_scalar(
+                    py,
+                    item.unbind(),
+                    &self.state_types[i],
+                    "aggregate UDF state() element",
+                )?;
+                out.push(scalar);
+            }
+            Ok(out)
+        })?;
+        Ok(scalars)
+    }
+
+    fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {
+        Python::with_gil(|py| -> Result<(), PySedonaError> {
+            let args = Self::arrays_to_py_values(py, &self.state_types, states)?;
+            self.instance.call_method1(py, "merge", (args,))?;
+            Ok(())
+        })?;
+        Ok(())
+    }
+
+    fn size(&self) -> usize {
+        // Only the Rust-side struct is accounted for; the Python accumulator's
+        // heap footprint is opaque to DataFusion's memory limiter. Acceptable
+        // for v1 (a conservative under-estimate). A future `mem_used()` hook on
+        // the Python class could report the true size.
+        std::mem::size_of::<Self>()
     }
 }

--- a/python/sedonadb/tests/test_aggregate_udf.py
+++ b/python/sedonadb/tests/test_aggregate_udf.py
@@ -1,0 +1,342 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pandas as pd
+import pandas.testing as pdt
+import pyarrow as pa
+import pytest
+from sedonadb import udf
+from sedonadb.expr import col
+
+
+def _mean_class():
+    @udf.arrow_aggregate_udf(
+        return_type=pa.float64(),
+        input_types=[udf.NUMERIC],
+        state_types=[pa.float64(), pa.int64()],
+    )
+    class my_mean:
+        def __init__(self):
+            self.total = 0.0
+            self.count = 0
+
+        def update(self, batch):
+            for v in batch:
+                if v.is_valid:
+                    self.total += float(v.as_py())
+                    self.count += 1
+
+        def state(self):
+            return (self.total, self.count)
+
+        def merge(self, totals, counts):
+            for i in range(len(totals)):
+                self.total += totals[i].as_py()
+                self.count += counts[i].as_py()
+
+        def evaluate(self):
+            return None if self.count == 0 else self.total / self.count
+
+    return my_mean
+
+
+def test_aggregate_udf_global_via_sql(con):
+    con.register_udf(_mean_class())
+    con.create_data_frame(pd.DataFrame({"v": [1.0, 3.0, 5.0, 7.0]})).to_view(
+        "t_global", overwrite=True
+    )
+    out = con.sql("SELECT my_mean(v) AS m FROM t_global").to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"m": [4.0]}))
+
+
+def test_aggregate_udf_grouped(con):
+    # Grouped aggregation exercises both update_batch and the merge path
+    # across groups under the slow Accumulator-per-group fallback.
+    con.register_udf(_mean_class())
+    df = con.create_data_frame(
+        pd.DataFrame({"k": ["a", "a", "b", "b", "b"], "v": [1.0, 3.0, 2.0, 4.0, 6.0]})
+    )
+    out = df.group_by("k").agg(m=con.funcs.my_mean(col("v"))).sort("k").to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"k": ["a", "b"], "m": [2.0, 4.0]}))
+
+
+def test_aggregate_udf_input_nulls_ignored(con):
+    con.register_udf(_mean_class())
+    df = con.create_data_frame(pd.DataFrame({"v": [1.0, None, 3.0, None, 5.0]}))
+    out = df.agg(m=con.funcs.my_mean(col("v"))).to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"m": [3.0]}))
+
+
+def test_aggregate_udf_multi_batch_forces_merge(con):
+    # The grouped test above relies on DataFusion choosing a two-phase
+    # aggregate; that's incidental to the current plan shape. This test
+    # forces the partial-state path with an input spanning many record
+    # batches and asserts merge() actually ran, so state()/merge_batch()
+    # coverage can't silently disappear if the planner changes.
+    import pyarrow.compute as pc
+
+    merge_calls = {"n": 0}
+
+    @udf.arrow_aggregate_udf(
+        return_type=pa.float64(),
+        input_types=[udf.NUMERIC],
+        state_types=[pa.float64(), pa.int64()],
+    )
+    class mean_with_probe:
+        def __init__(self):
+            self.total = 0.0
+            self.count = 0
+
+        def update(self, batch):
+            total = pc.sum(batch).as_py()
+            if total is not None:
+                self.total += float(total)
+            self.count += len(batch) - batch.null_count
+
+        def state(self):
+            return (self.total, self.count)
+
+        def merge(self, totals, counts):
+            merge_calls["n"] += 1
+            for i in range(len(totals)):
+                if totals[i].is_valid:
+                    self.total += totals[i].as_py()
+                    self.count += counts[i].as_py()
+
+        def evaluate(self):
+            return None if self.count == 0 else self.total / self.count
+
+    con.register_udf(mean_with_probe)
+    # 50k rows >> the 8192-row default batch size; keys interleave so both
+    # groups span every batch. k='a' holds the even values, k='b' the odds.
+    n = 50_000
+    df = con.create_data_frame(
+        pa.table(
+            {
+                "k": ["a", "b"] * (n // 2),
+                "v": [float(i) for i in range(n)],
+            }
+        )
+    )
+    out = (
+        df.group_by("k")
+        .agg(m=con.funcs.mean_with_probe(col("v")))
+        .sort("k")
+        .to_pandas()
+    )
+    pdt.assert_frame_equal(
+        out,
+        pd.DataFrame({"k": ["a", "b"], "m": [float(n - 2) / 2, float(n) / 2]}),
+    )
+    assert merge_calls["n"] > 0
+
+
+def test_aggregate_udf_empty_input_returns_null(con):
+    # No rows → count==0 → evaluate returns None → SQL NULL surfaces as
+    # NaN in float64 pandas.
+    con.register_udf(_mean_class())
+    con.create_data_frame(pd.DataFrame({"v": pd.Series([], dtype="float64")})).to_view(
+        "t_empty", overwrite=True
+    )
+    out = con.sql("SELECT my_mean(v) AS m FROM t_empty").to_pandas()
+    assert len(out) == 1
+    assert pd.isna(out["m"].iloc[0])
+
+
+def test_aggregate_udf_evaluate_returning_wrong_type_raises(con):
+    # evaluate() must return a value compatible with return_type; returning
+    # a string when float64 is declared fails when the wrapper builds the
+    # 1-element pyarrow array for the result.
+    @udf.arrow_aggregate_udf(
+        return_type=pa.float64(),
+        input_types=[udf.NUMERIC],
+        state_types=[pa.int64()],
+    )
+    class wrong_return_type:
+        def __init__(self):
+            self.n = 0
+
+        def update(self, batch):
+            self.n += len(batch)
+
+        def state(self):
+            return (self.n,)
+
+        def merge(self, counts):
+            for i in range(len(counts)):
+                self.n += counts[i].as_py()
+
+        def evaluate(self):
+            return "not a number"
+
+    con.register_udf(wrong_return_type)
+    df = con.create_data_frame(pd.DataFrame({"v": [1.0, 2.0, 3.0]}))
+    with pytest.raises(Exception, match="Could not convert"):
+        df.agg(n=con.funcs.wrong_return_type(col("v"))).to_pandas()
+
+
+def test_aggregate_udf_state_arity_mismatch_raises(con):
+    # state() must return exactly len(state_types) elements; the wrapper
+    # raises before handing the values to the engine.
+    @udf.arrow_aggregate_udf(
+        return_type=pa.int64(),
+        input_types=[udf.NUMERIC],
+        state_types=[pa.int64(), pa.int64()],
+    )
+    class wrong_state_arity:
+        def __init__(self):
+            self.n = 0
+
+        def update(self, batch):
+            self.n += len(batch)
+
+        def state(self):
+            return (self.n,)  # one element, but two declared
+
+        def merge(self, a, b):
+            for i in range(len(a)):
+                self.n += a[i].as_py()
+
+        def evaluate(self):
+            return self.n
+
+    con.register_udf(wrong_state_arity)
+    # A grouped multi-batch input forces a partial state() call.
+    n = 20_000
+    df = con.create_data_frame(
+        pa.table({"k": ["a", "b"] * (n // 2), "v": [float(i) for i in range(n)]})
+    )
+    with pytest.raises(Exception, match=r"state\(\) returned 1 elements"):
+        df.group_by("k").agg(m=con.funcs.wrong_state_arity(col("v"))).to_pandas()
+
+
+@pytest.mark.parametrize("failing_method", ["update", "state", "merge", "evaluate"])
+def test_aggregate_udf_exception_in_method_propagates(con, failing_method):
+    # A Python exception raised in any accumulator method surfaces as an
+    # error rather than crashing. The grouped multi-batch input ensures
+    # state() and merge() are actually invoked (two-phase aggregation).
+    @udf.arrow_aggregate_udf(
+        return_type=pa.float64(),
+        input_types=[udf.NUMERIC],
+        state_types=[pa.float64(), pa.int64()],
+    )
+    class boom:
+        def __init__(self):
+            self.total = 0.0
+            self.count = 0
+
+        def update(self, batch):
+            if failing_method == "update":
+                raise RuntimeError("boom in update")
+            self.count += len(batch)
+
+        def state(self):
+            if failing_method == "state":
+                raise RuntimeError("boom in state")
+            return (self.total, self.count)
+
+        def merge(self, totals, counts):
+            if failing_method == "merge":
+                raise RuntimeError("boom in merge")
+            for i in range(len(totals)):
+                self.count += counts[i].as_py()
+
+        def evaluate(self):
+            if failing_method == "evaluate":
+                raise RuntimeError("boom in evaluate")
+            return self.total
+
+    con.register_udf(boom)
+    n = 20_000
+    df = con.create_data_frame(
+        pa.table({"k": ["a", "b"] * (n // 2), "v": [float(i) for i in range(n)]})
+    )
+    with pytest.raises(Exception, match=f"boom in {failing_method}"):
+        df.group_by("k").agg(m=con.funcs.boom(col("v"))).to_pandas()
+
+
+def test_aggregate_udf_camel_case_name(con):
+    # A CamelCase class name is exposed as snake_case for SQL / funcs.
+    @udf.arrow_aggregate_udf(
+        return_type=pa.int64(),
+        input_types=[udf.NUMERIC],
+        state_types=[pa.int64()],
+    )
+    class MyRowCount:
+        def __init__(self):
+            self.n = 0
+
+        def update(self, batch):
+            self.n += len(batch)
+
+        def state(self):
+            return (self.n,)
+
+        def merge(self, counts):
+            for i in range(len(counts)):
+                self.n += counts[i].as_py()
+
+        def evaluate(self):
+            return self.n
+
+    assert MyRowCount._name == "my_row_count"
+    con.register_udf(MyRowCount)
+    df = con.create_data_frame(pd.DataFrame({"v": [1.0, 2.0, 3.0]}))
+    out = df.agg(n=con.funcs.my_row_count(col("v"))).to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"n": [3]}))
+
+
+def test_aggregate_udf_shapely_geometry(con):
+    # Geometry in + geometry out: union all input points into one geometry.
+    import shapely
+    import geoarrow.pyarrow as ga
+
+    @udf.arrow_aggregate_udf(
+        return_type=ga.wkb(),
+        input_types=[udf.GEOMETRY],
+        state_types=[pa.binary()],
+    )
+    class geom_union:
+        def __init__(self):
+            self.acc = None
+
+        def _absorb(self, wkbs):
+            for wkb in wkbs:
+                if wkb is None:
+                    continue
+                g = shapely.from_wkb(wkb)
+                self.acc = g if self.acc is None else shapely.union(self.acc, g)
+
+        def update(self, batch):
+            self._absorb(batch.to_pylist())
+
+        def state(self):
+            return (None if self.acc is None else shapely.to_wkb(self.acc),)
+
+        def merge(self, states):
+            self._absorb(states.to_pylist())
+
+        def evaluate(self):
+            return None if self.acc is None else shapely.to_wkb(self.acc)
+
+    con.register_udf(geom_union)
+    con.sql(
+        "SELECT * FROM (VALUES (ST_Point(0.0, 0.0)), (ST_Point(1.0, 1.0))) AS t(g)"
+    ).to_view("t_geom", overwrite=True)
+    out = con.sql("SELECT geom_union(g) AS u FROM t_geom").to_pandas()
+    expected = shapely.union(shapely.Point(0, 0), shapely.Point(1, 1))
+    assert out["u"].iloc[0].equals(expected)


### PR DESCRIPTION
Exposes a Python-side counterpart to `@udf.arrow_udf` for aggregates. Bridges a Python class implementing `init` / `update` / `state` / `merge` / `evaluate` to DataFusion's `Accumulator` plus the existing `SedonaAggregateUDF` / `SedonaAccumulator` Rust traits.

Next step in the UDF surface from #791. Scalar UDFs already shipped via `@udf.arrow_udf`; this fills the aggregate gap so users can write `df.group_by("k").agg(my_custom_udf(col("v")))`.

## API

```python
import pyarrow as pa
from sedonadb import udf

@udf.arrow_aggregate_udf(
    return_type=pa.float64(),
    input_types=[udf.NUMERIC],
    state_types=[pa.float64(), pa.int64()],
)
class my_mean:
    def __init__(self):
        self.total = 0.0
        self.count = 0
    def update(self, batch):
        for v in batch:
            if v.is_valid:
                self.total += float(v.as_py())
                self.count += 1
    def state(self):
        return (self.total, self.count)
    def merge(self, totals, counts):
        for i in range(len(totals)):
            self.total += totals[i].as_py()
            self.count += counts[i].as_py()
    def evaluate(self):
        return None if self.count == 0 else self.total / self.count

sd.register_udf(my_mean)
df.group_by("k").agg(m=sd.funcs.my_mean(col("v")))
sd.sql("SELECT my_mean(v) FROM t GROUP BY k")
```

### Class contract

- `update(*arrays)` — one `pa.Array` per declared input column, splatted positionally (single input today). Array can contain nulls.
- `state() -> tuple` — Python scalars matching `state_types` in order.
- `merge(*arrays)` — one `pa.Array` per element of `state_types`, splatted positionally. Each array has N rows for N partial states being merged.
- `evaluate() -> scalar` — Python value matching `return_type` (or `None` for SQL NULL).

## Implementation

| File | Change |
|---|---|
| `python/sedonadb/src/udf.rs` | New `PySedonaAggregateUdf` (wraps `SedonaAggregateUDF`) + `sedona_aggregate_udf` pyfunction constructor. `PySedonaAggregateKernel` impls `SedonaAccumulator`, holding a Python factory callable used to spawn a fresh accumulator per partial state. `PySedonaAccumulator` impls DataFusion's `Accumulator`, bridging `update_batch` / `evaluate` / `state` / `merge_batch` through to the Python class methods. Arrow arrays cross the boundary via the existing `PySedonaValue` (zero-copy via `__arrow_c_array__`). |
| `python/sedonadb/src/context.rs` | `register_udf` now disambiguates scalar vs. aggregate `__sedona_internal_udf__` return values and routes aggregate UDFs through `insert_aggregate_udf` + `register_udaf`. |
| `python/sedonadb/python/sedonadb/udf.py` | `arrow_aggregate_udf` decorator returns `AggregateUdfImpl` which, on registration, builds a closure-based factory producing per-call `_AccumulatorWrapper` instances. The wrapper converts `PySedonaValue` handoffs to `pa.Array` via the C-data interface and wraps the user's `evaluate`/`state` return values as 1-element Arrow arrays so the Rust side can extract `ScalarValue`s with the existing scalar-import helper. |
| `python/sedonadb/python/sedonadb/_lib.pyi` | (Implicit via PyO3 — no manual stubs in this package.) |

## Scope notes (follow-ups)

This is the **v1** aggregate UDF surface. Deliberately limited:

- **Single-input aggregates only.** `input_types` is wired through a single `ArgMatcher`. Multi-input is a small extension (loop over matchers).
- **No `GroupsAccumulator` fast-path.** Grouped aggregations use DataFusion's `Accumulator`-per-group fallback. The fast-path can land as a separate PR once we have a use case that demands it.
- **`return_type` and `state_types` must be concrete pyarrow types.** `TypeMatcher` constants (`udf.NUMERIC`, `udf.GEOMETRY`, …) remain valid for `input_types` only — output types need to be concrete so the wrapper can build 1-element Arrow arrays.

## Test plan

5 tests in `python/sedonadb/tests/test_aggregate_udf.py`:

- **Global via SQL**: `SELECT my_mean(v) FROM t` — exercises just `update_batch` + `evaluate`.
- **Grouped via DataFrame API**: `df.group_by("k").agg(...)` — exercises `state` + `merge_batch` (slow-path Accumulator-per-group fallback).
- **Nulls in input ignored**: input array with nulls, user code checks `v.is_valid`.
- **Empty input returns null**: zero rows → `count==0` → `evaluate` returns `None` → SQL NULL surfaces as NaN in float64 pandas.
- **`evaluate()` wrong-type raises**: returning a string when `return_type=float64` produces a clear error from the Rust scalar-import path.

Plus 2 doctests on the decorator itself.

Local: 5 new + 9 existing scalar UDF + 2 new doctests + `ruff format` + `ruff check` + `cargo fmt --check` all clean.
