### PR TITLE
feat(python/sedonadb): let aggregate UDFs return geometry via lit()

### DIFF
--- a/python/sedonadb/python/sedonadb/udf.py
+++ b/python/sedonadb/python/sedonadb/udf.py
@@ -357,7 +357,10 @@ def arrow_aggregate_udf(
       `state_types`, splatted positionally. Each array has N rows for N
       partial states being merged in.
     - `evaluate(self)`: return the final scalar Python value (or `None`
-      for SQL NULL) matching `return_type`.
+      for SQL NULL) matching `return_type`. When `return_type` is a
+      geometry/geography type, a Shapely (or GeoPandas / pyproj) object
+      may be returned directly; the same holds for `state()` elements
+      whose `state_types` entry is a geometry/geography type.
 
     Args:
         return_type: A pyarrow data type for the final aggregate result.
@@ -512,6 +515,20 @@ class _AccumulatorWrapper:
     def _wrap_scalar(value, pa_type):
         import pyarrow as pa
 
+        # For an extension type (e.g. geometry/geography), build with the
+        # declared type first so its metadata (CRS, edge type) is preserved
+        # when the value is already serialized (e.g. WKB bytes). Fall back to
+        # `lit()` only when pyarrow can't build the declared type from the
+        # Python object — the Shapely / GeoPandas / pyproj case. The fallback
+        # is scoped to extension types so a plain-type mismatch (e.g. a str
+        # for float64) still surfaces pyarrow's clear conversion error.
+        if value is not None and isinstance(pa_type, pa.ExtensionType):
+            try:
+                return pa.array([value], type=pa_type)
+            except (pa.ArrowInvalid, pa.ArrowTypeError):
+                from sedonadb.expr import lit
+
+                return lit(value)
         return pa.array([value], type=pa_type)
 
     def update(self, args):

--- a/python/sedonadb/tests/test_aggregate_udf.py
+++ b/python/sedonadb/tests/test_aggregate_udf.py
@@ -325,13 +325,16 @@ def test_aggregate_udf_shapely_geometry(con):
             self._absorb(batch.to_pylist())
 
         def state(self):
+            # State serializes to WKB binary (a plain Arrow type).
             return (None if self.acc is None else shapely.to_wkb(self.acc),)
 
         def merge(self, states):
             self._absorb(states.to_pylist())
 
         def evaluate(self):
-            return None if self.acc is None else shapely.to_wkb(self.acc)
+            # Return the Shapely geometry directly; the wrapper routes it
+            # through lit() since the declared return type is an extension.
+            return self.acc
 
     con.register_udf(geom_union)
     con.sql(
@@ -340,3 +343,44 @@ def test_aggregate_udf_shapely_geometry(con):
     out = con.sql("SELECT geom_union(g) AS u FROM t_geom").to_pandas()
     expected = shapely.union(shapely.Point(0, 0), shapely.Point(1, 1))
     assert out["u"].iloc[0].equals(expected)
+
+
+def test_aggregate_udf_geometry_wkb_bytes_preserves_crs(con):
+    # An aggregate that returns already-serialized WKB bytes (rather than a
+    # Shapely object) is still supported, and the declared return type's CRS
+    # metadata is preserved — the wrapper builds with the declared type
+    # before falling back to lit().
+    import geoarrow.pyarrow as ga
+
+    @udf.arrow_aggregate_udf(
+        return_type=ga.wkb().with_crs("EPSG:4326"),
+        input_types=[udf.GEOMETRY],
+        state_types=[pa.binary()],
+    )
+    class first_geom:
+        def __init__(self):
+            self.acc = None
+
+        def update(self, batch):
+            for wkb in batch.to_pylist():
+                if wkb is not None and self.acc is None:
+                    self.acc = wkb
+
+        def state(self):
+            return (self.acc,)
+
+        def merge(self, states):
+            for wkb in states.to_pylist():
+                if wkb is not None and self.acc is None:
+                    self.acc = wkb
+
+        def evaluate(self):
+            # Return WKB bytes; the declared type carries the CRS.
+            return self.acc
+
+    con.register_udf(first_geom)
+    con.sql("SELECT ST_SetSRID(ST_Point(1.0, 2.0), 4326) AS g").to_view(
+        "t_geom_crs", overwrite=True
+    )
+    out = con.sql("SELECT ST_SRID(first_geom(g)) AS srid FROM t_geom_crs").to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"srid": [4326]}, dtype="uint32"))


### PR DESCRIPTION
Follow-up to the aggregate UDF decorator (#937). Addresses the inline suggestion there to use `lit()` for return values so geometry can be returned directly.

## What changes

`evaluate()` and `state()` may now return a **Shapely / GeoPandas / pyproj object directly** when the corresponding declared type is a geometry/geography type — instead of requiring the user to pre-serialize to WKB bytes.

```python
@udf.arrow_aggregate_udf(
    return_type=ga.wkb(),          # geometry return
    input_types=[udf.GEOMETRY],
    state_types=[pa.binary()],
)
class geom_union:
    ...
    def evaluate(self):
        return self.acc            # a Shapely geometry — no to_wkb() needed
```

## How

`_AccumulatorWrapper._wrap_scalar` now routes a **non-null value through `lit()`** when the declared type is an Arrow **extension type** (geometry/geography), since pyarrow can't build those from native Python objects. Plain Arrow types — and any `None` — keep the existing `pa.array([value], type=...)` path, so:

- int/float coercion against the declared type is unchanged,
- typed SQL NULLs still work (including null geometry via `pa.array([None], type=ga.wkb())`),
- only the non-null geometry/geography case gains the new behavior.

`lit()` already exposes `__arrow_c_array__`, so it drops straight into the existing Rust import path — **no Rust changes** in this PR.

## Tests

`test_aggregate_udf_shapely_geometry` now returns the unioned Shapely geometry directly from `evaluate()` (previously WKB bytes), exercising the new path. The remaining 12 aggregate tests are unchanged.

Local: 26 tests (13 aggregate + 13 scalar) + 2 doctests + `ruff` clean. Python-only change.

## Not in this PR

The other deferred follow-up from #937 — a `GroupsAccumulator` fast-path (hold the GIL once per group) — is a larger Rust change and will be its own PR.
