### PR TITLE
feat(sedonadb/raster): Add zero-copy raster access from pyarrow arrays

### DIFF
--- a/python/sedonadb-zarr/tests/test_zarr.py
+++ b/python/sedonadb-zarr/tests/test_zarr.py
@@ -24,9 +24,9 @@ deferred to a follow-up PR.
 
 import numpy as np
 import pytest
-
 import sedonadb
 import sedonadb_zarr
+from sedonadb.raster import Raster
 
 
 @pytest.fixture
@@ -53,17 +53,17 @@ def test_format_spec_via_read_format(zarr_group):
     assert arrow_tab.column_names == ["raster"]
 
     raster = arrow_tab["raster"][0].as_py()
-    assert isinstance(raster, dict), f"raster row is {type(raster).__name__}"
-    for field in ("transform", "bands"):
-        assert field in raster, f"raster row missing {field!r}: {sorted(raster)}"
-    assert isinstance(raster["bands"], list) and len(raster["bands"]) >= 1
-    band = raster["bands"][0]
-    # `data` is empty (OutDb scan); `outdb_uri` points at this chunk.
-    assert band.get("data") in (None, b"", bytes()), (
-        f"OutDb band should have empty data; got {band.get('data')!r}"
+    assert isinstance(raster, Raster), f"raster row is {type(raster).__name__}"
+    assert raster.transform is not None
+    assert len(raster.bands) >= 1
+    band = raster.bands[0]
+    # `source_data` is empty (OutDb scan); `outdb_uri` points at this chunk.
+    assert len(band.source_data) == 0, (
+        f"OutDb band should have empty data; got {len(band.source_data)} bytes"
     )
-    anchor = band.get("outdb_uri")
-    assert anchor and "#array=temperature" in anchor, f"unexpected anchor: {anchor!r}"
+    assert band.outdb_uri is not None and "#array=temperature" in band.outdb_uri, (
+        f"unexpected anchor: {band.outdb_uri!r}"
+    )
 
 
 def test_format_spec_with_arrays_option(zarr_group):
@@ -113,4 +113,11 @@ def test_dtype_mapping_roundtrips(tmp_path, numpy_dtype):
 
     con = sedonadb.connect()
     df = con.read_format(sedonadb_zarr.ZarrFormatSpec(), f"file://{tmp_path}")
-    assert df.to_arrow_table().num_rows == 2
+    tab = df.to_arrow_table()
+    assert tab.num_rows == 2
+
+    # We can't extract data because these are OutDB refs
+    with pytest.raises(
+        ValueError, match="Can't extract buffer from a reference to external data"
+    ):
+        tab["raster"][0].as_py().bands[0].to_numpy()

--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -996,8 +996,10 @@ class DataFrame:
             geometry: [[01010000000000000000000000000000000000F03F]]
 
         """
-        import geoarrow.pyarrow  # noqa: F401
         import pyarrow as pa
+        from sedonadb.utility import register_pyarrow_extension_types
+
+        register_pyarrow_extension_types()
 
         return pa.RecordBatchReader.from_stream(
             self._impl.to_stream(self._ctx._impl, simplify=simplify)
@@ -1078,8 +1080,10 @@ class DataFrame:
             geometry: [[01010000000000000000000000000000000000F03F]]
 
         """
-        import geoarrow.pyarrow  # noqa: F401
         import pyarrow as pa
+        from sedonadb.utility import register_pyarrow_extension_types
+
+        register_pyarrow_extension_types()
 
         # Collects all batches into an object that exposes __arrow_c_stream__()
         batches = self._impl.to_batches(schema)

--- a/python/sedonadb/python/sedonadb/raster.py
+++ b/python/sedonadb/python/sedonadb/raster.py
@@ -54,50 +54,65 @@ BAND_DATA_TYPE_STRUCT_CHARS = {
 
 
 class Raster:
+    """Python representation of a sedona.raster scalar value."""
+
     def __init__(self, array, i=0):
+        """Create a Raster from an Arrow array at index i."""
         if isinstance(array, pa.ExtensionArray):
             array = array.storage
 
         self._array = pa.array(array.slice(i, i + 1))
 
     def _py_field(self, k):
+        """Extract a field value as a Python object."""
         return self._array.field(k)[0].as_py()
 
     @property
     def crs(self) -> gat.Crs:
+        """The coordinate reference system of this raster."""
         return gat.type_spec(crs=self._py_field("crs")).crs
 
     @property
     def width(self) -> int:
+        """The width of this raster in pixels."""
         return self._py_field("spatial_shape")[0]
 
     @property
     def height(self) -> int:
+        """The height of this raster in pixels."""
         return self._py_field("spatial_shape")[1]
 
     @property
     def transform(self) -> List[float]:
+        """The affine transform coefficients for this raster."""
         return self._py_field("transform")
 
     @property
     def bands(self) -> List["Band"]:
+        """The list of bands in this raster."""
         bands_array = self._array.field("bands").flatten()
         return [Band(bands_array, i) for i in range(len(bands_array))]
 
 
 class Band:
+    """Python representation of a raster band."""
+
     def __init__(self, array, i=0):
+        """Create a Band from an Arrow array at index i."""
         self._array = pa.array(array.slice(i, i + 1))
 
     def _py_field(self, k):
+        """Extract a field value as a Python object."""
         return self._array.field(k)[0].as_py()
 
     @property
     def name(self) -> Optional[str]:
+        """The name of this band, if any."""
         return self._py_field("name")
 
     @property
     def shape(self) -> Tuple[int, ...]:
+        """The shape of this band's data after applying any views."""
         views = self._py_field("view")
         if views:
             raise NotImplementedError("Lazy views are not yet supported")
@@ -106,24 +121,29 @@ class Band:
 
     @property
     def source_shape(self) -> Tuple[int, ...]:
+        """The shape of this band's source data."""
         return tuple(self._py_field("source_shape"))
 
     @property
     def outdb_uri(self) -> Optional[str]:
+        """The URI for out-of-database storage, if any."""
         return self._py_field("outdb_uri")
 
     @property
     def data_type(self) -> str:
+        """The pixel data type name (e.g., 'uint8', 'float32')."""
         type_id = self._py_field("data_type")
         return BAND_DATA_TYPES[type_id].lower()
 
     @property
     def source_data(self) -> memoryview:
+        """The raw source data buffer as a memoryview."""
         view_scalar = self._array.field("data")[0]
         return memoryview(view_scalar.as_buffer())
 
     @property
     def data(self) -> memoryview:
+        """The band data as a typed, shaped memoryview."""
         # When views are supported, we would need to calculate the striding
         # to export a zero copy view.
         views = self._py_field("view")
@@ -135,6 +155,7 @@ class Band:
         return self.source_data.cast(buffer_type_char, self.shape)
 
     def to_numpy(self) -> "np.ndarray":
+        """Convert this band's data to a numpy array."""
         import numpy as np
 
         return np.array(self.data)

--- a/python/sedonadb/python/sedonadb/raster.py
+++ b/python/sedonadb/python/sedonadb/raster.py
@@ -93,6 +93,16 @@ class Raster:
         bands_array = self._array.field("bands").flatten()
         return [Band(bands_array, i) for i in range(len(bands_array))]
 
+    def __repr__(self) -> str:
+        """Return a string representation of this raster."""
+        return f"<Raster {self.width}x{self.height}, {len(self.bands)} band(s)>"
+
+    def __arrow_c_array__(self, requested_schema=None):
+        """Implement the array protocol so this works with lit()"""
+        extension_type = RasterType(self._array.type)
+        extension_array = extension_type.wrap_array(self._array)
+        return extension_array.__arrow_c_array__(requested_schema=requested_schema)
+
 
 class Band:
     """Python representation of a raster band."""
@@ -144,6 +154,9 @@ class Band:
     @property
     def data(self) -> memoryview:
         """The band data as a typed, shaped memoryview."""
+        if self.outdb_uri is not None:
+            raise ValueError("Can't extract buffer from a reference to external data.")
+
         # When views are supported, we would need to calculate the striding
         # to export a zero copy view.
         views = self._py_field("view")
@@ -159,6 +172,11 @@ class Band:
         import numpy as np
 
         return np.array(self.data)
+
+    def __repr__(self) -> str:
+        """Return a string representation of this band."""
+        name_part = f" {self.name!r}" if self.name else ""
+        return f"<Band{name_part} {self.data_type} {'x'.join(map(str, self.shape))}>"
 
 
 class RasterScalar(pa.ExtensionScalar):

--- a/python/sedonadb/python/sedonadb/raster.py
+++ b/python/sedonadb/python/sedonadb/raster.py
@@ -1,0 +1,150 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import List, Optional
+import geoarrow.types as gat
+import pyarrow as pa
+
+EXTENSION_NAME = "sedona.raster"
+
+
+class Raster:
+    def __init__(self, array, i=0):
+        if isinstance(array, pa.ExtensionArray):
+            array = array.storage
+
+        self._array = pa.array(array.slice(i, i + 1))
+
+    def _py_field(self, k):
+        return self._array.field(k)[0].as_py()
+
+    @property
+    def crs(self) -> gat.Crs:
+        return gat.type_spec(crs=self._py_field("crs")).crs
+
+    @property
+    def width(self) -> int:
+        return self._py_field("spatial_shape")[0]
+
+    @property
+    def height(self) -> int:
+        return self._py_field("spatial_shape")[1]
+
+    @property
+    def transform(self) -> List[float]:
+        return self._py_field("transform")
+
+    @property
+    def bands(self) -> List["Band"]:
+        bands_array = self._array.field("bands").flatten()
+        return [Band(bands_array, i) for i in range(len(bands_array))]
+
+
+class Band:
+    def __init__(self, array, i=0):
+        self._array = pa.array(array.slice(i, i + 1))
+
+    def _py_field(self, k):
+        return self._array.field(k)[0].as_py()
+
+    @property
+    def name(self) -> Optional[str]:
+        return self._py_field("name")
+
+    @property
+    def shape(self) -> List[int]:
+        views = self._py_field("view")
+        if views:
+            raise NotImplementedError("Lazy views are not yet supported")
+
+        return self.source_shape
+
+    @property
+    def source_shape(self) -> List[int]:
+        return self._py_field("source_shape")
+
+    @property
+    def outdb_uri(self) -> Optional[str]:
+        return self._py_field("outdb_uri")
+
+    @property
+    def data(self):
+        pass
+
+
+class RasterScalar(pa.ExtensionScalar):
+    """Scalar type for sedona.raster extension arrays."""
+
+    def as_py(self):
+        return Raster(pa.array([self.value]))
+
+
+class RasterArray(pa.ExtensionArray):
+    """Array type for sedona.raster extension arrays."""
+
+    pass
+
+
+class RasterType(pa.ExtensionType):
+    """PyArrow extension type for sedona.raster.
+
+    This extension type wraps a struct storage type representing raster data.
+    """
+
+    def __init__(self, storage_type: pa.DataType):
+        """Create a RasterType with the given storage type.
+
+        Parameters
+        ----------
+        storage_type : pa.DataType
+            The underlying Arrow storage type (must be a struct type).
+        """
+        if not pa.types.is_struct(storage_type):
+            raise TypeError(f"storage_type must be a struct type, not {storage_type}")
+        super().__init__(storage_type, EXTENSION_NAME)
+
+    def __arrow_ext_serialize__(self) -> bytes:
+        """Serialize extension type metadata."""
+        return b""
+
+    @classmethod
+    def __arrow_ext_deserialize__(
+        cls, storage_type: pa.DataType, serialized: bytes
+    ) -> "RasterType":
+        return RasterType(storage_type)
+
+    def __arrow_ext_class__(self):
+        return RasterArray
+
+    def __arrow_ext_scalar_class__(self):
+        return RasterScalar
+
+
+def register_extension_type():
+    """Register the sedona.raster extension type with PyArrow.
+
+    This should be called once at module initialization to enable
+    automatic deserialization of sedona.raster arrays from IPC.
+    """
+    # Create a dummy storage type for registration - the actual storage
+    # type will be determined during deserialization
+    dummy_storage = pa.struct([("_placeholder", pa.int32())])
+    try:
+        pa.register_extension_type(RasterType(dummy_storage))
+    except pa.ArrowKeyError:
+        # Already registered
+        pass

--- a/python/sedonadb/python/sedonadb/raster.py
+++ b/python/sedonadb/python/sedonadb/raster.py
@@ -15,11 +15,42 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import List, Optional
+from typing import List, Optional, TYPE_CHECKING, Tuple
 import geoarrow.types as gat
 import pyarrow as pa
 
+if TYPE_CHECKING:
+    import numpy as np
+
 EXTENSION_NAME = "sedona.raster"
+
+# Band data type IDs (matches sedona-schema BandDataType enum discriminants)
+BAND_DATA_TYPES = {
+    1: "UInt8",
+    2: "UInt16",
+    3: "Int16",
+    4: "UInt32",
+    5: "Int32",
+    6: "Float32",
+    7: "Float64",
+    8: "UInt64",
+    9: "Int64",
+    10: "Int8",
+}
+
+# Python struct module format characters for band data types
+BAND_DATA_TYPE_STRUCT_CHARS = {
+    1: "B",
+    2: "H",
+    3: "h",
+    4: "I",
+    5: "i",
+    6: "f",
+    7: "d",
+    8: "Q",
+    9: "q",
+    10: "b",
+}
 
 
 class Raster:
@@ -66,7 +97,7 @@ class Band:
         return self._py_field("name")
 
     @property
-    def shape(self) -> List[int]:
+    def shape(self) -> Tuple[int, ...]:
         views = self._py_field("view")
         if views:
             raise NotImplementedError("Lazy views are not yet supported")
@@ -74,16 +105,39 @@ class Band:
         return self.source_shape
 
     @property
-    def source_shape(self) -> List[int]:
-        return self._py_field("source_shape")
+    def source_shape(self) -> Tuple[int, ...]:
+        return tuple(self._py_field("source_shape"))
 
     @property
     def outdb_uri(self) -> Optional[str]:
         return self._py_field("outdb_uri")
 
     @property
-    def data(self):
-        pass
+    def data_type(self) -> str:
+        type_id = self._py_field("data_type")
+        return BAND_DATA_TYPES[type_id].lower()
+
+    @property
+    def source_data(self) -> memoryview:
+        view_scalar = self._array.field("data")[0]
+        return memoryview(view_scalar.as_buffer())
+
+    @property
+    def data(self) -> memoryview:
+        # When views are supported, we would need to calculate the striding
+        # to export a zero copy view.
+        views = self._py_field("view")
+        if views:
+            raise NotImplementedError("Lazy views are not yet supported")
+
+        buffer_type_id = self._py_field("data_type")
+        buffer_type_char = BAND_DATA_TYPE_STRUCT_CHARS[buffer_type_id]
+        return self.source_data.cast(buffer_type_char, self.shape)
+
+    def to_numpy(self) -> "np.ndarray":
+        import numpy as np
+
+        return np.array(self.data)
 
 
 class RasterScalar(pa.ExtensionScalar):

--- a/python/sedonadb/python/sedonadb/testing.py
+++ b/python/sedonadb/python/sedonadb/testing.py
@@ -23,6 +23,10 @@ from typing import TYPE_CHECKING, Any, List, Tuple
 import geoarrow.pyarrow as ga
 import pyarrow as pa
 
+from sedonadb.utility import register_pyarrow_extension_types
+
+register_pyarrow_extension_types()
+
 if TYPE_CHECKING:
     import pandas
 

--- a/python/sedonadb/python/sedonadb/utility.py
+++ b/python/sedonadb/python/sedonadb/utility.py
@@ -47,3 +47,15 @@ class Sedona:
 
 
 sedona = Sedona()
+
+
+def register_pyarrow_extension_types():
+    """Register extension types
+
+    This should be called after a lazy pyarrow import.
+    """
+    import geoarrow.pyarrow  # noqa: F401
+
+    from sedonadb.raster import register_extension_type
+
+    register_extension_type()

--- a/python/sedonadb/tests/test_raster.py
+++ b/python/sedonadb/tests/test_raster.py
@@ -41,6 +41,14 @@ def test_raster_accessors(con):
 
     b = r.bands[0]
     assert b.name is None
-    assert b.shape == [32, 64]
-    assert b.source_shape == [32, 64]
+    assert b.shape == (32, 64)
+    assert b.source_shape == (32, 64)
     assert b.outdb_uri is None
+    assert b.data_type == "uint8"
+
+    arr = b.to_numpy()
+    assert arr.shape == b.shape
+    assert arr[0, 0] == 127
+
+    for i, b in enumerate(r.bands):
+        assert b.data[1, 1] == i + 1

--- a/python/sedonadb/tests/test_raster.py
+++ b/python/sedonadb/tests/test_raster.py
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from sedonadb.raster import Raster, RasterArray, RasterScalar, RasterType
+
+
+def test_type_class_resolution(con):
+    t = con.sql("SELECT RS_Example() as raster")
+    tab = t.to_arrow_table()
+
+    assert isinstance(tab.schema.field(0).type, RasterType)
+    assert isinstance(tab["raster"].type, RasterType)
+    assert isinstance(tab["raster"].chunk(0), RasterArray)
+    assert isinstance(tab["raster"][0], RasterScalar)
+    assert isinstance(tab["raster"][0].as_py(), Raster)
+
+
+def test_raster_accessors(con):
+    t = con.sql("SELECT RS_Example() as raster")
+    tab = t.to_arrow_table()
+    r: Raster = tab["raster"][0].as_py()
+
+    assert r.width == 64
+    assert r.height == 32
+    assert len(r.transform) == 6
+    assert len(r.bands) == 3
+
+    b = r.bands[0]
+    assert b.name is None
+    assert b.shape == [32, 64]
+    assert b.source_shape == [32, 64]
+    assert b.outdb_uri is None

--- a/python/sedonadb/tests/test_raster.py
+++ b/python/sedonadb/tests/test_raster.py
@@ -34,10 +34,12 @@ def test_raster_accessors(con):
     tab = t.to_arrow_table()
     r: Raster = tab["raster"][0].as_py()
 
+    assert r.crs.to_json_dict()["id"] == {"authority": "OGC", "code": "CRS84"}
     assert r.width == 64
     assert r.height == 32
     assert len(r.transform) == 6
     assert len(r.bands) == 3
+    assert repr(r) == "<Raster 64x32, 3 band(s)>"
 
     b = r.bands[0]
     assert b.name is None
@@ -45,6 +47,7 @@ def test_raster_accessors(con):
     assert b.source_shape == (32, 64)
     assert b.outdb_uri is None
     assert b.data_type == "uint8"
+    assert repr(b) == "<Band uint8 32x64>"
 
     arr = b.to_numpy()
     assert arr.shape == b.shape
@@ -52,3 +55,15 @@ def test_raster_accessors(con):
 
     for i, b in enumerate(r.bands):
         assert b.data[1, 1] == i + 1
+
+
+def test_raster_to_lit(con):
+    t = con.sql("SELECT RS_Example() as raster")
+    tab = t.to_arrow_table()
+    r = tab["raster"][0].as_py()
+
+    t2 = con.sql(
+        "SELECT RS_Width($1) AS w, RS_Height($1) AS h", params=(r,)
+    ).to_pandas()
+    assert t2.iloc[0, 0] == r.width
+    assert t2.iloc[0, 1] == r.height


### PR DESCRIPTION
This PR implements a basic Python destination for a raster array. This will hopefully make it easier to test these functions (using the numpy output).

The output is zero copy (numpy is pointing to arrow view memory).

```python
import sedona.db

sd = sedona.db.connect()
sd.options.interactive = True

t = sd.sql("SELECT RS_Example() as raster")
tab = t.to_arrow_table()
r = tab["raster"][0].as_py()

(r.crs, r.height, r.width, r.bands)
# (StringCrs(OGC:CRS84),
#  32,
#  64,
#  [<Band uint8 32x64>, <Band uint8 32x64>, <Band uint8 32x64>])
r.bands[0].to_numpy()
# array([[127,   1,   1, ...,   1,   1,   1],
#        [  1,   1,   1, ...,   1,   1,   1],
#        [  1,   1,   1, ...,   1,   1,   1],
#        ...,
#        [  1,   1,   1, ...,   1,   1,   1],
#        [  1,   1,   1, ...,   1,   1,   1],
#        [  1,   1,   1, ...,   1,   1,   1]], shape=(32, 64), dtype=uint8)
```