### PR TITLE
fix(rust/sedona-raster-zarr): discover child arrays via consolidated metadata

### DIFF
--- a/rust/sedona-raster-zarr/src/loader.rs
+++ b/rust/sedona-raster-zarr/src/loader.rs
@@ -37,9 +37,8 @@ use zarrs::array::Array;
 #[cfg(test)]
 use zarrs::array::ArrayBytes;
 use zarrs::group::Group;
-use zarrs::storage::{
-    AsyncReadableListableStorage, AsyncReadableListableStorageTraits, StorePrefix,
-};
+use zarrs::node::NodeMetadata;
+use zarrs::storage::{AsyncReadableListableStorage, AsyncReadableListableStorageTraits};
 
 use crate::dtype::zarr_to_band_data_type;
 use crate::geozarr::GroupGeoMetadata;
@@ -327,7 +326,7 @@ async fn open_and_validate(
         // (typical xarray coord variables) are silently dropped so a
         // canonical xarray layout reads cleanly.
         None => {
-            let arrays = enumerate_child_arrays(&storage, group_uri).await?;
+            let arrays = enumerate_child_arrays(&group, &storage, group_uri).await?;
             if arrays.is_empty() {
                 return Err(ArrowError::InvalidArgumentError(format!(
                     "Zarr group at {group_uri} has no child arrays"
@@ -425,36 +424,49 @@ async fn open_named_arrays(
     Ok(out)
 }
 
-/// List the direct children of the group and try to open each as an
-/// array. Per-array open failures are logged at warn level and the
-/// child is skipped — a single malformed sibling array (e.g. an
-/// xarray-style coord variable with a dtype zarrs can't yet parse)
-/// can no longer poison the whole group. Subgroups are filtered out by
-/// the same `Array::async_open`-error skip, so the externally
-/// observable behaviour matches the old `Group::child_arrays()`
-/// contract for well-formed groups while being permissive about
-/// partial breakage.
+/// Discover the group's direct child arrays.
+///
+/// Discovery goes through zarrs's [`Group::async_children`], which uses
+/// the group's V3 `consolidated_metadata` block when present (no
+/// per-node storage reads) and otherwise lists the store. Listing is
+/// unsupported on some backends — plain HTTPS / S3-behind-`HttpStore`
+/// answer directory listing with `405 Method Not Allowed` — so a store
+/// that has neither consolidated metadata nor listing yields an
+/// actionable error pointing at the `arrays` option rather than a raw
+/// store error.
+///
+/// Each array is then built from its already-parsed metadata. Per-array
+/// failures are logged at warn level and the child is skipped — a single
+/// malformed sibling array (e.g. an xarray-style coord variable with a
+/// dtype zarrs can't yet parse) can no longer poison the whole group.
+/// Subgroups are skipped via the `NodeMetadata::Group` arm.
 async fn enumerate_child_arrays(
+    group: &Group<dyn AsyncReadableListableStorageTraits>,
     storage: &AsyncReadableListableStorage,
     group_uri: &str,
 ) -> Result<Vec<Array<dyn AsyncReadableListableStorageTraits>>, ArrowError> {
-    let listing = storage.list_dir(&StorePrefix::root()).await.map_err(|e| {
+    let children = group.async_children(false).await.map_err(|e| {
         ArrowError::ExternalError(Box::new(sedona_internal_datafusion_err!(
-            "failed to list child nodes of Zarr group at {group_uri}: {e}"
+            "failed to discover child arrays of Zarr group at {group_uri}: {e}. \
+             If this store has no consolidated metadata and does not support \
+             directory listing (for example a plain HTTPS server), pass the \
+             `arrays` option to name the arrays to read."
         )))
     })?;
-    let mut arrays = Vec::with_capacity(listing.prefixes().len());
-    for child in listing.prefixes() {
-        let raw = child.as_str().trim_end_matches('/');
-        if raw.is_empty() {
-            continue;
-        }
-        let path = format!("/{raw}");
-        match Array::async_open(storage.clone(), &path).await {
-            Ok(array) => arrays.push(array),
-            Err(e) => log::warn!(
-                "skipping Zarr child {path} in {group_uri}: not openable as an array ({e})"
-            ),
+
+    let mut arrays = Vec::with_capacity(children.len());
+    for node in children {
+        let path = node.path().to_string();
+        match NodeMetadata::from(node) {
+            NodeMetadata::Array(metadata) => {
+                match Array::new_with_metadata(storage.clone(), &path, metadata) {
+                    Ok(array) => arrays.push(array),
+                    Err(e) => log::warn!(
+                        "skipping Zarr child {path} in {group_uri}: not usable as an array ({e})"
+                    ),
+                }
+            }
+            NodeMetadata::Group(_) => {}
         }
     }
     Ok(arrays)

--- a/rust/sedona-raster-zarr/tests/cloud.rs
+++ b/rust/sedona-raster-zarr/tests/cloud.rs
@@ -129,3 +129,30 @@ async fn https_zarr_smoke() {
     let rows = count_rows(reader);
     assert!(rows > 0, "expected at least one chunk row from {uri}");
 }
+
+/// Consolidated-metadata discovery over plain HTTPS, with NO `arrays`
+/// filter — the exact shape of issue #941. The ERA5 Hurricane Florence
+/// group (public, anonymous, UK JASMIN/CEDA) is a Zarr v3 group whose
+/// `zarr.json` carries an inline `consolidated_metadata` block, so child
+/// arrays are discovered from that block without ever listing the store.
+/// The host answers directory listing (`PROPFIND`) with 405, so this read
+/// would fail if discovery fell back to listing.
+#[tokio::test]
+#[ignore]
+async fn https_consolidated_metadata_discovery_no_filter() {
+    let uri = "https://atlantis-vis-o.s3-ext.jc.rl.ac.uk/hurricanes/era5/florence";
+    let authority = "https://atlantis-vis-o.s3-ext.jc.rl.ac.uk";
+    let store: Arc<dyn ObjectStore> = Arc::new(
+        HttpBuilder::new()
+            .with_url(authority)
+            .build()
+            .expect("build HttpStore"),
+    );
+    let storage = open_storage_from_uri(uri, store).expect("open_storage_from_uri");
+    // No arrays filter: discovery must come from consolidated metadata.
+    let reader = ZarrChunkReader::try_new(storage, uri, None, 1024)
+        .await
+        .expect("ZarrChunkReader::try_new against Florence over https:// (consolidated metadata)");
+    let rows = count_rows(reader);
+    assert!(rows > 0, "expected at least one chunk row from {uri}");
+}

--- a/rust/sedona-raster-zarr/tests/zarr_roundtrip.rs
+++ b/rust/sedona-raster-zarr/tests/zarr_roundtrip.rs
@@ -59,7 +59,11 @@ use sedona_schema::raster::BandDataType;
 use tempfile::TempDir;
 use zarrs::array::data_type;
 use zarrs::array::ArrayBuilder;
-use zarrs::group::GroupBuilder;
+use zarrs::group::{Group, GroupBuilder};
+use zarrs::metadata_ext::group::consolidated_metadata::{
+    ConsolidatedMetadata, ConsolidatedMetadataKind,
+};
+use zarrs::node::Node;
 use zarrs_filesystem::FilesystemStore;
 
 /// Build a 2-band group on disk:
@@ -113,6 +117,61 @@ fn build_fixture() -> TempDir {
     }
 
     tmp
+}
+
+/// Like [`build_fixture`], but folds a `consolidated_metadata` block into
+/// the group's `zarr.json` and then *removes* each child array's
+/// `zarr.json`. Discovery can then only succeed by reading the
+/// consolidated block — a list-then-open-each path would re-read the
+/// now-deleted per-array metadata and find nothing. This is the
+/// regression fixture for stores that can't list (e.g. plain HTTPS),
+/// where consolidated metadata is the only viable discovery mechanism.
+fn build_consolidated_fixture() -> TempDir {
+    let tmp = build_fixture();
+    let store = Arc::new(FilesystemStore::new(tmp.path()).unwrap());
+
+    // Build the consolidated map from the on-disk hierarchy (this lists,
+    // which is fine — the fixture is local) and fold it into the group.
+    let metadata = Node::open(&store, "/")
+        .unwrap()
+        .consolidate_metadata()
+        .expect("root group yields consolidated metadata");
+    let consolidated = ConsolidatedMetadata {
+        metadata,
+        kind: ConsolidatedMetadataKind::Inline,
+    };
+    Group::open(store.clone(), "/")
+        .unwrap()
+        .set_consolidated_metadata(Some(consolidated))
+        .store_metadata()
+        .unwrap();
+
+    // Remove the per-array metadata so a list-then-open read would find
+    // no openable arrays; only the consolidated block remains.
+    for name in ["temperature", "pressure"] {
+        std::fs::remove_file(tmp.path().join(name).join("zarr.json")).unwrap();
+    }
+
+    tmp
+}
+
+#[tokio::test]
+async fn discovers_child_arrays_from_consolidated_metadata() {
+    let tmp = build_consolidated_fixture();
+    let uri = format!("file://{}", tmp.path().display());
+
+    // Per-array zarr.json are gone, so this only succeeds via the group's
+    // consolidated_metadata block: the pre-fix list-then-open path would
+    // discover zero arrays and error.
+    let arr = read_all(&uri, None).await.unwrap();
+
+    let rasters = RasterStructArray::new(&arr);
+    assert_eq!(
+        rasters.len(),
+        8,
+        "8 chunk rows, discovered from consolidated metadata without per-array reads"
+    );
+    assert_eq!(rasters.get(0).unwrap().num_bands(), 2);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Zarr group child-array discovery hand-rolled a `storage.list_dir()` call, which bypassed zarrs's built-in consolidated-metadata support entirely. On backends that don't support directory listing — plain HTTPS / S3 behind `HttpStore`, which answer `PROPFIND` with `405 Method Not Allowed` — discovery always failed, even when the group's `zarr.json` carried an inline `consolidated_metadata` block naming every child array (the common case for cloud-hosted v3 groups). This is (kind of) #941.

## Changes

Discovery now routes through zarrs's `Group::async_children`, which:

1. **Uses consolidated metadata when present** — child nodes are populated from the inline `consolidated_metadata` block with no per-node storage reads and no listing. It only falls back to listing the store when there is no consolidated metadata (inevitable) and no array option. 
3. **Errors clearly when neither works** — a store with no consolidated metadata that also can't list now yields a message pointing at the `arrays` option, instead of a raw store error.

Each array is built from its already-parsed metadata via `Array::new_with_metadata`, so a single malformed sibling array (e.g. an xarray-style coord variable with a dtype zarrs can't parse) is still skipped rather than poisoning the whole group — preserving the prior permissive behavior.


Fixes #941