### PR TITLE
feat(python/sedonadb): add pandas-style Series (df["x"] -> Series)

### DIFF
--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -23,6 +23,7 @@ from sedonadb.expr import Expr, SortExpr
 from sedonadb.expr import Literal as _SedonaLit
 from sedonadb.expr import col as _col
 from sedonadb.expr.expression import _to_expr
+from sedonadb.series import Series
 from sedonadb.utility import sedona  # noqa: F401
 
 if TYPE_CHECKING:
@@ -200,12 +201,13 @@ class DataFrame:
         """
         return DataFrame(self._ctx, self._impl.alias(name))
 
-    def __getitem__(self, key: Union[str, int]) -> Expr:
+    def __getitem__(self, key: Union[str, int]) -> "Series":
         """Reference a single column by name or position.
 
-        Returns an `Expr` referencing the requested column. The
-        return-type is always `Expr` (no `DataFrame ⏐ Expr` union) so that
-        IDEs and type-aware tools can resolve `df["x"].<method>` cleanly.
+        Returns a `Series` (a pandas-flavored column) referencing the
+        requested column. The return-type is always `Series` (no
+        `DataFrame ⏐ Series` union) so that IDEs and type-aware tools can
+        resolve `df["x"].<method>` cleanly.
 
         For row filtering use `df.filter(predicate)`. For multi-column
         projection use `df.select(*cols)`.
@@ -227,11 +229,11 @@ class DataFrame:
             >>> sd = sedona.db.connect()
             >>> df = sd.sql("SELECT * FROM (VALUES (1, 10), (2, 20)) AS t(x, y)").alias("t")
             >>> df["x"]
-            Expr(t.x)
+            Series(t.x)
             >>> df[1]
-            Expr(t.y)
+            Series(t.y)
             >>> df[-1]
-            Expr(t.y)
+            Series(t.y)
         """
         # `bool` is a subclass of `int`, so guard explicitly — otherwise
         # `df[True]` would silently mean `df[1]`.
@@ -259,7 +261,7 @@ class DataFrame:
             )
 
         inner_expr = self._impl.qualified_column_expr(key)
-        return Expr(inner_expr, self._ctx)
+        return Series(inner_expr, self._ctx)
 
     def __getattr__(self, name):
         """Syntactic sugar for column access

--- a/python/sedonadb/python/sedonadb/series.py
+++ b/python/sedonadb/python/sedonadb/series.py
@@ -1,0 +1,257 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Any, Iterable
+
+from sedonadb.expr.expression import Expr
+from sedonadb.utility import sedona  # noqa: F401
+
+
+class Series(Expr):
+    """A lazy, pandas-style column.
+
+    A `Series` is a single column addressed with `df["x"]` or `df.x`. Like
+    `Expr` it is lazy — it carries no data and is only evaluated when the
+    surrounding `DataFrame` is executed (e.g. by `to_pandas()` or `show()`).
+
+    `Series` is a thin pandas-flavored layer over `Expr` (the lower-level
+    expression escape hatch reachable via `sd.col()`). Arithmetic,
+    comparison, and boolean operators behave the same and return a `Series`,
+    so element-wise transforms chain naturally:
+
+        df["x"].fillna(0).between(1, 10)
+
+    Boolean composition uses the bitwise operators `&`, `|`, `~` (Python
+    can't overload `and` / `or` / `not`).
+
+    Examples:
+
+        >>> sd = sedona.db.connect()
+        >>> df = sd.sql("SELECT * FROM (VALUES (1), (2), (3)) AS t(x)")
+        >>> df["x"]
+        Series(t.x)
+        >>> df["x"] + 1
+        Series(t.x + Int64(1))
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return f"Series({self._impl!r})"
+
+    def _wrap(self, expr: Expr) -> "Series":
+        # Re-wrap an Expr produced by a base-class method back into a Series
+        # so element-wise results keep the pandas surface and stay chainable.
+        return Series(expr._impl, expr._ctx)
+
+    # --- Transforms (Expr returns Expr; re-wrap as Series) ---------------
+
+    def alias(self, name: str) -> "Series":
+        """Return a copy of this column with a new output name."""
+        return self._wrap(super().alias(name))
+
+    def cast(self, target: Any) -> "Series":
+        """Cast to the given Arrow type (see `Expr.cast`)."""
+        return self._wrap(super().cast(target))
+
+    def is_null(self) -> "Series":
+        """Boolean column, true where the value is SQL NULL.
+
+        Note: this matches SQL NULL only, not floating-point NaN.
+        """
+        return self._wrap(super().is_null())
+
+    def is_not_null(self) -> "Series":
+        """Boolean column, true where the value is not SQL NULL."""
+        return self._wrap(super().is_not_null())
+
+    def isin(self, values: Iterable[Any]) -> "Series":
+        """Boolean column, true where the value is one of `values`.
+
+        Examples:
+
+            >>> sd = sedona.db.connect()
+            >>> df = sd.sql("SELECT * FROM (VALUES (1), (2), (3)) AS t(x)")
+            >>> df.filter(df["x"].isin([1, 3])).to_pandas()
+               x
+            0  1
+            1  3
+        """
+        return self._wrap(super().isin(values))
+
+    def negate(self) -> "Series":
+        """Arithmetic negation of this column."""
+        return self._wrap(super().negate())
+
+    # --- pandas-flavored element-wise methods ----------------------------
+
+    def astype(self, target: Any) -> "Series":
+        """Cast this column to an Arrow type (pandas spelling of `cast`).
+
+        Args:
+            target: An object exposing the Arrow C schema interface, e.g.
+                `pyarrow.float64()`.
+
+        Examples:
+
+            >>> import pyarrow as pa
+            >>> sd = sedona.db.connect()
+            >>> df = sd.sql("SELECT * FROM (VALUES (1), (2)) AS t(x)")
+            >>> df.select(x=df["x"].astype(pa.float64())).to_pandas()
+                 x
+            0  1.0
+            1  2.0
+        """
+        return self.cast(target)
+
+    def between(self, low: Any, high: Any) -> "Series":
+        """Boolean column, true where `low <= value <= high` (inclusive).
+
+        Examples:
+
+            >>> sd = sedona.db.connect()
+            >>> df = sd.sql("SELECT * FROM (VALUES (1), (2), (3), (4)) AS t(x)")
+            >>> df.filter(df["x"].between(2, 3)).to_pandas()
+               x
+            0  2
+            1  3
+        """
+        return (self >= low) & (self <= high)
+
+    def fillna(self, value: Any) -> "Series":
+        """Replace SQL NULLs with `value`.
+
+        Examples:
+
+            >>> sd = sedona.db.connect()
+            >>> df = sd.sql("SELECT * FROM (VALUES (1), (NULL), (3)) AS t(x)")
+            >>> df.select(x=df["x"].fillna(0)).to_pandas()
+               x
+            0  1
+            1  0
+            2  3
+        """
+        return self._wrap(self.funcs.coalesce(value))
+
+    def clip(self, lower: Any = None, upper: Any = None) -> "Series":
+        """Bound the values to the interval `[lower, upper]`.
+
+        Either bound may be omitted. `lower`/`upper` are applied with
+        `greatest` / `least` respectively.
+
+        Examples:
+
+            >>> sd = sedona.db.connect()
+            >>> df = sd.sql("SELECT * FROM (VALUES (1), (5), (9)) AS t(x)")
+            >>> df.select(x=df["x"].clip(lower=2, upper=8)).to_pandas()
+               x
+            0  2
+            1  5
+            2  8
+        """
+        result = self
+        if lower is not None:
+            result = result._wrap(result.funcs.greatest(lower))
+        if upper is not None:
+            result = result._wrap(result.funcs.least(upper))
+        return result
+
+    # --- Arithmetic operators --------------------------------------------
+
+    def __add__(self, other: Any) -> "Series":
+        return self._wrap(super().__add__(other))
+
+    def __radd__(self, other: Any) -> "Series":
+        return self._wrap(super().__radd__(other))
+
+    def __sub__(self, other: Any) -> "Series":
+        return self._wrap(super().__sub__(other))
+
+    def __rsub__(self, other: Any) -> "Series":
+        return self._wrap(super().__rsub__(other))
+
+    def __mul__(self, other: Any) -> "Series":
+        return self._wrap(super().__mul__(other))
+
+    def __rmul__(self, other: Any) -> "Series":
+        return self._wrap(super().__rmul__(other))
+
+    def __truediv__(self, other: Any) -> "Series":
+        return self._wrap(super().__truediv__(other))
+
+    def __rtruediv__(self, other: Any) -> "Series":
+        return self._wrap(super().__rtruediv__(other))
+
+    def __neg__(self) -> "Series":
+        return self._wrap(super().__neg__())
+
+    # --- Comparison operators --------------------------------------------
+
+    def __eq__(self, other: Any) -> "Series":  # type: ignore[override]
+        return self._wrap(super().__eq__(other))
+
+    def __ne__(self, other: Any) -> "Series":  # type: ignore[override]
+        return self._wrap(super().__ne__(other))
+
+    def __lt__(self, other: Any) -> "Series":
+        return self._wrap(super().__lt__(other))
+
+    def __le__(self, other: Any) -> "Series":
+        return self._wrap(super().__le__(other))
+
+    def __gt__(self, other: Any) -> "Series":
+        return self._wrap(super().__gt__(other))
+
+    def __ge__(self, other: Any) -> "Series":
+        return self._wrap(super().__ge__(other))
+
+    # `__eq__` makes the class unhashable; keep the base class's explicit
+    # `__hash__ = None` so Series can't be used as a dict key / set member.
+    __hash__ = None  # type: ignore[assignment]
+
+    # --- Boolean operators -----------------------------------------------
+
+    def __and__(self, other: Any) -> "Series":
+        return self._wrap(super().__and__(other))
+
+    def __rand__(self, other: Any) -> "Series":
+        return self._wrap(super().__rand__(other))
+
+    def __or__(self, other: Any) -> "Series":
+        return self._wrap(super().__or__(other))
+
+    def __ror__(self, other: Any) -> "Series":
+        return self._wrap(super().__ror__(other))
+
+    def __invert__(self) -> "Series":
+        return self._wrap(super().__invert__())
+
+    # --- Truthiness / length guards --------------------------------------
+
+    def __bool__(self) -> bool:
+        raise TypeError(
+            "The truth value of a Series is ambiguous. Use bitwise operators "
+            "`&`, `|`, `~` for boolean composition (e.g. "
+            "`(df['x'] > 0) & (df['y'] < 10)`), or pass the Series to "
+            "`DataFrame.filter()` to evaluate it."
+        )
+
+    def __len__(self) -> int:
+        raise TypeError(
+            "Series has no length: it is lazy and carries no data. Use "
+            "`DataFrame.count()` to execute and count rows."
+        )

--- a/python/sedonadb/tests/expr/test_dataframe_getitem.py
+++ b/python/sedonadb/tests/expr/test_dataframe_getitem.py
@@ -17,20 +17,22 @@
 
 # Tests for DataFrame.__getitem__ — single-column lookup by name or
 # position. `__getitem__` is deliberately not a polymorphic
-# select/filter shortcut: keeping the return type strictly `Expr`
-# preserves IDE/type-checker inference on `df["x"].<method>`.
+# select/filter shortcut: keeping the return type strictly `Series`
+# preserves IDE/type-checker inference on `df["x"].<method>`. `Series`
+# subclasses `Expr`, so it is still accepted everywhere an `Expr` is.
 
 import pandas as pd
 import pytest
 
-from sedonadb.expr import Expr, col
+from sedonadb.expr import col
+from sedonadb.series import Series
 
 
 def test_getitem_string_returns_col_expr(con):
     df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]})).alias("foofy")
     e = df["x"]
-    assert isinstance(e, Expr)
-    assert repr(e) == "Expr(foofy.x)"
+    assert isinstance(e, Series)
+    assert repr(e) == "Series(foofy.x)"
     assert e._ctx is not None
 
 
@@ -39,8 +41,8 @@ def test_getitem_positive_int_returns_col_expr(con):
         "foofy"
     )
     e = df[1]
-    assert isinstance(e, Expr)
-    assert repr(e) == "Expr(foofy.y)"
+    assert isinstance(e, Series)
+    assert repr(e) == "Series(foofy.y)"
     assert e._ctx is not None
 
 
@@ -48,25 +50,26 @@ def test_getitem_first_int_index(con):
     df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3], "y": [10, 20, 30]})).alias(
         "foofy"
     )
-    assert repr(df[0]) == "Expr(foofy.x)"
+    assert repr(df[0]) == "Series(foofy.x)"
 
 
 def test_getitem_negative_int_returns_col_expr(con):
     df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3], "y": [10, 20, 30]})).alias(
         "foofy"
     )
-    assert repr(df[-1]) == "Expr(foofy.y)"
-    assert repr(df[-2]) == "Expr(foofy.x)"
+    assert repr(df[-1]) == "Series(foofy.y)"
+    assert repr(df[-2]) == "Series(foofy.x)"
 
 
 def test_getitem_string_composes_with_operators(con):
-    # Single-column return preserves the operator-overloading chain.
+    # Single-column return preserves the operator-overloading chain, and
+    # operators keep the result a Series.
     df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3], "y": [10, 20, 30]})).alias(
         "foofy"
     )
     e = df["x"] + df["y"]
-    assert isinstance(e, Expr)
-    assert repr(e) == "Expr(foofy.x + foofy.y)"
+    assert isinstance(e, Series)
+    assert repr(e) == "Series(foofy.x + foofy.y)"
     assert e._ctx is not None
 
 
@@ -116,8 +119,8 @@ def test_getitem_slice_raises_typeerror(con):
 def test_getattr_returns_col_expr(con):
     df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]})).alias("foofy")
     e = df.x
-    assert isinstance(e, Expr)
-    assert repr(e) == "Expr(foofy.x)"
+    assert isinstance(e, Series)
+    assert repr(e) == "Series(foofy.x)"
     assert e._ctx is not None
 
 

--- a/python/sedonadb/tests/expr/test_series.py
+++ b/python/sedonadb/tests/expr/test_series.py
@@ -1,0 +1,138 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pandas as pd
+import pandas.testing as pdt
+import pyarrow as pa
+import pytest
+
+from sedonadb.expr import Expr
+from sedonadb.series import Series
+
+
+def test_series_is_expr_subclass(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
+    s = df["x"]
+    assert isinstance(s, Series)
+    assert isinstance(s, Expr)
+
+
+def test_operators_return_series(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}))
+    # Arithmetic, comparison, and boolean operators all stay Series so they
+    # remain chainable with Series methods.
+    assert isinstance(df["x"] + 1, Series)
+    assert isinstance(1 + df["x"], Series)
+    assert isinstance(-df["x"], Series)
+    assert isinstance(df["x"] > 1, Series)
+    assert isinstance(df["x"] == df["y"], Series)
+    assert isinstance((df["x"] > 1) & (df["y"] < 6), Series)
+    assert isinstance(~(df["x"] > 1), Series)
+
+
+def test_transforms_return_series(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
+    assert isinstance(df["x"].alias("z"), Series)
+    assert isinstance(df["x"].cast(pa.float64()), Series)
+    assert isinstance(df["x"].is_null(), Series)
+    assert isinstance(df["x"].is_not_null(), Series)
+    assert isinstance(df["x"].isin([1, 2]), Series)
+
+
+def test_series_repr(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]})).alias("t")
+    assert repr(df["x"]) == "Series(t.x)"
+    assert repr(df["x"] + 1) == "Series(t.x + Int64(1))"
+
+
+def test_astype(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
+    out = df.select(x=df["x"].astype(pa.float64())).to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [1.0, 2.0, 3.0]}))
+
+
+def test_between_inclusive(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3, 4, 5]}))
+    out = df.filter(df["x"].between(2, 4)).sort("x").to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [2, 3, 4]}))
+
+
+def test_fillna(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1.0, None, 3.0]}))
+    out = df.select(x=df["x"].fillna(0.0)).to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [1.0, 0.0, 3.0]}))
+
+
+def test_clip_both_bounds(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 5, 9]}))
+    out = df.select(x=df["x"].clip(lower=2, upper=8)).to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [2, 5, 8]}))
+
+
+def test_clip_lower_only(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 5, 9]}))
+    out = df.select(x=df["x"].clip(lower=4)).to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [4, 5, 9]}))
+
+
+def test_clip_upper_only(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 5, 9]}))
+    out = df.select(x=df["x"].clip(upper=6)).to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [1, 5, 6]}))
+
+
+def test_chained_element_wise(con):
+    # The point of returning Series from operators + methods: chaining.
+    df = con.create_data_frame(pd.DataFrame({"x": [1.0, None, 9.0]}))
+    out = df.select(x=df["x"].fillna(0.0).clip(upper=5).astype(pa.int64())).to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [1, 0, 5]}))
+
+
+def test_series_accepted_by_select(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2], "y": [3, 4]}))
+    out = df.select(df["x"], df["y"]).to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [1, 2], "y": [3, 4]}))
+
+
+def test_series_accepted_by_filter(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
+    out = df.filter(df["x"] > 1).sort("x").to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"x": [2, 3]}))
+
+
+def test_series_accepted_by_agg(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
+    out = df.agg(total=con.funcs.sum(df["x"])).to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"total": [6]}))
+
+
+def test_series_bool_is_ambiguous(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
+    with pytest.raises(TypeError, match="truth value of a Series is ambiguous"):
+        bool(df["x"] > 1)
+
+
+def test_series_has_no_len(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
+    with pytest.raises(TypeError, match="Series has no length"):
+        len(df["x"])
+
+
+def test_series_unhashable(con):
+    df = con.create_data_frame(pd.DataFrame({"x": [1, 2, 3]}))
+    with pytest.raises(TypeError):
+        {df["x"]: 1}


### PR DESCRIPTION
First step of the pandas `Series` surface (the Series/Scalar phase of #791). `df["x"]` and `df.x` now return a `Series` instead of a bare `Expr`.

## What changes

`Series` **subclasses `Expr`**, so it is accepted unchanged everywhere an `Expr` already is — `select`, `filter`, `sort`, `agg`, `group_by`, `join` all keep working with no signature changes (they gate on `isinstance(.., Expr)` and unwrap `._impl`, both still true). The difference is that operators and transforms are overridden to return `Series` rather than `Expr`, so element-wise work chains naturally:

```python
df["x"].fillna(0).clip(upper=5).astype(pa.int64())
df.filter(df["x"].between(2, 4))
df.select(z=(df["x"] + df["y"]).alias("z"))
```

## API in this PR

pandas-flavored element-wise methods (all return `Series`):

- `astype(target)` — pandas spelling of `cast`
- `between(low, high)` — inclusive
- `fillna(value)` — via `coalesce`
- `clip(lower=None, upper=None)` — via `greatest` / `least`

Inherited `Expr` transforms (`alias`, `cast`, `is_null`, `is_not_null`, `isin`, `negate`) and all operators are re-wrapped to return `Series`. `asc`/`desc` still return `SortExpr`. `__bool__`/`__len__` raise with `Series`-specific guidance; `Series` stays unhashable (inherited `__hash__ = None`). Repr is `Series(<expr>)`.

`Series` lives at `sedonadb.series.Series` — consistent with `Expr` at `sedonadb.expr` (neither is a top-level export yet).

## Design note

The alternative was composition (`Series` *wraps* an `Expr`). Subclassing was chosen to avoid touching the 8 integration points and to reuse the operator machinery; the tradeoff is that `Series` inherits a few non-pandas `Expr` methods (`asc`/`desc`/`cast`/`is_null`). Happy to revisit if you'd prefer composition.

## Deferred to follow-up sub-PRs

- Parent-`DataFrame` link + `Scalar` + lazy reductions (`mean`/`sum`/`min`/`max`/`std`/`count`/`nunique`, auto-materializing on Python coercion).
- `isna`/`notna` with NaN-aware semantics (per the #791 decision that `isna` matches NULL *and* NaN — wants deliberate handling, `isnan` is available).
- `unique` / `value_counts`.
- `.str.*` / `.dt.*` accessors.

## Tests

New `tests/expr/test_series.py`: operators/transforms return `Series`; `astype`/`between`/`fillna`/`clip`; chaining; `select`/`filter`/`agg` accept `Series`; `bool`/`len`/`hash` guards; repr. `tests/expr/test_dataframe_getitem.py` updated to assert the `Series` contract.

Local: 207 expr tests + 63 doctests + `ruff` all clean. No regressions (the broader suite's PostGIS/DuckDB failures are pre-existing/environmental, identical on main).
