### PR TITLE
feat(rust/sedona-raster-gdal): add RS_AsRaster for rasterizing geometries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6139,6 +6139,7 @@ dependencies = [
  "sedona-expr",
  "sedona-functions",
  "sedona-gdal",
+ "sedona-proj",
  "sedona-raster",
  "sedona-raster-functions",
  "sedona-schema",

--- a/docs/reference/sql/rs_asraster.qmd
+++ b/docs/reference/sql/rs_asraster.qmd
@@ -1,0 +1,125 @@
+---
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+title: RS_AsRaster
+description: Rasterizes a geometry using the grid of a reference raster.
+kernels:
+  - returns: raster
+    args:
+    - name: geometry
+      type: geometry
+    - name: reference_raster
+      type: raster
+    - name: pixel_type
+      type: string
+  - returns: raster
+    args:
+    - name: geometry
+      type: geometry
+    - name: reference_raster
+      type: raster
+    - name: pixel_type
+      type: string
+    - name: all_touched
+      type: boolean
+  - returns: raster
+    args:
+    - name: geometry
+      type: geometry
+    - name: reference_raster
+      type: raster
+    - name: pixel_type
+      type: string
+    - name: all_touched
+      type: boolean
+    - name: burn_value
+      type: double
+  - returns: raster
+    args:
+    - name: geometry
+      type: geometry
+    - name: reference_raster
+      type: raster
+    - name: pixel_type
+      type: string
+    - name: all_touched
+      type: boolean
+    - name: burn_value
+      type: double
+    - name: nodata_value
+      type: double
+  - returns: raster
+    args:
+    - name: geometry
+      type: geometry
+    - name: reference_raster
+      type: raster
+    - name: pixel_type
+      type: string
+    - name: all_touched
+      type: boolean
+    - name: burn_value
+      type: double
+    - name: nodata_value
+      type: double
+    - name: use_geometry_extent
+      type: boolean
+  - returns: raster
+    args:
+    - name: geometry
+      type: geometry
+    - name: reference_raster
+      type: raster
+    - name: pixel_type
+      type: string
+    - name: all_touched
+      type: boolean
+    - name: burn_value
+      type: double
+    - name: nodata_value
+      type: double
+    - name: use_geometry_extent
+      type: boolean
+---
+
+## Description
+
+Creates a single-band in-db raster by rasterizing `geometry` onto the grid
+defined by `reference_raster`.
+
+The output pixel type is controlled by `pixel_type`. Optional arguments control
+whether pixels touched by the geometry are burned, the value burned into covered
+pixels, the nodata fill value, and whether the output extent is cropped to the
+geometry extent or kept equal to the full reference raster extent.
+
+## Examples
+
+```sql
+SELECT
+  RS_Width(
+    RS_AsRaster(
+      ST_GeomFromWKT('POLYGON((1 1, 1 2, 2 2, 2 1, 1 1))'),
+      RS_FromPath('../../../submodules/sedona-testing/data/raster/test4.tiff'),
+      'D',
+      false,
+      1.0,
+      0.0,
+      true
+    )
+  );
+```

--- a/docs/reference/sql/rs_asraster.qmd
+++ b/docs/reference/sql/rs_asraster.qmd
@@ -110,16 +110,19 @@ geometry extent or kept equal to the full reference raster extent.
 ## Examples
 
 ```sql
-SELECT
-  RS_Width(
-    RS_AsRaster(
-      ST_GeomFromWKT('POLYGON((1 1, 1 2, 2 2, 2 1, 1 1))'),
-      RS_FromPath('../../../submodules/sedona-testing/data/raster/test4.tiff'),
-      'D',
-      false,
-      1.0,
-      0.0,
-      true
-    )
-  );
+WITH r AS (
+  SELECT RS_FromPath('https://download.osgeo.org/geotiff/samples/gdal_eg/cea.tif') AS raster
+)
+SELECT RS_Width(
+  RS_AsRaster(
+    RS_ConvexHull(raster),
+    raster,
+    'float64',
+    false,
+    1.0,
+    0.0,
+    false
+  )
+)
+FROM r;
 ```

--- a/docs/reference/sql/rs_asraster.qmd
+++ b/docs/reference/sql/rs_asraster.qmd
@@ -97,6 +97,10 @@ kernels:
       type: boolean
 ---
 
+::: callout-warning
+**Experimental.** This function is experimental; its behavior may change without notice.
+:::
+
 ## Description
 
 Creates a single-band in-db raster by rasterizing `geometry` onto the grid

--- a/docs/reference/sql/rs_asraster.qmd
+++ b/docs/reference/sql/rs_asraster.qmd
@@ -111,6 +111,10 @@ whether pixels touched by the geometry are burned, the value burned into covered
 pixels, the nodata fill value, and whether the output extent is cropped to the
 geometry extent or kept equal to the full reference raster extent.
 
+When both `geometry` and `reference_raster` have a CRS and they differ,
+`geometry` is reprojected into the reference raster's CRS before rasterization.
+Geometries without a CRS are rasterized using their coordinates as given.
+
 ## Examples
 
 ```sql

--- a/docs/reference/sql/rs_asraster.qmd
+++ b/docs/reference/sql/rs_asraster.qmd
@@ -113,7 +113,7 @@ geometry extent or kept equal to the full reference raster extent.
 
 When both `geometry` and `reference_raster` have a CRS and they differ,
 `geometry` is reprojected into the reference raster's CRS before rasterization.
-Geometries without a CRS are rasterized using their coordinates as given.
+An error is returned if exactly one of them has a CRS.
 
 ## Examples
 

--- a/python/sedonadb/tests/functions/test_raster_functions.py
+++ b/python/sedonadb/tests/functions/test_raster_functions.py
@@ -16,8 +16,10 @@
 # under the License.
 
 import pytest
+import numpy as np
 
 from sedonadb.testing import SedonaDB
+from sedonadb.raster import Raster
 
 
 @pytest.mark.parametrize(
@@ -295,8 +297,6 @@ def _rs_as_raster_sql(
 def test_rs_as_raster_matches_rasterio(
     con, sedona_testing, all_touched, use_geometry_extent
 ):
-    import numpy as np
-
     pytest.importorskip("rasterio")
     from rasterio.features import rasterize
     from rasterio.transform import Affine
@@ -305,14 +305,11 @@ def test_rs_as_raster_matches_rasterio(
     path = sedona_testing / "data/raster/test4.tiff"
     transform = (0.0, 1.0, 0.0, 10.0, 0.0, -1.0)
 
-    result = (
-        con.sql(
-            _rs_as_raster_sql("float64", all_touched, 7.0, 0.0, use_geometry_extent),
-            params=(str(path),),
-        )
-        .to_arrow_table()["raster"][0]
-        .as_py()
-    )
+    table = con.sql(
+        _rs_as_raster_sql("float64", all_touched, 7.0, 0.0, use_geometry_extent),
+        params=(str(path),),
+    ).to_arrow_table()
+    result = Raster(table["raster"], 0)
 
     got = result.bands[0].to_numpy()
     geom = wkt.loads("POLYGON((2 8, 2 5, 5 5, 5 8, 2 8))")

--- a/python/sedonadb/tests/functions/test_raster_functions.py
+++ b/python/sedonadb/tests/functions/test_raster_functions.py
@@ -268,3 +268,191 @@ def test_rs_setbandnodatavalue_two_arg_requires_single_band():
         SedonaDB().assert_query_result(
             "SELECT RS_SetBandNoDataValue(RS_Example(), 0)", None
         )
+
+
+def _rs_as_raster_sql(
+    pixel_type, all_touched, burn_value, nodata_value, use_geometry_extent
+):
+    return f"""
+        WITH src AS (SELECT RS_FromPath($1) AS raster)
+        SELECT RS_AsRaster(
+            ST_GeomFromText('POLYGON((2 8, 2 5, 5 5, 5 8, 2 8))'),
+            raster,
+            '{pixel_type}',
+            {str(all_touched).upper()},
+            {burn_value},
+            {nodata_value},
+            {str(use_geometry_extent).upper()}
+        ) AS raster
+        FROM src
+    """
+
+
+@pytest.mark.parametrize(
+    ("all_touched", "use_geometry_extent"),
+    [(False, False), (False, True), (True, False)],
+)
+def test_rs_as_raster_matches_rasterio(
+    con, sedona_testing, all_touched, use_geometry_extent
+):
+    import numpy as np
+
+    pytest.importorskip("rasterio")
+    from rasterio.features import rasterize
+    from rasterio.transform import Affine
+    from shapely import wkt
+
+    path = sedona_testing / "data/raster/test4.tiff"
+    transform = (0.0, 1.0, 0.0, 10.0, 0.0, -1.0)
+
+    result = (
+        con.sql(
+            _rs_as_raster_sql("float64", all_touched, 7.0, 0.0, use_geometry_extent),
+            params=(str(path),),
+        )
+        .to_arrow_table()["raster"][0]
+        .as_py()
+    )
+
+    got = result.bands[0].to_numpy()
+    geom = wkt.loads("POLYGON((2 8, 2 5, 5 5, 5 8, 2 8))")
+
+    if use_geometry_extent:
+        expected_shape = (3, 3)
+        expected_transform = (2.0, 1.0, 0.0, 8.0, 0.0, -1.0)
+    else:
+        expected_shape = (10, 10)
+        expected_transform = transform
+
+    expected = rasterize(
+        [(geom, 7.0)],
+        out_shape=expected_shape,
+        transform=Affine.from_gdal(*expected_transform),
+        all_touched=all_touched,
+        fill=0.0,
+        dtype="float64",
+    )
+
+    assert tuple(result.transform) == expected_transform
+    assert result.width == expected_shape[1]
+    assert result.height == expected_shape[0]
+    np.testing.assert_array_equal(got, expected)
+
+
+def test_rs_as_raster_all_touched_changes_pixels(con, sedona_testing):
+    import numpy as np
+
+    pytest.importorskip("rasterio")
+    from rasterio.features import rasterize
+    from rasterio.transform import Affine
+    from shapely import wkt
+
+    path = sedona_testing / "data/raster/test4.tiff"
+    transform = (0.0, 1.0, 0.0, 10.0, 0.0, -1.0)
+    geom = "POLYGON((1.9 8.9, 1.9 6.1, 3.1 6.1, 3.1 8.9, 1.9 8.9))"
+
+    false_result = (
+        con.sql(
+            f"WITH src AS (SELECT RS_FromPath($1) AS raster) SELECT RS_AsRaster(ST_GeomFromText('{geom}'), raster, 'uint8', FALSE, 1, 0, FALSE) AS raster FROM src",
+            params=(str(path),),
+        )
+        .to_arrow_table()["raster"][0]
+        .as_py()
+    )
+    true_result = (
+        con.sql(
+            f"WITH src AS (SELECT RS_FromPath($1) AS raster) SELECT RS_AsRaster(ST_GeomFromText('{geom}'), raster, 'uint8', TRUE, 1, 0, FALSE) AS raster FROM src",
+            params=(str(path),),
+        )
+        .to_arrow_table()["raster"][0]
+        .as_py()
+    )
+
+    false_pixels = false_result.bands[0].to_numpy()
+    true_pixels = true_result.bands[0].to_numpy()
+
+    geom = wkt.loads(geom)
+    expected_false = rasterize(
+        [(geom, 1)],
+        out_shape=(10, 10),
+        transform=Affine.from_gdal(*transform),
+        all_touched=False,
+        fill=0,
+        dtype="uint8",
+    )
+    expected_true = rasterize(
+        [(geom, 1)],
+        out_shape=(10, 10),
+        transform=Affine.from_gdal(*transform),
+        all_touched=True,
+        fill=0,
+        dtype="uint8",
+    )
+
+    np.testing.assert_array_equal(false_pixels, expected_false)
+    np.testing.assert_array_equal(true_pixels, expected_true)
+    assert np.count_nonzero(true_pixels) >= np.count_nonzero(false_pixels)
+    assert not np.array_equal(true_pixels, false_pixels)
+
+
+def test_rs_as_raster_rejects_fractional_integer_nodata(con, sedona_testing):
+    path = sedona_testing / "data/raster/test4.tiff"
+
+    with pytest.raises(Exception, match="initial fill value must be an integer"):
+        con.sql(
+            """
+            WITH src AS (SELECT RS_FromPath($1) AS raster)
+            SELECT RS_AsRaster(
+                ST_GeomFromText('POLYGON((0 2, 0 0, 2 0, 2 2, 0 2))'),
+                raster,
+                'uint8',
+                FALSE,
+                1,
+                1.5,
+                FALSE
+            )
+            FROM src
+            """,
+            params=(str(path),),
+        ).to_arrow_table()
+
+
+def test_rs_as_raster_sets_output_nodata(con, sedona_testing):
+    import numpy as np
+
+    path = sedona_testing / "data/raster/test4.tiff"
+    tab = con.sql(
+        """
+        WITH src AS (SELECT RS_FromPath($1) AS raster)
+        SELECT
+            RS_AsRaster(
+                ST_GeomFromText('POLYGON((0 10, 0 9, 1 9, 1 10, 0 10))'),
+                raster,
+                'uint8',
+                FALSE,
+                5,
+                9,
+                FALSE
+            ) AS raster,
+            RS_BandNoDataValue(
+                RS_AsRaster(
+                    ST_GeomFromText('POLYGON((0 10, 0 9, 1 9, 1 10, 0 10))'),
+                    raster,
+                    'uint8',
+                    FALSE,
+                    5,
+                    9,
+                    FALSE
+                ),
+                1
+            ) AS nodata
+        FROM src
+        """,
+        params=(str(path),),
+    ).to_arrow_table()
+
+    assert tab["nodata"][0].as_py() == 9.0
+    raster = tab["raster"][0].as_py()
+    expected = np.full((10, 10), 9, dtype="uint8")
+    expected[0, 0] = 5
+    np.testing.assert_array_equal(raster.bands[0].to_numpy(), expected)

--- a/python/sedonadb/tests/functions/test_raster_functions.py
+++ b/python/sedonadb/tests/functions/test_raster_functions.py
@@ -278,7 +278,7 @@ def _rs_as_raster_sql(
     return f"""
         WITH src AS (SELECT RS_FromPath($1) AS raster)
         SELECT RS_AsRaster(
-            ST_GeomFromText('POLYGON((2 8, 2 5, 5 5, 5 8, 2 8))'),
+            ST_GeomFromText('POLYGON((2 8, 2 5, 5 5, 5 8, 2 8))', 'EPSG:4326'),
             raster,
             '{pixel_type}',
             {str(all_touched).upper()},
@@ -350,7 +350,7 @@ def test_rs_as_raster_all_touched_changes_pixels(con, sedona_testing):
 
     false_result = (
         con.sql(
-            f"WITH src AS (SELECT RS_FromPath($1) AS raster) SELECT RS_AsRaster(ST_GeomFromText('{geom}'), raster, 'uint8', FALSE, 1, 0, FALSE) AS raster FROM src",
+            f"WITH src AS (SELECT RS_FromPath($1) AS raster) SELECT RS_AsRaster(ST_GeomFromText('{geom}', 'EPSG:4326'), raster, 'uint8', FALSE, 1, 0, FALSE) AS raster FROM src",
             params=(str(path),),
         )
         .to_arrow_table()["raster"][0]
@@ -358,7 +358,7 @@ def test_rs_as_raster_all_touched_changes_pixels(con, sedona_testing):
     )
     true_result = (
         con.sql(
-            f"WITH src AS (SELECT RS_FromPath($1) AS raster) SELECT RS_AsRaster(ST_GeomFromText('{geom}'), raster, 'uint8', TRUE, 1, 0, FALSE) AS raster FROM src",
+            f"WITH src AS (SELECT RS_FromPath($1) AS raster) SELECT RS_AsRaster(ST_GeomFromText('{geom}', 'EPSG:4326'), raster, 'uint8', TRUE, 1, 0, FALSE) AS raster FROM src",
             params=(str(path),),
         )
         .to_arrow_table()["raster"][0]
@@ -400,7 +400,7 @@ def test_rs_as_raster_rejects_fractional_integer_nodata(con, sedona_testing):
             """
             WITH src AS (SELECT RS_FromPath($1) AS raster)
             SELECT RS_AsRaster(
-                ST_GeomFromText('POLYGON((0 2, 0 0, 2 0, 2 2, 0 2))'),
+                ST_GeomFromText('POLYGON((0 2, 0 0, 2 0, 2 2, 0 2))', 'EPSG:4326'),
                 raster,
                 'uint8',
                 FALSE,
@@ -423,7 +423,7 @@ def test_rs_as_raster_sets_output_nodata(con, sedona_testing):
         WITH src AS (SELECT RS_FromPath($1) AS raster)
         SELECT
             RS_AsRaster(
-                ST_GeomFromText('POLYGON((0 10, 0 9, 1 9, 1 10, 0 10))'),
+                ST_GeomFromText('POLYGON((0 10, 0 9, 1 9, 1 10, 0 10))', 'EPSG:4326'),
                 raster,
                 'uint8',
                 FALSE,
@@ -433,7 +433,7 @@ def test_rs_as_raster_sets_output_nodata(con, sedona_testing):
             ) AS raster,
             RS_BandNoDataValue(
                 RS_AsRaster(
-                    ST_GeomFromText('POLYGON((0 10, 0 9, 1 9, 1 10, 0 10))'),
+                    ST_GeomFromText('POLYGON((0 10, 0 9, 1 9, 1 10, 0 10))', 'EPSG:4326'),
                     raster,
                     'uint8',
                     FALSE,

--- a/rust/sedona-raster-functions/src/crs_utils.rs
+++ b/rust/sedona-raster-functions/src/crs_utils.rs
@@ -17,7 +17,7 @@
 
 use std::borrow::Cow;
 
-use datafusion_common::{exec_datafusion_err, DataFusionError, Result};
+use datafusion_common::{exec_datafusion_err, exec_err, DataFusionError, Result};
 use sedona_geometry::transform::{transform, CrsEngine};
 use sedona_schema::crs::{deserialize_crs, CoordinateReferenceSystem, Crs, CrsRef};
 use wkb::reader::read_wkb;
@@ -68,21 +68,41 @@ pub fn crs_transform_wkb(
 
 /// Align WKB coordinates with a target CRS when both CRSes are known.
 ///
-/// Missing CRS metadata leaves coordinates unchanged. This preserves existing
-/// behavior for untagged geometries while transforming values that explicitly
-/// identify a differing CRS.
+/// Both inputs must either carry a CRS or omit one. When present CRSes differ,
+/// the WKB is transformed into the target CRS.
+pub fn crs_transform_required(
+    source_crs: CrsRef<'_>,
+    target_crs: CrsRef<'_>,
+    source_name: &str,
+    target_name: &str,
+) -> Result<bool> {
+    match (source_crs, target_crs) {
+        (Some(source_crs), Some(target_crs)) => Ok(!source_crs.crs_equals(target_crs)),
+        (None, None) => Ok(false),
+        (Some(_), None) => exec_err!("{source_name} has a CRS but the {target_name} does not"),
+        (None, Some(_)) => exec_err!("{target_name} has a CRS but the {source_name} does not"),
+    }
+}
+
+/// Align WKB coordinates with a target CRS.
 pub fn align_wkb_to_crs<'a>(
     wkb: &'a [u8],
     source_crs: CrsRef<'_>,
     target_crs: CrsRef<'_>,
+    source_name: &str,
+    target_name: &str,
     engine: &dyn CrsEngine,
 ) -> Result<Cow<'a, [u8]>> {
-    match (source_crs, target_crs) {
-        (Some(source_crs), Some(target_crs)) if !source_crs.crs_equals(target_crs) => Ok(
-            Cow::Owned(crs_transform_wkb(wkb, source_crs, target_crs, engine)?),
-        ),
-        _ => Ok(Cow::Borrowed(wkb)),
+    if !crs_transform_required(source_crs, target_crs, source_name, target_name)? {
+        return Ok(Cow::Borrowed(wkb));
     }
+
+    let (Some(source_crs), Some(target_crs)) = (source_crs, target_crs) else {
+        unreachable!("a CRS transform requires both source and target CRSes")
+    };
+    Ok(Cow::Owned(crs_transform_wkb(
+        wkb, source_crs, target_crs, engine,
+    )?))
 }
 
 #[cfg(test)]
@@ -105,26 +125,34 @@ mod tests {
     ) -> Result<Vec<u8>> {
         let from_crs = resolve_crs(from)?;
         let to_crs = resolve_crs(to)?;
-        align_wkb_to_crs(wkb, from_crs.as_deref(), to_crs.as_deref(), engine).map(Cow::into_owned)
+        match (from_crs, to_crs) {
+            (Some(from_crs), Some(to_crs)) if !from_crs.crs_equals(to_crs.as_ref()) => {
+                crs_transform_wkb(wkb, from_crs.as_ref(), to_crs.as_ref(), engine)
+            }
+            _ => Ok(wkb.to_vec()),
+        }
     }
 
     #[test]
-    fn align_wkb_borrows_when_a_crs_is_missing_or_equal() {
+    fn align_wkb_borrows_when_crses_are_missing_or_equal() {
         let wkb = sample_wkb();
         with_global_proj_engine(|engine| {
             let source = resolve_crs(Some("EPSG:4326"))?;
             let target = resolve_crs(Some("EPSG:4326"))?;
 
             assert!(matches!(
-                align_wkb_to_crs(&wkb, None, target.as_deref(), engine)?,
+                align_wkb_to_crs(&wkb, None, None, "source", "target", engine)?,
                 Cow::Borrowed(_)
             ));
             assert!(matches!(
-                align_wkb_to_crs(&wkb, source.as_deref(), None, engine)?,
-                Cow::Borrowed(_)
-            ));
-            assert!(matches!(
-                align_wkb_to_crs(&wkb, source.as_deref(), target.as_deref(), engine)?,
+                align_wkb_to_crs(
+                    &wkb,
+                    source.as_deref(),
+                    target.as_deref(),
+                    "source",
+                    "target",
+                    engine,
+                )?,
                 Cow::Borrowed(_)
             ));
             Ok(())
@@ -138,9 +166,48 @@ mod tests {
         with_global_proj_engine(|engine| {
             let source = resolve_crs(Some("EPSG:4326"))?;
             let target = resolve_crs(Some("EPSG:3857"))?;
-            let aligned = align_wkb_to_crs(&wkb, source.as_deref(), target.as_deref(), engine)?;
+            let aligned = align_wkb_to_crs(
+                &wkb,
+                source.as_deref(),
+                target.as_deref(),
+                "source",
+                "target",
+                engine,
+            )?;
             assert!(matches!(aligned, Cow::Owned(_)));
             assert_ne!(aligned.as_ref(), wkb);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn align_wkb_errors_when_only_one_crs_is_present() {
+        let wkb = sample_wkb();
+        with_global_proj_engine(|engine| {
+            let crs = resolve_crs(Some("EPSG:4326"))?;
+            assert!(align_wkb_to_crs(
+                &wkb,
+                crs.as_deref(),
+                None,
+                "geometry",
+                "reference raster",
+                engine,
+            )
+            .unwrap_err()
+            .to_string()
+            .contains("geometry has a CRS but the reference raster does not"));
+            assert!(align_wkb_to_crs(
+                &wkb,
+                None,
+                crs.as_deref(),
+                "geometry",
+                "reference raster",
+                engine,
+            )
+            .unwrap_err()
+            .to_string()
+            .contains("reference raster has a CRS but the geometry does not"));
             Ok(())
         })
         .unwrap();

--- a/rust/sedona-raster-functions/src/crs_utils.rs
+++ b/rust/sedona-raster-functions/src/crs_utils.rs
@@ -15,9 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::borrow::Cow;
+
 use datafusion_common::{exec_datafusion_err, DataFusionError, Result};
 use sedona_geometry::transform::{transform, CrsEngine};
-use sedona_schema::crs::{deserialize_crs, CoordinateReferenceSystem, Crs};
+use sedona_schema::crs::{deserialize_crs, CoordinateReferenceSystem, Crs, CrsRef};
 use wkb::reader::read_wkb;
 
 /// Resolve an optional CRS string to a concrete CRS object.
@@ -64,6 +66,25 @@ pub fn crs_transform_wkb(
     Ok(out)
 }
 
+/// Align WKB coordinates with a target CRS when both CRSes are known.
+///
+/// Missing CRS metadata leaves coordinates unchanged. This preserves existing
+/// behavior for untagged geometries while transforming values that explicitly
+/// identify a differing CRS.
+pub fn align_wkb_to_crs<'a>(
+    wkb: &'a [u8],
+    source_crs: CrsRef<'_>,
+    target_crs: CrsRef<'_>,
+    engine: &dyn CrsEngine,
+) -> Result<Cow<'a, [u8]>> {
+    match (source_crs, target_crs) {
+        (Some(source_crs), Some(target_crs)) if !source_crs.crs_equals(target_crs) => Ok(
+            Cow::Owned(crs_transform_wkb(wkb, source_crs, target_crs, engine)?),
+        ),
+        _ => Ok(Cow::Borrowed(wkb)),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -84,12 +105,45 @@ mod tests {
     ) -> Result<Vec<u8>> {
         let from_crs = resolve_crs(from)?;
         let to_crs = resolve_crs(to)?;
-        match (from_crs, to_crs) {
-            (Some(from_crs), Some(to_crs)) => {
-                crs_transform_wkb(wkb, from_crs.as_ref(), to_crs.as_ref(), engine)
-            }
-            _ => Ok(wkb.to_vec()),
-        }
+        align_wkb_to_crs(wkb, from_crs.as_deref(), to_crs.as_deref(), engine).map(Cow::into_owned)
+    }
+
+    #[test]
+    fn align_wkb_borrows_when_a_crs_is_missing_or_equal() {
+        let wkb = sample_wkb();
+        with_global_proj_engine(|engine| {
+            let source = resolve_crs(Some("EPSG:4326"))?;
+            let target = resolve_crs(Some("EPSG:4326"))?;
+
+            assert!(matches!(
+                align_wkb_to_crs(&wkb, None, target.as_deref(), engine)?,
+                Cow::Borrowed(_)
+            ));
+            assert!(matches!(
+                align_wkb_to_crs(&wkb, source.as_deref(), None, engine)?,
+                Cow::Borrowed(_)
+            ));
+            assert!(matches!(
+                align_wkb_to_crs(&wkb, source.as_deref(), target.as_deref(), engine)?,
+                Cow::Borrowed(_)
+            ));
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn align_wkb_owns_transformed_coordinates() {
+        let wkb = sample_wkb();
+        with_global_proj_engine(|engine| {
+            let source = resolve_crs(Some("EPSG:4326"))?;
+            let target = resolve_crs(Some("EPSG:3857"))?;
+            let aligned = align_wkb_to_crs(&wkb, source.as_deref(), target.as_deref(), engine)?;
+            assert!(matches!(aligned, Cow::Owned(_)));
+            assert_ne!(aligned.as_ref(), wkb);
+            Ok(())
+        })
+        .unwrap();
     }
 
     // -----------------------------------------------------------------------

--- a/rust/sedona-raster-functions/src/rs_value.rs
+++ b/rust/sedona-raster-functions/src/rs_value.rs
@@ -32,7 +32,7 @@
 //! [`NdBuffer`](sedona_raster::traits::NdBuffer) — no GDAL involved. Only 2-D
 //! rasters are supported; a band with extra (non-spatial) dimensions errors.
 
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 
 use arrow_array::{builder::Float64Builder, Array, ArrayRef, Float64Array, StructArray};
 use arrow_schema::DataType;
@@ -48,7 +48,7 @@ use sedona_raster::traits::{nodata_bytes_to_f64_lossless, NdBuffer, RasterRef};
 use sedona_schema::crs::CrsRef;
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
 
-use crate::crs_utils::{crs_transform_wkb, resolve_crs};
+use crate::crs_utils::{align_wkb_to_crs, resolve_crs};
 use crate::executor::RasterExecutor;
 use crate::rs_ensure_loaded::NEEDS_PIXELS_METADATA_KEY;
 
@@ -133,7 +133,7 @@ impl SedonaScalarKernel for RsValuePoint {
                 // points (and non-finite coordinates) have no location to sample.
                 let raster_crs = resolve_crs(raster.crs())?;
                 let Some((x, y)) =
-                    resolve_point_xy(point_wkb, point_crs, raster_crs.as_deref(), false, engine)?
+                    resolve_point_xy(point_wkb, point_crs, raster_crs.as_deref(), engine)?
                 else {
                     builder.append_null();
                     return Ok(());
@@ -214,14 +214,9 @@ impl RsValuePoint {
             .map(|a| as_int32_array(a))
             .transpose()?;
 
-        // Affine transform and raster CRS, resolved once for all points.
+        // Affine transform and raster CRS are shared by every point in this batch.
         let affine = AffineMatrix::from_metadata(&raster.metadata());
         let raster_crs = resolve_crs(raster.crs())?;
-        // Decide reprojection once when the point CRS is column-level (the common
-        // case). This skips a per-point `crs_equals`, which allocates a String —
-        // ~15 ns/point, uniform across CRS types.
-        let needs_reproject = column_reproject_decision(&arg_types[1], raster_crs.as_deref())?;
-        let skip_reproject = needs_reproject == Some(false);
 
         let mut geom = executor.make_geom_wkb_crs_accessor(1)?;
 
@@ -245,13 +240,9 @@ impl RsValuePoint {
                 let Some(point_wkb) = wkb_opt else {
                     continue;
                 };
-                if let Some((x, y)) = resolve_point_xy(
-                    point_wkb,
-                    point_crs,
-                    raster_crs.as_deref(),
-                    skip_reproject,
-                    engine,
-                )? {
+                if let Some((x, y)) =
+                    resolve_point_xy(point_wkb, point_crs, raster_crs.as_deref(), engine)?
+                {
                     selection.push((i, x, y, band_num));
                 }
             }
@@ -325,83 +316,12 @@ fn next_band(
     }
 }
 
-/// Reproject `point_wkb` from its CRS into the raster CRS, returning the
-/// transformed WKB only when a reprojection actually happened (so the caller
-/// can sample the original bytes otherwise — no allocation in the common case).
-///
-/// Errors if exactly one of the point / raster carries a CRS: sampling across a
-/// known and an unknown CRS would silently mislocate the point.
-///
-/// Unlike the spatial predicates (`RS_Intersects` et al.), which fall back to a
-/// WGS84 pivot when a direct transform between two CRSes fails, a failed
-/// transform here is propagated as an error. Sampling has to land the point in
-/// the raster's own CRS — that is the only space its affine/pixel grid is
-/// defined in — so there is no neutral CRS to fall back to: a WGS84 pivot would
-/// silently sample the wrong pixel rather than compare geometries in a shared
-/// space.
-fn reproject_point(
-    point_wkb: &[u8],
-    point_crs: CrsRef<'_>,
-    raster_crs: CrsRef<'_>,
-    engine: &dyn sedona_geometry::transform::CrsEngine,
-) -> Result<Option<Vec<u8>>> {
-    match (point_crs, raster_crs) {
-        (Some(point_crs), Some(raster_crs)) => {
-            if point_crs.crs_equals(raster_crs) {
-                Ok(None)
-            } else {
-                Ok(Some(crs_transform_wkb(
-                    point_wkb, point_crs, raster_crs, engine,
-                )?))
-            }
-        }
-        (None, None) => Ok(None),
-        (Some(_), None) => {
-            exec_err!("RS_Value: point has a CRS but the raster does not")
-        }
-        (None, Some(_)) => {
-            exec_err!("RS_Value: raster has a CRS but the point does not")
-        }
-    }
-}
-
-/// For a **column-level** point CRS, decide once whether sampling needs a
-/// reprojection into the raster CRS:
-/// - `Some(true)`  — CRSes differ, reproject each point;
-/// - `Some(false)` — CRSes match (or both absent), sample original coordinates;
-/// - `None`        — the point CRS is carried per row, so decide per point.
-///
-/// Errors when exactly one side carries a CRS. Hoisting this out of the per-point
-/// loop avoids a per-point `crs_equals`, whose `to_authority_code()` allocates a
-/// `String` every call (~15 ns/point, uniform across CRS types).
-fn column_reproject_decision(
-    point_type: &SedonaType,
-    raster_crs: CrsRef<'_>,
-) -> Result<Option<bool>> {
-    let point_crs = match point_type {
-        SedonaType::Wkb(_, c) | SedonaType::WkbView(_, c) => c.as_deref(),
-        // A per-item CRS varies by row; the caller decides per point.
-        _ => return Ok(None),
-    };
-    match (point_crs, raster_crs) {
-        (Some(p), Some(r)) => Ok(Some(!p.crs_equals(r))),
-        (None, None) => Ok(Some(false)),
-        (Some(_), None) => exec_err!("RS_Value: point has a CRS but the raster does not"),
-        (None, Some(_)) => exec_err!("RS_Value: raster has a CRS but the point does not"),
-    }
-}
-
 /// Parse a Point WKB and return its `(x, y)` in the raster's CRS, or `None` when
 /// there is nothing to sample (the point is empty — both ordinates NaN).
-///
-/// `skip_reproject` is the hoisted column-level decision: when `true` the
-/// original coordinates are returned without consulting [`reproject_point`] (and
-/// its per-point `crs_equals`); when `false` reprojection is decided per point.
 fn resolve_point_xy(
     point_wkb: &[u8],
     point_crs: CrsRef<'_>,
     raster_crs: CrsRef<'_>,
-    skip_reproject: bool,
     engine: &dyn sedona_geometry::transform::CrsEngine,
 ) -> Result<Option<(f64, f64)>> {
     let Some((px, py)) =
@@ -409,19 +329,13 @@ fn resolve_point_xy(
     else {
         return Ok(None);
     };
-    if skip_reproject {
-        return Ok(Some((px, py)));
-    }
-    // A reprojection only happens when both sides carry a (differing) CRS;
-    // otherwise the original coordinates are sampled directly.
-    match reproject_point(point_wkb, point_crs, raster_crs, engine)? {
-        Some(reprojected) => {
-            let xy = read_point_xy(&reprojected)
-                .map_err(|e| exec_datafusion_err!("RS_Value: {e}"))?
-                .ok_or_else(|| exec_datafusion_err!("RS_Value: reprojected point is empty"))?;
-            Ok(Some(xy))
-        }
-        None => Ok(Some((px, py))),
+
+    match align_wkb_to_crs(point_wkb, point_crs, raster_crs, engine)? {
+        Cow::Borrowed(_) => Ok(Some((px, py))),
+        Cow::Owned(reprojected) => read_point_xy(&reprojected)
+            .map_err(|e| exec_datafusion_err!("RS_Value: {e}"))?
+            .ok_or_else(|| exec_datafusion_err!("RS_Value: reprojected point is empty"))
+            .map(Some),
     }
 }
 
@@ -653,39 +567,55 @@ mod tests {
     }
 
     #[test]
-    fn point_crs_mismatch_errors() {
+    fn point_with_missing_crs_is_sampled_without_transform() {
         let udf: ScalarUDF = rs_value_udf().into();
 
-        // Raster has a CRS (generate_test_rasters sets OGC:CRS84), point does not.
+        let raster = || {
+            RasterSpec::d2(2, 2)
+                .band_values(&[1u8, 2, 3, 4])
+                .transform([0.0, 1.0, 0.0, 2.0, 0.0, -1.0])
+        };
+
+        // A raster CRS does not reinterpret an untagged point's coordinates.
         let geom_type = SedonaType::Wkb(Edges::Planar, None);
         let tester = ScalarUdfTester::new(udf.clone(), vec![RASTER, geom_type.clone()]);
-        let rasters = generate_test_rasters(1, None).unwrap();
-        let geoms = create_geom_array(&[Some("POINT (2.1 2.6)")], &geom_type);
-        let err = tester
-            .invoke_arrays(vec![Arc::new(rasters), geoms])
-            .unwrap_err()
-            .to_string();
-        assert!(
-            err.contains("raster has a CRS but the point does not"),
-            "unexpected error: {err}"
-        );
+        let geoms = create_geom_array(&[Some("POINT (0.5 1.5)")], &geom_type);
+        let result = tester
+            .invoke_arrays(vec![
+                Arc::new(raster().crs(Some("EPSG:4326")).build()),
+                geoms,
+            ])
+            .unwrap();
+        let result = result.as_any().downcast_ref::<Float64Array>().unwrap();
+        assert_eq!(result.value(0), 1.0);
 
-        // Point has a CRS, raster does not.
+        // A point CRS does not reinterpret coordinates when the raster lacks one.
         let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
         let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
-        let rasters = RasterSpec::d2(2, 2)
-            .band(BandDataType::UInt8)
-            .crs(None)
+        let geoms = create_geom_array(&[Some("POINT (0.5 1.5)")], &geom_type);
+        let result = tester
+            .invoke_arrays(vec![Arc::new(raster().crs(None).build()), geoms])
+            .unwrap();
+        let result = result.as_any().downcast_ref::<Float64Array>().unwrap();
+        assert_eq!(result.value(0), 1.0);
+    }
+
+    #[test]
+    fn point_with_differing_crs_is_reprojected() {
+        use sedona_schema::crs::deserialize_crs;
+
+        let udf: ScalarUDF = rs_value_udf().into();
+        let geom_type = SedonaType::Wkb(Edges::Planar, deserialize_crs("OGC:CRS84").unwrap());
+        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
+        let raster = RasterSpec::d2(1, 1)
+            .band_values(&[9u8])
+            .transform([111_000.0, 1_000.0, 0.0, 112_000.0, 0.0, -1_000.0])
+            .crs(Some("EPSG:3857"))
             .build();
-        let geoms = create_geom_array(&[Some("POINT (0 0)")], &geom_type);
-        let err = tester
-            .invoke_arrays(vec![Arc::new(rasters), geoms])
-            .unwrap_err()
-            .to_string();
-        assert!(
-            err.contains("point has a CRS but the raster does not"),
-            "unexpected error: {err}"
-        );
+        let geoms = create_geom_array(&[Some("POINT (1 1)")], &geom_type);
+        let result = tester.invoke_arrays(vec![Arc::new(raster), geoms]).unwrap();
+        let result = result.as_any().downcast_ref::<Float64Array>().unwrap();
+        assert_eq!(result.value(0), 9.0);
     }
 
     #[test]
@@ -942,51 +872,5 @@ mod tests {
         // A real point forces band resolution, which rejects the non-2-D raster.
         let err = invoke(Some("POINT (0 0)")).unwrap_err().to_string();
         assert!(err.contains("2-D"), "unexpected error: {err}");
-    }
-
-    #[test]
-    fn crs_decision_equal_crs_skips_reproject() {
-        // The common case: a lng/lat point CRS and a lng/lat raster are detected
-        // as equal, so the per-point reproject (and its crs_equals) is skipped.
-        // This is what the B1 hoist relies on — if it returned Some(true) the
-        // optimization would silently no-op.
-        let raster = RasterSpec::d2(2, 2).band(BandDataType::UInt8).build(); // default lng/lat
-        let rasters = RasterStructArray::try_new(&raster).unwrap();
-        let raster_crs = resolve_crs(rasters.get(0).unwrap().crs()).unwrap();
-        let point_type = SedonaType::Wkb(Edges::Planar, lnglat());
-        assert_eq!(
-            column_reproject_decision(&point_type, raster_crs.as_deref()).unwrap(),
-            Some(false),
-            "lng/lat point + lng/lat raster must be detected as equal (skip reproject)"
-        );
-    }
-
-    #[test]
-    fn crs_decision_differing_crs_reprojects() {
-        use sedona_schema::crs::deserialize_crs;
-        let raster = RasterSpec::d2(2, 2)
-            .crs(Some("EPSG:4326"))
-            .band(BandDataType::UInt8)
-            .build();
-        let rasters = RasterStructArray::try_new(&raster).unwrap();
-        let raster_crs = resolve_crs(rasters.get(0).unwrap().crs()).unwrap();
-        let point_type = SedonaType::Wkb(Edges::Planar, deserialize_crs("EPSG:3857").unwrap());
-        assert_eq!(
-            column_reproject_decision(&point_type, raster_crs.as_deref()).unwrap(),
-            Some(true),
-            "EPSG:3857 point + EPSG:4326 raster must require reprojection"
-        );
-    }
-
-    #[test]
-    fn crs_decision_one_sided_crs_errors() {
-        let raster = RasterSpec::d2(2, 2)
-            .crs(None)
-            .band(BandDataType::UInt8)
-            .build();
-        let rasters = RasterStructArray::try_new(&raster).unwrap();
-        let raster_crs = resolve_crs(rasters.get(0).unwrap().crs()).unwrap();
-        let point_type = SedonaType::Wkb(Edges::Planar, lnglat());
-        assert!(column_reproject_decision(&point_type, raster_crs.as_deref()).is_err());
     }
 }

--- a/rust/sedona-raster-functions/src/rs_value.rs
+++ b/rust/sedona-raster-functions/src/rs_value.rs
@@ -133,7 +133,7 @@ impl SedonaScalarKernel for RsValuePoint {
                 // points (and non-finite coordinates) have no location to sample.
                 let raster_crs = resolve_crs(raster.crs())?;
                 let Some((x, y)) =
-                    resolve_point_xy(point_wkb, point_crs, raster_crs.as_deref(), engine)?
+                    resolve_point_xy(point_wkb, point_crs, raster_crs.as_deref(), false, engine)?
                 else {
                     builder.append_null();
                     return Ok(());
@@ -217,6 +217,10 @@ impl RsValuePoint {
         // Affine transform and raster CRS are shared by every point in this batch.
         let affine = AffineMatrix::from_metadata(&raster.metadata());
         let raster_crs = resolve_crs(raster.crs())?;
+        // A type-level CRS is constant for this batch, so avoid resolving and
+        // comparing it for every point when alignment cannot change coordinates.
+        let skip_reproject =
+            column_reproject_decision(&arg_types[1], raster_crs.as_deref())? == Some(false);
 
         let mut geom = executor.make_geom_wkb_crs_accessor(1)?;
 
@@ -240,9 +244,13 @@ impl RsValuePoint {
                 let Some(point_wkb) = wkb_opt else {
                     continue;
                 };
-                if let Some((x, y)) =
-                    resolve_point_xy(point_wkb, point_crs, raster_crs.as_deref(), engine)?
-                {
+                if let Some((x, y)) = resolve_point_xy(
+                    point_wkb,
+                    point_crs,
+                    raster_crs.as_deref(),
+                    skip_reproject,
+                    engine,
+                )? {
                     selection.push((i, x, y, band_num));
                 }
             }
@@ -318,10 +326,14 @@ fn next_band(
 
 /// Parse a Point WKB and return its `(x, y)` in the raster's CRS, or `None` when
 /// there is nothing to sample (the point is empty — both ordinates NaN).
+///
+/// `skip_reproject` is the scalar-raster fast path's column-level decision. Item
+/// CRS values always pass `false` because their CRS can vary by row.
 fn resolve_point_xy(
     point_wkb: &[u8],
     point_crs: CrsRef<'_>,
     raster_crs: CrsRef<'_>,
+    skip_reproject: bool,
     engine: &dyn sedona_geometry::transform::CrsEngine,
 ) -> Result<Option<(f64, f64)>> {
     let Some((px, py)) =
@@ -330,6 +342,10 @@ fn resolve_point_xy(
         return Ok(None);
     };
 
+    if skip_reproject {
+        return Ok(Some((px, py)));
+    }
+
     match align_wkb_to_crs(point_wkb, point_crs, raster_crs, engine)? {
         Cow::Borrowed(_) => Ok(Some((px, py))),
         Cow::Owned(reprojected) => read_point_xy(&reprojected)
@@ -337,6 +353,25 @@ fn resolve_point_xy(
             .ok_or_else(|| exec_datafusion_err!("RS_Value: reprojected point is empty"))
             .map(Some),
     }
+}
+
+/// For a column-level geometry CRS, decide once whether every point can skip
+/// CRS alignment. Item-level CRS values vary by row and must be handled by the
+/// shared alignment helper for each point.
+fn column_reproject_decision(
+    point_type: &SedonaType,
+    raster_crs: CrsRef<'_>,
+) -> Result<Option<bool>> {
+    let point_crs = match point_type {
+        SedonaType::Wkb(_, crs) | SedonaType::WkbView(_, crs) => crs.as_deref(),
+        _ => return Ok(None),
+    };
+
+    Ok(Some(match (point_crs, raster_crs) {
+        (Some(point_crs), Some(raster_crs)) => !point_crs.crs_equals(raster_crs),
+        // Without CRS metadata on either input, coordinates are already used as-is.
+        _ => false,
+    }))
 }
 
 /// Map a coordinate in the raster's CRS to a 0-based `(col, row)` pixel index,
@@ -872,5 +907,48 @@ mod tests {
         // A real point forces band resolution, which rejects the non-2-D raster.
         let err = invoke(Some("POINT (0 0)")).unwrap_err().to_string();
         assert!(err.contains("2-D"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn crs_decision_skips_equal_or_missing_crs() {
+        use sedona_schema::crs::deserialize_crs;
+
+        let raster_crs = deserialize_crs("EPSG:4326").unwrap();
+        let equal_point = SedonaType::Wkb(Edges::Planar, deserialize_crs("EPSG:4326").unwrap());
+        let untagged_point = SedonaType::Wkb(Edges::Planar, None);
+
+        assert_eq!(
+            column_reproject_decision(&equal_point, raster_crs.as_deref()).unwrap(),
+            Some(false)
+        );
+        assert_eq!(
+            column_reproject_decision(&untagged_point, raster_crs.as_deref()).unwrap(),
+            Some(false)
+        );
+        assert_eq!(
+            column_reproject_decision(&equal_point, None).unwrap(),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn crs_decision_reprojects_differing_type_level_crs() {
+        use sedona_schema::crs::deserialize_crs;
+
+        let raster_crs = deserialize_crs("EPSG:3857").unwrap();
+        let point_type = SedonaType::Wkb(Edges::Planar, deserialize_crs("EPSG:4326").unwrap());
+
+        assert_eq!(
+            column_reproject_decision(&point_type, raster_crs.as_deref()).unwrap(),
+            Some(true)
+        );
+        assert_eq!(
+            column_reproject_decision(
+                &SedonaType::new_item_crs(&point_type).unwrap(),
+                raster_crs.as_deref()
+            )
+            .unwrap(),
+            None
+        );
     }
 }

--- a/rust/sedona-raster-functions/src/rs_value.rs
+++ b/rust/sedona-raster-functions/src/rs_value.rs
@@ -48,7 +48,7 @@ use sedona_raster::traits::{nodata_bytes_to_f64_lossless, NdBuffer, RasterRef};
 use sedona_schema::crs::CrsRef;
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
 
-use crate::crs_utils::{align_wkb_to_crs, resolve_crs};
+use crate::crs_utils::{align_wkb_to_crs, crs_transform_required, resolve_crs};
 use crate::executor::RasterExecutor;
 use crate::rs_ensure_loaded::NEEDS_PIXELS_METADATA_KEY;
 
@@ -346,7 +346,7 @@ fn resolve_point_xy(
         return Ok(Some((px, py)));
     }
 
-    match align_wkb_to_crs(point_wkb, point_crs, raster_crs, engine)? {
+    match align_wkb_to_crs(point_wkb, point_crs, raster_crs, "point", "raster", engine)? {
         Cow::Borrowed(_) => Ok(Some((px, py))),
         Cow::Owned(reprojected) => read_point_xy(&reprojected)
             .map_err(|e| exec_datafusion_err!("RS_Value: {e}"))?
@@ -367,11 +367,7 @@ fn column_reproject_decision(
         _ => return Ok(None),
     };
 
-    Ok(Some(match (point_crs, raster_crs) {
-        (Some(point_crs), Some(raster_crs)) => !point_crs.crs_equals(raster_crs),
-        // Without CRS metadata on either input, coordinates are already used as-is.
-        _ => false,
-    }))
+    crs_transform_required(point_crs, raster_crs, "point", "raster").map(Some)
 }
 
 /// Map a coordinate in the raster's CRS to a 0-based `(col, row)` pixel index,
@@ -602,55 +598,39 @@ mod tests {
     }
 
     #[test]
-    fn point_with_missing_crs_is_sampled_without_transform() {
+    fn point_crs_mismatch_errors() {
         let udf: ScalarUDF = rs_value_udf().into();
 
-        let raster = || {
-            RasterSpec::d2(2, 2)
-                .band_values(&[1u8, 2, 3, 4])
-                .transform([0.0, 1.0, 0.0, 2.0, 0.0, -1.0])
-        };
-
-        // A raster CRS does not reinterpret an untagged point's coordinates.
+        // Raster has a CRS (generate_test_rasters sets OGC:CRS84), point does not.
         let geom_type = SedonaType::Wkb(Edges::Planar, None);
         let tester = ScalarUdfTester::new(udf.clone(), vec![RASTER, geom_type.clone()]);
-        let geoms = create_geom_array(&[Some("POINT (0.5 1.5)")], &geom_type);
-        let result = tester
-            .invoke_arrays(vec![
-                Arc::new(raster().crs(Some("EPSG:4326")).build()),
-                geoms,
-            ])
-            .unwrap();
-        let result = result.as_any().downcast_ref::<Float64Array>().unwrap();
-        assert_eq!(result.value(0), 1.0);
+        let rasters = generate_test_rasters(1, None).unwrap();
+        let geoms = create_geom_array(&[Some("POINT (2.1 2.6)")], &geom_type);
+        let err = tester
+            .invoke_arrays(vec![Arc::new(rasters), geoms])
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("raster has a CRS but the point does not"),
+            "unexpected error: {err}"
+        );
 
-        // A point CRS does not reinterpret coordinates when the raster lacks one.
+        // Point has a CRS, raster does not.
         let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
         let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
-        let geoms = create_geom_array(&[Some("POINT (0.5 1.5)")], &geom_type);
-        let result = tester
-            .invoke_arrays(vec![Arc::new(raster().crs(None).build()), geoms])
-            .unwrap();
-        let result = result.as_any().downcast_ref::<Float64Array>().unwrap();
-        assert_eq!(result.value(0), 1.0);
-    }
-
-    #[test]
-    fn point_with_differing_crs_is_reprojected() {
-        use sedona_schema::crs::deserialize_crs;
-
-        let udf: ScalarUDF = rs_value_udf().into();
-        let geom_type = SedonaType::Wkb(Edges::Planar, deserialize_crs("OGC:CRS84").unwrap());
-        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
-        let raster = RasterSpec::d2(1, 1)
-            .band_values(&[9u8])
-            .transform([111_000.0, 1_000.0, 0.0, 112_000.0, 0.0, -1_000.0])
-            .crs(Some("EPSG:3857"))
+        let rasters = RasterSpec::d2(2, 2)
+            .band(BandDataType::UInt8)
+            .crs(None)
             .build();
-        let geoms = create_geom_array(&[Some("POINT (1 1)")], &geom_type);
-        let result = tester.invoke_arrays(vec![Arc::new(raster), geoms]).unwrap();
-        let result = result.as_any().downcast_ref::<Float64Array>().unwrap();
-        assert_eq!(result.value(0), 9.0);
+        let geoms = create_geom_array(&[Some("POINT (0 0)")], &geom_type);
+        let err = tester
+            .invoke_arrays(vec![Arc::new(rasters), geoms])
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("point has a CRS but the raster does not"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
@@ -910,45 +890,48 @@ mod tests {
     }
 
     #[test]
-    fn crs_decision_skips_equal_or_missing_crs() {
-        use sedona_schema::crs::deserialize_crs;
-
-        let raster_crs = deserialize_crs("EPSG:4326").unwrap();
-        let equal_point = SedonaType::Wkb(Edges::Planar, deserialize_crs("EPSG:4326").unwrap());
-        let untagged_point = SedonaType::Wkb(Edges::Planar, None);
-
+    fn crs_decision_equal_crs_skips_reproject() {
+        // The common case: a lng/lat point CRS and a lng/lat raster are detected
+        // as equal, so the per-point reproject (and its crs_equals) is skipped.
+        // This is what the B1 hoist relies on — if it returned Some(true) the
+        // optimization would silently no-op.
+        let raster = RasterSpec::d2(2, 2).band(BandDataType::UInt8).build(); // default lng/lat
+        let rasters = RasterStructArray::try_new(&raster).unwrap();
+        let raster_crs = resolve_crs(rasters.get(0).unwrap().crs()).unwrap();
+        let point_type = SedonaType::Wkb(Edges::Planar, lnglat());
         assert_eq!(
-            column_reproject_decision(&equal_point, raster_crs.as_deref()).unwrap(),
-            Some(false)
-        );
-        assert_eq!(
-            column_reproject_decision(&untagged_point, raster_crs.as_deref()).unwrap(),
-            Some(false)
-        );
-        assert_eq!(
-            column_reproject_decision(&equal_point, None).unwrap(),
-            Some(false)
+            column_reproject_decision(&point_type, raster_crs.as_deref()).unwrap(),
+            Some(false),
+            "lng/lat point + lng/lat raster must be detected as equal (skip reproject)"
         );
     }
 
     #[test]
-    fn crs_decision_reprojects_differing_type_level_crs() {
+    fn crs_decision_differing_crs_reprojects() {
         use sedona_schema::crs::deserialize_crs;
-
-        let raster_crs = deserialize_crs("EPSG:3857").unwrap();
-        let point_type = SedonaType::Wkb(Edges::Planar, deserialize_crs("EPSG:4326").unwrap());
-
+        let raster = RasterSpec::d2(2, 2)
+            .crs(Some("EPSG:4326"))
+            .band(BandDataType::UInt8)
+            .build();
+        let rasters = RasterStructArray::try_new(&raster).unwrap();
+        let raster_crs = resolve_crs(rasters.get(0).unwrap().crs()).unwrap();
+        let point_type = SedonaType::Wkb(Edges::Planar, deserialize_crs("EPSG:3857").unwrap());
         assert_eq!(
             column_reproject_decision(&point_type, raster_crs.as_deref()).unwrap(),
-            Some(true)
+            Some(true),
+            "EPSG:3857 point + EPSG:4326 raster must require reprojection"
         );
-        assert_eq!(
-            column_reproject_decision(
-                &SedonaType::new_item_crs(&point_type).unwrap(),
-                raster_crs.as_deref()
-            )
-            .unwrap(),
-            None
-        );
+    }
+
+    #[test]
+    fn crs_decision_one_sided_crs_errors() {
+        let raster = RasterSpec::d2(2, 2)
+            .crs(None)
+            .band(BandDataType::UInt8)
+            .build();
+        let rasters = RasterStructArray::try_new(&raster).unwrap();
+        let raster_crs = resolve_crs(rasters.get(0).unwrap().crs()).unwrap();
+        let point_type = SedonaType::Wkb(Edges::Planar, lnglat());
+        assert!(column_reproject_decision(&point_type, raster_crs.as_deref()).is_err());
     }
 }

--- a/rust/sedona-raster-gdal/Cargo.toml
+++ b/rust/sedona-raster-gdal/Cargo.toml
@@ -72,3 +72,8 @@ path = "benches/rs_metadata.rs"
 harness = false
 name = "rs_polygonize"
 path = "benches/rs_polygonize.rs"
+
+[[bench]]
+harness = false
+name = "rs_as_raster"
+path = "benches/rs_as_raster.rs"

--- a/rust/sedona-raster-gdal/Cargo.toml
+++ b/rust/sedona-raster-gdal/Cargo.toml
@@ -45,7 +45,6 @@ sedona-gdal = { workspace = true }
 sedona-raster = { workspace = true }
 sedona-raster-functions = { workspace = true }
 sedona-schema = { workspace = true }
-sedona-proj = { workspace = true, features = ["proj-sys"] }
 tokio = { workspace = true }
 
 [features]
@@ -56,6 +55,7 @@ bindgen = ["sedona-gdal/bindgen"]
 criterion = { workspace = true }
 sedona-gdal = { workspace = true, features = ["gdal-sys"] }
 sedona-testing = { workspace = true }
+sedona-proj = { workspace = true, features = ["proj-sys"] }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 

--- a/rust/sedona-raster-gdal/Cargo.toml
+++ b/rust/sedona-raster-gdal/Cargo.toml
@@ -45,6 +45,7 @@ sedona-gdal = { workspace = true }
 sedona-raster = { workspace = true }
 sedona-raster-functions = { workspace = true }
 sedona-schema = { workspace = true }
+sedona-proj = { workspace = true, features = ["proj-sys"] }
 tokio = { workspace = true }
 
 [features]

--- a/rust/sedona-raster-gdal/benches/rs_as_raster.rs
+++ b/rust/sedona-raster-gdal/benches/rs_as_raster.rs
@@ -1,0 +1,169 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Benchmarks for RS_AsRaster UDF.
+
+use std::{hint::black_box, sync::Arc};
+
+use arrow_array::{ArrayRef, BooleanArray, Float64Array, StringArray};
+use arrow_schema::DataType;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use datafusion_expr::ScalarUDF;
+use sedona_gdal::global::with_global_gdal;
+use sedona_gdal::raster::types::Buffer;
+use sedona_raster::array::RasterStructArray;
+use sedona_raster::builder::RasterBuilder;
+use sedona_raster::traits::RasterRef;
+use sedona_schema::datatypes::{SedonaType, RASTER, WKB_GEOMETRY};
+use sedona_testing::{create::create_array, testers::ScalarUdfTester};
+
+fn base_raster() -> arrow_array::StructArray {
+    with_global_gdal(|gdal| {
+        let driver = gdal.get_driver_by_name("MEM").unwrap();
+        let dataset = driver.create_with_band_type::<u8>("", 4, 3, 1).unwrap();
+        dataset
+            .set_geo_transform(&[10.0, 2.0, 0.0, 20.0, 0.0, -2.0])
+            .unwrap();
+        dataset.set_projection("EPSG:4326").unwrap();
+        let band = dataset.rasterband(1).unwrap();
+        band.set_no_data_value(Some(0.0)).unwrap();
+        let mut buffer = Buffer::new((4, 3), vec![0u8; 12]);
+        band.write((0, 0), (4, 3), &mut buffer).unwrap();
+        sedona_raster_gdal::dataset_to_indb_raster(&dataset).unwrap()
+    })
+    .unwrap()
+}
+
+fn raster_array(rows: usize) -> ArrayRef {
+    let raster = base_raster();
+
+    if rows == 1 {
+        Arc::new(raster)
+    } else {
+        let raster_struct = RasterStructArray::new(&raster);
+        let raster_ref = raster_struct.get(0).unwrap();
+        let mut builder = RasterBuilder::new(rows);
+        for _ in 0..rows {
+            builder
+                .start_raster(&raster_ref.metadata(), raster_ref.crs())
+                .unwrap();
+            let band = raster_ref.bands().band(1).unwrap();
+            builder.start_band(band.metadata()).unwrap();
+            builder
+                .band_data_writer()
+                .append_value(band.nd_buffer().unwrap().as_contiguous().unwrap());
+            builder.finish_band().unwrap();
+            builder.finish_raster().unwrap();
+        }
+        Arc::new(builder.finish().unwrap())
+    }
+}
+
+fn geometry_array(rows: usize) -> ArrayRef {
+    let polygon = with_global_gdal(|_gdal| {
+        let raster = base_raster();
+        let raster_struct = RasterStructArray::new(&raster);
+        let raster = raster_struct.get(0).unwrap();
+        let md = raster.metadata();
+        format!(
+            "POLYGON(({x0} {y1}, {x0} {y0}, {x1} {y0}, {x1} {y1}, {x0} {y1}))",
+            x0 = md.upper_left_x(),
+            x1 = md.upper_left_x() + md.scale_x(),
+            y0 = md.upper_left_y(),
+            y1 = md.upper_left_y() + md.scale_y(),
+        )
+    })
+    .unwrap();
+
+    create_array(&vec![Some(polygon.as_str()); rows], &WKB_GEOMETRY)
+}
+
+fn bench_rs_as_raster(c: &mut Criterion) {
+    let udf: ScalarUDF = sedona_raster_gdal::rs_as_raster_udf().into();
+    let tester = ScalarUdfTester::new(
+        udf,
+        vec![
+            WKB_GEOMETRY,
+            RASTER,
+            SedonaType::Arrow(DataType::Utf8),
+            SedonaType::Arrow(DataType::Boolean),
+            SedonaType::Arrow(DataType::Float64),
+            SedonaType::Arrow(DataType::Float64),
+            SedonaType::Arrow(DataType::Boolean),
+        ],
+    );
+
+    let single_geom = geometry_array(1);
+    let single_raster = raster_array(1);
+    let batch_geom = geometry_array(128);
+    let batch_raster = raster_array(128);
+    let pixel_type_single = Arc::new(StringArray::from(vec!["D"]));
+    let pixel_type_batch = Arc::new(StringArray::from(vec!["D"; 128]));
+    let all_touched_single = Arc::new(BooleanArray::from(vec![false]));
+    let all_touched_batch = Arc::new(BooleanArray::from(vec![false; 128]));
+    let burn_single = Arc::new(Float64Array::from(vec![1.0]));
+    let burn_batch = Arc::new(Float64Array::from(vec![1.0; 128]));
+    let nodata_single = Arc::new(Float64Array::from(vec![0.0]));
+    let nodata_batch = Arc::new(Float64Array::from(vec![0.0; 128]));
+    let extent_single = Arc::new(BooleanArray::from(vec![true]));
+    let extent_batch = Arc::new(BooleanArray::from(vec![true; 128]));
+
+    let mut group = c.benchmark_group("rs_as_raster");
+
+    group.throughput(Throughput::Elements(1));
+    group.bench_with_input(BenchmarkId::new("fixtures", "single"), &(), |b, _| {
+        b.iter(|| {
+            black_box(
+                tester
+                    .invoke_arrays(vec![
+                        single_geom.clone(),
+                        single_raster.clone(),
+                        pixel_type_single.clone(),
+                        all_touched_single.clone(),
+                        burn_single.clone(),
+                        nodata_single.clone(),
+                        extent_single.clone(),
+                    ])
+                    .unwrap(),
+            )
+        })
+    });
+
+    group.throughput(Throughput::Elements(128));
+    group.bench_with_input(BenchmarkId::new("fixtures", "batch_128"), &(), |b, _| {
+        b.iter(|| {
+            black_box(
+                tester
+                    .invoke_arrays(vec![
+                        batch_geom.clone(),
+                        batch_raster.clone(),
+                        pixel_type_batch.clone(),
+                        all_touched_batch.clone(),
+                        burn_batch.clone(),
+                        nodata_batch.clone(),
+                        extent_batch.clone(),
+                    ])
+                    .unwrap(),
+            )
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_rs_as_raster);
+criterion_main!(benches);

--- a/rust/sedona-raster-gdal/benches/rs_as_raster.rs
+++ b/rust/sedona-raster-gdal/benches/rs_as_raster.rs
@@ -54,7 +54,7 @@ fn raster_array(rows: usize) -> ArrayRef {
     if rows == 1 {
         Arc::new(raster)
     } else {
-        let raster_struct = RasterStructArray::new(&raster);
+        let raster_struct = RasterStructArray::try_new(&raster).unwrap();
         let raster_ref = raster_struct.get(0).unwrap();
         let mut builder = RasterBuilder::new(rows);
         for _ in 0..rows {
@@ -76,7 +76,7 @@ fn raster_array(rows: usize) -> ArrayRef {
 fn geometry_array(rows: usize) -> ArrayRef {
     let polygon = with_global_gdal(|_gdal| {
         let raster = base_raster();
-        let raster_struct = RasterStructArray::new(&raster);
+        let raster_struct = RasterStructArray::try_new(&raster).unwrap();
         let raster = raster_struct.get(0).unwrap();
         let md = raster.metadata();
         format!(

--- a/rust/sedona-raster-gdal/benches/rs_as_raster.rs
+++ b/rust/sedona-raster-gdal/benches/rs_as_raster.rs
@@ -23,7 +23,8 @@ use arrow_array::{ArrayRef, BooleanArray, Float64Array, StringArray};
 use arrow_schema::DataType;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use datafusion_expr::ScalarUDF;
-use sedona_schema::datatypes::{SedonaType, RASTER, WKB_GEOMETRY};
+use sedona_schema::crs::deserialize_crs;
+use sedona_schema::datatypes::{Edges, SedonaType, RASTER};
 use sedona_testing::{
     create::create_array,
     raster_spec::{raster_array as build_raster_array, RasterSpec},
@@ -45,18 +46,19 @@ fn raster_array(rows: usize) -> ArrayRef {
     ]))
 }
 
-fn geometry_array(rows: usize) -> ArrayRef {
+fn geometry_array(rows: usize, geom_type: &SedonaType) -> ArrayRef {
     let polygon = "POLYGON((10 18, 10 20, 12 20, 12 18, 10 18))";
 
-    create_array(&vec![Some(polygon); rows], &WKB_GEOMETRY)
+    create_array(&vec![Some(polygon); rows], geom_type)
 }
 
 fn bench_rs_as_raster(c: &mut Criterion) {
     let udf: ScalarUDF = sedona_raster_gdal::rs_as_raster_udf().into();
+    let geom_type = SedonaType::Wkb(Edges::Planar, deserialize_crs("EPSG:4326").unwrap());
     let tester = ScalarUdfTester::new(
         udf,
         vec![
-            WKB_GEOMETRY,
+            geom_type.clone(),
             RASTER,
             SedonaType::Arrow(DataType::Utf8),
             SedonaType::Arrow(DataType::Boolean),
@@ -66,9 +68,9 @@ fn bench_rs_as_raster(c: &mut Criterion) {
         ],
     );
 
-    let single_geom = geometry_array(1);
+    let single_geom = geometry_array(1, &geom_type);
     let single_raster = raster_array(1);
-    let batch_geom = geometry_array(128);
+    let batch_geom = geometry_array(128, &geom_type);
     let batch_raster = raster_array(128);
     let pixel_type_single = Arc::new(StringArray::from(vec!["D"]));
     let pixel_type_batch = Arc::new(StringArray::from(vec!["D"; 128]));

--- a/rust/sedona-raster-gdal/benches/rs_as_raster.rs
+++ b/rust/sedona-raster-gdal/benches/rs_as_raster.rs
@@ -23,73 +23,32 @@ use arrow_array::{ArrayRef, BooleanArray, Float64Array, StringArray};
 use arrow_schema::DataType;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use datafusion_expr::ScalarUDF;
-use sedona_gdal::global::with_global_gdal;
-use sedona_gdal::raster::types::Buffer;
-use sedona_raster::array::RasterStructArray;
-use sedona_raster::builder::RasterBuilder;
-use sedona_raster::traits::RasterRef;
 use sedona_schema::datatypes::{SedonaType, RASTER, WKB_GEOMETRY};
-use sedona_testing::{create::create_array, testers::ScalarUdfTester};
+use sedona_testing::{
+    create::create_array,
+    raster_spec::{raster_array as build_raster_array, RasterSpec},
+    testers::ScalarUdfTester,
+};
 
-fn base_raster() -> arrow_array::StructArray {
-    with_global_gdal(|gdal| {
-        let driver = gdal.get_driver_by_name("MEM").unwrap();
-        let dataset = driver.create_with_band_type::<u8>("", 4, 3, 1).unwrap();
-        dataset
-            .set_geo_transform(&[10.0, 2.0, 0.0, 20.0, 0.0, -2.0])
-            .unwrap();
-        dataset.set_projection("EPSG:4326").unwrap();
-        let band = dataset.rasterband(1).unwrap();
-        band.set_no_data_value(Some(0.0)).unwrap();
-        let mut buffer = Buffer::new((4, 3), vec![0u8; 12]);
-        band.write((0, 0), (4, 3), &mut buffer).unwrap();
-        sedona_raster_gdal::dataset_to_indb_raster(&dataset).unwrap()
-    })
-    .unwrap()
+fn reference_raster_spec() -> RasterSpec {
+    RasterSpec::d2(4, 3)
+        .transform([10.0, 2.0, 0.0, 20.0, 0.0, -2.0])
+        .crs(Some("EPSG:4326"))
+        .band_values(&[0u8; 12])
+        .nodata(0u8)
 }
 
 fn raster_array(rows: usize) -> ArrayRef {
-    let raster = base_raster();
-
-    if rows == 1 {
-        Arc::new(raster)
-    } else {
-        let raster_struct = RasterStructArray::try_new(&raster).unwrap();
-        let raster_ref = raster_struct.get(0).unwrap();
-        let mut builder = RasterBuilder::new(rows);
-        for _ in 0..rows {
-            builder
-                .start_raster(&raster_ref.metadata(), raster_ref.crs())
-                .unwrap();
-            let band = raster_ref.bands().band(1).unwrap();
-            builder.start_band(band.metadata()).unwrap();
-            builder
-                .band_data_writer()
-                .append_value(band.nd_buffer().unwrap().as_contiguous().unwrap());
-            builder.finish_band().unwrap();
-            builder.finish_raster().unwrap();
-        }
-        Arc::new(builder.finish().unwrap())
-    }
+    Arc::new(build_raster_array(vec![
+        Some(reference_raster_spec());
+        rows
+    ]))
 }
 
 fn geometry_array(rows: usize) -> ArrayRef {
-    let polygon = with_global_gdal(|_gdal| {
-        let raster = base_raster();
-        let raster_struct = RasterStructArray::try_new(&raster).unwrap();
-        let raster = raster_struct.get(0).unwrap();
-        let md = raster.metadata();
-        format!(
-            "POLYGON(({x0} {y1}, {x0} {y0}, {x1} {y0}, {x1} {y1}, {x0} {y1}))",
-            x0 = md.upper_left_x(),
-            x1 = md.upper_left_x() + md.scale_x(),
-            y0 = md.upper_left_y(),
-            y1 = md.upper_left_y() + md.scale_y(),
-        )
-    })
-    .unwrap();
+    let polygon = "POLYGON((10 18, 10 20, 12 20, 12 18, 10 18))";
 
-    create_array(&vec![Some(polygon.as_str()); rows], &WKB_GEOMETRY)
+    create_array(&vec![Some(polygon); rows], &WKB_GEOMETRY)
 }
 
 fn bench_rs_as_raster(c: &mut Criterion) {

--- a/rust/sedona-raster-gdal/src/lib.rs
+++ b/rust/sedona-raster-gdal/src/lib.rs
@@ -33,6 +33,7 @@ mod gdal_common;
 mod gdal_dataset_provider;
 
 mod raster_loader;
+mod rs_as_raster;
 mod rs_frompath;
 mod rs_metadata;
 mod rs_polygonize;
@@ -45,6 +46,7 @@ pub use gdal_common::{
     nodata_bytes_to_f64, nodata_f64_to_bytes, GdalBandLayout, GdalBandPlan,
 };
 pub use raster_loader::{GdalLoader, GDAL_FORMAT};
+pub use rs_as_raster::rs_as_raster_udf;
 pub use rs_frompath::rs_frompath_udf;
 pub use rs_metadata::rs_metadata_udf;
 pub use rs_polygonize::rs_polygonize_udf;

--- a/rust/sedona-raster-gdal/src/register.rs
+++ b/rust/sedona-raster-gdal/src/register.rs
@@ -20,6 +20,7 @@ use sedona_expr::function_set::FunctionSet;
 /// Export the set of GDAL-backed functions defined in this crate.
 pub fn default_function_set() -> FunctionSet {
     let mut function_set = FunctionSet::new();
+    function_set.insert_scalar_udf(crate::rs_as_raster::rs_as_raster_udf());
     function_set.insert_scalar_udf(crate::rs_frompath::rs_frompath_udf());
     function_set.insert_scalar_udf(crate::rs_metadata::rs_metadata_udf());
     function_set.insert_scalar_udf(crate::rs_polygonize::rs_polygonize_udf());

--- a/rust/sedona-raster-gdal/src/rs_as_raster.rs
+++ b/rust/sedona-raster-gdal/src/rs_as_raster.rs
@@ -1,0 +1,820 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! RS_AsRaster UDF - rasterize a vector geometry onto a raster grid.
+
+use std::sync::Arc;
+
+use arrow_array::{Array, StructArray};
+use arrow_schema::DataType;
+use datafusion_common::cast::{
+    as_binary_array, as_boolean_array, as_float64_array, as_string_array,
+};
+use datafusion_common::config::ConfigOptions;
+use datafusion_common::error::Result;
+use datafusion_common::{exec_datafusion_err, exec_err, ScalarValue};
+use datafusion_expr::{ColumnarValue, Volatility};
+use sedona_common::{sedona_internal_datafusion_err, sedona_internal_err};
+use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
+use sedona_gdal::dataset::Dataset;
+use sedona_gdal::gdal::Gdal;
+use sedona_gdal::mem::MemDatasetBuilder;
+use sedona_gdal::raster::types::Buffer;
+use sedona_raster::array::{RasterRefImpl, RasterStructArray};
+use sedona_raster::builder::RasterBuilder;
+use sedona_raster::traits::{BandMetadata, RasterMetadata, RasterRef};
+use sedona_schema::datatypes::{SedonaType, RASTER};
+use sedona_schema::matchers::ArgMatcher;
+use sedona_schema::raster::{BandDataType, StorageType};
+
+use crate::gdal_common::{band_data_type_to_gdal, nodata_f64_to_bytes, with_gdal};
+use crate::gdal_dataset_provider::{configure_thread_local_options, thread_local_provider};
+
+pub fn rs_as_raster_udf() -> SedonaScalarUDF {
+    SedonaScalarUDF::new(
+        "rs_asraster",
+        vec![
+            Arc::new(RsAsRaster { arg_count: 3 }),
+            Arc::new(RsAsRaster { arg_count: 4 }),
+            Arc::new(RsAsRaster { arg_count: 5 }),
+            Arc::new(RsAsRaster { arg_count: 6 }),
+            Arc::new(RsAsRaster { arg_count: 7 }),
+        ],
+        Volatility::Immutable,
+    )
+}
+
+#[derive(Debug)]
+struct RsAsRaster {
+    arg_count: usize,
+}
+
+impl SedonaScalarKernel for RsAsRaster {
+    fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
+        let mut matchers = vec![
+            ArgMatcher::is_geometry_or_geography(),
+            ArgMatcher::is_raster(),
+            ArgMatcher::is_string(),
+        ];
+
+        if self.arg_count >= 4 {
+            matchers.push(ArgMatcher::is_boolean());
+        }
+        if self.arg_count >= 5 {
+            matchers.push(ArgMatcher::is_numeric());
+        }
+        if self.arg_count >= 6 {
+            matchers.push(ArgMatcher::is_numeric());
+        }
+        if self.arg_count >= 7 {
+            matchers.push(ArgMatcher::is_boolean());
+        }
+
+        ArgMatcher::new(matchers, RASTER).match_args(args)
+    }
+
+    fn invoke_batch(
+        &self,
+        arg_types: &[SedonaType],
+        args: &[ColumnarValue],
+    ) -> Result<ColumnarValue> {
+        self.invoke_batch_from_args(arg_types, args, &SedonaType::Arrow(DataType::Null), 0, None)
+    }
+
+    fn invoke_batch_from_args(
+        &self,
+        arg_types: &[SedonaType],
+        args: &[ColumnarValue],
+        _return_type: &SedonaType,
+        _num_rows: usize,
+        config_options: Option<&ConfigOptions>,
+    ) -> Result<ColumnarValue> {
+        let num_iterations = calc_num_iterations(args);
+
+        let geom_array = args[0].clone().into_array(num_iterations)?;
+        let geom_array = as_binary_array(&geom_array)?;
+
+        let pixel_type_array = args[2]
+            .clone()
+            .cast_to(&DataType::Utf8, None)?
+            .into_array(num_iterations)?;
+        let pixel_type_array = as_string_array(&pixel_type_array)?;
+
+        let all_touched_array = if self.arg_count >= 4 {
+            args[3]
+                .clone()
+                .cast_to(&DataType::Boolean, None)?
+                .into_array(num_iterations)?
+        } else {
+            ScalarValue::Boolean(Some(false)).to_array_of_size(num_iterations)?
+        };
+        let all_touched_array = as_boolean_array(&all_touched_array)?;
+
+        let burn_value_array = if self.arg_count >= 5 {
+            args[4]
+                .clone()
+                .cast_to(&DataType::Float64, None)?
+                .into_array(num_iterations)?
+        } else {
+            ScalarValue::Float64(Some(1.0)).to_array_of_size(num_iterations)?
+        };
+        let burn_value_array = as_float64_array(&burn_value_array)?;
+
+        let nodata_value_array = if self.arg_count >= 6 {
+            args[5]
+                .clone()
+                .cast_to(&DataType::Float64, None)?
+                .into_array(num_iterations)?
+        } else {
+            ScalarValue::Float64(None).to_array_of_size(num_iterations)?
+        };
+        let nodata_value_array = as_float64_array(&nodata_value_array)?;
+
+        let use_geom_extent_array = if self.arg_count >= 7 {
+            args[6]
+                .clone()
+                .cast_to(&DataType::Boolean, None)?
+                .into_array(num_iterations)?
+        } else {
+            ScalarValue::Boolean(Some(true)).to_array_of_size(num_iterations)?
+        };
+        let use_geom_extent_array = as_boolean_array(&use_geom_extent_array)?;
+
+        let mut builder = RasterBuilder::new(num_iterations);
+
+        with_gdal(|gdal| {
+            configure_thread_local_options(gdal, config_options)?;
+
+            execute_raster_arg(arg_types, args, 1, num_iterations, |index, raster_opt| {
+                let geom_opt = if geom_array.is_null(index) {
+                    None
+                } else {
+                    Some(geom_array.value(index))
+                };
+                let pixel_type_opt = if pixel_type_array.is_null(index) {
+                    None
+                } else {
+                    Some(pixel_type_array.value(index))
+                };
+                let all_touched_opt = if all_touched_array.is_null(index) {
+                    false
+                } else {
+                    all_touched_array.value(index)
+                };
+                let burn_value_opt = if burn_value_array.is_null(index) {
+                    1.0
+                } else {
+                    burn_value_array.value(index)
+                };
+                let nodata_value_opt = if nodata_value_array.is_null(index) {
+                    None
+                } else {
+                    Some(nodata_value_array.value(index))
+                };
+                let use_geometry_extent_opt = if use_geom_extent_array.is_null(index) {
+                    true
+                } else {
+                    use_geom_extent_array.value(index)
+                };
+
+                let raster = match raster_opt {
+                    Some(raster) => raster,
+                    None => {
+                        builder.append_null()?;
+                        return Ok(());
+                    }
+                };
+                let geom_wkb = match geom_opt {
+                    Some(geom_wkb) => geom_wkb,
+                    None => {
+                        builder.append_null()?;
+                        return Ok(());
+                    }
+                };
+                let pixel_type = match pixel_type_opt {
+                    Some(pixel_type) => pixel_type,
+                    None => {
+                        builder.append_null()?;
+                        return Ok(());
+                    }
+                };
+
+                let band_type = parse_pixel_type(pixel_type)?;
+
+                match as_raster(
+                    gdal,
+                    geom_wkb,
+                    raster,
+                    band_type,
+                    all_touched_opt,
+                    burn_value_opt,
+                    nodata_value_opt,
+                    use_geometry_extent_opt,
+                ) {
+                    Ok((out_metadata, out_band_metadata, out_band_bytes)) => {
+                        builder
+                            .start_raster(&out_metadata, raster.crs())
+                            .map_err(|e| {
+                                exec_datafusion_err!("Failed to start output raster: {}", e)
+                            })?;
+                        builder.start_band(out_band_metadata).map_err(|e| {
+                            exec_datafusion_err!("Failed to start output raster band: {}", e)
+                        })?;
+                        builder.band_data_writer().append_value(out_band_bytes);
+                        builder.finish_band().map_err(|e| {
+                            exec_datafusion_err!("Failed to finish output raster band: {}", e)
+                        })?;
+                        builder.finish_raster().map_err(|e| {
+                            exec_datafusion_err!("Failed to finish output raster: {}", e)
+                        })?;
+                    }
+                    Err(_) => builder.append_null()?,
+                }
+
+                Ok(())
+            })?;
+
+            finish_result(args, Arc::new(builder.finish()?))
+        })
+    }
+}
+
+fn parse_pixel_type(value: &str) -> Result<BandDataType> {
+    match value.trim().to_ascii_uppercase().as_str() {
+        "D" => Ok(BandDataType::Float64),
+        "F" => Ok(BandDataType::Float32),
+        "I" => Ok(BandDataType::Int32),
+        "S" => Ok(BandDataType::Int16),
+        "US" => Ok(BandDataType::UInt16),
+        "B" => Ok(BandDataType::UInt8),
+        "I8" | "INT8" => Ok(BandDataType::Int8),
+        "U64" | "UINT64" => Ok(BandDataType::UInt64),
+        "I64" | "INT64" => Ok(BandDataType::Int64),
+        other => exec_err!(
+            "Unsupported pixelType: {} (expected one of D, F, I, S, US, B, I8, U64, I64)",
+            other
+        ),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn as_raster(
+    gdal: &Gdal,
+    geom_wkb: &[u8],
+    reference_raster: &RasterRefImpl<'_>,
+    band_type: BandDataType,
+    all_touched: bool,
+    burn_value: f64,
+    nodata_value: Option<f64>,
+    use_geometry_extent: bool,
+) -> Result<(RasterMetadata, BandMetadata, Vec<u8>)> {
+    let ref_md = reference_raster.metadata();
+
+    if ref_md.skew_x() != 0.0 || ref_md.skew_y() != 0.0 {
+        return exec_err!(
+            "RS_AsRaster currently requires skew_x=0 and skew_y=0 in the reference raster"
+        );
+    }
+
+    let geometry = gdal
+        .geometry_from_wkb(geom_wkb)
+        .map_err(|e| exec_datafusion_err!("Failed to parse geometry from WKB: {}", e))?;
+
+    let (out_width, out_height, out_ulx, out_uly) = if use_geometry_extent {
+        let env = geometry.envelope();
+        let ulx = ref_md.upper_left_x();
+        let uly = ref_md.upper_left_y();
+        let scale_x = ref_md.scale_x();
+        let scale_y = ref_md.scale_y();
+
+        if scale_x == 0.0 || scale_y == 0.0 {
+            return exec_err!("Reference raster has zero scale");
+        }
+
+        let start_col = ((env.MinX - ulx) / scale_x).floor() as isize;
+        let end_col_excl = ((env.MaxX - ulx) / scale_x).ceil() as isize;
+        let start_row = ((env.MaxY - uly) / scale_y).floor() as isize;
+        let end_row_excl = ((env.MinY - uly) / scale_y).ceil() as isize;
+
+        let width = (end_col_excl - start_col).max(0) as usize;
+        let height = (end_row_excl - start_row).max(0) as usize;
+
+        if width == 0 || height == 0 {
+            return exec_err!("Geometry extent produced an empty raster");
+        }
+
+        (
+            width,
+            height,
+            ulx + (start_col as f64) * scale_x,
+            uly + (start_row as f64) * scale_y,
+        )
+    } else {
+        (
+            ref_md.width() as usize,
+            ref_md.height() as usize,
+            ref_md.upper_left_x(),
+            ref_md.upper_left_y(),
+        )
+    };
+
+    let out_dataset = MemDatasetBuilder::create(
+        gdal,
+        out_width,
+        out_height,
+        1,
+        band_data_type_to_gdal(&band_type),
+    )
+    .map_err(|e| exec_datafusion_err!("Failed to create dataset: {}", e))?;
+
+    out_dataset
+        .set_geo_transform(&[
+            out_ulx,
+            ref_md.scale_x(),
+            ref_md.skew_x(),
+            out_uly,
+            ref_md.skew_y(),
+            ref_md.scale_y(),
+        ])
+        .map_err(|e| exec_datafusion_err!("Failed to set geotransform: {}", e))?;
+
+    let provider = thread_local_provider(gdal)
+        .map_err(|e| exec_datafusion_err!("Failed to init GDAL provider: {}", e))?;
+    let ref_raster_ds = provider
+        .raster_ref_to_gdal(reference_raster)
+        .map_err(|e| exec_datafusion_err!("Failed to create GDAL dataset: {}", e))?;
+    if let Ok(srs) = ref_raster_ds.as_dataset().spatial_ref() {
+        out_dataset
+            .set_spatial_ref(&srs)
+            .map_err(|e| exec_datafusion_err!("Failed to set spatial reference: {}", e))?;
+    }
+
+    let init_value = nodata_value.unwrap_or(0.0);
+    initialize_band(&out_dataset, &band_type, out_width, out_height, init_value)?;
+
+    if let Some(nodata) = nodata_value {
+        let band = out_dataset
+            .rasterband(1)
+            .map_err(|e| exec_datafusion_err!("Failed to get output band: {}", e))?;
+        match band_type {
+            BandDataType::UInt64 => band
+                .set_no_data_value_u64(Some(nodata as u64))
+                .map_err(|e| exec_datafusion_err!("Failed to set nodata value: {}", e))?,
+            BandDataType::Int64 => band
+                .set_no_data_value_i64(Some(nodata as i64))
+                .map_err(|e| exec_datafusion_err!("Failed to set nodata value: {}", e))?,
+            _ => band
+                .set_no_data_value(Some(nodata))
+                .map_err(|e| exec_datafusion_err!("Failed to set nodata value: {}", e))?,
+        }
+    }
+
+    gdal.rasterize_affine(&out_dataset, &[1], &[geometry], &[burn_value], all_touched)
+        .map_err(|e| exec_datafusion_err!("Failed to rasterize geometry: {}", e))?;
+
+    let band_bytes = read_band_as_bytes(&out_dataset, 1, out_width, out_height, &band_type)?;
+
+    Ok((
+        RasterMetadata {
+            width: out_width as i64,
+            height: out_height as i64,
+            upperleft_x: out_ulx,
+            upperleft_y: out_uly,
+            scale_x: ref_md.scale_x(),
+            scale_y: ref_md.scale_y(),
+            skew_x: ref_md.skew_x(),
+            skew_y: ref_md.skew_y(),
+        },
+        BandMetadata {
+            nodata_value: nodata_value.map(|value| nodata_f64_to_bytes(value, &band_type)),
+            storage_type: StorageType::InDb,
+            datatype: band_type,
+            outdb_url: None,
+            outdb_band_id: None,
+        },
+        band_bytes,
+    ))
+}
+
+fn initialize_band(
+    dataset: &Dataset,
+    band_type: &BandDataType,
+    width: usize,
+    height: usize,
+    init_value: f64,
+) -> Result<()> {
+    match band_type {
+        BandDataType::UInt8 => initialize_band_t::<u8>(dataset, width, height, init_value as u8),
+        BandDataType::Int8 => initialize_band_t::<i8>(dataset, width, height, init_value as i8),
+        BandDataType::UInt16 => initialize_band_t::<u16>(dataset, width, height, init_value as u16),
+        BandDataType::Int16 => initialize_band_t::<i16>(dataset, width, height, init_value as i16),
+        BandDataType::UInt32 => initialize_band_t::<u32>(dataset, width, height, init_value as u32),
+        BandDataType::Int32 => initialize_band_t::<i32>(dataset, width, height, init_value as i32),
+        BandDataType::UInt64 => initialize_band_t::<u64>(dataset, width, height, init_value as u64),
+        BandDataType::Int64 => initialize_band_t::<i64>(dataset, width, height, init_value as i64),
+        BandDataType::Float32 => {
+            initialize_band_t::<f32>(dataset, width, height, init_value as f32)
+        }
+        BandDataType::Float64 => initialize_band_t::<f64>(dataset, width, height, init_value),
+    }
+}
+
+fn initialize_band_t<T: sedona_gdal::raster::types::GdalType + Copy>(
+    dataset: &Dataset,
+    width: usize,
+    height: usize,
+    init_value: T,
+) -> Result<()> {
+    let band = dataset
+        .rasterband(1)
+        .map_err(|e| exec_datafusion_err!("Failed to get output band: {}", e))?;
+    let mut buffer = Buffer::new((width, height), vec![init_value; width * height]);
+    band.write((0, 0), (width, height), &mut buffer)
+        .map_err(|e| exec_datafusion_err!("Failed to initialize band: {}", e))?;
+    Ok(())
+}
+
+fn read_band_as_bytes(
+    dataset: &Dataset,
+    band_idx: usize,
+    width: usize,
+    height: usize,
+    band_type: &BandDataType,
+) -> Result<Vec<u8>> {
+    let band = dataset
+        .rasterband(band_idx)
+        .map_err(|e| exec_datafusion_err!("Failed to get band {}: {}", band_idx, e))?;
+
+    let data = match band_type {
+        BandDataType::UInt8 => band
+            .read_as::<u8>((0, 0), (width, height), (width, height), None)
+            .map(|buffer| buffer.data().to_vec()),
+        BandDataType::Int8 => band
+            .read_as::<i8>((0, 0), (width, height), (width, height), None)
+            .map(|buffer| buffer.data().iter().map(|value| *value as u8).collect()),
+        BandDataType::UInt16 => band
+            .read_as::<u16>((0, 0), (width, height), (width, height), None)
+            .map(|buffer| {
+                buffer
+                    .data()
+                    .iter()
+                    .flat_map(|value| value.to_le_bytes())
+                    .collect()
+            }),
+        BandDataType::Int16 => band
+            .read_as::<i16>((0, 0), (width, height), (width, height), None)
+            .map(|buffer| {
+                buffer
+                    .data()
+                    .iter()
+                    .flat_map(|value| value.to_le_bytes())
+                    .collect()
+            }),
+        BandDataType::UInt32 => band
+            .read_as::<u32>((0, 0), (width, height), (width, height), None)
+            .map(|buffer| {
+                buffer
+                    .data()
+                    .iter()
+                    .flat_map(|value| value.to_le_bytes())
+                    .collect()
+            }),
+        BandDataType::Int32 => band
+            .read_as::<i32>((0, 0), (width, height), (width, height), None)
+            .map(|buffer| {
+                buffer
+                    .data()
+                    .iter()
+                    .flat_map(|value| value.to_le_bytes())
+                    .collect()
+            }),
+        BandDataType::UInt64 => band
+            .read_as::<u64>((0, 0), (width, height), (width, height), None)
+            .map(|buffer| {
+                buffer
+                    .data()
+                    .iter()
+                    .flat_map(|value| value.to_le_bytes())
+                    .collect()
+            }),
+        BandDataType::Int64 => band
+            .read_as::<i64>((0, 0), (width, height), (width, height), None)
+            .map(|buffer| {
+                buffer
+                    .data()
+                    .iter()
+                    .flat_map(|value| value.to_le_bytes())
+                    .collect()
+            }),
+        BandDataType::Float32 => band
+            .read_as::<f32>((0, 0), (width, height), (width, height), None)
+            .map(|buffer| {
+                buffer
+                    .data()
+                    .iter()
+                    .flat_map(|value| value.to_le_bytes())
+                    .collect()
+            }),
+        BandDataType::Float64 => band
+            .read_as::<f64>((0, 0), (width, height), (width, height), None)
+            .map(|buffer| {
+                buffer
+                    .data()
+                    .iter()
+                    .flat_map(|value| value.to_le_bytes())
+                    .collect()
+            }),
+    }
+    .map_err(|e| exec_datafusion_err!("Failed to read band {} data: {}", band_idx, e))?;
+
+    Ok(data)
+}
+
+fn calc_num_iterations(args: &[ColumnarValue]) -> usize {
+    args.iter()
+        .find_map(|arg| match arg {
+            ColumnarValue::Array(array) => Some(array.len()),
+            ColumnarValue::Scalar(_) => None,
+        })
+        .unwrap_or(1)
+}
+
+fn finish_result(args: &[ColumnarValue], out: Arc<dyn Array>) -> Result<ColumnarValue> {
+    if args
+        .iter()
+        .any(|arg| matches!(arg, ColumnarValue::Array(_)))
+    {
+        Ok(ColumnarValue::Array(out))
+    } else {
+        Ok(ColumnarValue::Scalar(ScalarValue::try_from_array(&out, 0)?))
+    }
+}
+
+fn execute_raster_arg<F>(
+    arg_types: &[SedonaType],
+    args: &[ColumnarValue],
+    index: usize,
+    num_iterations: usize,
+    mut func: F,
+) -> Result<()>
+where
+    F: FnMut(usize, Option<&RasterRefImpl<'_>>) -> Result<()>,
+{
+    if arg_types.get(index) != Some(&RASTER) {
+        return sedona_internal_err!("Argument {index} must be a raster type");
+    }
+
+    match &args[index] {
+        ColumnarValue::Array(array) => {
+            let raster_struct = array
+                .as_any()
+                .downcast_ref::<StructArray>()
+                .ok_or_else(|| {
+                    sedona_internal_datafusion_err!("Expected StructArray for raster data")
+                })?;
+            let raster_array = RasterStructArray::new(raster_struct);
+
+            for i in 0..num_iterations {
+                if raster_array.is_null(i) {
+                    func(i, None)?;
+                } else {
+                    let raster = raster_array.get(i)?;
+                    func(i, Some(&raster))?;
+                }
+            }
+
+            Ok(())
+        }
+        ColumnarValue::Scalar(ScalarValue::Struct(raster_struct)) => {
+            let raster_array = RasterStructArray::new(raster_struct.as_ref());
+            let raster = if raster_array.is_null(0) {
+                None
+            } else {
+                Some(raster_array.get(0)?)
+            };
+
+            for i in 0..num_iterations {
+                func(i, raster.as_ref())?;
+            }
+
+            Ok(())
+        }
+        ColumnarValue::Scalar(ScalarValue::Null) => {
+            for i in 0..num_iterations {
+                func(i, None)?;
+            }
+            Ok(())
+        }
+        _ => sedona_internal_err!("Expected Struct scalar for raster"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow_array::{BooleanArray, Float64Array, StringArray};
+    use datafusion_common::cast::as_struct_array;
+    use datafusion_expr::{ScalarUDF, ScalarUDFImpl};
+    use sedona_gdal::raster::types::Buffer;
+    use sedona_raster::array::RasterStructArray;
+    use sedona_schema::datatypes::WKB_GEOMETRY;
+    use sedona_testing::{create::create_array, testers::ScalarUdfTester};
+
+    use super::*;
+
+    fn build_reference_raster() -> arrow_array::StructArray {
+        with_gdal(|gdal| {
+            let driver = gdal.get_driver_by_name("MEM").unwrap();
+            let dataset = driver.create_with_band_type::<u8>("", 4, 3, 1).unwrap();
+            dataset
+                .set_geo_transform(&[10.0, 2.0, 0.0, 20.0, 0.0, -2.0])
+                .unwrap();
+            dataset.set_projection("EPSG:4326").unwrap();
+            let band = dataset.rasterband(1).unwrap();
+            band.set_no_data_value(Some(0.0)).unwrap();
+            let mut buffer = Buffer::new((4, 3), vec![0u8; 12]);
+            band.write((0, 0), (4, 3), &mut buffer).unwrap();
+            crate::utils::dataset_to_indb_raster(&dataset)
+        })
+        .unwrap()
+    }
+
+    fn wkb_from_wkt(gdal: &Gdal, wkt: &str) -> Result<Vec<u8>> {
+        let geom = gdal.geometry_from_wkt(wkt).unwrap();
+        geom.wkb().map_err(|e| exec_datafusion_err!("{e}"))
+    }
+
+    fn bytes_to_f64_vec(bytes: &[u8]) -> Vec<f64> {
+        bytes
+            .chunks_exact(8)
+            .map(|chunk| f64::from_le_bytes(chunk.try_into().unwrap()))
+            .collect()
+    }
+
+    fn load_reference_raster() -> RasterMetadata {
+        let raster_array = build_reference_raster();
+        let raster_struct = RasterStructArray::new(&raster_array);
+        raster_struct.get(0).unwrap().metadata()
+    }
+
+    #[test]
+    fn test_parse_pixel_type() {
+        assert_eq!(parse_pixel_type("D").unwrap(), BandDataType::Float64);
+        assert_eq!(parse_pixel_type("f").unwrap(), BandDataType::Float32);
+        assert_eq!(parse_pixel_type("I").unwrap(), BandDataType::Int32);
+        assert_eq!(parse_pixel_type("S").unwrap(), BandDataType::Int16);
+        assert_eq!(parse_pixel_type("US").unwrap(), BandDataType::UInt16);
+        assert_eq!(parse_pixel_type("B").unwrap(), BandDataType::UInt8);
+        assert_eq!(parse_pixel_type("I8").unwrap(), BandDataType::Int8);
+        assert_eq!(parse_pixel_type("U64").unwrap(), BandDataType::UInt64);
+        assert_eq!(parse_pixel_type("I64").unwrap(), BandDataType::Int64);
+    }
+
+    #[test]
+    fn test_rs_as_raster_use_reference_extent() {
+        let raster_array = build_reference_raster();
+        with_gdal(|gdal| {
+            let raster_struct = RasterStructArray::new(&raster_array);
+            let raster = raster_struct.get(0).unwrap();
+            let md = raster.metadata();
+
+            let wkt = format!(
+                "POLYGON(({x0} {y1}, {x0} {y0}, {x1} {y0}, {x1} {y1}, {x0} {y1}))",
+                x0 = md.upper_left_x(),
+                x1 = md.upper_left_x() + md.scale_x(),
+                y0 = md.upper_left_y(),
+                y1 = md.upper_left_y() + md.scale_y(),
+            );
+            let geom_wkb = wkb_from_wkt(gdal, &wkt)?;
+
+            let (out_md, _band_md, out_bytes) = as_raster(
+                gdal,
+                &geom_wkb,
+                &raster,
+                BandDataType::Float64,
+                false,
+                255.0,
+                Some(0.0),
+                false,
+            )?;
+
+            assert_eq!(out_md.width, md.width());
+            assert_eq!(out_md.height, md.height());
+            assert_eq!(out_md.upperleft_x, md.upper_left_x());
+            assert_eq!(out_md.upperleft_y, md.upper_left_y());
+            assert_eq!(bytes_to_f64_vec(&out_bytes)[0], 255.0);
+            Ok::<_, datafusion_common::DataFusionError>(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn test_rs_as_raster_use_geometry_extent() {
+        let raster_array = build_reference_raster();
+        with_gdal(|gdal| {
+            let raster_struct = RasterStructArray::new(&raster_array);
+            let raster = raster_struct.get(0).unwrap();
+            let md = raster.metadata();
+
+            let wkt = format!(
+                "POLYGON(({x0} {y1}, {x0} {y0}, {x1} {y0}, {x1} {y1}, {x0} {y1}))",
+                x0 = md.upper_left_x(),
+                x1 = md.upper_left_x() + md.scale_x(),
+                y0 = md.upper_left_y(),
+                y1 = md.upper_left_y() + md.scale_y(),
+            );
+            let geom_wkb = wkb_from_wkt(gdal, &wkt)?;
+
+            let (out_md, _band_md, out_bytes) = as_raster(
+                gdal,
+                &geom_wkb,
+                &raster,
+                BandDataType::Float64,
+                false,
+                255.0,
+                Some(0.0),
+                true,
+            )?;
+
+            assert_eq!(out_md.width, 1);
+            assert_eq!(out_md.height, 1);
+            assert_eq!(out_md.upperleft_x, md.upper_left_x());
+            assert_eq!(out_md.upperleft_y, md.upper_left_y());
+            assert_eq!(bytes_to_f64_vec(&out_bytes), vec![255.0]);
+            Ok::<_, datafusion_common::DataFusionError>(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn test_rs_as_raster_udf_name() {
+        assert_eq!(rs_as_raster_udf().name(), "rs_asraster");
+    }
+
+    #[test]
+    fn test_rs_as_raster_udf_batch() {
+        let raster_array = build_reference_raster();
+
+        let metadata = load_reference_raster();
+        let geom = format!(
+            "POLYGON(({x0} {y1}, {x0} {y0}, {x1} {y0}, {x1} {y1}, {x0} {y1}))",
+            x0 = metadata.upper_left_x(),
+            x1 = metadata.upper_left_x() + metadata.scale_x(),
+            y0 = metadata.upper_left_y(),
+            y1 = metadata.upper_left_y() + metadata.scale_y(),
+        );
+
+        let udf: ScalarUDF = rs_as_raster_udf().into();
+        let tester = ScalarUdfTester::new(
+            udf,
+            vec![
+                WKB_GEOMETRY,
+                RASTER,
+                SedonaType::Arrow(DataType::Utf8),
+                SedonaType::Arrow(DataType::Boolean),
+                SedonaType::Arrow(DataType::Float64),
+                SedonaType::Arrow(DataType::Float64),
+                SedonaType::Arrow(DataType::Boolean),
+            ],
+        );
+
+        let result = tester
+            .invoke_arrays(vec![
+                create_array(&[Some(geom.as_str())], &WKB_GEOMETRY),
+                Arc::new(raster_array),
+                Arc::new(StringArray::from(vec!["D"])),
+                Arc::new(BooleanArray::from(vec![false])),
+                Arc::new(Float64Array::from(vec![255.0])),
+                Arc::new(Float64Array::from(vec![0.0])),
+                Arc::new(BooleanArray::from(vec![true])),
+            ])
+            .unwrap();
+
+        let struct_array = as_struct_array(&result).unwrap();
+        let raster_array = RasterStructArray::new(struct_array);
+        let raster = raster_array.get(0).unwrap();
+
+        assert_eq!(raster.metadata().width(), 1);
+        assert_eq!(raster.metadata().height(), 1);
+        let band = raster.bands().band(1).unwrap();
+        assert_eq!(
+            bytes_to_f64_vec(band.nd_buffer().unwrap().as_contiguous().unwrap()),
+            vec![255.0]
+        );
+    }
+}

--- a/rust/sedona-raster-gdal/src/rs_as_raster.rs
+++ b/rust/sedona-raster-gdal/src/rs_as_raster.rs
@@ -628,30 +628,22 @@ mod tests {
     use std::sync::Arc;
 
     use arrow_array::{BooleanArray, Float64Array, StringArray};
-    use datafusion_common::cast::as_struct_array;
     use datafusion_expr::{ScalarUDF, ScalarUDFImpl};
-    use sedona_gdal::raster::types::Buffer;
     use sedona_raster::array::RasterStructArray;
+    use sedona_schema::datatypes::RASTER;
     use sedona_schema::datatypes::WKB_GEOMETRY;
+    use sedona_schema::raster::BandDataType;
+    use sedona_testing::raster_spec::{assert_rasters_equal, RasterSpec};
     use sedona_testing::{create::create_array, testers::ScalarUdfTester};
 
     use super::*;
 
-    fn build_reference_raster() -> arrow_array::StructArray {
-        with_gdal(|gdal| {
-            let driver = gdal.get_driver_by_name("MEM").unwrap();
-            let dataset = driver.create_with_band_type::<u8>("", 4, 3, 1).unwrap();
-            dataset
-                .set_geo_transform(&[10.0, 2.0, 0.0, 20.0, 0.0, -2.0])
-                .unwrap();
-            dataset.set_projection("EPSG:4326").unwrap();
-            let band = dataset.rasterband(1).unwrap();
-            band.set_no_data_value(Some(0.0)).unwrap();
-            let mut buffer = Buffer::new((4, 3), vec![0u8; 12]);
-            band.write((0, 0), (4, 3), &mut buffer).unwrap();
-            crate::utils::dataset_to_indb_raster(&dataset)
-        })
-        .unwrap()
+    fn reference_raster_spec() -> RasterSpec {
+        RasterSpec::d2(4, 3)
+            .transform([10.0, 2.0, 0.0, 20.0, 0.0, -2.0])
+            .crs(Some("EPSG:4326"))
+            .band_values(&[0u8; 12])
+            .nodata(0u8)
     }
 
     fn wkb_from_wkt(gdal: &Gdal, wkt: &str) -> Result<Vec<u8>> {
@@ -667,7 +659,7 @@ mod tests {
     }
 
     fn load_reference_raster() -> RasterMetadata {
-        let raster_array = build_reference_raster();
+        let raster_array = reference_raster_spec().build();
         let raster_struct = RasterStructArray::new(&raster_array);
         raster_struct.get(0).unwrap().metadata()
     }
@@ -687,7 +679,7 @@ mod tests {
 
     #[test]
     fn test_rs_as_raster_use_reference_extent() {
-        let raster_array = build_reference_raster();
+        let raster_array = reference_raster_spec().build();
         with_gdal(|gdal| {
             let raster_struct = RasterStructArray::new(&raster_array);
             let raster = raster_struct.get(0).unwrap();
@@ -725,7 +717,7 @@ mod tests {
 
     #[test]
     fn test_rs_as_raster_use_geometry_extent() {
-        let raster_array = build_reference_raster();
+        let raster_array = reference_raster_spec().build();
         with_gdal(|gdal| {
             let raster_struct = RasterStructArray::new(&raster_array);
             let raster = raster_struct.get(0).unwrap();
@@ -768,8 +760,6 @@ mod tests {
 
     #[test]
     fn test_rs_as_raster_udf_batch() {
-        let raster_array = build_reference_raster();
-
         let metadata = load_reference_raster();
         let geom = format!(
             "POLYGON(({x0} {y1}, {x0} {y0}, {x1} {y0}, {x1} {y1}, {x0} {y1}))",
@@ -796,7 +786,7 @@ mod tests {
         let result = tester
             .invoke_arrays(vec![
                 create_array(&[Some(geom.as_str())], &WKB_GEOMETRY),
-                Arc::new(raster_array),
+                Arc::new(reference_raster_spec().build()),
                 Arc::new(StringArray::from(vec!["D"])),
                 Arc::new(BooleanArray::from(vec![false])),
                 Arc::new(Float64Array::from(vec![255.0])),
@@ -805,16 +795,11 @@ mod tests {
             ])
             .unwrap();
 
-        let struct_array = as_struct_array(&result).unwrap();
-        let raster_array = RasterStructArray::new(struct_array);
-        let raster = raster_array.get(0).unwrap();
-
-        assert_eq!(raster.metadata().width(), 1);
-        assert_eq!(raster.metadata().height(), 1);
-        let band = raster.bands().band(1).unwrap();
-        assert_eq!(
-            bytes_to_f64_vec(band.nd_buffer().unwrap().as_contiguous().unwrap()),
-            vec![255.0]
-        );
+        let expected = RasterSpec::d2(1, 1)
+            .transform([10.0, 2.0, 0.0, 20.0, 0.0, -2.0])
+            .crs(Some("EPSG:4326"))
+            .band_values(&[255.0f64])
+            .nodata(0.0f64);
+        assert_rasters_equal(&result, &[Some(expected)]);
     }
 }

--- a/rust/sedona-raster-gdal/src/rs_as_raster.rs
+++ b/rust/sedona-raster-gdal/src/rs_as_raster.rs
@@ -586,7 +586,7 @@ where
                 .ok_or_else(|| {
                     sedona_internal_datafusion_err!("Expected StructArray for raster data")
                 })?;
-            let raster_array = RasterStructArray::new(raster_struct);
+            let raster_array = RasterStructArray::try_new(raster_struct)?;
 
             for i in 0..num_iterations {
                 if raster_array.is_null(i) {
@@ -600,7 +600,7 @@ where
             Ok(())
         }
         ColumnarValue::Scalar(ScalarValue::Struct(raster_struct)) => {
-            let raster_array = RasterStructArray::new(raster_struct.as_ref());
+            let raster_array = RasterStructArray::try_new(raster_struct.as_ref())?;
             let raster = if raster_array.is_null(0) {
                 None
             } else {
@@ -660,7 +660,7 @@ mod tests {
 
     fn load_reference_raster() -> RasterMetadata {
         let raster_array = reference_raster_spec().build();
-        let raster_struct = RasterStructArray::new(&raster_array);
+        let raster_struct = RasterStructArray::try_new(&raster_array).unwrap();
         raster_struct.get(0).unwrap().metadata()
     }
 
@@ -681,7 +681,7 @@ mod tests {
     fn test_rs_as_raster_use_reference_extent() {
         let raster_array = reference_raster_spec().build();
         with_gdal(|gdal| {
-            let raster_struct = RasterStructArray::new(&raster_array);
+            let raster_struct = RasterStructArray::try_new(&raster_array).unwrap();
             let raster = raster_struct.get(0).unwrap();
             let md = raster.metadata();
 
@@ -719,7 +719,7 @@ mod tests {
     fn test_rs_as_raster_use_geometry_extent() {
         let raster_array = reference_raster_spec().build();
         with_gdal(|gdal| {
-            let raster_struct = RasterStructArray::new(&raster_array);
+            let raster_struct = RasterStructArray::try_new(&raster_array).unwrap();
             let raster = raster_struct.get(0).unwrap();
             let md = raster.metadata();
 

--- a/rust/sedona-raster-gdal/src/rs_as_raster.rs
+++ b/rust/sedona-raster-gdal/src/rs_as_raster.rs
@@ -156,40 +156,23 @@ impl SedonaScalarKernel for RsAsRaster {
 
         let mut builder = RasterBuilder::new(num_iterations);
 
+        let mut geom_iter = geom_array.iter();
+        let mut pixel_type_iter = pixel_type_array.iter();
+        let mut all_touched_iter = all_touched_array.iter();
+        let mut burn_value_iter = burn_value_array.iter();
+        let mut nodata_value_iter = nodata_value_array.iter();
+        let mut use_geom_extent_iter = use_geom_extent_array.iter();
+
         with_gdal(|gdal| {
             configure_thread_local_options(gdal, config_options)?;
 
-            execute_raster_arg(arg_types, args, 1, num_iterations, |index, raster_opt| {
-                let geom_opt = if geom_array.is_null(index) {
-                    None
-                } else {
-                    Some(geom_array.value(index))
-                };
-                let pixel_type_opt = if pixel_type_array.is_null(index) {
-                    None
-                } else {
-                    Some(pixel_type_array.value(index))
-                };
-                let all_touched_opt = if all_touched_array.is_null(index) {
-                    false
-                } else {
-                    all_touched_array.value(index)
-                };
-                let burn_value_opt = if burn_value_array.is_null(index) {
-                    1.0
-                } else {
-                    burn_value_array.value(index)
-                };
-                let nodata_value_opt = if nodata_value_array.is_null(index) {
-                    None
-                } else {
-                    Some(nodata_value_array.value(index))
-                };
-                let use_geometry_extent_opt = if use_geom_extent_array.is_null(index) {
-                    true
-                } else {
-                    use_geom_extent_array.value(index)
-                };
+            execute_raster_arg(arg_types, args, 1, num_iterations, |_, raster_opt| {
+                let geom_opt = geom_iter.next().unwrap();
+                let pixel_type_opt = pixel_type_iter.next().unwrap();
+                let all_touched_opt = all_touched_iter.next().unwrap().unwrap_or(false);
+                let burn_value_opt = burn_value_iter.next().unwrap().unwrap_or(1.0);
+                let nodata_value_opt = nodata_value_iter.next().unwrap();
+                let use_geometry_extent_opt = use_geom_extent_iter.next().unwrap().unwrap_or(true);
 
                 let raster = match raster_opt {
                     Some(raster) => raster,
@@ -386,7 +369,17 @@ fn as_raster(
     gdal.rasterize_affine(&out_dataset, &[1], &[geometry], &[burn_value], all_touched)
         .map_err(|e| exec_datafusion_err!("Failed to rasterize geometry: {}", e))?;
 
-    let band_bytes = read_band_as_bytes(&out_dataset, 1, out_width, out_height, &band_type)?;
+    let band = out_dataset
+        .rasterband(1)
+        .map_err(|e| exec_datafusion_err!("Failed to get output band: {}", e))?;
+    let band_bytes = band
+        .read_as_bytes(
+            (0, 0),
+            (out_width, out_height),
+            (out_width, out_height),
+            None,
+        )
+        .map_err(|e| exec_datafusion_err!("Failed to read band data: {}", e))?;
 
     Ok((
         RasterMetadata {
@@ -446,102 +439,6 @@ fn initialize_band_t<T: sedona_gdal::raster::types::GdalType + Copy>(
     band.write((0, 0), (width, height), &mut buffer)
         .map_err(|e| exec_datafusion_err!("Failed to initialize band: {}", e))?;
     Ok(())
-}
-
-fn read_band_as_bytes(
-    dataset: &Dataset,
-    band_idx: usize,
-    width: usize,
-    height: usize,
-    band_type: &BandDataType,
-) -> Result<Vec<u8>> {
-    let band = dataset
-        .rasterband(band_idx)
-        .map_err(|e| exec_datafusion_err!("Failed to get band {}: {}", band_idx, e))?;
-
-    let data = match band_type {
-        BandDataType::UInt8 => band
-            .read_as::<u8>((0, 0), (width, height), (width, height), None)
-            .map(|buffer| buffer.data().to_vec()),
-        BandDataType::Int8 => band
-            .read_as::<i8>((0, 0), (width, height), (width, height), None)
-            .map(|buffer| buffer.data().iter().map(|value| *value as u8).collect()),
-        BandDataType::UInt16 => band
-            .read_as::<u16>((0, 0), (width, height), (width, height), None)
-            .map(|buffer| {
-                buffer
-                    .data()
-                    .iter()
-                    .flat_map(|value| value.to_le_bytes())
-                    .collect()
-            }),
-        BandDataType::Int16 => band
-            .read_as::<i16>((0, 0), (width, height), (width, height), None)
-            .map(|buffer| {
-                buffer
-                    .data()
-                    .iter()
-                    .flat_map(|value| value.to_le_bytes())
-                    .collect()
-            }),
-        BandDataType::UInt32 => band
-            .read_as::<u32>((0, 0), (width, height), (width, height), None)
-            .map(|buffer| {
-                buffer
-                    .data()
-                    .iter()
-                    .flat_map(|value| value.to_le_bytes())
-                    .collect()
-            }),
-        BandDataType::Int32 => band
-            .read_as::<i32>((0, 0), (width, height), (width, height), None)
-            .map(|buffer| {
-                buffer
-                    .data()
-                    .iter()
-                    .flat_map(|value| value.to_le_bytes())
-                    .collect()
-            }),
-        BandDataType::UInt64 => band
-            .read_as::<u64>((0, 0), (width, height), (width, height), None)
-            .map(|buffer| {
-                buffer
-                    .data()
-                    .iter()
-                    .flat_map(|value| value.to_le_bytes())
-                    .collect()
-            }),
-        BandDataType::Int64 => band
-            .read_as::<i64>((0, 0), (width, height), (width, height), None)
-            .map(|buffer| {
-                buffer
-                    .data()
-                    .iter()
-                    .flat_map(|value| value.to_le_bytes())
-                    .collect()
-            }),
-        BandDataType::Float32 => band
-            .read_as::<f32>((0, 0), (width, height), (width, height), None)
-            .map(|buffer| {
-                buffer
-                    .data()
-                    .iter()
-                    .flat_map(|value| value.to_le_bytes())
-                    .collect()
-            }),
-        BandDataType::Float64 => band
-            .read_as::<f64>((0, 0), (width, height), (width, height), None)
-            .map(|buffer| {
-                buffer
-                    .data()
-                    .iter()
-                    .flat_map(|value| value.to_le_bytes())
-                    .collect()
-            }),
-    }
-    .map_err(|e| exec_datafusion_err!("Failed to read band {} data: {}", band_idx, e))?;
-
-    Ok(data)
 }
 
 fn calc_num_iterations(args: &[ColumnarValue]) -> usize {

--- a/rust/sedona-raster-gdal/src/rs_as_raster.rs
+++ b/rust/sedona-raster-gdal/src/rs_as_raster.rs
@@ -185,11 +185,8 @@ impl SedonaScalarKernel for RsAsRaster {
         with_global_proj_engine(|engine| {
             with_gdal(|gdal| {
                 configure_thread_local_options(gdal, config_options)?;
-                let mut row_index = 0;
 
                 executor.execute_raster_wkb_crs_void(|raster_opt, geom_opt, geom_crs| {
-                    let current_row = row_index;
-                    row_index += 1;
                     let pixel_type_opt = pixel_type_iter.next().unwrap();
                     let all_touched_opt = all_touched_iter.next().unwrap().unwrap_or(false);
                     let burn_value_opt = burn_value_iter.next().unwrap().unwrap_or(1.0);
@@ -240,9 +237,7 @@ impl SedonaScalarKernel for RsAsRaster {
                         nodata_value_opt,
                         use_geometry_extent_opt,
                     )
-                    .map_err(|e| {
-                        exec_datafusion_err!("RS_AsRaster failed at row {}: {}", current_row, e)
-                    })?;
+                    .map_err(|e| exec_datafusion_err!("RS_AsRaster failed: {}", e))?;
 
                     builder
                         .start_raster(&out_metadata, raster.crs())

--- a/rust/sedona-raster-gdal/src/rs_as_raster.rs
+++ b/rust/sedona-raster-gdal/src/rs_as_raster.rs
@@ -221,8 +221,14 @@ impl SedonaScalarKernel for RsAsRaster {
 
                     let band_type = parse_pixel_type(pixel_type)?;
                     let raster_crs = resolve_crs(raster.crs())?;
-                    let geom_wkb =
-                        align_wkb_to_crs(geom_wkb, geom_crs, raster_crs.as_deref(), engine)?;
+                    let geom_wkb = align_wkb_to_crs(
+                        geom_wkb,
+                        geom_crs,
+                        raster_crs.as_deref(),
+                        "geometry",
+                        "reference raster",
+                        engine,
+                    )?;
 
                     let (out_metadata, out_band_metadata, out_band_bytes) = as_raster(
                         gdal,
@@ -791,6 +797,7 @@ mod tests {
     #[test]
     fn test_rs_as_raster_udf_batch() {
         let metadata = load_reference_raster();
+        let geometry_type = SedonaType::Wkb(Edges::Planar, deserialize_crs("EPSG:4326").unwrap());
         let geom = format!(
             "POLYGON(({x0} {y1}, {x0} {y0}, {x1} {y0}, {x1} {y1}, {x0} {y1}))",
             x0 = metadata.upper_left_x(),
@@ -803,7 +810,7 @@ mod tests {
         let tester = ScalarUdfTester::new(
             udf,
             vec![
-                WKB_GEOMETRY,
+                geometry_type.clone(),
                 RASTER,
                 SedonaType::Arrow(DataType::Utf8),
                 SedonaType::Arrow(DataType::Boolean),
@@ -815,7 +822,7 @@ mod tests {
 
         let result = tester
             .invoke_arrays(vec![
-                create_array(&[Some(geom.as_str())], &WKB_GEOMETRY),
+                create_array(&[Some(geom.as_str())], &geometry_type),
                 Arc::new(reference_raster_spec().build()),
                 Arc::new(StringArray::from(vec!["D"])),
                 Arc::new(BooleanArray::from(vec![false])),
@@ -831,6 +838,57 @@ mod tests {
             .band_values(&[255.0f64])
             .nodata(0.0f64);
         assert_rasters_equal(&result, &[Some(expected)]);
+    }
+
+    #[test]
+    fn test_rs_as_raster_udf_rejects_one_sided_crs() {
+        let geometry_with_crs =
+            SedonaType::Wkb(Edges::Planar, deserialize_crs("EPSG:4326").unwrap());
+        let udf: ScalarUDF = rs_as_raster_udf().into();
+
+        let tester = ScalarUdfTester::new(
+            udf.clone(),
+            vec![WKB_GEOMETRY, RASTER, SedonaType::Arrow(DataType::Utf8)],
+        );
+        let err = tester
+            .invoke_arrays(vec![
+                create_array(
+                    &[Some("POLYGON((10 20, 10 18, 12 18, 12 20, 10 20))")],
+                    &WKB_GEOMETRY,
+                ),
+                Arc::new(reference_raster_spec().build()),
+                Arc::new(StringArray::from(vec!["D"])),
+            ])
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("reference raster has a CRS but the geometry does not"),
+            "unexpected error: {err}"
+        );
+
+        let tester = ScalarUdfTester::new(
+            udf,
+            vec![
+                geometry_with_crs.clone(),
+                RASTER,
+                SedonaType::Arrow(DataType::Utf8),
+            ],
+        );
+        let err = tester
+            .invoke_arrays(vec![
+                create_array(
+                    &[Some("POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))")],
+                    &geometry_with_crs,
+                ),
+                Arc::new(RasterSpec::d2(1, 1).crs(None).band_values(&[0u8]).build()),
+                Arc::new(StringArray::from(vec!["D"])),
+            ])
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("geometry has a CRS but the reference raster does not"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/rust/sedona-raster-gdal/src/rs_as_raster.rs
+++ b/rust/sedona-raster-gdal/src/rs_as_raster.rs
@@ -26,6 +26,7 @@ use datafusion_common::config::ConfigOptions;
 use datafusion_common::error::Result;
 use datafusion_common::{exec_datafusion_err, exec_err, ScalarValue};
 use datafusion_expr::{ColumnarValue, Volatility};
+use sedona_common::SedonaOptions;
 use sedona_expr::{
     item_crs::parse_item_crs_arg_type,
     scalar_udf::{SedonaScalarKernel, SedonaScalarUDF},
@@ -34,7 +35,6 @@ use sedona_gdal::dataset::Dataset;
 use sedona_gdal::gdal::Gdal;
 use sedona_gdal::mem::MemDatasetBuilder;
 use sedona_gdal::raster::{rasterband::RasterBand, types::Buffer};
-use sedona_proj::transform::with_global_proj_engine;
 use sedona_raster::array::RasterRefImpl;
 use sedona_raster::builder::RasterBuilder;
 use sedona_raster::traits::{BandMetadata, RasterMetadata, RasterRef};
@@ -182,81 +182,80 @@ impl SedonaScalarKernel for RsAsRaster {
         let mut nodata_value_iter = nodata_value_array.iter();
         let mut use_geom_extent_iter = use_geom_extent_array.iter();
 
-        with_global_proj_engine(|engine| {
-            with_gdal(|gdal| {
-                configure_thread_local_options(gdal, config_options)?;
+        let default_options = SedonaOptions::default();
+        let sedona_options = config_options
+            .and_then(|c| c.extensions.get::<SedonaOptions>())
+            .unwrap_or(&default_options);
+        let engine = sedona_options.runtime.crs_engine();
 
-                executor.execute_raster_wkb_crs_void(|raster_opt, geom_opt, geom_crs| {
-                    let pixel_type_opt = pixel_type_iter.next().unwrap();
-                    let all_touched_opt = all_touched_iter.next().unwrap().unwrap_or(false);
-                    let burn_value_opt = burn_value_iter.next().unwrap().unwrap_or(1.0);
-                    let nodata_value_opt = nodata_value_iter.next().unwrap();
-                    let use_geometry_extent_opt =
-                        use_geom_extent_iter.next().unwrap().unwrap_or(true);
+        with_gdal(|gdal| {
+            configure_thread_local_options(gdal, config_options)?;
 
-                    let raster = match raster_opt {
-                        Some(raster) => raster,
-                        None => {
-                            builder.append_null()?;
-                            return Ok(());
-                        }
-                    };
-                    let geom_wkb = match geom_opt {
-                        Some(geom_wkb) => geom_wkb,
-                        None => {
-                            builder.append_null()?;
-                            return Ok(());
-                        }
-                    };
-                    let pixel_type = match pixel_type_opt {
-                        Some(pixel_type) => pixel_type,
-                        None => {
-                            builder.append_null()?;
-                            return Ok(());
-                        }
-                    };
+            executor.execute_raster_wkb_crs_void(|raster_opt, geom_opt, geom_crs| {
+                let pixel_type_opt = pixel_type_iter.next().unwrap();
+                let all_touched_opt = all_touched_iter.next().unwrap().unwrap_or(false);
+                let burn_value_opt = burn_value_iter.next().unwrap().unwrap_or(1.0);
+                let nodata_value_opt = nodata_value_iter.next().unwrap();
+                let use_geometry_extent_opt = use_geom_extent_iter.next().unwrap().unwrap_or(true);
 
-                    let band_type = parse_pixel_type(pixel_type)?;
-                    let raster_crs = resolve_crs(raster.crs())?;
-                    let geom_wkb = align_wkb_to_crs(
-                        geom_wkb,
-                        geom_crs,
-                        raster_crs.as_deref(),
-                        "geometry",
-                        "reference raster",
-                        engine,
-                    )?;
+                let raster = match raster_opt {
+                    Some(raster) => raster,
+                    None => {
+                        builder.append_null()?;
+                        return Ok(());
+                    }
+                };
+                let geom_wkb = match geom_opt {
+                    Some(geom_wkb) => geom_wkb,
+                    None => {
+                        builder.append_null()?;
+                        return Ok(());
+                    }
+                };
+                let pixel_type = match pixel_type_opt {
+                    Some(pixel_type) => pixel_type,
+                    None => {
+                        builder.append_null()?;
+                        return Ok(());
+                    }
+                };
 
-                    let (out_metadata, out_band_metadata, out_band_bytes) = as_raster(
-                        gdal,
-                        &geom_wkb,
-                        raster,
-                        band_type,
-                        all_touched_opt,
-                        burn_value_opt,
-                        nodata_value_opt,
-                        use_geometry_extent_opt,
-                    )
-                    .map_err(|e| exec_datafusion_err!("RS_AsRaster failed: {}", e))?;
+                let band_type = parse_pixel_type(pixel_type)?;
+                let raster_crs = resolve_crs(raster.crs())?;
+                let geom_wkb = align_wkb_to_crs(
+                    geom_wkb,
+                    geom_crs,
+                    raster_crs.as_deref(),
+                    "geometry",
+                    "reference raster",
+                    engine.as_ref(),
+                )?;
 
-                    builder
-                        .start_raster(&out_metadata, raster.crs())
-                        .map_err(|e| {
-                            exec_datafusion_err!("Failed to start output raster: {}", e)
-                        })?;
-                    builder.start_band(out_band_metadata).map_err(|e| {
-                        exec_datafusion_err!("Failed to start output raster band: {}", e)
-                    })?;
-                    builder.band_data_writer().append_value(out_band_bytes);
-                    builder.finish_band().map_err(|e| {
-                        exec_datafusion_err!("Failed to finish output raster band: {}", e)
-                    })?;
-                    builder.finish_raster().map_err(|e| {
-                        exec_datafusion_err!("Failed to finish output raster: {}", e)
-                    })?;
+                let (out_metadata, out_band_metadata, out_band_bytes) = as_raster(
+                    gdal,
+                    &geom_wkb,
+                    raster,
+                    band_type,
+                    all_touched_opt,
+                    burn_value_opt,
+                    nodata_value_opt,
+                    use_geometry_extent_opt,
+                )
+                .map_err(|e| exec_datafusion_err!("RS_AsRaster failed: {}", e))?;
 
-                    Ok(())
+                builder
+                    .start_raster(&out_metadata, raster.crs())
+                    .map_err(|e| exec_datafusion_err!("Failed to start output raster: {}", e))?;
+                builder.start_band(out_band_metadata).map_err(|e| {
+                    exec_datafusion_err!("Failed to start output raster band: {}", e)
                 })?;
+                builder.band_data_writer().append_value(out_band_bytes);
+                builder.finish_band().map_err(|e| {
+                    exec_datafusion_err!("Failed to finish output raster band: {}", e)
+                })?;
+                builder
+                    .finish_raster()
+                    .map_err(|e| exec_datafusion_err!("Failed to finish output raster: {}", e))?;
 
                 Ok(())
             })
@@ -890,7 +889,7 @@ mod tests {
     fn test_rs_as_raster_udf_reprojects_type_level_crs_geometry() {
         let geometry_type = SedonaType::Wkb(Edges::Planar, deserialize_crs("OGC:CRS84").unwrap());
         let udf: ScalarUDF = rs_as_raster_udf().into();
-        let tester = ScalarUdfTester::new(
+        let mut tester = ScalarUdfTester::new(
             udf,
             vec![
                 geometry_type.clone(),
@@ -902,6 +901,10 @@ mod tests {
                 SedonaType::Arrow(DataType::Boolean),
             ],
         );
+        tester.sedona_options_mut().runtime = tester
+            .sedona_options()
+            .runtime
+            .with_crs_engine(Arc::new(sedona_proj::transform::LazyProjEngine));
         let reference = RasterSpec::d2(1, 1)
             .transform([111_000.0, 1_000.0, 0.0, 112_000.0, 0.0, -1_000.0])
             .crs(Some("EPSG:3857"))
@@ -934,7 +937,7 @@ mod tests {
     #[test]
     fn test_rs_as_raster_udf_reprojects_item_crs_geometry() {
         let udf: ScalarUDF = rs_as_raster_udf().into();
-        let tester = ScalarUdfTester::new(
+        let mut tester = ScalarUdfTester::new(
             udf,
             vec![
                 SedonaType::new_item_crs(&WKB_GEOMETRY).unwrap(),
@@ -946,6 +949,10 @@ mod tests {
                 SedonaType::Arrow(DataType::Boolean),
             ],
         );
+        tester.sedona_options_mut().runtime = tester
+            .sedona_options()
+            .runtime
+            .with_crs_engine(Arc::new(sedona_proj::transform::LazyProjEngine));
         let reference = RasterSpec::d2(1, 1)
             .transform([111_000.0, 1_000.0, 0.0, 112_000.0, 0.0, -1_000.0])
             .crs(Some("EPSG:3857"))

--- a/rust/sedona-raster-gdal/src/rs_as_raster.rs
+++ b/rust/sedona-raster-gdal/src/rs_as_raster.rs
@@ -617,9 +617,13 @@ mod tests {
     use sedona_schema::datatypes::WKB_GEOMETRY;
     use sedona_schema::raster::BandDataType;
     use sedona_testing::raster_spec::{assert_rasters_equal, RasterSpec};
-    use sedona_testing::{create::create_array, testers::ScalarUdfTester};
+    use sedona_testing::{
+        create::{create_array, make_wkb},
+        testers::ScalarUdfTester,
+    };
 
     use super::*;
+    use crate::gdal_common::bytes_to_f64;
 
     fn reference_raster_spec() -> RasterSpec {
         RasterSpec::d2(4, 3)
@@ -627,18 +631,6 @@ mod tests {
             .crs(Some("EPSG:4326"))
             .band_values(&[0u8; 12])
             .nodata(0u8)
-    }
-
-    fn wkb_from_wkt(gdal: &Gdal, wkt: &str) -> Result<Vec<u8>> {
-        let geom = gdal.geometry_from_wkt(wkt).unwrap();
-        geom.wkb().map_err(|e| exec_datafusion_err!("{e}"))
-    }
-
-    fn bytes_to_f64_vec(bytes: &[u8]) -> Vec<f64> {
-        bytes
-            .chunks_exact(8)
-            .map(|chunk| f64::from_le_bytes(chunk.try_into().unwrap()))
-            .collect()
     }
 
     fn load_reference_raster() -> RasterMetadata {
@@ -704,7 +696,7 @@ mod tests {
                 y0 = md.upper_left_y(),
                 y1 = md.upper_left_y() + md.scale_y(),
             );
-            let geom_wkb = wkb_from_wkt(gdal, &wkt)?;
+            let geom_wkb = make_wkb(&wkt);
 
             let (out_md, _band_md, out_bytes) = as_raster(
                 gdal,
@@ -721,7 +713,10 @@ mod tests {
             assert_eq!(out_md.height, md.height());
             assert_eq!(out_md.upperleft_x, md.upper_left_x());
             assert_eq!(out_md.upperleft_y, md.upper_left_y());
-            assert_eq!(bytes_to_f64_vec(&out_bytes)[0], 255.0);
+            assert_eq!(
+                bytes_to_f64(&out_bytes[..8], &BandDataType::Float64).unwrap(),
+                255.0
+            );
             Ok::<_, datafusion_common::DataFusionError>(())
         })
         .unwrap();
@@ -742,7 +737,7 @@ mod tests {
                 y0 = md.upper_left_y(),
                 y1 = md.upper_left_y() + md.scale_y(),
             );
-            let geom_wkb = wkb_from_wkt(gdal, &wkt)?;
+            let geom_wkb = make_wkb(&wkt);
 
             let (out_md, _band_md, out_bytes) = as_raster(
                 gdal,
@@ -759,7 +754,10 @@ mod tests {
             assert_eq!(out_md.height, 1);
             assert_eq!(out_md.upperleft_x, md.upper_left_x());
             assert_eq!(out_md.upperleft_y, md.upper_left_y());
-            assert_eq!(bytes_to_f64_vec(&out_bytes), vec![255.0]);
+            assert_eq!(
+                bytes_to_f64(&out_bytes, &BandDataType::Float64).unwrap(),
+                255.0
+            );
             Ok::<_, datafusion_common::DataFusionError>(())
         })
         .unwrap();

--- a/rust/sedona-raster-gdal/src/rs_as_raster.rs
+++ b/rust/sedona-raster-gdal/src/rs_as_raster.rs
@@ -21,25 +21,27 @@ use std::{convert::TryFrom, sync::Arc};
 
 use arrow_array::ArrayRef;
 use arrow_schema::DataType;
-use datafusion_common::cast::{
-    as_binary_array, as_boolean_array, as_float64_array, as_string_array,
-};
+use datafusion_common::cast::{as_boolean_array, as_float64_array, as_string_array};
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::error::Result;
 use datafusion_common::{exec_datafusion_err, exec_err, ScalarValue};
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_expr::{
-    item_crs::ItemCrsKernel,
+    item_crs::parse_item_crs_arg_type,
     scalar_udf::{SedonaScalarKernel, SedonaScalarUDF},
 };
 use sedona_gdal::dataset::Dataset;
 use sedona_gdal::gdal::Gdal;
 use sedona_gdal::mem::MemDatasetBuilder;
 use sedona_gdal::raster::{rasterband::RasterBand, types::Buffer};
+use sedona_proj::transform::with_global_proj_engine;
 use sedona_raster::array::RasterRefImpl;
 use sedona_raster::builder::RasterBuilder;
 use sedona_raster::traits::{BandMetadata, RasterMetadata, RasterRef};
-use sedona_raster_functions::RasterExecutor;
+use sedona_raster_functions::{
+    crs_utils::{align_wkb_to_crs, resolve_crs},
+    RasterExecutor,
+};
 use sedona_schema::datatypes::{SedonaType, RASTER};
 use sedona_schema::matchers::ArgMatcher;
 use sedona_schema::raster::{BandDataType, StorageType};
@@ -50,13 +52,13 @@ use crate::gdal_dataset_provider::{configure_thread_local_options, thread_local_
 pub fn rs_as_raster_udf() -> SedonaScalarUDF {
     SedonaScalarUDF::new(
         "rs_asraster",
-        ItemCrsKernel::wrap_impl(vec![
+        vec![
             Arc::new(RsAsRaster { arg_count: 3 }),
             Arc::new(RsAsRaster { arg_count: 4 }),
             Arc::new(RsAsRaster { arg_count: 5 }),
             Arc::new(RsAsRaster { arg_count: 6 }),
             Arc::new(RsAsRaster { arg_count: 7 }),
-        ]),
+        ],
         Volatility::Immutable,
     )
 }
@@ -68,6 +70,13 @@ struct RsAsRaster {
 
 impl SedonaScalarKernel for RsAsRaster {
     fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
+        let Some(first_arg) = args.first() else {
+            return Ok(None);
+        };
+        let (geometry_type, _) = parse_item_crs_arg_type(first_arg)?;
+        let mut arg_types = args.to_vec();
+        arg_types[0] = geometry_type;
+
         let mut matchers = vec![
             ArgMatcher::is_geometry_or_geography(),
             ArgMatcher::is_raster(),
@@ -87,7 +96,7 @@ impl SedonaScalarKernel for RsAsRaster {
             matchers.push(ArgMatcher::is_boolean());
         }
 
-        ArgMatcher::new(matchers, RASTER).match_args(args)
+        ArgMatcher::new(matchers, RASTER).match_args(&arg_types)
     }
 
     fn invoke_batch(
@@ -118,9 +127,6 @@ impl SedonaScalarKernel for RsAsRaster {
         let exec_args = vec![args[1].clone(), args[0].clone()];
         let executor =
             RasterExecutor::new_with_num_iterations(&exec_arg_types, &exec_args, num_iterations);
-
-        let geom_array = args[0].clone().into_array(num_iterations)?;
-        let geom_array = as_binary_array(&geom_array)?;
 
         let pixel_type_array = args[2]
             .clone()
@@ -170,84 +176,93 @@ impl SedonaScalarKernel for RsAsRaster {
 
         let mut builder = RasterBuilder::new(num_iterations);
 
-        let mut geom_iter = geom_array.iter();
         let mut pixel_type_iter = pixel_type_array.iter();
         let mut all_touched_iter = all_touched_array.iter();
         let mut burn_value_iter = burn_value_array.iter();
         let mut nodata_value_iter = nodata_value_array.iter();
         let mut use_geom_extent_iter = use_geom_extent_array.iter();
 
-        with_gdal(|gdal| {
-            configure_thread_local_options(gdal, config_options)?;
+        with_global_proj_engine(|engine| {
+            with_gdal(|gdal| {
+                configure_thread_local_options(gdal, config_options)?;
+                let mut row_index = 0;
 
-            executor.execute_raster_void(|row_index, raster_opt| {
-                let geom_opt = geom_iter
-                    .next()
-                    .expect("geometry iteration should match rows");
-                let pixel_type_opt = pixel_type_iter.next().unwrap();
-                let all_touched_opt = all_touched_iter.next().unwrap().unwrap_or(false);
-                let burn_value_opt = burn_value_iter.next().unwrap().unwrap_or(1.0);
-                let nodata_value_opt = nodata_value_iter.next().unwrap();
-                let use_geometry_extent_opt = use_geom_extent_iter.next().unwrap().unwrap_or(true);
+                executor.execute_raster_wkb_crs_void(|raster_opt, geom_opt, geom_crs| {
+                    let current_row = row_index;
+                    row_index += 1;
+                    let pixel_type_opt = pixel_type_iter.next().unwrap();
+                    let all_touched_opt = all_touched_iter.next().unwrap().unwrap_or(false);
+                    let burn_value_opt = burn_value_iter.next().unwrap().unwrap_or(1.0);
+                    let nodata_value_opt = nodata_value_iter.next().unwrap();
+                    let use_geometry_extent_opt =
+                        use_geom_extent_iter.next().unwrap().unwrap_or(true);
 
-                let raster = match raster_opt {
-                    Some(raster) => raster,
-                    None => {
-                        builder.append_null()?;
-                        return Ok(());
-                    }
-                };
-                let geom_wkb = match geom_opt {
-                    Some(geom_wkb) => geom_wkb,
-                    None => {
-                        builder.append_null()?;
-                        return Ok(());
-                    }
-                };
-                let pixel_type = match pixel_type_opt {
-                    Some(pixel_type) => pixel_type,
-                    None => {
-                        builder.append_null()?;
-                        return Ok(());
-                    }
-                };
+                    let raster = match raster_opt {
+                        Some(raster) => raster,
+                        None => {
+                            builder.append_null()?;
+                            return Ok(());
+                        }
+                    };
+                    let geom_wkb = match geom_opt {
+                        Some(geom_wkb) => geom_wkb,
+                        None => {
+                            builder.append_null()?;
+                            return Ok(());
+                        }
+                    };
+                    let pixel_type = match pixel_type_opt {
+                        Some(pixel_type) => pixel_type,
+                        None => {
+                            builder.append_null()?;
+                            return Ok(());
+                        }
+                    };
 
-                let band_type = parse_pixel_type(pixel_type)?;
+                    let band_type = parse_pixel_type(pixel_type)?;
+                    let raster_crs = resolve_crs(raster.crs())?;
+                    let geom_wkb =
+                        align_wkb_to_crs(geom_wkb, geom_crs, raster_crs.as_deref(), engine)?;
 
-                let (out_metadata, out_band_metadata, out_band_bytes) = as_raster(
-                    gdal,
-                    geom_wkb,
-                    raster,
-                    band_type,
-                    all_touched_opt,
-                    burn_value_opt,
-                    nodata_value_opt,
-                    use_geometry_extent_opt,
-                )
-                .map_err(|e| {
-                    exec_datafusion_err!("RS_AsRaster failed at row {}: {}", row_index, e)
+                    let (out_metadata, out_band_metadata, out_band_bytes) = as_raster(
+                        gdal,
+                        &geom_wkb,
+                        raster,
+                        band_type,
+                        all_touched_opt,
+                        burn_value_opt,
+                        nodata_value_opt,
+                        use_geometry_extent_opt,
+                    )
+                    .map_err(|e| {
+                        exec_datafusion_err!("RS_AsRaster failed at row {}: {}", current_row, e)
+                    })?;
+
+                    builder
+                        .start_raster(&out_metadata, raster.crs())
+                        .map_err(|e| {
+                            exec_datafusion_err!("Failed to start output raster: {}", e)
+                        })?;
+                    builder.start_band(out_band_metadata).map_err(|e| {
+                        exec_datafusion_err!("Failed to start output raster band: {}", e)
+                    })?;
+                    builder.band_data_writer().append_value(out_band_bytes);
+                    builder.finish_band().map_err(|e| {
+                        exec_datafusion_err!("Failed to finish output raster band: {}", e)
+                    })?;
+                    builder.finish_raster().map_err(|e| {
+                        exec_datafusion_err!("Failed to finish output raster: {}", e)
+                    })?;
+
+                    Ok(())
                 })?;
-
-                builder
-                    .start_raster(&out_metadata, raster.crs())
-                    .map_err(|e| exec_datafusion_err!("Failed to start output raster: {}", e))?;
-                builder.start_band(out_band_metadata).map_err(|e| {
-                    exec_datafusion_err!("Failed to start output raster band: {}", e)
-                })?;
-                builder.band_data_writer().append_value(out_band_bytes);
-                builder.finish_band().map_err(|e| {
-                    exec_datafusion_err!("Failed to finish output raster band: {}", e)
-                })?;
-                builder
-                    .finish_raster()
-                    .map_err(|e| exec_datafusion_err!("Failed to finish output raster: {}", e))?;
 
                 Ok(())
-            })?;
+            })
+        })?;
 
-            let result: ArrayRef = Arc::new(builder.finish()?);
-            executor.finish(result)
-        })
+        let result: ArrayRef = Arc::new(builder.finish()?);
+        executor.finish(result)
     }
 }
 
@@ -616,6 +631,8 @@ mod tests {
     use arrow_array::{BooleanArray, Float64Array, StringArray};
     use datafusion_expr::{ScalarUDF, ScalarUDFImpl};
     use sedona_raster::array::RasterStructArray;
+    use sedona_schema::crs::deserialize_crs;
+    use sedona_schema::datatypes::Edges;
     use sedona_schema::datatypes::RASTER;
     use sedona_schema::datatypes::WKB_GEOMETRY;
     use sedona_schema::raster::BandDataType;
@@ -813,6 +830,96 @@ mod tests {
             .crs(Some("EPSG:4326"))
             .band_values(&[255.0f64])
             .nodata(0.0f64);
+        assert_rasters_equal(&result, &[Some(expected)]);
+    }
+
+    #[test]
+    fn test_rs_as_raster_udf_reprojects_type_level_crs_geometry() {
+        let geometry_type = SedonaType::Wkb(Edges::Planar, deserialize_crs("OGC:CRS84").unwrap());
+        let udf: ScalarUDF = rs_as_raster_udf().into();
+        let tester = ScalarUdfTester::new(
+            udf,
+            vec![
+                geometry_type.clone(),
+                RASTER,
+                SedonaType::Arrow(DataType::Utf8),
+                SedonaType::Arrow(DataType::Boolean),
+                SedonaType::Arrow(DataType::Float64),
+                SedonaType::Arrow(DataType::Float64),
+                SedonaType::Arrow(DataType::Boolean),
+            ],
+        );
+        let reference = RasterSpec::d2(1, 1)
+            .transform([111_000.0, 1_000.0, 0.0, 112_000.0, 0.0, -1_000.0])
+            .crs(Some("EPSG:3857"))
+            .band_values(&[0u8]);
+
+        let result = tester
+            .invoke_arrays(vec![
+                create_array(
+                    &[Some(
+                        "POLYGON((0.99 0.99, 0.99 1.01, 1.01 1.01, 1.01 0.99, 0.99 0.99))",
+                    )],
+                    &geometry_type,
+                ),
+                Arc::new(reference.build()),
+                Arc::new(StringArray::from(vec!["D"])),
+                Arc::new(BooleanArray::from(vec![false])),
+                Arc::new(Float64Array::from(vec![1.0])),
+                Arc::new(Float64Array::from(vec![None])),
+                Arc::new(BooleanArray::from(vec![false])),
+            ])
+            .unwrap();
+
+        let expected = RasterSpec::d2(1, 1)
+            .transform([111_000.0, 1_000.0, 0.0, 112_000.0, 0.0, -1_000.0])
+            .crs(Some("EPSG:3857"))
+            .band_values(&[1.0f64]);
+        assert_rasters_equal(&result, &[Some(expected)]);
+    }
+
+    #[test]
+    fn test_rs_as_raster_udf_reprojects_item_crs_geometry() {
+        let udf: ScalarUDF = rs_as_raster_udf().into();
+        let tester = ScalarUdfTester::new(
+            udf,
+            vec![
+                SedonaType::new_item_crs(&WKB_GEOMETRY).unwrap(),
+                RASTER,
+                SedonaType::Arrow(DataType::Utf8),
+                SedonaType::Arrow(DataType::Boolean),
+                SedonaType::Arrow(DataType::Float64),
+                SedonaType::Arrow(DataType::Float64),
+                SedonaType::Arrow(DataType::Boolean),
+            ],
+        );
+        let reference = RasterSpec::d2(1, 1)
+            .transform([111_000.0, 1_000.0, 0.0, 112_000.0, 0.0, -1_000.0])
+            .crs(Some("EPSG:3857"))
+            .band_values(&[0u8]);
+
+        let result = tester
+            .invoke_arrays(vec![
+                create_array_item_crs(
+                    &[Some(
+                        "POLYGON((0.99 0.99, 0.99 1.01, 1.01 1.01, 1.01 0.99, 0.99 0.99))",
+                    )],
+                    [Some("OGC:CRS84")],
+                    &WKB_GEOMETRY,
+                ),
+                Arc::new(reference.build()),
+                Arc::new(StringArray::from(vec!["D"])),
+                Arc::new(BooleanArray::from(vec![false])),
+                Arc::new(Float64Array::from(vec![1.0])),
+                Arc::new(Float64Array::from(vec![None])),
+                Arc::new(BooleanArray::from(vec![false])),
+            ])
+            .unwrap();
+
+        let expected = RasterSpec::d2(1, 1)
+            .transform([111_000.0, 1_000.0, 0.0, 112_000.0, 0.0, -1_000.0])
+            .crs(Some("EPSG:3857"))
+            .band_values(&[1.0f64]);
         assert_rasters_equal(&result, &[Some(expected)]);
     }
 

--- a/rust/sedona-raster-gdal/src/rs_as_raster.rs
+++ b/rust/sedona-raster-gdal/src/rs_as_raster.rs
@@ -17,9 +17,9 @@
 
 //! RS_AsRaster UDF - rasterize a vector geometry onto a raster grid.
 
-use std::sync::Arc;
+use std::{convert::TryFrom, sync::Arc};
 
-use arrow_array::{Array, StructArray};
+use arrow_array::ArrayRef;
 use arrow_schema::DataType;
 use datafusion_common::cast::{
     as_binary_array, as_boolean_array, as_float64_array, as_string_array,
@@ -28,20 +28,20 @@ use datafusion_common::config::ConfigOptions;
 use datafusion_common::error::Result;
 use datafusion_common::{exec_datafusion_err, exec_err, ScalarValue};
 use datafusion_expr::{ColumnarValue, Volatility};
-use sedona_common::{sedona_internal_datafusion_err, sedona_internal_err};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_gdal::dataset::Dataset;
 use sedona_gdal::gdal::Gdal;
 use sedona_gdal::mem::MemDatasetBuilder;
-use sedona_gdal::raster::types::Buffer;
-use sedona_raster::array::{RasterRefImpl, RasterStructArray};
+use sedona_gdal::raster::{rasterband::RasterBand, types::Buffer};
+use sedona_raster::array::RasterRefImpl;
 use sedona_raster::builder::RasterBuilder;
 use sedona_raster::traits::{BandMetadata, RasterMetadata, RasterRef};
+use sedona_raster_functions::RasterExecutor;
 use sedona_schema::datatypes::{SedonaType, RASTER};
 use sedona_schema::matchers::ArgMatcher;
 use sedona_schema::raster::{BandDataType, StorageType};
 
-use crate::gdal_common::{band_data_type_to_gdal, nodata_f64_to_bytes, with_gdal};
+use crate::gdal_common::{band_data_type_to_gdal, with_gdal};
 use crate::gdal_dataset_provider::{configure_thread_local_options, thread_local_provider};
 
 pub fn rs_as_raster_udf() -> SedonaScalarUDF {
@@ -103,7 +103,18 @@ impl SedonaScalarKernel for RsAsRaster {
         _num_rows: usize,
         config_options: Option<&ConfigOptions>,
     ) -> Result<ColumnarValue> {
-        let num_iterations = calc_num_iterations(args);
+        let num_iterations = args
+            .iter()
+            .find_map(|arg| match arg {
+                ColumnarValue::Array(array) => Some(array.len()),
+                ColumnarValue::Scalar(_) => None,
+            })
+            .unwrap_or(1);
+
+        let exec_arg_types = vec![arg_types[1].clone(), arg_types[0].clone()];
+        let exec_args = vec![args[1].clone(), args[0].clone()];
+        let executor =
+            RasterExecutor::new_with_num_iterations(&exec_arg_types, &exec_args, num_iterations);
 
         let geom_array = args[0].clone().into_array(num_iterations)?;
         let geom_array = as_binary_array(&geom_array)?;
@@ -166,8 +177,10 @@ impl SedonaScalarKernel for RsAsRaster {
         with_gdal(|gdal| {
             configure_thread_local_options(gdal, config_options)?;
 
-            execute_raster_arg(arg_types, args, 1, num_iterations, |_, raster_opt| {
-                let geom_opt = geom_iter.next().unwrap();
+            executor.execute_raster_void(|row_index, raster_opt| {
+                let geom_opt = geom_iter
+                    .next()
+                    .expect("geometry iteration should match rows");
                 let pixel_type_opt = pixel_type_iter.next().unwrap();
                 let all_touched_opt = all_touched_iter.next().unwrap().unwrap_or(false);
                 let burn_value_opt = burn_value_iter.next().unwrap().unwrap_or(1.0);
@@ -198,7 +211,7 @@ impl SedonaScalarKernel for RsAsRaster {
 
                 let band_type = parse_pixel_type(pixel_type)?;
 
-                match as_raster(
+                let (out_metadata, out_band_metadata, out_band_bytes) = as_raster(
                     gdal,
                     geom_wkb,
                     raster,
@@ -207,51 +220,168 @@ impl SedonaScalarKernel for RsAsRaster {
                     burn_value_opt,
                     nodata_value_opt,
                     use_geometry_extent_opt,
-                ) {
-                    Ok((out_metadata, out_band_metadata, out_band_bytes)) => {
-                        builder
-                            .start_raster(&out_metadata, raster.crs())
-                            .map_err(|e| {
-                                exec_datafusion_err!("Failed to start output raster: {}", e)
-                            })?;
-                        builder.start_band(out_band_metadata).map_err(|e| {
-                            exec_datafusion_err!("Failed to start output raster band: {}", e)
-                        })?;
-                        builder.band_data_writer().append_value(out_band_bytes);
-                        builder.finish_band().map_err(|e| {
-                            exec_datafusion_err!("Failed to finish output raster band: {}", e)
-                        })?;
-                        builder.finish_raster().map_err(|e| {
-                            exec_datafusion_err!("Failed to finish output raster: {}", e)
-                        })?;
-                    }
-                    Err(_) => builder.append_null()?,
-                }
+                )
+                .map_err(|e| {
+                    exec_datafusion_err!("RS_AsRaster failed at row {}: {}", row_index, e)
+                })?;
+
+                builder
+                    .start_raster(&out_metadata, raster.crs())
+                    .map_err(|e| exec_datafusion_err!("Failed to start output raster: {}", e))?;
+                builder.start_band(out_band_metadata).map_err(|e| {
+                    exec_datafusion_err!("Failed to start output raster band: {}", e)
+                })?;
+                builder.band_data_writer().append_value(out_band_bytes);
+                builder.finish_band().map_err(|e| {
+                    exec_datafusion_err!("Failed to finish output raster band: {}", e)
+                })?;
+                builder
+                    .finish_raster()
+                    .map_err(|e| exec_datafusion_err!("Failed to finish output raster: {}", e))?;
 
                 Ok(())
             })?;
 
-            finish_result(args, Arc::new(builder.finish()?))
+            let result: ArrayRef = Arc::new(builder.finish()?);
+            executor.finish(result)
         })
     }
 }
 
 fn parse_pixel_type(value: &str) -> Result<BandDataType> {
-    match value.trim().to_ascii_uppercase().as_str() {
-        "D" => Ok(BandDataType::Float64),
-        "F" => Ok(BandDataType::Float32),
-        "I" => Ok(BandDataType::Int32),
-        "S" => Ok(BandDataType::Int16),
-        "US" => Ok(BandDataType::UInt16),
-        "B" => Ok(BandDataType::UInt8),
-        "I8" | "INT8" => Ok(BandDataType::Int8),
-        "U64" | "UINT64" => Ok(BandDataType::UInt64),
-        "I64" | "INT64" => Ok(BandDataType::Int64),
+    match value.trim().to_ascii_lowercase().as_str() {
+        "d" | "float64" => Ok(BandDataType::Float64),
+        "f" | "float32" => Ok(BandDataType::Float32),
+        "i" | "int32" => Ok(BandDataType::Int32),
+        "ui" | "uint32" => Ok(BandDataType::UInt32),
+        "s" | "int16" => Ok(BandDataType::Int16),
+        "us" | "uint16" => Ok(BandDataType::UInt16),
+        "b" | "uint8" => Ok(BandDataType::UInt8),
+        "i8" | "int8" => Ok(BandDataType::Int8),
+        "u64" | "uint64" => Ok(BandDataType::UInt64),
+        "i64" | "int64" => Ok(BandDataType::Int64),
         other => exec_err!(
-            "Unsupported pixelType: {} (expected one of D, F, I, S, US, B, I8, U64, I64)",
+            "Unsupported pixelType: {} (expected one of D/F/I/UI/S/US/B/I8/U64/I64 or int8/uint8/int16/uint16/int32/uint32/int64/uint64/float32/float64)",
             other
         ),
     }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum TypedBandValue {
+    UInt8(u8),
+    Int8(i8),
+    UInt16(u16),
+    Int16(i16),
+    UInt32(u32),
+    Int32(i32),
+    UInt64(u64),
+    Int64(i64),
+    Float32(f32),
+    Float64(f64),
+}
+
+impl TypedBandValue {
+    fn metadata_bytes(self) -> Vec<u8> {
+        match self {
+            Self::UInt8(value) => vec![value],
+            Self::Int8(value) => value.to_le_bytes().to_vec(),
+            Self::UInt16(value) => value.to_le_bytes().to_vec(),
+            Self::Int16(value) => value.to_le_bytes().to_vec(),
+            Self::UInt32(value) => value.to_le_bytes().to_vec(),
+            Self::Int32(value) => value.to_le_bytes().to_vec(),
+            Self::UInt64(value) => value.to_le_bytes().to_vec(),
+            Self::Int64(value) => value.to_le_bytes().to_vec(),
+            Self::Float32(value) => value.to_le_bytes().to_vec(),
+            Self::Float64(value) => value.to_le_bytes().to_vec(),
+        }
+    }
+}
+
+fn checked_floor_to_i64(value: f64, label: &str) -> Result<i64> {
+    checked_float_to_i64(value.floor(), label)
+}
+
+fn checked_ceil_to_i64(value: f64, label: &str) -> Result<i64> {
+    checked_float_to_i64(value.ceil(), label)
+}
+
+fn checked_float_to_i64(value: f64, label: &str) -> Result<i64> {
+    if !value.is_finite() {
+        return exec_err!("{} must be finite", label);
+    }
+
+    if value < i64::MIN as f64 || value > i64::MAX as f64 {
+        return exec_err!("{} is out of range for i64: {}", label, value);
+    }
+
+    Ok(value as i64)
+}
+
+fn cast_f64_to_band_value(
+    value: f64,
+    band_type: BandDataType,
+    role: &str,
+) -> Result<TypedBandValue> {
+    if !value.is_finite() && !matches!(band_type, BandDataType::Float32 | BandDataType::Float64) {
+        return exec_err!("{} must be finite for {:?}: {}", role, band_type, value);
+    }
+
+    match band_type {
+        BandDataType::UInt8 => Ok(TypedBandValue::UInt8(checked_integral_cast::<u8>(
+            value, role, band_type,
+        )?)),
+        BandDataType::Int8 => Ok(TypedBandValue::Int8(checked_integral_cast::<i8>(
+            value, role, band_type,
+        )?)),
+        BandDataType::UInt16 => Ok(TypedBandValue::UInt16(checked_integral_cast::<u16>(
+            value, role, band_type,
+        )?)),
+        BandDataType::Int16 => Ok(TypedBandValue::Int16(checked_integral_cast::<i16>(
+            value, role, band_type,
+        )?)),
+        BandDataType::UInt32 => Ok(TypedBandValue::UInt32(checked_integral_cast::<u32>(
+            value, role, band_type,
+        )?)),
+        BandDataType::Int32 => Ok(TypedBandValue::Int32(checked_integral_cast::<i32>(
+            value, role, band_type,
+        )?)),
+        BandDataType::UInt64 => Ok(TypedBandValue::UInt64(checked_integral_cast::<u64>(
+            value, role, band_type,
+        )?)),
+        BandDataType::Int64 => Ok(TypedBandValue::Int64(checked_integral_cast::<i64>(
+            value, role, band_type,
+        )?)),
+        BandDataType::Float32 => {
+            let casted = value as f32;
+            if value.is_finite() && !casted.is_finite() {
+                return exec_err!("{} is out of range for {:?}: {}", role, band_type, value);
+            }
+            Ok(TypedBandValue::Float32(casted))
+        }
+        BandDataType::Float64 => Ok(TypedBandValue::Float64(value)),
+    }
+}
+
+fn checked_integral_cast<T>(value: f64, role: &str, band_type: BandDataType) -> Result<T>
+where
+    T: TryFrom<i128>,
+    <T as TryFrom<i128>>::Error: std::fmt::Debug,
+{
+    if !value.is_finite() {
+        return exec_err!("{} must be finite for {:?}: {}", role, band_type, value);
+    }
+    if value.fract() != 0.0 {
+        return exec_err!("{} must be an integer for {:?}: {}", role, band_type, value);
+    }
+
+    let integer = value as i128;
+    T::try_from(integer).map_err(|_| {
+        datafusion_common::DataFusionError::Execution(format!(
+            "{} is out of range for {:?}: {}",
+            role, band_type, value
+        ))
+    })
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -288,13 +418,21 @@ fn as_raster(
             return exec_err!("Reference raster has zero scale");
         }
 
-        let start_col = ((env.MinX - ulx) / scale_x).floor() as isize;
-        let end_col_excl = ((env.MaxX - ulx) / scale_x).ceil() as isize;
-        let start_row = ((env.MaxY - uly) / scale_y).floor() as isize;
-        let end_row_excl = ((env.MinY - uly) / scale_y).ceil() as isize;
+        let start_col = checked_floor_to_i64((env.MinX - ulx) / scale_x, "start_col")?;
+        let end_col_excl = checked_ceil_to_i64((env.MaxX - ulx) / scale_x, "end_col_excl")?;
+        let start_row = checked_floor_to_i64((env.MaxY - uly) / scale_y, "start_row")?;
+        let end_row_excl = checked_ceil_to_i64((env.MinY - uly) / scale_y, "end_row_excl")?;
 
-        let width = (end_col_excl - start_col).max(0) as usize;
-        let height = (end_row_excl - start_row).max(0) as usize;
+        let width = usize::try_from((end_col_excl - start_col).max(0)).map_err(|_| {
+            datafusion_common::DataFusionError::Execution(
+                "Geometry extent width is out of range for usize".to_string(),
+            )
+        })?;
+        let height = usize::try_from((end_row_excl - start_row).max(0)).map_err(|_| {
+            datafusion_common::DataFusionError::Execution(
+                "Geometry extent height is out of range for usize".to_string(),
+            )
+        })?;
 
         if width == 0 || height == 0 {
             return exec_err!("Geometry extent produced an empty raster");
@@ -346,24 +484,16 @@ fn as_raster(
             .map_err(|e| exec_datafusion_err!("Failed to set spatial reference: {}", e))?;
     }
 
-    let init_value = nodata_value.unwrap_or(0.0);
-    initialize_band(&out_dataset, &band_type, out_width, out_height, init_value)?;
+    let init_value =
+        cast_f64_to_band_value(nodata_value.unwrap_or(0.0), band_type, "initial fill value")?;
+    initialize_band(&out_dataset, out_width, out_height, init_value)?;
 
     if let Some(nodata) = nodata_value {
+        let nodata = cast_f64_to_band_value(nodata, band_type, "nodata value")?;
         let band = out_dataset
             .rasterband(1)
             .map_err(|e| exec_datafusion_err!("Failed to get output band: {}", e))?;
-        match band_type {
-            BandDataType::UInt64 => band
-                .set_no_data_value_u64(Some(nodata as u64))
-                .map_err(|e| exec_datafusion_err!("Failed to set nodata value: {}", e))?,
-            BandDataType::Int64 => band
-                .set_no_data_value_i64(Some(nodata as i64))
-                .map_err(|e| exec_datafusion_err!("Failed to set nodata value: {}", e))?,
-            _ => band
-                .set_no_data_value(Some(nodata))
-                .map_err(|e| exec_datafusion_err!("Failed to set nodata value: {}", e))?,
-        }
+        set_band_nodata(&band, nodata)?;
     }
 
     gdal.rasterize_affine(&out_dataset, &[1], &[geometry], &[burn_value], all_touched)
@@ -393,7 +523,10 @@ fn as_raster(
             skew_y: ref_md.skew_y(),
         },
         BandMetadata {
-            nodata_value: nodata_value.map(|value| nodata_f64_to_bytes(value, &band_type)),
+            nodata_value: nodata_value
+                .map(|value| cast_f64_to_band_value(value, band_type, "nodata value"))
+                .transpose()?
+                .map(TypedBandValue::metadata_bytes),
             storage_type: StorageType::InDb,
             datatype: band_type,
             outdb_url: None,
@@ -405,24 +538,56 @@ fn as_raster(
 
 fn initialize_band(
     dataset: &Dataset,
-    band_type: &BandDataType,
     width: usize,
     height: usize,
-    init_value: f64,
+    init_value: TypedBandValue,
 ) -> Result<()> {
-    match band_type {
-        BandDataType::UInt8 => initialize_band_t::<u8>(dataset, width, height, init_value as u8),
-        BandDataType::Int8 => initialize_band_t::<i8>(dataset, width, height, init_value as i8),
-        BandDataType::UInt16 => initialize_band_t::<u16>(dataset, width, height, init_value as u16),
-        BandDataType::Int16 => initialize_band_t::<i16>(dataset, width, height, init_value as i16),
-        BandDataType::UInt32 => initialize_band_t::<u32>(dataset, width, height, init_value as u32),
-        BandDataType::Int32 => initialize_band_t::<i32>(dataset, width, height, init_value as i32),
-        BandDataType::UInt64 => initialize_band_t::<u64>(dataset, width, height, init_value as u64),
-        BandDataType::Int64 => initialize_band_t::<i64>(dataset, width, height, init_value as i64),
-        BandDataType::Float32 => {
-            initialize_band_t::<f32>(dataset, width, height, init_value as f32)
-        }
-        BandDataType::Float64 => initialize_band_t::<f64>(dataset, width, height, init_value),
+    match init_value {
+        TypedBandValue::UInt8(value) => initialize_band_t::<u8>(dataset, width, height, value),
+        TypedBandValue::Int8(value) => initialize_band_t::<i8>(dataset, width, height, value),
+        TypedBandValue::UInt16(value) => initialize_band_t::<u16>(dataset, width, height, value),
+        TypedBandValue::Int16(value) => initialize_band_t::<i16>(dataset, width, height, value),
+        TypedBandValue::UInt32(value) => initialize_band_t::<u32>(dataset, width, height, value),
+        TypedBandValue::Int32(value) => initialize_band_t::<i32>(dataset, width, height, value),
+        TypedBandValue::UInt64(value) => initialize_band_t::<u64>(dataset, width, height, value),
+        TypedBandValue::Int64(value) => initialize_band_t::<i64>(dataset, width, height, value),
+        TypedBandValue::Float32(value) => initialize_band_t::<f32>(dataset, width, height, value),
+        TypedBandValue::Float64(value) => initialize_band_t::<f64>(dataset, width, height, value),
+    }
+}
+
+fn set_band_nodata(band: &RasterBand<'_>, nodata: TypedBandValue) -> Result<()> {
+    match nodata {
+        TypedBandValue::UInt64(value) => band
+            .set_no_data_value_u64(Some(value))
+            .map_err(|e| exec_datafusion_err!("Failed to set nodata value: {}", e)),
+        TypedBandValue::Int64(value) => band
+            .set_no_data_value_i64(Some(value))
+            .map_err(|e| exec_datafusion_err!("Failed to set nodata value: {}", e)),
+        TypedBandValue::UInt8(value) => band
+            .set_no_data_value(Some(value as f64))
+            .map_err(|e| exec_datafusion_err!("Failed to set nodata value: {}", e)),
+        TypedBandValue::Int8(value) => band
+            .set_no_data_value(Some(value as f64))
+            .map_err(|e| exec_datafusion_err!("Failed to set nodata value: {}", e)),
+        TypedBandValue::UInt16(value) => band
+            .set_no_data_value(Some(value as f64))
+            .map_err(|e| exec_datafusion_err!("Failed to set nodata value: {}", e)),
+        TypedBandValue::Int16(value) => band
+            .set_no_data_value(Some(value as f64))
+            .map_err(|e| exec_datafusion_err!("Failed to set nodata value: {}", e)),
+        TypedBandValue::UInt32(value) => band
+            .set_no_data_value(Some(value as f64))
+            .map_err(|e| exec_datafusion_err!("Failed to set nodata value: {}", e)),
+        TypedBandValue::Int32(value) => band
+            .set_no_data_value(Some(value as f64))
+            .map_err(|e| exec_datafusion_err!("Failed to set nodata value: {}", e)),
+        TypedBandValue::Float32(value) => band
+            .set_no_data_value(Some(value as f64))
+            .map_err(|e| exec_datafusion_err!("Failed to set nodata value: {}", e)),
+        TypedBandValue::Float64(value) => band
+            .set_no_data_value(Some(value))
+            .map_err(|e| exec_datafusion_err!("Failed to set nodata value: {}", e)),
     }
 }
 
@@ -439,85 +604,6 @@ fn initialize_band_t<T: sedona_gdal::raster::types::GdalType + Copy>(
     band.write((0, 0), (width, height), &mut buffer)
         .map_err(|e| exec_datafusion_err!("Failed to initialize band: {}", e))?;
     Ok(())
-}
-
-fn calc_num_iterations(args: &[ColumnarValue]) -> usize {
-    args.iter()
-        .find_map(|arg| match arg {
-            ColumnarValue::Array(array) => Some(array.len()),
-            ColumnarValue::Scalar(_) => None,
-        })
-        .unwrap_or(1)
-}
-
-fn finish_result(args: &[ColumnarValue], out: Arc<dyn Array>) -> Result<ColumnarValue> {
-    if args
-        .iter()
-        .any(|arg| matches!(arg, ColumnarValue::Array(_)))
-    {
-        Ok(ColumnarValue::Array(out))
-    } else {
-        Ok(ColumnarValue::Scalar(ScalarValue::try_from_array(&out, 0)?))
-    }
-}
-
-fn execute_raster_arg<F>(
-    arg_types: &[SedonaType],
-    args: &[ColumnarValue],
-    index: usize,
-    num_iterations: usize,
-    mut func: F,
-) -> Result<()>
-where
-    F: FnMut(usize, Option<&RasterRefImpl<'_>>) -> Result<()>,
-{
-    if arg_types.get(index) != Some(&RASTER) {
-        return sedona_internal_err!("Argument {index} must be a raster type");
-    }
-
-    match &args[index] {
-        ColumnarValue::Array(array) => {
-            let raster_struct = array
-                .as_any()
-                .downcast_ref::<StructArray>()
-                .ok_or_else(|| {
-                    sedona_internal_datafusion_err!("Expected StructArray for raster data")
-                })?;
-            let raster_array = RasterStructArray::try_new(raster_struct)?;
-
-            for i in 0..num_iterations {
-                if raster_array.is_null(i) {
-                    func(i, None)?;
-                } else {
-                    let raster = raster_array.get(i)?;
-                    func(i, Some(&raster))?;
-                }
-            }
-
-            Ok(())
-        }
-        ColumnarValue::Scalar(ScalarValue::Struct(raster_struct)) => {
-            let raster_array = RasterStructArray::try_new(raster_struct.as_ref())?;
-            let raster = if raster_array.is_null(0) {
-                None
-            } else {
-                Some(raster_array.get(0)?)
-            };
-
-            for i in 0..num_iterations {
-                func(i, raster.as_ref())?;
-            }
-
-            Ok(())
-        }
-        ColumnarValue::Scalar(ScalarValue::Null) => {
-            for i in 0..num_iterations {
-                func(i, None)?;
-            }
-            Ok(())
-        }
-        _ => sedona_internal_err!("Expected Struct scalar for raster"),
-    }
 }
 
 #[cfg(test)]
@@ -570,8 +656,37 @@ mod tests {
         assert_eq!(parse_pixel_type("US").unwrap(), BandDataType::UInt16);
         assert_eq!(parse_pixel_type("B").unwrap(), BandDataType::UInt8);
         assert_eq!(parse_pixel_type("I8").unwrap(), BandDataType::Int8);
+        assert_eq!(parse_pixel_type("uint32").unwrap(), BandDataType::UInt32);
         assert_eq!(parse_pixel_type("U64").unwrap(), BandDataType::UInt64);
         assert_eq!(parse_pixel_type("I64").unwrap(), BandDataType::Int64);
+        assert_eq!(parse_pixel_type("float64").unwrap(), BandDataType::Float64);
+        assert_eq!(parse_pixel_type("float32").unwrap(), BandDataType::Float32);
+        assert_eq!(parse_pixel_type("int16").unwrap(), BandDataType::Int16);
+        assert_eq!(parse_pixel_type("uint16").unwrap(), BandDataType::UInt16);
+        assert_eq!(parse_pixel_type("int32").unwrap(), BandDataType::Int32);
+        assert_eq!(parse_pixel_type("uint8").unwrap(), BandDataType::UInt8);
+    }
+
+    #[test]
+    fn test_checked_integral_nodata_cast_errors() {
+        let err = cast_f64_to_band_value(1.5, BandDataType::UInt8, "nodata value").unwrap_err();
+        assert!(err.to_string().contains("must be an integer"));
+
+        let err = cast_f64_to_band_value(-1.0, BandDataType::UInt8, "nodata value").unwrap_err();
+        assert!(err.to_string().contains("out of range"));
+    }
+
+    #[test]
+    fn test_checked_extent_conversion_errors_on_infinite_values() {
+        let err = checked_floor_to_i64(f64::INFINITY, "start_col").unwrap_err();
+        assert!(err.to_string().contains("must be finite"));
+    }
+
+    #[test]
+    fn test_float32_nodata_overflow_errors() {
+        let err =
+            cast_f64_to_band_value(f64::MAX, BandDataType::Float32, "nodata value").unwrap_err();
+        assert!(err.to_string().contains("out of range"));
     }
 
     #[test]

--- a/rust/sedona-raster-gdal/src/rs_as_raster.rs
+++ b/rust/sedona-raster-gdal/src/rs_as_raster.rs
@@ -28,7 +28,10 @@ use datafusion_common::config::ConfigOptions;
 use datafusion_common::error::Result;
 use datafusion_common::{exec_datafusion_err, exec_err, ScalarValue};
 use datafusion_expr::{ColumnarValue, Volatility};
-use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
+use sedona_expr::{
+    item_crs::ItemCrsKernel,
+    scalar_udf::{SedonaScalarKernel, SedonaScalarUDF},
+};
 use sedona_gdal::dataset::Dataset;
 use sedona_gdal::gdal::Gdal;
 use sedona_gdal::mem::MemDatasetBuilder;
@@ -47,13 +50,13 @@ use crate::gdal_dataset_provider::{configure_thread_local_options, thread_local_
 pub fn rs_as_raster_udf() -> SedonaScalarUDF {
     SedonaScalarUDF::new(
         "rs_asraster",
-        vec![
+        ItemCrsKernel::wrap_impl(vec![
             Arc::new(RsAsRaster { arg_count: 3 }),
             Arc::new(RsAsRaster { arg_count: 4 }),
             Arc::new(RsAsRaster { arg_count: 5 }),
             Arc::new(RsAsRaster { arg_count: 6 }),
             Arc::new(RsAsRaster { arg_count: 7 }),
-        ],
+        ]),
         Volatility::Immutable,
     )
 }
@@ -618,7 +621,7 @@ mod tests {
     use sedona_schema::raster::BandDataType;
     use sedona_testing::raster_spec::{assert_rasters_equal, RasterSpec};
     use sedona_testing::{
-        create::{create_array, make_wkb},
+        create::{create_array, create_array_item_crs, make_wkb},
         testers::ScalarUdfTester,
     };
 
@@ -810,6 +813,42 @@ mod tests {
             .crs(Some("EPSG:4326"))
             .band_values(&[255.0f64])
             .nodata(0.0f64);
+        assert_rasters_equal(&result, &[Some(expected)]);
+    }
+
+    #[test]
+    fn test_rs_as_raster_udf_accepts_item_crs_geometry() {
+        let metadata = load_reference_raster();
+        let geom = format!(
+            "POLYGON(({x0} {y1}, {x0} {y0}, {x1} {y0}, {x1} {y1}, {x0} {y1}))",
+            x0 = metadata.upper_left_x(),
+            x1 = metadata.upper_left_x() + metadata.scale_x(),
+            y0 = metadata.upper_left_y(),
+            y1 = metadata.upper_left_y() + metadata.scale_y(),
+        );
+
+        let udf: ScalarUDF = rs_as_raster_udf().into();
+        let tester = ScalarUdfTester::new(
+            udf,
+            vec![
+                SedonaType::new_item_crs(&WKB_GEOMETRY).unwrap(),
+                RASTER,
+                SedonaType::Arrow(DataType::Utf8),
+            ],
+        );
+
+        let result = tester
+            .invoke_arrays(vec![
+                create_array_item_crs(&[Some(geom.as_str())], [Some("EPSG:4326")], &WKB_GEOMETRY),
+                Arc::new(reference_raster_spec().build()),
+                Arc::new(StringArray::from(vec!["D"])),
+            ])
+            .unwrap();
+
+        let expected = RasterSpec::d2(1, 1)
+            .transform([10.0, 2.0, 0.0, 20.0, 0.0, -2.0])
+            .crs(Some("EPSG:4326"))
+            .band_values(&[1.0f64]);
         assert_rasters_equal(&result, &[Some(expected)]);
     }
 }


### PR DESCRIPTION
## Summary
- add the GDAL-backed `rs_asraster` raster function
- normalize the SQL name to `rs_asraster`
- add SQL reference docs and a dedicated Criterion benchmark

## Dependency
- Independent branch based on `main`

## Testing
- `cargo clippy -p sedona-raster-gdal -p sedona --all-targets -- -D warnings`
- `cargo bench -p sedona-raster-gdal --bench rs_as_raster --no-run`
- `cargo test -p sedona-raster-gdal`
  - blocked in this environment by existing missing raster fixture files in other tests
- `PATH="/home/kontinuation/workspace/github/apache/sedona-db/.venv/bin:$PATH" quarto render docs/reference/sql/rs_asraster.qmd`
  - front matter validated; example execution is currently blocked by an existing `sedonadb._lib` Python import mismatch in this environment
