### PR TITLE
fix(rust): clean up CRS string handling (preserve definitions, consolidate equality/SRID)

### DIFF
--- a/rust/sedona-expr/src/item_crs.rs
+++ b/rust/sedona-expr/src/item_crs.rs
@@ -622,12 +622,11 @@ pub fn parse_item_crs_arg(
 
     match item_type {
         SedonaType::Wkb(_, crs) | SedonaType::WkbView(_, crs) => {
+            // Store the round-trippable definition (the item-level CRS column is
+            // read back through deserialize_crs), preserving a full PROJJSON/WKT
+            // rather than collapsing it to its embedded authority code.
             let crs_scalar = if let Some(crs) = crs {
-                if let Some(auth_code) = crs.to_authority_code()? {
-                    ScalarValue::Utf8View(Some(auth_code))
-                } else {
-                    ScalarValue::Utf8View(Some(crs.to_json()))
-                }
+                ScalarValue::Utf8View(Some(crs.to_crs_string()))
             } else {
                 ScalarValue::Utf8View(None)
             };

--- a/rust/sedona-functions/src/st_geomfromwkb.rs
+++ b/rust/sedona-functions/src/st_geomfromwkb.rs
@@ -324,7 +324,7 @@ mod tests {
                     None
                 ],
                 [
-                    Some("OGC:CRS84"),
+                    Some("EPSG:4326"),
                     Some("EPSG:3857"),
                     Some("EPSG:3857"),
                     None,

--- a/rust/sedona-functions/src/st_geomfromwkt.rs
+++ b/rust/sedona-functions/src/st_geomfromwkt.rs
@@ -429,7 +429,7 @@ mod tests {
                     None
                 ],
                 [
-                    Some("OGC:CRS84"),
+                    Some("EPSG:4326"),
                     Some("EPSG:3857"),
                     Some("EPSG:3857"),
                     None,

--- a/rust/sedona-functions/src/st_point.rs
+++ b/rust/sedona-functions/src/st_point.rs
@@ -318,7 +318,7 @@ mod tests {
                     None
                 ],
                 [
-                    Some("OGC:CRS84"),
+                    Some("EPSG:4326"),
                     Some("EPSG:3857"),
                     Some("EPSG:3857"),
                     None,

--- a/rust/sedona-functions/src/st_setsrid.rs
+++ b/rust/sedona-functions/src/st_setsrid.rs
@@ -658,12 +658,12 @@ mod test {
         assert!(out.value(0).contains("GeographicCRS"));
         assert_ne!(out.value(0), "EPSG:4269");
         assert_eq!(out.value(0), out.value(2));
-        // EPSG:4326 folds to OGC:CRS84 (<=12 bytes, inlined into the view).
-        assert_eq!(out.value(3), "OGC:CRS84");
+        // EPSG:4326 is kept verbatim (<=12 bytes, inlined into the view).
+        assert_eq!(out.value(3), "EPSG:4326");
 
         // Deduplication: the repeated PROJJSON lives in the shared data buffer
         // exactly once, so total buffer bytes equal a single copy (the inlined
-        // OGC:CRS84 contributes nothing to the buffer).
+        // EPSG:4326 contributes nothing to the buffer).
         let buffer_bytes: usize = out.data_buffers().iter().map(|b| b.len()).sum();
         assert_eq!(buffer_bytes, out.value(0).len());
     }
@@ -906,7 +906,7 @@ mod test {
                     None
                 ],
                 [
-                    Some("OGC:CRS84"),
+                    Some("EPSG:4326"),
                     Some("EPSG:3857"),
                     Some("EPSG:3857"),
                     None,
@@ -959,7 +959,7 @@ mod test {
                     Some("POINT (4 5)"),
                     None
                 ],
-                [Some("OGC:CRS84"), Some("EPSG:4269"), None, None],
+                [Some("EPSG:4326"), Some("EPSG:4269"), None, None],
                 &WKB_GEOGRAPHY
             )
         );

--- a/rust/sedona-functions/src/st_setsrid.rs
+++ b/rust/sedona-functions/src/st_setsrid.rs
@@ -39,7 +39,7 @@ use sedona_expr::{
 };
 use sedona_geometry::transform::CrsEngine;
 use sedona_schema::{
-    crs::{deserialize_crs, CachedCrsNormalization, CachedSRIDToCrs, Crs},
+    crs::{deserialize_crs, normalize_crs, CachedSRIDToCrs, Crs},
     datatypes::{Edges, SedonaType},
     matchers::ArgMatcher,
 };
@@ -463,9 +463,11 @@ fn crs_input_nulls(crs_value: &ColumnarValue) -> Option<&NullBuffer> {
 /// to a null value in the CRS array) and 4326 (which maps to a value of OGC:CRS84
 /// in the CRS array).
 ///
-/// For CRS arrays of strings, this function attempts to abbreviate any inputs. For example,
-/// PROJJSON input will attempt to be abbreviated to authority:code if possible (or left
-/// as is otherwise). The special value "0" maps to a null value in the CRS array.
+/// For CRS arrays of strings, this function normalizes each input to its
+/// round-trippable definition (`to_crs_string`): an `authority:code` stays
+/// compact, while a PROJJSON/WKT definition is preserved in full rather than
+/// collapsed to its embedded code. The special value "0" maps to a null value
+/// in the CRS array.
 fn normalize_crs_array(
     crs_value: &ColumnarValue,
     maybe_engine: Option<&Arc<dyn CrsEngine + Send + Sync>>,
@@ -502,8 +504,6 @@ fn normalize_crs_array(
             Ok(Arc::new(utf8_view_array))
         }
         _ => {
-            let mut crs_norm = CachedCrsNormalization::new();
-
             let string_value = crs_value.cast_to(&DataType::Utf8View, None)?;
             let string_array_ref = ColumnarValue::values_to_arrays(&[string_value])?;
             let string_view_array = as_string_view_array(&string_array_ref[0])?;
@@ -514,7 +514,7 @@ fn normalize_crs_array(
                 .with_deduplicate_strings();
             for maybe_crs in string_view_array.iter() {
                 match maybe_crs {
-                    Some(crs_str) => builder.append_option(crs_norm.normalize(crs_str)?),
+                    Some(crs_str) => builder.append_option(normalize_crs(crs_str)?),
                     None => builder.append_null(),
                 }
             }

--- a/rust/sedona-functions/src/st_setsrid.rs
+++ b/rust/sedona-functions/src/st_setsrid.rs
@@ -17,8 +17,8 @@
 use std::sync::{Arc, OnceLock};
 
 use arrow_array::{
-    builder::{BinaryBuilder, NullBufferBuilder},
-    new_null_array, ArrayRef, StringViewArray,
+    builder::{BinaryBuilder, NullBufferBuilder, StringViewBuilder},
+    new_null_array, Array, ArrayRef, StringViewArray,
 };
 use arrow_buffer::NullBuffer;
 use arrow_schema::DataType;
@@ -507,18 +507,19 @@ fn normalize_crs_array(
             let string_value = crs_value.cast_to(&DataType::Utf8View, None)?;
             let string_array_ref = ColumnarValue::values_to_arrays(&[string_value])?;
             let string_view_array = as_string_view_array(&string_array_ref[0])?;
-            let utf8_view_array = string_view_array
-                .iter()
-                .map(|maybe_crs| -> Result<Option<String>> {
-                    if let Some(crs_str) = maybe_crs {
-                        crs_norm.normalize(crs_str)
-                    } else {
-                        Ok(None)
-                    }
-                })
-                .collect::<Result<StringViewArray>>()?;
+            // Deduplicate: when many rows carry the same (possibly large)
+            // PROJJSON/WKT definition, the bytes are stored once in the view
+            // buffer and shared across rows.
+            let mut builder = StringViewBuilder::with_capacity(string_view_array.len())
+                .with_deduplicate_strings();
+            for maybe_crs in string_view_array.iter() {
+                match maybe_crs {
+                    Some(crs_str) => builder.append_option(crs_norm.normalize(crs_str)?),
+                    None => builder.append_null(),
+                }
+            }
 
-            Ok(Arc::new(utf8_view_array))
+            Ok(Arc::new(builder.finish()))
         }
     }
 }

--- a/rust/sedona-functions/src/st_setsrid.rs
+++ b/rust/sedona-functions/src/st_setsrid.rs
@@ -637,6 +637,38 @@ mod test {
     }
 
     #[test]
+    fn normalize_crs_array_dedups_repeats_and_preserves_nulls() {
+        // A large PROJJSON repeated across rows, interleaved with a null and a
+        // short authority code, exercises the string path of normalize_crs_array.
+        const PROJJSON: &str = r#"{"type":"GeographicCRS","name":"NAD83","datum":{"type":"GeodeticReferenceFrame","name":"NAD83","ellipsoid":{"name":"GRS 1980","semi_major_axis":6378137,"inverse_flattening":298.257222101}},"coordinate_system":{"subtype":"ellipsoidal","axis":[{"name":"Geodetic latitude","abbreviation":"Lat","direction":"north","unit":"degree"},{"name":"Geodetic longitude","abbreviation":"Lon","direction":"east","unit":"degree"}]},"id":{"authority":"EPSG","code":4269}}"#;
+        let input = StringViewArray::from(vec![
+            Some(PROJJSON),
+            None,
+            Some(PROJJSON),
+            Some("EPSG:4326"),
+        ]);
+        let out = normalize_crs_array(&ColumnarValue::Array(Arc::new(input)), None).unwrap();
+        let out = out.as_any().downcast_ref::<StringViewArray>().unwrap();
+
+        // Null placement matches the input row-for-row.
+        assert_eq!(out.len(), 4);
+        assert!(out.is_null(1), "the null row must be preserved");
+        // The PROJJSON is preserved in full (not collapsed to "EPSG:4269") and
+        // is identical across the two rows that carried it.
+        assert!(out.value(0).contains("GeographicCRS"));
+        assert_ne!(out.value(0), "EPSG:4269");
+        assert_eq!(out.value(0), out.value(2));
+        // EPSG:4326 folds to OGC:CRS84 (<=12 bytes, inlined into the view).
+        assert_eq!(out.value(3), "OGC:CRS84");
+
+        // Deduplication: the repeated PROJJSON lives in the shared data buffer
+        // exactly once, so total buffer bytes equal a single copy (the inlined
+        // OGC:CRS84 contributes nothing to the buffer).
+        let buffer_bytes: usize = out.data_buffers().iter().map(|b| b.len()).sum();
+        assert_eq!(buffer_bytes, out.value(0).len());
+    }
+
+    #[test]
     fn udf_srid() {
         let udf: ScalarUDF = st_set_srid_udf().into();
 

--- a/rust/sedona-functions/src/st_srid.rs
+++ b/rust/sedona-functions/src/st_srid.rs
@@ -180,7 +180,7 @@ impl SedonaScalarKernel for StCrs {
                 // Return the full round-trippable definition rather than
                 // collapsing to the authority code: an `authority:code` CRS
                 // stays compact, while a PROJJSON/WKT definition is preserved
-                // verbatim instead of being reduced to its embedded code.
+                // in full instead of being reduced to its embedded code.
                 Some(crs.to_crs_string())
             }
             _ => None,

--- a/rust/sedona-functions/src/st_srid.rs
+++ b/rust/sedona-functions/src/st_srid.rs
@@ -177,7 +177,11 @@ impl SedonaScalarKernel for StCrs {
         let mut builder = StringViewBuilder::with_capacity(executor.num_iterations());
         let crs_opt: Option<String> = match &arg_types[0] {
             SedonaType::Wkb(_, Some(crs)) | SedonaType::WkbView(_, Some(crs)) => {
-                Some(crs.to_authority_code()?.unwrap_or_else(|| crs.to_json()))
+                // Return the full round-trippable definition rather than
+                // collapsing to the authority code: an `authority:code` CRS
+                // stays compact, while a PROJJSON/WKT definition is preserved
+                // verbatim instead of being reduced to its embedded code.
+                Some(crs.to_crs_string())
             }
             _ => None,
         };
@@ -419,6 +423,28 @@ mod test {
         // Test with a CRS but null geom
         let result = tester.invoke_scalar(ScalarValue::Null).unwrap();
         tester.assert_scalar_result_equals(result, ScalarValue::Null);
+
+        // A PROJJSON type-CRS with an embedded authority id returns the full
+        // definition, not the collapsed "EPSG:4269" authority code.
+        const NAD83_PROJJSON: &str = r#"{"type":"GeographicCRS","name":"NAD83","datum":{"type":"GeodeticReferenceFrame","name":"NAD83","ellipsoid":{"name":"GRS 1980","semi_major_axis":6378137,"inverse_flattening":298.257222101}},"coordinate_system":{"subtype":"ellipsoidal","axis":[{"name":"Lat","abbreviation":"Lat","direction":"north","unit":"degree"},{"name":"Lon","abbreviation":"Lon","direction":"east","unit":"degree"}]},"id":{"authority":"EPSG","code":4269}}"#;
+        let crs = deserialize_crs(NAD83_PROJJSON).unwrap();
+        let tester = ScalarUdfTester::new(
+            udf.clone(),
+            vec![SedonaType::Wkb(Edges::Planar, crs.clone())],
+        );
+        let result = tester
+            .invoke_scalar("POLYGON ((0 0, 1 0, 0 1, 0 0))")
+            .unwrap();
+        let ScalarValue::Utf8View(Some(crs_out)) = result else {
+            panic!("expected a Utf8View CRS string, got {result:?}");
+        };
+        assert!(
+            crs_out.contains("GeographicCRS"),
+            "expected full PROJJSON, got {crs_out}"
+        );
+        assert_ne!(crs_out, "EPSG:4269");
+        // The returned string round-trips back to the same CRS.
+        assert_eq!(deserialize_crs(&crs_out).unwrap(), crs);
     }
 
     #[test]

--- a/rust/sedona-raster-functions/src/rs_setsrid.rs
+++ b/rust/sedona-raster-functions/src/rs_setsrid.rs
@@ -140,7 +140,7 @@ impl SedonaScalarKernel for RsSetCrs {
 
         let input_nulls = extract_input_nulls(crs_arg);
 
-        // Normalize the CRS string(s) — abbreviate PROJJSON to authority:code, map "0" to null
+        // Normalize the CRS string(s) — preserve the full definition, map "0" to null
         let crs_columnar = normalize_crs_columnar(crs_arg, self.engine.as_ref())?;
 
         replace_raster_crs(raster_arg, &crs_columnar, input_nulls)
@@ -380,6 +380,37 @@ mod tests {
     use sedona_schema::datatypes::RASTER;
     use sedona_testing::rasters::generate_test_rasters;
     use sedona_testing::testers::ScalarUdfTester;
+
+    #[test]
+    fn normalize_crs_columnar_dedups_repeats_and_preserves_nulls() {
+        // Rasters are always stored with an item-level CRS, so a batch
+        // typically repeats the same definition. A large PROJJSON repeated
+        // across rows, with a null and a short authority code interleaved.
+        const PROJJSON: &str = r#"{"type":"GeographicCRS","name":"NAD83","datum":{"type":"GeodeticReferenceFrame","name":"NAD83","ellipsoid":{"name":"GRS 1980","semi_major_axis":6378137,"inverse_flattening":298.257222101}},"coordinate_system":{"subtype":"ellipsoidal","axis":[{"name":"Geodetic latitude","abbreviation":"Lat","direction":"north","unit":"degree"},{"name":"Geodetic longitude","abbreviation":"Lon","direction":"east","unit":"degree"}]},"id":{"authority":"EPSG","code":4269}}"#;
+        let input = StringViewArray::from(vec![
+            Some(PROJJSON),
+            None,
+            Some(PROJJSON),
+            Some("EPSG:4326"),
+        ]);
+        let out = normalize_crs_columnar(&ColumnarValue::Array(Arc::new(input)), None).unwrap();
+
+        // Null placement matches the input row-for-row.
+        assert_eq!(out.len(), 4);
+        assert!(out.is_null(1), "the null row must be preserved");
+        // The PROJJSON is preserved in full (not collapsed to "EPSG:4269") and
+        // is identical across the two rows that carried it.
+        assert!(out.value(0).contains("GeographicCRS"));
+        assert_ne!(out.value(0), "EPSG:4269");
+        assert_eq!(out.value(0), out.value(2));
+        // EPSG:4326 folds to OGC:CRS84 (<=12 bytes, inlined into the view).
+        assert_eq!(out.value(3), "OGC:CRS84");
+
+        // Deduplication: the repeated PROJJSON lives in the shared data buffer
+        // exactly once, so total buffer bytes equal a single copy.
+        let buffer_bytes: usize = out.data_buffers().iter().map(|b| b.len()).sum();
+        assert_eq!(buffer_bytes, out.value(0).len());
+    }
 
     #[test]
     fn udf_metadata() {

--- a/rust/sedona-raster-functions/src/rs_setsrid.rs
+++ b/rust/sedona-raster-functions/src/rs_setsrid.rs
@@ -395,6 +395,7 @@ mod tests {
     use datafusion_expr::ScalarUDF;
     use sedona_raster::array::RasterStructArray;
     use sedona_raster::traits::RasterRef;
+    use sedona_schema::crs::deserialize_crs;
     use sedona_schema::datatypes::RASTER;
     use sedona_testing::rasters::generate_test_rasters;
     use sedona_testing::testers::ScalarUdfTester;
@@ -421,8 +422,8 @@ mod tests {
         assert!(out.value(0).contains("GeographicCRS"));
         assert_ne!(out.value(0), "EPSG:4269");
         assert_eq!(out.value(0), out.value(2));
-        // EPSG:4326 folds to OGC:CRS84 (<=12 bytes, inlined into the view).
-        assert_eq!(out.value(3), "OGC:CRS84");
+        // EPSG:4326 is kept verbatim (<=12 bytes, inlined into the view).
+        assert_eq!(out.value(3), "EPSG:4326");
 
         // Deduplication: the repeated PROJJSON lives in the shared data buffer
         // exactly once, so total buffer bytes equal a single copy.
@@ -567,7 +568,7 @@ mod tests {
     }
 
     #[test]
-    fn set_crs_epsg_4326_normalizes_to_ogc_crs84() {
+    fn set_crs_epsg_4326_kept_verbatim() {
         let udf: ScalarUDF = rs_set_crs_udf().into();
         let tester = ScalarUdfTester::new(udf, vec![RASTER, SedonaType::Arrow(DataType::Utf8)]);
 
@@ -579,8 +580,13 @@ mod tests {
         let result_struct = result.as_any().downcast_ref::<StructArray>().unwrap();
         let raster_array = RasterStructArray::new(result_struct);
         let raster = raster_array.get(0).unwrap();
-        // EPSG:4326 should normalize to OGC:CRS84
-        assert_eq!(raster.crs(), Some("OGC:CRS84"));
+        // EPSG:4326 is preserved as given (not folded to OGC:CRS84), but the two
+        // still deserialize to equal CRSes.
+        assert_eq!(raster.crs(), Some("EPSG:4326"));
+        assert_eq!(
+            deserialize_crs(raster.crs().unwrap()).unwrap(),
+            deserialize_crs("OGC:CRS84").unwrap()
+        );
     }
 
     #[test]

--- a/rust/sedona-raster-functions/src/rs_setsrid.rs
+++ b/rust/sedona-raster-functions/src/rs_setsrid.rs
@@ -323,8 +323,18 @@ fn srid_to_crs_columnar(
 // CRS string normalization
 // ---------------------------------------------------------------------------
 
-/// Normalize a CRS string ColumnarValue — abbreviate PROJJSON to authority:code
-/// where possible, and map "0" to null.
+/// Normalize a CRS string ColumnarValue — preserve the full definition, and
+/// map "0" to null.
+///
+/// Handles the scalar and array cases distinctly, because raster batches are
+/// typically high-cardinality in records but low-cardinality in CRS:
+/// - A scalar CRS is normalized once and returned as a single-element array.
+///   `broadcast_string_view` later fans it out to the raster's row count with
+///   `try_append_value_n`, so the (possibly large) definition is stored once
+///   regardless of how many rasters share it.
+/// - An array CRS is normalized per row with a deduplicating builder: a column
+///   of many rasters usually carries only a handful of distinct definitions, so
+///   each is stored once in the shared view buffer and shared across rows.
 ///
 /// Uses [CachedCrsNormalization] to avoid repeated deserialization of the same CRS
 /// string within a batch.
@@ -334,23 +344,31 @@ fn normalize_crs_columnar(
 ) -> Result<StringViewArray> {
     let mut crs_norm = CachedCrsNormalization::new();
 
-    let string_value = crs_arg.cast_to(&DataType::Utf8View, None)?;
-    let string_array_ref = ColumnarValue::values_to_arrays(&[string_value])?;
-    let string_view_array = as_string_view_array(&string_array_ref[0])?;
+    match crs_arg {
+        ColumnarValue::Scalar(scalar) => {
+            let normalized = match scalar.cast_to(&DataType::Utf8)? {
+                ScalarValue::Utf8(Some(crs_str)) => crs_norm.normalize(&crs_str)?,
+                _ => None,
+            };
+            Ok(std::iter::once(normalized).collect())
+        }
+        ColumnarValue::Array(_) => {
+            let string_value = crs_arg.cast_to(&DataType::Utf8View, None)?;
+            let string_array_ref = ColumnarValue::values_to_arrays(&[string_value])?;
+            let string_view_array = as_string_view_array(&string_array_ref[0])?;
 
-    // Deduplicate: rasters are always stored with an item-level CRS, so a
-    // batch typically repeats the same (possibly large) PROJJSON/WKT
-    // definition. Sharing the bytes across rows keeps the column compact.
-    let mut builder =
-        StringViewBuilder::with_capacity(string_view_array.len()).with_deduplicate_strings();
-    for maybe_crs in string_view_array.iter() {
-        match maybe_crs {
-            Some(crs_str) => builder.append_option(crs_norm.normalize(crs_str)?),
-            None => builder.append_null(),
+            let mut builder = StringViewBuilder::with_capacity(string_view_array.len())
+                .with_deduplicate_strings();
+            for maybe_crs in string_view_array.iter() {
+                match maybe_crs {
+                    Some(crs_str) => builder.append_option(crs_norm.normalize(crs_str)?),
+                    None => builder.append_null(),
+                }
+            }
+
+            Ok(builder.finish())
         }
     }
-
-    Ok(builder.finish())
 }
 
 /// Validate a CRS string
@@ -382,9 +400,9 @@ mod tests {
     use sedona_testing::testers::ScalarUdfTester;
 
     #[test]
-    fn normalize_crs_columnar_dedups_repeats_and_preserves_nulls() {
-        // Rasters are always stored with an item-level CRS, so a batch
-        // typically repeats the same definition. A large PROJJSON repeated
+    fn normalize_crs_columnar_array_dedups_repeats_and_preserves_nulls() {
+        // The array branch: a column of many rasters carries only a few distinct
+        // CRS definitions, so they are deduplicated. A large PROJJSON repeated
         // across rows, with a null and a short authority code interleaved.
         const PROJJSON: &str = r#"{"type":"GeographicCRS","name":"NAD83","datum":{"type":"GeodeticReferenceFrame","name":"NAD83","ellipsoid":{"name":"GRS 1980","semi_major_axis":6378137,"inverse_flattening":298.257222101}},"coordinate_system":{"subtype":"ellipsoidal","axis":[{"name":"Geodetic latitude","abbreviation":"Lat","direction":"north","unit":"degree"},{"name":"Geodetic longitude","abbreviation":"Lon","direction":"east","unit":"degree"}]},"id":{"authority":"EPSG","code":4269}}"#;
         let input = StringViewArray::from(vec![
@@ -410,6 +428,49 @@ mod tests {
         // exactly once, so total buffer bytes equal a single copy.
         let buffer_bytes: usize = out.data_buffers().iter().map(|b| b.len()).sum();
         assert_eq!(buffer_bytes, out.value(0).len());
+    }
+
+    #[test]
+    fn normalize_crs_columnar_scalar_normalizes_once() {
+        // The scalar branch: the definition is normalized a single time and
+        // returned as a one-element array; fan-out to the raster row count is
+        // broadcast_string_view's job.
+        const PROJJSON: &str = r#"{"type":"GeographicCRS","name":"NAD83","datum":{"type":"GeodeticReferenceFrame","name":"NAD83","ellipsoid":{"name":"GRS 1980","semi_major_axis":6378137,"inverse_flattening":298.257222101}},"coordinate_system":{"subtype":"ellipsoidal","axis":[{"name":"Geodetic latitude","abbreviation":"Lat","direction":"north","unit":"degree"},{"name":"Geodetic longitude","abbreviation":"Lon","direction":"east","unit":"degree"}]},"id":{"authority":"EPSG","code":4269}}"#;
+        let out = normalize_crs_columnar(
+            &ColumnarValue::Scalar(ScalarValue::Utf8(Some(PROJJSON.to_string()))),
+            None,
+        )
+        .unwrap();
+        assert_eq!(out.len(), 1);
+        // Preserved in full, not collapsed to the embedded "EPSG:4269".
+        assert!(out.value(0).contains("GeographicCRS"));
+        assert_ne!(out.value(0), "EPSG:4269");
+
+        // "0" clears the CRS (maps to null).
+        let out = normalize_crs_columnar(
+            &ColumnarValue::Scalar(ScalarValue::Utf8(Some("0".to_string()))),
+            None,
+        )
+        .unwrap();
+        assert_eq!(out.len(), 1);
+        assert!(out.is_null(0));
+    }
+
+    #[test]
+    fn broadcast_string_view_stores_one_copy_across_many_rows() {
+        // The payoff for the scalar branch: many rasters, one CRS. Fanning the
+        // single definition out to a high row count stores its bytes exactly
+        // once in the shared view buffer (via try_append_value_n).
+        const PROJJSON: &str = r#"{"type":"GeographicCRS","name":"NAD83","datum":{"type":"GeodeticReferenceFrame","name":"NAD83","ellipsoid":{"name":"GRS 1980","semi_major_axis":6378137,"inverse_flattening":298.257222101}},"coordinate_system":{"subtype":"ellipsoidal","axis":[{"name":"Geodetic latitude","abbreviation":"Lat","direction":"north","unit":"degree"},{"name":"Geodetic longitude","abbreviation":"Lon","direction":"east","unit":"degree"}]},"id":{"authority":"EPSG","code":4269}}"#;
+        let scalar = StringViewArray::from(vec![Some(PROJJSON)]);
+        let out = broadcast_string_view(&scalar, 1000).unwrap();
+        let out = out.as_any().downcast_ref::<StringViewArray>().unwrap();
+
+        assert_eq!(out.len(), 1000);
+        assert_eq!(out.value(0), PROJJSON);
+        assert_eq!(out.value(999), PROJJSON);
+        let buffer_bytes: usize = out.data_buffers().iter().map(|b| b.len()).sum();
+        assert_eq!(buffer_bytes, PROJJSON.len());
     }
 
     #[test]

--- a/rust/sedona-raster-functions/src/rs_setsrid.rs
+++ b/rust/sedona-raster-functions/src/rs_setsrid.rs
@@ -338,19 +338,19 @@ fn normalize_crs_columnar(
     let string_array_ref = ColumnarValue::values_to_arrays(&[string_value])?;
     let string_view_array = as_string_view_array(&string_array_ref[0])?;
 
-    let crs_array: StringViewArray = string_view_array
-        .iter()
-        .map(|maybe_crs| -> Result<Option<String>> {
-            if let Some(crs_str) = maybe_crs {
-                let normalized = crs_norm.normalize(crs_str)?;
-                Ok(normalized)
-            } else {
-                Ok(None)
-            }
-        })
-        .collect::<Result<_>>()?;
+    // Deduplicate: rasters are always stored with an item-level CRS, so a
+    // batch typically repeats the same (possibly large) PROJJSON/WKT
+    // definition. Sharing the bytes across rows keeps the column compact.
+    let mut builder =
+        StringViewBuilder::with_capacity(string_view_array.len()).with_deduplicate_strings();
+    for maybe_crs in string_view_array.iter() {
+        match maybe_crs {
+            Some(crs_str) => builder.append_option(crs_norm.normalize(crs_str)?),
+            None => builder.append_null(),
+        }
+    }
 
-    Ok(crs_array)
+    Ok(builder.finish())
 }
 
 /// Validate a CRS string

--- a/rust/sedona-raster-functions/src/rs_setsrid.rs
+++ b/rust/sedona-raster-functions/src/rs_setsrid.rs
@@ -28,7 +28,7 @@ use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_common::{sedona_internal_datafusion_err, sedona_internal_err};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_geometry::transform::CrsEngine;
-use sedona_schema::crs::{CachedCrsNormalization, CachedSRIDToCrs};
+use sedona_schema::crs::{normalize_crs, CachedSRIDToCrs};
 use sedona_schema::datatypes::SedonaType;
 use sedona_schema::matchers::ArgMatcher;
 use sedona_schema::raster::{raster_indices, RasterSchema};
@@ -336,18 +336,16 @@ fn srid_to_crs_columnar(
 ///   of many rasters usually carries only a handful of distinct definitions, so
 ///   each is stored once in the shared view buffer and shared across rows.
 ///
-/// Uses [CachedCrsNormalization] to avoid repeated deserialization of the same CRS
-/// string within a batch.
+/// Parsing is memoized by [deserialize_crs]'s thread-local cache via
+/// [normalize_crs], so repeated definitions in a batch aren't re-parsed.
 fn normalize_crs_columnar(
     crs_arg: &ColumnarValue,
     _maybe_engine: Option<&Arc<dyn CrsEngine + Send + Sync>>,
 ) -> Result<StringViewArray> {
-    let mut crs_norm = CachedCrsNormalization::new();
-
     match crs_arg {
         ColumnarValue::Scalar(scalar) => {
             let normalized = match scalar.cast_to(&DataType::Utf8)? {
-                ScalarValue::Utf8(Some(crs_str)) => crs_norm.normalize(&crs_str)?,
+                ScalarValue::Utf8(Some(crs_str)) => normalize_crs(&crs_str)?,
                 _ => None,
             };
             Ok(std::iter::once(normalized).collect())
@@ -361,7 +359,7 @@ fn normalize_crs_columnar(
                 .with_deduplicate_strings();
             for maybe_crs in string_view_array.iter() {
                 match maybe_crs {
-                    Some(crs_str) => builder.append_option(crs_norm.normalize(crs_str)?),
+                    Some(crs_str) => builder.append_option(normalize_crs(crs_str)?),
                     None => builder.append_null(),
                 }
             }

--- a/rust/sedona-schema/src/crs.rs
+++ b/rust/sedona-schema/src/crs.rs
@@ -52,10 +52,10 @@ pub fn deserialize_crs(crs_str: &str) -> Result<Crs> {
         return Ok(cached);
     }
 
-    // Handle JSON strings "OGC:CRS84", "EPSG:4326", "{AUTH}:{CODE}", WKT CRS strings and "0"
-    let crs = if LngLat::is_str_lnglat(crs_str) {
-        lnglat()
-    } else if crs_str == "0" {
+    // Handle "0", "{AUTH}:{CODE}" authority codes (including the OGC:CRS84 /
+    // EPSG:4326 lon/lat aliases, which are kept verbatim rather than folded),
+    // and PROJJSON strings.
+    let crs = if crs_str == "0" {
         None
     } else if AuthorityCode::is_authority_code(crs_str) {
         AuthorityCode::crs(crs_str)
@@ -84,11 +84,8 @@ pub fn deserialize_crs_from_obj(crs_value: &serde_json::Value) -> Result<Crs> {
             return Ok(None);
         }
 
-        // Handle JSON strings "OGC:CRS84" and "EPSG:4326"
-        if LngLat::is_str_lnglat(crs_str) {
-            return Ok(lnglat());
-        }
-
+        // Authority codes (including the OGC:CRS84 / EPSG:4326 lon/lat aliases)
+        // are kept verbatim rather than folded.
         if AuthorityCode::is_authority_code(crs_str) {
             return Ok(AuthorityCode::crs(crs_str));
         }
@@ -289,11 +286,9 @@ impl PartialEq<dyn CoordinateReferenceSystem + Send + Sync>
     for dyn CoordinateReferenceSystem + Send + Sync
 {
     fn eq(&self, other: &Self) -> bool {
-        if LngLat::is_lnglat(self) && LngLat::is_lnglat(other) {
-            true
-        } else {
-            self.crs_equals(other)
-        }
+        // `crs_equals` is the single source of truth for CRS equality (including
+        // the lon/lat alias); the operator is a pure delegate.
+        self.crs_equals(other)
     }
 }
 
@@ -328,7 +323,7 @@ pub trait CoordinateReferenceSystem: Debug {
     ///
     /// The default derives the SRID from [`to_authority_code`](Self::to_authority_code):
     /// the lon/lat alias maps to 4326, an `EPSG:{code}` authority parses to its
-    /// code, and anything else is `None`. Implementors only need to override
+    /// code, and anything else is `None`. Implementers only need to override
     /// this if they can supply an SRID without an authority code.
     fn srid(&self) -> Result<Option<u32>> {
         let Some(auth_code) = self.to_authority_code()? else {
@@ -390,18 +385,6 @@ impl LngLat {
         Crs::Some(Arc::new(AuthorityCode {
             auth_code: "OGC:CRS84".to_string(),
         }))
-    }
-
-    pub fn is_lnglat(crs: &dyn CoordinateReferenceSystem) -> bool {
-        if let Ok(Some(auth_code)) = crs.to_authority_code() {
-            Self::is_authority_code_lnglat(&auth_code)
-        } else {
-            false
-        }
-    }
-
-    pub fn is_str_lnglat(string_value: &str) -> bool {
-        Self::is_authority_code_lnglat(string_value)
     }
 
     pub fn is_authority_code_lnglat(string_value: &str) -> bool {
@@ -468,13 +451,30 @@ impl AuthorityCode {
     }
 }
 
+/// Compare two authority codes, treating the lon/lat aliases
+/// (`EPSG:4326` and `OGC:CRS84`) as equal. This keeps the aliases equivalent
+/// for `crs_equals` now that `deserialize_crs` preserves them verbatim instead
+/// of folding `EPSG:4326` to `OGC:CRS84`.
+fn authority_codes_equal(a: &str, b: &str) -> bool {
+    a == b || (LngLat::is_authority_code_lnglat(a) && LngLat::is_authority_code_lnglat(b))
+}
+
 /// Implementation of an authority:code CoordinateReferenceSystem
 impl CoordinateReferenceSystem for AuthorityCode {
     /// Convert to a JSON string
+    ///
+    /// The lon/lat aliases (`EPSG:4326`/`OGC:CRS84`) canonicalize to `OGC:CRS84`
+    /// here so CRS metadata stays axis-order-explicit for GeoParquet/GeoArrow,
+    /// even though `to_crs_string` preserves the authority code verbatim.
     fn to_json(&self) -> String {
-        let mut result = String::with_capacity(self.auth_code.len() + 2);
+        let code = if LngLat::is_authority_code_lnglat(&self.auth_code) {
+            "OGC:CRS84"
+        } else {
+            &self.auth_code
+        };
+        let mut result = String::with_capacity(code.len() + 2);
         result.push('"');
-        result.push_str(&self.auth_code);
+        result.push_str(code);
         result.push('"');
         result
     }
@@ -487,7 +487,7 @@ impl CoordinateReferenceSystem for AuthorityCode {
     /// Check equality with another CoordinateReferenceSystem
     fn crs_equals(&self, other: &dyn CoordinateReferenceSystem) -> bool {
         match other.to_authority_code() {
-            Ok(Some(other_ac)) => other_ac == self.auth_code,
+            Ok(Some(other_ac)) => authority_codes_equal(&other_ac, &self.auth_code),
             _ => false,
         }
     }
@@ -585,7 +585,7 @@ impl CoordinateReferenceSystem for ProjJSON {
         if let (Ok(Some(auth_code)), Ok(Some(other_auth_code))) =
             (self.to_authority_code(), other.to_authority_code())
         {
-            auth_code == other_auth_code
+            authority_codes_equal(&auth_code, &other_auth_code)
         } else if let Ok(other_value) = serde_json::from_str::<Value>(&other.to_json()) {
             self.value == other_value
         } else {
@@ -967,10 +967,15 @@ mod test {
             Some("EPSG:3857")
         );
 
-        // lnglat folds to the canonical OGC:CRS84 (pre-existing behavior).
+        // The lon/lat alias is kept verbatim (not folded to OGC:CRS84); the two
+        // still compare equal, but the user's input string is preserved.
         assert_eq!(
             norm.normalize("EPSG:4326").unwrap().as_deref(),
-            Some("OGC:CRS84")
+            Some("EPSG:4326")
+        );
+        assert_eq!(
+            deserialize_crs("EPSG:4326").unwrap(),
+            deserialize_crs("OGC:CRS84").unwrap()
         );
 
         // A PROJJSON carrying an embedded authority id is preserved in full
@@ -998,5 +1003,29 @@ mod test {
         let from_original = deserialize_crs(NO_ID_PROJJSON).unwrap().unwrap();
         assert!(from_normalized.to_authority_code().unwrap().is_none());
         assert!(from_normalized.crs_equals(from_original.as_ref()));
+    }
+
+    #[test]
+    fn lnglat_alias_preserved_in_string_canonical_in_metadata() {
+        // EPSG:4326 is preserved as the round-trippable string (to_crs_string),
+        // but the JSON metadata form (to_json) canonicalizes to OGC:CRS84 so
+        // GeoParquet/GeoArrow stay axis-order-explicit.
+        let crs = deserialize_crs("EPSG:4326").unwrap().unwrap();
+        assert_eq!(crs.to_crs_string(), "EPSG:4326");
+        assert_eq!(crs.to_json(), r#""OGC:CRS84""#);
+
+        // OGC:CRS84 is unchanged in both forms.
+        let crs84 = deserialize_crs("OGC:CRS84").unwrap().unwrap();
+        assert_eq!(crs84.to_crs_string(), "OGC:CRS84");
+        assert_eq!(crs84.to_json(), r#""OGC:CRS84""#);
+
+        // The two aliases still compare equal, and both report SRID 4326.
+        assert!(crs.crs_equals(crs84.as_ref()));
+        assert_eq!(crs.srid().unwrap(), Some(4326));
+
+        // A non-lnglat authority code is untouched in both forms.
+        let crs3857 = deserialize_crs("EPSG:3857").unwrap().unwrap();
+        assert_eq!(crs3857.to_crs_string(), "EPSG:3857");
+        assert_eq!(crs3857.to_json(), r#""EPSG:3857""#);
     }
 }

--- a/rust/sedona-schema/src/crs.rs
+++ b/rust/sedona-schema/src/crs.rs
@@ -198,12 +198,13 @@ impl CachedSRIDToCrs {
     }
 }
 
-/// Cache for normalizing CRS strings to their abbreviated form.
+/// Cache for normalizing CRS strings to their round-trippable definition.
 ///
-/// Maps CRS input strings to their abbreviated `authority:code` representation
-/// with caching to avoid repeated deserialization of the same CRS string:
+/// Maps CRS input strings to their canonical `to_crs_string` form with caching
+/// to avoid repeated deserialization of the same CRS string:
 /// - `"0"` or `""` → `None` (no CRS)
-/// - other → deserialized and abbreviated to `authority:code` if possible
+/// - other → deserialized and re-emitted verbatim (authority code stays an
+///   authority code; a PROJJSON/WKT definition is preserved in full)
 #[derive(Default)]
 pub struct CachedCrsNormalization {
     cache: HashMap<String, Option<String>>,
@@ -226,8 +227,11 @@ impl CachedCrsNormalization {
 
     /// Normalize a CRS string, using the cache to avoid repeated deserialization.
     ///
-    /// Returns the abbreviated `authority:code` form if available, otherwise the
-    /// original string. Returns `None` for `"0"`, `""`, or CRS strings that
+    /// Returns the round-trippable CRS definition (`to_crs_string`) — the
+    /// authority code for an `authority:code` CRS, or the full PROJJSON/WKT for
+    /// a definition-based one. The full definition is preserved rather than
+    /// collapsed to its embedded authority code, so no information is lost on
+    /// the way in. Returns `None` for `"0"`, `""`, or CRS strings that
     /// deserialize to `None`.
     pub fn normalize(&mut self, crs_str: &str) -> Result<Option<String>> {
         if crs_str == "0" || crs_str.is_empty() {
@@ -238,15 +242,7 @@ impl CachedCrsNormalization {
             return Ok(cached.clone());
         }
 
-        let result = if let Some(crs) = deserialize_crs(crs_str)? {
-            if let Some(auth_code) = crs.to_authority_code()? {
-                Some(auth_code)
-            } else {
-                Some(crs_str.to_string())
-            }
-        } else {
-            None
-        };
+        let result = deserialize_crs(crs_str)?.map(|crs| crs.to_crs_string());
 
         self.cache.insert(crs_str.to_string(), result.clone());
         Ok(result)
@@ -963,5 +959,40 @@ mod test {
         .unwrap();
         let params = datum_ensemble.geographic_params().unwrap().unwrap();
         assert_eq!(params.spherical_radius(), 6371000.0);
+    }
+
+    #[test]
+    fn normalize_preserves_definition() {
+        let mut norm = CachedCrsNormalization::new();
+
+        // Empty / "0" -> no CRS.
+        assert_eq!(norm.normalize("0").unwrap(), None);
+        assert_eq!(norm.normalize("").unwrap(), None);
+
+        // An authority:code stays compact.
+        assert_eq!(
+            norm.normalize("EPSG:3857").unwrap().as_deref(),
+            Some("EPSG:3857")
+        );
+
+        // lnglat folds to the canonical OGC:CRS84 (pre-existing behavior).
+        assert_eq!(
+            norm.normalize("EPSG:4326").unwrap().as_deref(),
+            Some("OGC:CRS84")
+        );
+
+        // A PROJJSON carrying an embedded authority id is preserved verbatim
+        // rather than collapsed to "EPSG:6318" — no information lost on input.
+        let normalized = norm.normalize(EPSG_6318_PROJJSON).unwrap().unwrap();
+        assert!(
+            normalized.contains("GeographicCRS"),
+            "expected full PROJJSON, got {normalized}"
+        );
+        assert_ne!(normalized, "EPSG:6318");
+        // It round-trips back to the same CRS.
+        assert_eq!(
+            deserialize_crs(&normalized).unwrap(),
+            deserialize_crs(EPSG_6318_PROJJSON).unwrap()
+        );
     }
 }

--- a/rust/sedona-schema/src/crs.rs
+++ b/rust/sedona-schema/src/crs.rs
@@ -195,57 +195,21 @@ impl CachedSRIDToCrs {
     }
 }
 
-/// Cache for normalizing CRS strings to their round-trippable definition.
+/// Normalize a CRS string to the round-trippable definition stored on
+/// geometry/raster CRSes.
 ///
-/// Maps CRS input strings to their canonical `to_crs_string` form with caching
-/// to avoid repeated deserialization of the same CRS string:
-/// - `"0"` or `""` → `None` (no CRS)
-/// - other → deserialized and re-emitted via `to_crs_string` (authority code
-///   stays an authority code; a PROJJSON/WKT definition is preserved in full —
-///   semantically, though PROJJSON object keys may be reordered and whitespace
-///   normalized when re-serialized from the parsed tree)
-#[derive(Default)]
-pub struct CachedCrsNormalization {
-    cache: HashMap<String, Option<String>>,
-}
-
-impl CachedCrsNormalization {
-    /// Create a new CachedCrsNormalization with an empty cache.
-    pub fn new() -> Self {
-        Self {
-            cache: HashMap::new(),
-        }
-    }
-
-    /// Create a new CachedCrsNormalization with a pre-allocated cache.
-    pub fn with_capacity(capacity: usize) -> Self {
-        Self {
-            cache: HashMap::with_capacity(capacity),
-        }
-    }
-
-    /// Normalize a CRS string, using the cache to avoid repeated deserialization.
-    ///
-    /// Returns the round-trippable CRS definition (`to_crs_string`) — the
-    /// authority code for an `authority:code` CRS, or the full PROJJSON/WKT for
-    /// a definition-based one. The full definition is preserved rather than
-    /// collapsed to its embedded authority code, so no information is lost on
-    /// the way in. Returns `None` for `"0"`, `""`, or CRS strings that
-    /// deserialize to `None`.
-    pub fn normalize(&mut self, crs_str: &str) -> Result<Option<String>> {
-        if crs_str == "0" || crs_str.is_empty() {
-            return Ok(None);
-        }
-
-        if let Some(cached) = self.cache.get(crs_str) {
-            return Ok(cached.clone());
-        }
-
-        let result = deserialize_crs(crs_str)?.map(|crs| crs.to_crs_string());
-
-        self.cache.insert(crs_str.to_string(), result.clone());
-        Ok(result)
-    }
+/// Returns the [`CoordinateReferenceSystem::to_crs_string`] form — an
+/// `authority:code` stays compact, while a PROJJSON/WKT definition is preserved
+/// in full rather than collapsed to its embedded authority code, so no
+/// information is lost on the way in. Returns `None` for `"0"`, `""`, or CRS
+/// strings that deserialize to `None`.
+///
+/// Parsing is memoized by [`deserialize_crs`]'s thread-local cache, so this is
+/// cheap to call per row. The "full definition" guarantee is semantic, not
+/// byte-for-byte: a PROJJSON re-serializes from its parsed tree, so object keys
+/// may reorder and whitespace normalize; it round-trips and compares equal.
+pub fn normalize_crs(crs_str: &str) -> Result<Option<String>> {
+    Ok(deserialize_crs(crs_str)?.map(|crs| crs.to_crs_string()))
 }
 
 /// Longitude/latitude CRS (WGS84)
@@ -955,22 +919,20 @@ mod test {
 
     #[test]
     fn normalize_preserves_definition() {
-        let mut norm = CachedCrsNormalization::new();
-
         // Empty / "0" -> no CRS.
-        assert_eq!(norm.normalize("0").unwrap(), None);
-        assert_eq!(norm.normalize("").unwrap(), None);
+        assert_eq!(normalize_crs("0").unwrap(), None);
+        assert_eq!(normalize_crs("").unwrap(), None);
 
         // An authority:code stays compact.
         assert_eq!(
-            norm.normalize("EPSG:3857").unwrap().as_deref(),
+            normalize_crs("EPSG:3857").unwrap().as_deref(),
             Some("EPSG:3857")
         );
 
         // The lon/lat alias is kept verbatim (not folded to OGC:CRS84); the two
         // still compare equal, but the user's input string is preserved.
         assert_eq!(
-            norm.normalize("EPSG:4326").unwrap().as_deref(),
+            normalize_crs("EPSG:4326").unwrap().as_deref(),
             Some("EPSG:4326")
         );
         assert_eq!(
@@ -980,7 +942,7 @@ mod test {
 
         // A PROJJSON carrying an embedded authority id is preserved in full
         // rather than collapsed to "EPSG:6318" — no information lost on input.
-        let normalized = norm.normalize(EPSG_6318_PROJJSON).unwrap().unwrap();
+        let normalized = normalize_crs(EPSG_6318_PROJJSON).unwrap().unwrap();
         assert!(
             normalized.contains("GeographicCRS"),
             "expected full PROJJSON, got {normalized}"
@@ -998,7 +960,7 @@ mod test {
         // authority-code short circuit), proving the definition survives
         // re-serialization.
         const NO_ID_PROJJSON: &str = r#"{"type":"GeographicCRS","name":"Custom","datum":{"type":"GeodeticReferenceFrame","name":"Custom datum","ellipsoid":{"name":"Custom","semi_major_axis":6378137,"inverse_flattening":298.257223563}},"coordinate_system":{"subtype":"ellipsoidal","axis":[{"name":"Geodetic latitude","abbreviation":"Lat","direction":"north","unit":"degree"},{"name":"Geodetic longitude","abbreviation":"Lon","direction":"east","unit":"degree"}]}}"#;
-        let normalized = norm.normalize(NO_ID_PROJJSON).unwrap().unwrap();
+        let normalized = normalize_crs(NO_ID_PROJJSON).unwrap().unwrap();
         let from_normalized = deserialize_crs(&normalized).unwrap().unwrap();
         let from_original = deserialize_crs(NO_ID_PROJJSON).unwrap().unwrap();
         assert!(from_normalized.to_authority_code().unwrap().is_none());

--- a/rust/sedona-schema/src/crs.rs
+++ b/rust/sedona-schema/src/crs.rs
@@ -203,8 +203,10 @@ impl CachedSRIDToCrs {
 /// Maps CRS input strings to their canonical `to_crs_string` form with caching
 /// to avoid repeated deserialization of the same CRS string:
 /// - `"0"` or `""` → `None` (no CRS)
-/// - other → deserialized and re-emitted verbatim (authority code stays an
-///   authority code; a PROJJSON/WKT definition is preserved in full)
+/// - other → deserialized and re-emitted via `to_crs_string` (authority code
+///   stays an authority code; a PROJJSON/WKT definition is preserved in full —
+///   semantically, though PROJJSON object keys may be reordered and whitespace
+///   normalized when re-serialized from the parsed tree)
 #[derive(Default)]
 pub struct CachedCrsNormalization {
     cache: HashMap<String, Option<String>>,
@@ -981,7 +983,7 @@ mod test {
             Some("OGC:CRS84")
         );
 
-        // A PROJJSON carrying an embedded authority id is preserved verbatim
+        // A PROJJSON carrying an embedded authority id is preserved in full
         // rather than collapsed to "EPSG:6318" — no information lost on input.
         let normalized = norm.normalize(EPSG_6318_PROJJSON).unwrap().unwrap();
         assert!(

--- a/rust/sedona-schema/src/crs.rs
+++ b/rust/sedona-schema/src/crs.rs
@@ -325,7 +325,25 @@ pub trait CoordinateReferenceSystem: Debug {
     /// authority_code `"EPSG:{srid}"`. Note that other SRID representations
     /// (e.g., GeoArrow, Parquet GEOMETRY/GEOGRAPHY) do not make any guarantees
     /// that an SRID comes from the EPSG authority.
-    fn srid(&self) -> Result<Option<u32>>;
+    ///
+    /// The default derives the SRID from [`to_authority_code`](Self::to_authority_code):
+    /// the lon/lat alias maps to 4326, an `EPSG:{code}` authority parses to its
+    /// code, and anything else is `None`. Implementors only need to override
+    /// this if they can supply an SRID without an authority code.
+    fn srid(&self) -> Result<Option<u32>> {
+        let Some(auth_code) = self.to_authority_code()? else {
+            return Ok(None);
+        };
+        if LngLat::is_authority_code_lnglat(&auth_code) {
+            return Ok(LngLat::srid());
+        }
+        match auth_code.split_once(':') {
+            Some((authority, code)) if authority.eq_ignore_ascii_case("EPSG") => {
+                Ok(code.parse().ok())
+            }
+            _ => Ok(None),
+        }
+    }
 
     /// Compute a CRS string representation
     ///
@@ -474,19 +492,6 @@ impl CoordinateReferenceSystem for AuthorityCode {
         }
     }
 
-    /// Get the SRID if authority is EPSG
-    fn srid(&self) -> Result<Option<u32>> {
-        if LngLat::is_authority_code_lnglat(&self.auth_code) {
-            return Ok(LngLat::srid());
-        }
-        if let Some(pos) = self.auth_code.find(':') {
-            if self.auth_code[..pos].eq_ignore_ascii_case("EPSG") {
-                return Ok(self.auth_code[pos + 1..].parse::<u32>().ok());
-            }
-        }
-        Ok(None)
-    }
-
     /// Convert to a CRS string
     fn to_crs_string(&self) -> String {
         self.auth_code.clone()
@@ -586,21 +591,6 @@ impl CoordinateReferenceSystem for ProjJSON {
         } else {
             false
         }
-    }
-
-    fn srid(&self) -> Result<Option<u32>> {
-        let authority_code_opt = self.to_authority_code()?;
-        if let Some(authority_code) = authority_code_opt {
-            if LngLat::is_authority_code_lnglat(&authority_code) {
-                return Ok(LngLat::srid());
-            } else if let Some(colon_pos) = authority_code.find(':') {
-                if authority_code[..colon_pos].eq_ignore_ascii_case("EPSG") {
-                    return Ok(authority_code[colon_pos + 1..].parse::<u32>().ok());
-                }
-            }
-        }
-
-        Ok(None)
     }
 
     fn to_crs_string(&self) -> String {

--- a/rust/sedona-schema/src/crs.rs
+++ b/rust/sedona-schema/src/crs.rs
@@ -994,5 +994,17 @@ mod test {
             deserialize_crs(&normalized).unwrap(),
             deserialize_crs(EPSG_6318_PROJJSON).unwrap()
         );
+
+        // A PROJJSON with no authority id: there's nothing to collapse to, so
+        // the full definition is the only faithful output. Round-trip equality
+        // here exercises ProjJSON::crs_equals' full-body comparison (not the
+        // authority-code short circuit), proving the definition survives
+        // re-serialization.
+        const NO_ID_PROJJSON: &str = r#"{"type":"GeographicCRS","name":"Custom","datum":{"type":"GeodeticReferenceFrame","name":"Custom datum","ellipsoid":{"name":"Custom","semi_major_axis":6378137,"inverse_flattening":298.257223563}},"coordinate_system":{"subtype":"ellipsoidal","axis":[{"name":"Geodetic latitude","abbreviation":"Lat","direction":"north","unit":"degree"},{"name":"Geodetic longitude","abbreviation":"Lon","direction":"east","unit":"degree"}]}}"#;
+        let normalized = norm.normalize(NO_ID_PROJJSON).unwrap().unwrap();
+        let from_normalized = deserialize_crs(&normalized).unwrap().unwrap();
+        let from_original = deserialize_crs(NO_ID_PROJJSON).unwrap().unwrap();
+        assert!(from_normalized.to_authority_code().unwrap().is_none());
+        assert!(from_normalized.crs_equals(from_original.as_ref()));
     }
 }

--- a/rust/sedona-schema/src/datatypes.rs
+++ b/rust/sedona-schema/src/datatypes.rs
@@ -624,6 +624,18 @@ mod tests {
             serialize_edges_and_crs(&Edges::Spherical, &lnglat()),
             r#"{"edges":"spherical","crs":"OGC:CRS84"}"#
         );
+        // An EPSG:4326 type-CRS is canonicalized to OGC:CRS84 in metadata (so
+        // GeoArrow/GeoParquet stay axis-order-explicit), even though
+        // deserialize_crs now preserves the "EPSG:4326" string for round-trips.
+        assert_eq!(
+            serialize_edges_and_crs(&Edges::Planar, &deserialize_crs("EPSG:4326").unwrap()),
+            r#"{"crs":"OGC:CRS84"}"#
+        );
+        // A non-lnglat authority code is serialized verbatim.
+        assert_eq!(
+            serialize_edges_and_crs(&Edges::Planar, &deserialize_crs("EPSG:3857").unwrap()),
+            r#"{"crs":"EPSG:3857"}"#
+        );
     }
 
     #[test]


### PR DESCRIPTION
Cleans up how CRS strings flow through `ST_Crs`/`RS_Crs` and `ST_SetCRS`/`RS_SetCRS` so a CRS is preserved as the user gave it rather than rewritten, and consolidates the CRS equality/SRID logic. Groundwork before adding WKT CRS support.

Note: I didnt change the numeric SRID path (ST_SRID/RS_SRID, EWKT SRID=4326) still maps 4326→OGC:CRS84, so `RS_SetSRID(r, 4326)` stores OGC:CRS84 while `RS_SetCRS(r, 'EPSG:4326')` stores EPSG:4326 — equal CRSes, different strings.

<details>
<summary>Implementation notes (AI-generated)</summary>

- `ST_Crs`/`RS_Crs` and `ST_SetCRS`/`RS_SetCRS` emit `to_crs_string()`: an `authority:code` stays compact, but a PROJJSON/WKT definition with an embedded `id` is kept in full instead of being collapsed to that code. Same fix when widening a fixed-CRS geometry to an item-level CRS.
- The `EPSG:4326`/`OGC:CRS84` lon/lat aliases are kept verbatim in the round-trippable string (`deserialize_crs` no longer folds `4326`→`CRS84`), but are canonicalized to `OGC:CRS84` in the `to_json` metadata path so GeoParquet/GeoArrow stay axis-order-explicit. The two still compare equal.
- CRS equality is consolidated into `crs_equals` (the lon/lat alias rule lives in one `authority_codes_equal` helper); `PartialEq` delegates to it. `CoordinateReferenceSystem::srid()` is now a trait default derived from `to_authority_code()`.
- `RS_SetCRS` normalization handles the scalar case (one definition fanned out via `try_append_value_n`) and the array case (deduplicating builder) distinctly, so a high-row-count / few-distinct-CRS batch stays compact.
- `CachedCrsNormalization` is replaced by a one-line `normalize_crs()` free function; parsing is already memoized by `deserialize_crs`'s thread-local cache.
- "Kept in full" is semantic, not byte-for-byte: a PROJJSON re-serializes from its parsed tree (keys may reorder, whitespace normalizes); it round-trips and compares equal.

</details>
