### PR TITLE
fix(c/sedona-gdal): resolve MEMDataset::Create on GDAL 3.13 + use MEMCreate C-API when available

### DIFF
--- a/c/sedona-gdal/src/dyn_load.rs
+++ b/c/sedona-gdal/src/dyn_load.rs
@@ -52,10 +52,13 @@ macro_rules! load_fn {
     };
 }
 
-/// Try to load a symbol under one of several names (e.g. for C++ mangled symbols).
-/// Writes the first successful match into `$api.$field`. Returns an error only if
-/// *none* of the names resolve.
-macro_rules! load_fn_any {
+/// Try to load a symbol under one of several names (e.g. for C++ mangled
+/// symbols) and return whether a match was found, writing the first successful
+/// match into `$api.$field`. Unlike [`load_fn!`], it does not error when none
+/// resolve — used when a symbol has acceptable alternatives whose presence
+/// varies by GDAL version (e.g. the public `MEMCreate` C API vs. the mangled
+/// `MEMDataset::Create`), so the caller decides what counts as a fatal miss.
+macro_rules! try_load_fn_any {
     ($lib:expr, $api:expr, $field:ident, [$($name:expr),+ $(,)?]) => {{
         let mut found = false;
         $(
@@ -70,12 +73,7 @@ macro_rules! load_fn_any {
                 }
             }
         )+
-        if !found {
-            return Err(GdalInitLibraryError::LibraryError(format!(
-                "Failed to resolve {} under any known mangled name",
-                stringify!($field),
-            )));
-        }
+        found
     }};
 }
 
@@ -184,22 +182,36 @@ fn load_all_symbols(lib: &Library, api: &mut SedonaGdalApi) -> Result<(), GdalIn
     // --- Data Type ---
     load_fn!(lib, api, GDALGetDataTypeSizeBytes);
 
-    // --- C++ API: MEMDataset::Create (resolved via mangled symbol names) ---
-    // The symbol is mangled differently on Linux, macOS, and MSVC, and the
-    // `char**` vs `const char**` parameter also affects the mangling.
-    load_fn_any!(
+    // --- MEM dataset Create ---
+    // Prefer the stable public C API `MEMCreate`, which GDAL added upstream for
+    // exactly this purpose. It has no `pszFilename` parameter, so it uses its own
+    // signature and call path (see `create_mem_dataset`). Fall back to the C++
+    // `MEMDataset::Create` mangled symbol for GDAL builds that predate the
+    // `MEMCreate` export — that mangled name varies by platform *and* by the
+    // `char**` vs `char const* const*` parameter, so relying on it alone
+    // re-breaks whenever the mangling changes (as it did in GDAL 3.13).
+    // At least one of the two must resolve.
+    let have_mem_create = try_load_fn_any!(lib, api, MEMCreate, [b"MEMCreate\0"]);
+    let have_mem_dataset_create = try_load_fn_any!(
         lib,
         api,
         MEMDatasetCreate,
         [
-            // Linux and macOS, GDAL <= 3.12 (last param `char**`)
+            // Linux/macOS, GDAL <= 3.12 (last param `char**`).
             b"_ZN10MEMDataset6CreateEPKciii12GDALDataTypePPc\0",
-            // Linux and macOS, GDAL >= 3.13 (last param `char const* const*`)
+            // Linux/macOS, GDAL >= 3.13 (last param `char const* const*`).
             b"_ZN10MEMDataset6CreateEPKciii12GDALDataTypePKS1_\0",
-            // MSVC
+            // MSVC.
             b"?Create@MEMDataset@@SAPEAV1@PEBDHHHW4GDALDataType@@PEAPEAD@Z\0",
         ]
     );
+    if !have_mem_create && !have_mem_dataset_create {
+        return Err(GdalInitLibraryError::LibraryError(
+            "Failed to resolve a MEM dataset Create entry point (tried the \
+             MEMCreate C API and the MEMDataset::Create mangled names)"
+                .to_string(),
+        ));
+    }
 
     Ok(())
 }

--- a/c/sedona-gdal/src/dyn_load.rs
+++ b/c/sedona-gdal/src/dyn_load.rs
@@ -192,8 +192,10 @@ fn load_all_symbols(lib: &Library, api: &mut SedonaGdalApi) -> Result<(), GdalIn
         api,
         MEMDatasetCreate,
         [
-            // Linux and macOS
+            // Linux and macOS, GDAL <= 3.12 (last param `char**`)
             b"_ZN10MEMDataset6CreateEPKciii12GDALDataTypePPc\0",
+            // Linux and macOS, GDAL >= 3.13 (last param `char const* const*`)
+            b"_ZN10MEMDataset6CreateEPKciii12GDALDataTypePKS1_\0",
             // MSVC
             b"?Create@MEMDataset@@SAPEAV1@PEBDHHHW4GDALDataType@@PEAPEAD@Z\0",
         ]

--- a/c/sedona-gdal/src/gdal_dyn_bindgen.rs
+++ b/c/sedona-gdal/src/gdal_dyn_bindgen.rs
@@ -542,7 +542,20 @@ pub(crate) struct SedonaGdalApi {
     // --- Data Type ---
     pub GDALGetDataTypeSizeBytes: Option<unsafe extern "C" fn(eDataType: GDALDataType) -> c_int>,
 
-    // --- C++ API ---
+    // --- MEM dataset Create ---
+    // Public C API `MEMCreate` (no filename parameter), preferred over the C++
+    // `MEMDataset::Create` below because its symbol is unmangled and ABI-stable.
+    pub MEMCreate: Option<
+        unsafe extern "C" fn(
+            nXSize: c_int,
+            nYSize: c_int,
+            nBands: c_int,
+            eType: GDALDataType,
+            papszOptions: *const *const c_char,
+        ) -> GDALDatasetH,
+    >,
+    // C++ `MEMDataset::Create` (resolved via mangled symbol names), fallback for
+    // GDAL builds that predate the `MEMCreate` C API.
     pub MEMDatasetCreate: Option<
         unsafe extern "C" fn(
             pszFilename: *const c_char,

--- a/c/sedona-gdal/src/mem.rs
+++ b/c/sedona-gdal/src/mem.rs
@@ -233,19 +233,33 @@ pub(crate) fn create_mem_dataset(
     n_owned_bands: usize,
     owned_bands_data_type: GdalDataType,
 ) -> Result<Dataset> {
-    let empty_filename = c"";
     let c_data_type = owned_bands_data_type.to_c();
     let handle = unsafe {
-        call_gdal_api!(
-            api,
-            MEMDatasetCreate,
-            empty_filename.as_ptr(),
-            width.try_into()?,
-            height.try_into()?,
-            n_owned_bands.try_into()?,
-            c_data_type,
-            std::ptr::null_mut()
-        )
+        if api.inner.MEMCreate.is_some() {
+            // Public C API: no filename parameter.
+            call_gdal_api!(
+                api,
+                MEMCreate,
+                width.try_into()?,
+                height.try_into()?,
+                n_owned_bands.try_into()?,
+                c_data_type,
+                std::ptr::null()
+            )
+        } else {
+            // Fallback: the C++ MEMDataset::Create takes a leading filename.
+            let empty_filename = c"";
+            call_gdal_api!(
+                api,
+                MEMDatasetCreate,
+                empty_filename.as_ptr(),
+                width.try_into()?,
+                height.try_into()?,
+                n_owned_bands.try_into()?,
+                c_data_type,
+                std::ptr::null_mut()
+            )
+        }
     };
 
     if handle.is_null() {


### PR DESCRIPTION
I'm not really sure what this does but it makes it so that GDAL 3.13 doesnt break the build/runtime anymore.

I integrated the fix Kristin recommended below as well

<details>
<summary>Summary (AI-generated)</summary>

The GDAL MEM-dataset bridge resolves the MEM `Create` entry point dynamically in `c/sedona-gdal/src/dyn_load.rs`. It originally relied solely on the C++ `MEMDataset::Create` symbol, looked up by its mangled name. That mangling is fragile — it depends on the platform *and* on the parameters' constness — so GDAL 3.13 changed the final parameter from `char**` to `char const* const*` (`…GDALDataTypePPc` → `…GDALDataTypePKS1_`), the candidate list only had the ≤3.12 name, and the bridge panicked at load time ("Failed to resolve … under any known mangled name"), breaking every GDAL raster op. Each future re-mangling would break it again.

GDAL has since added `MEMCreate` as a stable, unmangled public C API. This change resolves `MEMCreate` first and falls back to the mangled `MEMDataset::Create` only when it is absent (older GDAL), erroring only if neither resolves. Because `MEMCreate` drops the `pszFilename` parameter, it gets its own fn-pointer type and call path: `create_mem_dataset` calls `MEMCreate` (no filename) when present, otherwise the mangled C++ method with a leading empty filename.

Verified against a local GDAL 3.13.1 install: `cargo test -p sedona-gdal --features gdal-sys/bindgen` → 102 passed.

</details>
