### PR TITLE
chore(rust/sedona-raster): Ensure creating a RasterStructArray does not panic

### DIFF
--- a/rust/sedona-functions/src/sd_format.rs
+++ b/rust/sedona-functions/src/sd_format.rs
@@ -340,7 +340,7 @@ fn raster_value_to_formatted_value(
     match columnar_value {
         ColumnarValue::Array(array) => {
             let struct_array = array.as_struct();
-            let raster_array = RasterStructArray::new(struct_array);
+            let raster_array = RasterStructArray::try_new(struct_array)?;
             let min_output_size = match maybe_width_hint {
                 Some(width_hint) => raster_array.len() * width_hint,
                 None => raster_array.len() * 48,

--- a/rust/sedona-raster-functions/src/executor.rs
+++ b/rust/sedona-raster-functions/src/executor.rs
@@ -258,7 +258,7 @@ impl<'a, 'b> RasterExecutor<'a, 'b> {
                             sedona_internal_datafusion_err!("Expected StructArray for raster data")
                         })?;
 
-                let raster_array = RasterStructArray::new(raster_struct);
+                let raster_array = RasterStructArray::try_new(raster_struct)?;
 
                 // Iterate through each raster in the array
                 for i in 0..self.num_iterations {
@@ -274,7 +274,7 @@ impl<'a, 'b> RasterExecutor<'a, 'b> {
             }
             ColumnarValue::Scalar(scalar_value) => match scalar_value {
                 ScalarValue::Struct(arc_struct) => {
-                    let raster_array = RasterStructArray::new(arc_struct.as_ref());
+                    let raster_array = RasterStructArray::try_new(arc_struct.as_ref())?;
                     let raster_opt = if raster_array.is_null(0) {
                         None
                     } else {
@@ -320,8 +320,8 @@ impl<'a, 'b> RasterExecutor<'a, 'b> {
                     sedona_internal_datafusion_err!("Expected StructArray for raster data")
                 })?;
 
-                let arr0 = RasterStructArray::new(s0);
-                let arr1 = RasterStructArray::new(s1);
+                let arr0 = RasterStructArray::try_new(s0)?;
+                let arr1 = RasterStructArray::try_new(s1)?;
                 if arr0.len() != self.num_iterations || arr1.len() != self.num_iterations {
                     return sedona_internal_err!(
                         "Expected arrays of length {} but got ({}, {})",
@@ -350,7 +350,7 @@ impl<'a, 'b> RasterExecutor<'a, 'b> {
                 let s0 = a0.as_any().downcast_ref::<StructArray>().ok_or_else(|| {
                     sedona_internal_datafusion_err!("Expected StructArray for raster data")
                 })?;
-                let arr0 = RasterStructArray::new(s0);
+                let arr0 = RasterStructArray::try_new(s0)?;
                 if arr0.len() != self.num_iterations {
                     return sedona_internal_err!(
                         "Expected array of length {} but got {}",
@@ -360,7 +360,7 @@ impl<'a, 'b> RasterExecutor<'a, 'b> {
                 }
                 let r1 = match sv1 {
                     ScalarValue::Struct(arc_struct) => {
-                        let arr1 = RasterStructArray::new(arc_struct.as_ref());
+                        let arr1 = RasterStructArray::try_new(arc_struct.as_ref())?;
                         if arr1.is_null(0) {
                             None
                         } else {
@@ -387,7 +387,7 @@ impl<'a, 'b> RasterExecutor<'a, 'b> {
                 let s1 = a1.as_any().downcast_ref::<StructArray>().ok_or_else(|| {
                     sedona_internal_datafusion_err!("Expected StructArray for raster data")
                 })?;
-                let arr1 = RasterStructArray::new(s1);
+                let arr1 = RasterStructArray::try_new(s1)?;
                 if arr1.len() != self.num_iterations {
                     return sedona_internal_err!(
                         "Expected array of length {} but got {}",
@@ -397,7 +397,7 @@ impl<'a, 'b> RasterExecutor<'a, 'b> {
                 }
                 let r0 = match sv0 {
                     ScalarValue::Struct(arc_struct) => {
-                        let arr0 = RasterStructArray::new(arc_struct.as_ref());
+                        let arr0 = RasterStructArray::try_new(arc_struct.as_ref())?;
                         if arr0.is_null(0) {
                             None
                         } else {
@@ -423,7 +423,7 @@ impl<'a, 'b> RasterExecutor<'a, 'b> {
             (ColumnarValue::Scalar(sv0), ColumnarValue::Scalar(sv1)) => {
                 let r0 = match sv0 {
                     ScalarValue::Struct(arc_struct) => {
-                        let arr0 = RasterStructArray::new(arc_struct.as_ref());
+                        let arr0 = RasterStructArray::try_new(arc_struct.as_ref())?;
                         if arr0.is_null(0) {
                             None
                         } else {
@@ -437,7 +437,7 @@ impl<'a, 'b> RasterExecutor<'a, 'b> {
                 };
                 let r1 = match sv1 {
                     ScalarValue::Struct(arc_struct) => {
-                        let arr1 = RasterStructArray::new(arc_struct.as_ref());
+                        let arr1 = RasterStructArray::try_new(arc_struct.as_ref())?;
                         if arr1.is_null(0) {
                             None
                         } else {
@@ -487,7 +487,7 @@ impl<'a, 'b> RasterExecutor<'a, 'b> {
                         .ok_or_else(|| {
                             sedona_internal_datafusion_err!("Expected StructArray for raster data")
                         })?;
-                let raster_array = RasterStructArray::new(raster_struct);
+                let raster_array = RasterStructArray::try_new(raster_struct)?;
 
                 for i in 0..self.num_iterations {
                     let (maybe_wkb, maybe_crs) = geom_accessor.get(i)?;
@@ -503,7 +503,7 @@ impl<'a, 'b> RasterExecutor<'a, 'b> {
             }
             ColumnarValue::Scalar(scalar_value) => match scalar_value {
                 ScalarValue::Struct(arc_struct) => {
-                    let raster_array = RasterStructArray::new(arc_struct.as_ref());
+                    let raster_array = RasterStructArray::try_new(arc_struct.as_ref())?;
                     let raster_opt = if raster_array.is_null(0) {
                         None
                     } else {

--- a/rust/sedona-raster-functions/src/rs_ensure_loaded.rs
+++ b/rust/sedona-raster-functions/src/rs_ensure_loaded.rs
@@ -268,7 +268,7 @@ where
             )
         })?;
 
-    let rasters = RasterStructArray::new(input_struct);
+    let rasters = RasterStructArray::try_new(input_struct)?;
     // Shared band `data` column of the input; addressed per band via
     // `rasters.band_data_row(..)` for zero-copy InDb passthrough below.
     let band_data_array = rasters.band_data_array();
@@ -655,7 +655,7 @@ mod tests {
             .unwrap();
 
         let out_struct = out.as_any().downcast_ref::<StructArray>().unwrap();
-        let out_rasters = RasterStructArray::new(out_struct);
+        let out_rasters = RasterStructArray::try_new(out_struct).unwrap();
         assert_eq!(out_rasters.len(), 1);
         let r = out_rasters.get(0).unwrap();
         let band = r.band(0).unwrap();
@@ -691,7 +691,7 @@ mod tests {
             .unwrap();
 
         let out_struct = out.as_any().downcast_ref::<StructArray>().unwrap();
-        let out_rasters = RasterStructArray::new(out_struct);
+        let out_rasters = RasterStructArray::try_new(out_struct).unwrap();
         let r = out_rasters.get(0).unwrap();
         let band = r.band(0).unwrap();
         assert_eq!(band.nd_buffer().unwrap().as_contiguous().unwrap(), &pixels);
@@ -711,7 +711,7 @@ mod tests {
         // is moved into the call (the backing Buffer is refcounted, so the move
         // doesn't reallocate).
         let in_ptr = {
-            let in_rasters = RasterStructArray::new(&input_struct);
+            let in_rasters = RasterStructArray::try_new(&input_struct).unwrap();
             let r = in_rasters.get(0).unwrap();
             let band = r.band(0).unwrap();
             let ndb = band.nd_buffer().unwrap();
@@ -728,7 +728,7 @@ mod tests {
             .unwrap();
 
         let out_struct = out.as_any().downcast_ref::<StructArray>().unwrap();
-        let out_rasters = RasterStructArray::new(out_struct);
+        let out_rasters = RasterStructArray::try_new(out_struct).unwrap();
         let r = out_rasters.get(0).unwrap();
         let band = r.band(0).unwrap();
         let out_bytes = band.nd_buffer().unwrap().as_contiguous().unwrap();
@@ -781,7 +781,7 @@ mod tests {
             .unwrap();
 
         let out_struct = out.as_any().downcast_ref::<StructArray>().unwrap();
-        let out_rasters = RasterStructArray::new(out_struct);
+        let out_rasters = RasterStructArray::try_new(out_struct).unwrap();
         let r = out_rasters.get(0).unwrap();
         let band = r.band(0).unwrap();
         let out_bytes = band.nd_buffer().unwrap().as_contiguous().unwrap();

--- a/rust/sedona-raster-functions/src/rs_example.rs
+++ b/rust/sedona-raster-functions/src/rs_example.rs
@@ -117,7 +117,7 @@ mod tests {
 
         let result = kernel.invoke_batch(&arg_types, &args).unwrap();
         if let ColumnarValue::Scalar(ScalarValue::Struct(arc_struct)) = result {
-            let raster_array = RasterStructArray::new(arc_struct.as_ref());
+            let raster_array = RasterStructArray::try_new(arc_struct.as_ref()).unwrap();
 
             assert_eq!(raster_array.len(), 1);
             let raster = raster_array.get(0).unwrap();

--- a/rust/sedona-raster-functions/src/rs_setsrid.rs
+++ b/rust/sedona-raster-functions/src/rs_setsrid.rs
@@ -405,7 +405,7 @@ mod tests {
 
         // Verify CRS was changed to EPSG:3857
         let result_struct = result.as_any().downcast_ref::<StructArray>().unwrap();
-        let raster_array = RasterStructArray::new(result_struct);
+        let raster_array = RasterStructArray::try_new(result_struct).unwrap();
         assert_eq!(raster_array.len(), 3);
 
         let raster0 = raster_array.get(0).unwrap();
@@ -429,7 +429,7 @@ mod tests {
             .unwrap();
 
         let result_struct = result.as_any().downcast_ref::<StructArray>().unwrap();
-        let raster_array = RasterStructArray::new(result_struct);
+        let raster_array = RasterStructArray::try_new(result_struct).unwrap();
         let raster = raster_array.get(0).unwrap();
         assert_eq!(raster.crs(), Some("OGC:CRS84"));
     }
@@ -443,7 +443,7 @@ mod tests {
         let result = tester.invoke_array_scalar(Arc::new(rasters), 0u32).unwrap();
 
         let result_struct = result.as_any().downcast_ref::<StructArray>().unwrap();
-        let raster_array = RasterStructArray::new(result_struct);
+        let raster_array = RasterStructArray::try_new(result_struct).unwrap();
         let raster = raster_array.get(0).unwrap();
         // CRS should be None (null) for SRID 0
         assert_eq!(raster.crs(), None);
@@ -462,7 +462,7 @@ mod tests {
             .unwrap();
 
         let result_struct = result.as_any().downcast_ref::<StructArray>().unwrap();
-        let raster_array = RasterStructArray::new(result_struct);
+        let raster_array = RasterStructArray::try_new(result_struct).unwrap();
         assert_eq!(raster_array.len(), 3);
 
         let raster0 = raster_array.get(0).unwrap();
@@ -485,7 +485,7 @@ mod tests {
             .unwrap();
 
         let result_struct = result.as_any().downcast_ref::<StructArray>().unwrap();
-        let raster_array = RasterStructArray::new(result_struct);
+        let raster_array = RasterStructArray::try_new(result_struct).unwrap();
         let raster = raster_array.get(0).unwrap();
         // EPSG:4326 should normalize to OGC:CRS84
         assert_eq!(raster.crs(), Some("OGC:CRS84"));
@@ -500,7 +500,7 @@ mod tests {
         let result = tester.invoke_array_scalar(Arc::new(rasters), "0").unwrap();
 
         let result_struct = result.as_any().downcast_ref::<StructArray>().unwrap();
-        let raster_array = RasterStructArray::new(result_struct);
+        let raster_array = RasterStructArray::try_new(result_struct).unwrap();
         let raster = raster_array.get(0).unwrap();
         assert_eq!(raster.crs(), None);
     }
@@ -511,13 +511,13 @@ mod tests {
         let tester = ScalarUdfTester::new(udf, vec![RASTER, SedonaType::Arrow(DataType::UInt32)]);
 
         let rasters = generate_test_rasters(3, Some(1)).unwrap();
-        let original_array = RasterStructArray::new(&rasters);
+        let original_array = RasterStructArray::try_new(&rasters).unwrap();
 
         let result = tester
             .invoke_array_scalar(Arc::new(rasters.clone()), 3857u32)
             .unwrap();
         let result_struct = result.as_any().downcast_ref::<StructArray>().unwrap();
-        let result_array = RasterStructArray::new(result_struct);
+        let result_array = RasterStructArray::try_new(result_struct).unwrap();
 
         // Verify non-null rasters have same metadata and band data
         for i in [0, 2] {
@@ -603,7 +603,8 @@ mod tests {
             .invoke_array_scalar(Arc::new(rasters), null_srid)
             .unwrap();
         let raster_array =
-            RasterStructArray::new(result.as_any().downcast_ref::<StructArray>().unwrap());
+            RasterStructArray::try_new(result.as_any().downcast_ref::<StructArray>().unwrap())
+                .unwrap();
         for i in 0..raster_array.len() {
             assert!(
                 raster_array.is_null(i),
@@ -624,7 +625,8 @@ mod tests {
             .invoke_array_scalar(Arc::new(rasters), null_crs)
             .unwrap();
         let raster_array =
-            RasterStructArray::new(result.as_any().downcast_ref::<StructArray>().unwrap());
+            RasterStructArray::try_new(result.as_any().downcast_ref::<StructArray>().unwrap())
+                .unwrap();
         for i in 0..raster_array.len() {
             assert!(
                 raster_array.is_null(i),
@@ -650,7 +652,7 @@ mod tests {
             .invoke_array_array(Arc::new(rasters), srid_array)
             .unwrap();
         let result_struct = result.as_any().downcast_ref::<StructArray>().unwrap();
-        let raster_array = RasterStructArray::new(result_struct);
+        let raster_array = RasterStructArray::try_new(result_struct).unwrap();
 
         // Row 0: valid raster + valid SRID -> EPSG:3857
         let raster0 = raster_array.get(0).unwrap();
@@ -683,7 +685,7 @@ mod tests {
             .invoke_array_array(Arc::new(rasters), crs_array)
             .unwrap();
         let result_struct = result.as_any().downcast_ref::<StructArray>().unwrap();
-        let raster_array = RasterStructArray::new(result_struct);
+        let raster_array = RasterStructArray::try_new(result_struct).unwrap();
 
         // Row 0: valid raster + valid CRS -> EPSG:3857
         let raster0 = raster_array.get(0).unwrap();

--- a/rust/sedona-raster-gdal/src/gdal_common.rs
+++ b/rust/sedona-raster-gdal/src/gdal_common.rs
@@ -580,7 +580,10 @@ mod tests {
     fn single_raster<'a>(
         raster_array: &'a arrow_array::StructArray,
     ) -> impl sedona_raster::traits::RasterRef + 'a {
-        RasterStructArray::new(raster_array).get(0).unwrap()
+        RasterStructArray::try_new(raster_array)
+            .unwrap()
+            .get(0)
+            .unwrap()
     }
 
     fn read_band_u64(dataset: &Dataset, band_index: usize, size: (usize, usize)) -> Vec<u64> {

--- a/rust/sedona-raster-gdal/src/gdal_dataset_provider.rs
+++ b/rust/sedona-raster-gdal/src/gdal_dataset_provider.rs
@@ -775,8 +775,8 @@ mod tests {
         let raster_s3_struct = build_outdb_raster("s3://bucket/path/test.tif");
         let raster_s3a_struct = build_outdb_raster("s3a://bucket/path/test.tif");
 
-        let raster_s3_array = RasterStructArray::new(&raster_s3_struct);
-        let raster_s3a_array = RasterStructArray::new(&raster_s3a_struct);
+        let raster_s3_array = RasterStructArray::try_new(&raster_s3_struct).unwrap();
+        let raster_s3a_array = RasterStructArray::try_new(&raster_s3a_struct).unwrap();
 
         let raster_s3 = raster_s3_array.get(0).unwrap();
         let raster_s3a = raster_s3a_array.get(0).unwrap();
@@ -796,12 +796,12 @@ mod tests {
         let raster_abfs_struct = build_outdb_raster("abfs://filesystem/path/test.tif");
         let raster_abfss_struct = build_outdb_raster("abfss://filesystem/path/test.tif");
 
-        let raster_gs_array = RasterStructArray::new(&raster_gs_struct);
-        let raster_gcs_array = RasterStructArray::new(&raster_gcs_struct);
-        let raster_az_array = RasterStructArray::new(&raster_az_struct);
-        let raster_wasbs_array = RasterStructArray::new(&raster_wasbs_struct);
-        let raster_abfs_array = RasterStructArray::new(&raster_abfs_struct);
-        let raster_abfss_array = RasterStructArray::new(&raster_abfss_struct);
+        let raster_gs_array = RasterStructArray::try_new(&raster_gs_struct).unwrap();
+        let raster_gcs_array = RasterStructArray::try_new(&raster_gcs_struct).unwrap();
+        let raster_az_array = RasterStructArray::try_new(&raster_az_struct).unwrap();
+        let raster_wasbs_array = RasterStructArray::try_new(&raster_wasbs_struct).unwrap();
+        let raster_abfs_array = RasterStructArray::try_new(&raster_abfs_struct).unwrap();
+        let raster_abfss_array = RasterStructArray::try_new(&raster_abfss_struct).unwrap();
 
         let key_gs = super::VrtKey::from_raster(&raster_gs_array.get(0).unwrap()).unwrap();
         let key_gcs = super::VrtKey::from_raster(&raster_gcs_array.get(0).unwrap()).unwrap();
@@ -821,7 +821,7 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let path = create_source_tiff(&temp_dir);
         let raster_struct = build_outdb_raster(&path);
-        let raster_array = RasterStructArray::new(&raster_struct);
+        let raster_array = RasterStructArray::try_new(&raster_struct).unwrap();
         let raster = raster_array.get(0).unwrap();
 
         let cache = Rc::new(GDALDatasetCache::try_new(4, 4).unwrap());
@@ -852,7 +852,7 @@ mod tests {
             skew_y: 0.0,
         };
         let raster_struct = build_in_db_raster(metadata, Some("EPSG:4326"), &[]);
-        let raster_array = RasterStructArray::new(&raster_struct);
+        let raster_array = RasterStructArray::try_new(&raster_struct).unwrap();
         let raster = raster_array.get(0).unwrap();
         let cache = Rc::new(GDALDatasetCache::try_new(4, 4).unwrap());
 
@@ -897,7 +897,7 @@ mod tests {
                 },
             ],
         );
-        let raster_array = RasterStructArray::new(&raster_struct);
+        let raster_array = RasterStructArray::try_new(&raster_struct).unwrap();
         let raster = raster_array.get(0).unwrap();
         let cache = Rc::new(GDALDatasetCache::try_new(4, 4).unwrap());
 
@@ -922,7 +922,7 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let path = create_source_tiff(&temp_dir);
         let raster_struct = build_mixed_raster(&path);
-        let raster_array = RasterStructArray::new(&raster_struct);
+        let raster_array = RasterStructArray::try_new(&raster_struct).unwrap();
         let raster = raster_array.get(0).unwrap();
         let cache = Rc::new(GDALDatasetCache::try_new(4, 4).unwrap());
 
@@ -979,10 +979,20 @@ mod tests {
             }],
         );
 
-        let key_a =
-            super::VrtKey::from_raster(&RasterStructArray::new(&raster_a).get(0).unwrap()).unwrap();
-        let key_b =
-            super::VrtKey::from_raster(&RasterStructArray::new(&raster_b).get(0).unwrap()).unwrap();
+        let key_a = super::VrtKey::from_raster(
+            &RasterStructArray::try_new(&raster_a)
+                .unwrap()
+                .get(0)
+                .unwrap(),
+        )
+        .unwrap();
+        let key_b = super::VrtKey::from_raster(
+            &RasterStructArray::try_new(&raster_b)
+                .unwrap()
+                .get(0)
+                .unwrap(),
+        )
+        .unwrap();
 
         assert!(key_a != key_b);
     }
@@ -1028,7 +1038,7 @@ mod tests {
         builder.finish_band().unwrap();
         builder.finish_raster().unwrap();
         let raster_struct = builder.finish().unwrap();
-        let raster_array = RasterStructArray::new(&raster_struct);
+        let raster_array = RasterStructArray::try_new(&raster_struct).unwrap();
         let raster = raster_array.get(0).unwrap();
         let cache = Rc::new(GDALDatasetCache::try_new(4, 4).unwrap());
 
@@ -1073,7 +1083,7 @@ mod tests {
         builder.finish_band().unwrap();
         builder.finish_raster().unwrap();
         let raster_struct = builder.finish().unwrap();
-        let raster_array = RasterStructArray::new(&raster_struct);
+        let raster_array = RasterStructArray::try_new(&raster_struct).unwrap();
         let raster = raster_array.get(0).unwrap();
         let cache = Rc::new(GDALDatasetCache::try_new(4, 4).unwrap());
 

--- a/rust/sedona-raster-gdal/src/rs_frompath.rs
+++ b/rust/sedona-raster-gdal/src/rs_frompath.rs
@@ -120,7 +120,7 @@ mod tests {
             width: i64,
             height: i64,
         ) {
-            let raster_array = RasterStructArray::new(struct_arr);
+            let raster_array = RasterStructArray::try_new(struct_arr).unwrap();
             assert_eq!(raster_array.len(), expected_len);
 
             for idx in 0..expected_len {
@@ -220,7 +220,7 @@ mod tests {
                 assert!(!struct_arr.is_null(0));
                 assert!(struct_arr.is_null(1));
 
-                let raster_array = RasterStructArray::new(struct_arr);
+                let raster_array = RasterStructArray::try_new(struct_arr).unwrap();
                 let raster = raster_array.get(0).unwrap();
                 assert_eq!(raster.metadata().width(), 10);
                 assert_eq!(raster.metadata().height(), 10);

--- a/rust/sedona-raster-gdal/src/utils.rs
+++ b/rust/sedona-raster-gdal/src/utils.rs
@@ -430,7 +430,7 @@ mod tests {
         .unwrap();
 
         let raster_array = with_gdal(|gdal| load_as_indb_raster(gdal, &path_str)).unwrap();
-        let raster_struct = RasterStructArray::new(&raster_array);
+        let raster_struct = RasterStructArray::try_new(&raster_array).unwrap();
         let raster = raster_struct.get(0).unwrap();
         let band = raster.bands().band(1).unwrap();
 
@@ -453,7 +453,7 @@ mod tests {
         let path = test_raster("test4.tiff").expect("test4.tiff should exist");
 
         let raster = with_gdal(|gdal| load_as_outdb_raster(gdal, &path)).unwrap();
-        let raster_struct = RasterStructArray::new(&raster);
+        let raster_struct = RasterStructArray::try_new(&raster).unwrap();
         assert_eq!(raster_struct.len(), 1);
 
         let raster = raster_struct.get(0).unwrap();
@@ -483,7 +483,7 @@ mod tests {
         .unwrap();
 
         let raster = with_gdal(|gdal| load_as_outdb_raster(gdal, &path_str)).unwrap();
-        let raster_struct = RasterStructArray::new(&raster);
+        let raster_struct = RasterStructArray::try_new(&raster).unwrap();
         let raster = raster_struct.get(0).unwrap();
         let band = raster.bands().band(1).unwrap();
 
@@ -507,7 +507,7 @@ mod tests {
         .unwrap();
 
         let raster = with_gdal(|gdal| load_as_outdb_raster(gdal, &path_str)).unwrap();
-        let raster_struct = RasterStructArray::new(&raster);
+        let raster_struct = RasterStructArray::try_new(&raster).unwrap();
         let raster = raster_struct.get(0).unwrap();
         let band = raster.bands().band(1).unwrap();
 
@@ -531,7 +531,7 @@ mod tests {
         .unwrap();
 
         let raster_array = with_gdal(|gdal| load_as_indb_raster(gdal, &path_str)).unwrap();
-        let raster_struct = RasterStructArray::new(&raster_array);
+        let raster_struct = RasterStructArray::try_new(&raster_array).unwrap();
         let raster = raster_struct.get(0).unwrap();
         let band = raster.bands().band(1).unwrap();
 
@@ -570,7 +570,7 @@ mod tests {
         .unwrap();
 
         let raster_array = with_gdal(|gdal| load_as_indb_raster(gdal, &path_str)).unwrap();
-        let raster_struct = RasterStructArray::new(&raster_array);
+        let raster_struct = RasterStructArray::try_new(&raster_array).unwrap();
         let raster = raster_struct.get(0).unwrap();
         let band = raster.bands().band(1).unwrap();
 
@@ -605,7 +605,7 @@ mod tests {
         .unwrap();
 
         let raster_array = with_gdal(|gdal| load_as_indb_raster(gdal, &path_str)).unwrap();
-        let raster_struct = RasterStructArray::new(&raster_array);
+        let raster_struct = RasterStructArray::try_new(&raster_array).unwrap();
         let raster = raster_struct.get(0).unwrap();
         let band = raster.bands().band(1).unwrap();
 
@@ -639,7 +639,7 @@ mod tests {
         .unwrap();
 
         let raster_array = with_gdal(|gdal| load_as_indb_raster(gdal, &path_str)).unwrap();
-        let raster_struct = RasterStructArray::new(&raster_array);
+        let raster_struct = RasterStructArray::try_new(&raster_array).unwrap();
         let raster = raster_struct.get(0).unwrap();
         let band1 = raster.bands().band(1).unwrap();
         let band2 = raster.bands().band(2).unwrap();
@@ -670,7 +670,7 @@ mod tests {
         })
         .unwrap();
 
-        let raster_struct = RasterStructArray::new(&raster_array);
+        let raster_struct = RasterStructArray::try_new(&raster_array).unwrap();
         let raster = raster_struct.get(0).unwrap();
         let band1 = raster.bands().band(1).unwrap();
         let band2 = raster.bands().band(2).unwrap();
@@ -723,7 +723,7 @@ mod tests {
         })
         .unwrap();
 
-        let raster_struct = RasterStructArray::new(&raster_array);
+        let raster_struct = RasterStructArray::try_new(&raster_array).unwrap();
         assert_eq!(raster_struct.len(), 2);
 
         let first = raster_struct.get(0).unwrap();

--- a/rust/sedona-raster-zarr/tests/cloud.rs
+++ b/rust/sedona-raster-zarr/tests/cloud.rs
@@ -69,7 +69,7 @@ fn count_rows(reader: ZarrChunkReader) -> usize {
             .as_any()
             .downcast_ref::<arrow_array::StructArray>()
             .expect("raster column is a StructArray");
-        rows += RasterStructArray::new(s).len();
+        rows += RasterStructArray::try_new(s).unwrap().len();
     }
     rows
 }

--- a/rust/sedona-raster-zarr/tests/zarr_roundtrip.rs
+++ b/rust/sedona-raster-zarr/tests/zarr_roundtrip.rs
@@ -168,7 +168,7 @@ async fn discovers_child_arrays_from_consolidated_metadata() {
     // discover zero arrays and error.
     let arr = read_all(&uri, None).await.unwrap();
 
-    let rasters = RasterStructArray::new(&arr);
+    let rasters = RasterStructArray::try_new(&arr).unwrap();
     assert_eq!(
         rasters.len(),
         8,
@@ -183,7 +183,7 @@ async fn round_trip_emits_one_row_per_chunk_position_with_outdb_anchors() {
     let uri = format!("file://{}", tmp.path().display());
     let arr = read_all(&uri, None).await.unwrap();
 
-    let rasters = RasterStructArray::new(&arr);
+    let rasters = RasterStructArray::try_new(&arr).unwrap();
     assert_eq!(rasters.len(), 8, "expected 8 chunk rows (2*2*2)");
 
     // First row corresponds to chunk (t=0, y=0, x=0). With group transform
@@ -286,7 +286,7 @@ async fn auto_skips_1d_coord_variables() {
     let tmp = build_xarray_style_fixture();
     let uri = format!("file://{}", tmp.path().display());
     let arr = read_all(&uri, None).await.unwrap();
-    let rasters = RasterStructArray::new(&arr);
+    let rasters = RasterStructArray::try_new(&arr).unwrap();
     // 2*2*2 = 8 chunk positions, with 2 bands per row (pressure, temperature).
     assert_eq!(rasters.len(), 8);
     let r0 = rasters.get(0).unwrap();
@@ -299,7 +299,7 @@ async fn explicit_arrays_filter_selects_subset() {
     let uri = format!("file://{}", tmp.path().display());
     let filter = vec!["temperature".to_string()];
     let arr = read_all(&uri, Some(&filter)).await.unwrap();
-    let rasters = RasterStructArray::new(&arr);
+    let rasters = RasterStructArray::try_new(&arr).unwrap();
     assert_eq!(rasters.len(), 8);
     let r0 = rasters.get(0).unwrap();
     assert_eq!(r0.num_bands(), 1, "only temperature should be read");
@@ -404,7 +404,7 @@ async fn falls_back_to_array_dimensions_attribute() {
 
     let uri = format!("file://{}", tmp.path().display());
     let arr = read_all(&uri, None).await.unwrap();
-    let rasters = RasterStructArray::new(&arr);
+    let rasters = RasterStructArray::try_new(&arr).unwrap();
     assert_eq!(rasters.len(), 2);
     let r0 = rasters.get(0).unwrap();
     let band = r0.band(0).unwrap();
@@ -491,7 +491,7 @@ async fn derives_geotransform_and_crs_from_coordinate_arrays() {
     let uri = format!("file://{}", tmp.path().display());
     let arr = read_all(&uri, None).await.unwrap();
 
-    let rasters = RasterStructArray::new(&arr);
+    let rasters = RasterStructArray::try_new(&arr).unwrap();
     assert_eq!(
         rasters.len(),
         1,
@@ -517,7 +517,7 @@ async fn derives_transform_without_crs_for_generic_xy_dims() {
     let uri = format!("file://{}", tmp.path().display());
     let arr = read_all(&uri, None).await.unwrap();
 
-    let raster = RasterStructArray::new(&arr).get(0).unwrap();
+    let raster = RasterStructArray::try_new(&arr).unwrap().get(0).unwrap();
     assert_eq!(
         raster.transform().to_vec(),
         vec![9.5, 1.0, 0.0, 20.5, 0.0, -1.0]
@@ -533,7 +533,7 @@ async fn irregular_coordinate_arrays_fall_back_to_identity() {
     let uri = format!("file://{}", tmp.path().display());
     let arr = read_all(&uri, None).await.unwrap();
 
-    let raster = RasterStructArray::new(&arr).get(0).unwrap();
+    let raster = RasterStructArray::try_new(&arr).unwrap().get(0).unwrap();
     assert_eq!(
         raster.transform().to_vec(),
         vec![0.0, 1.0, 0.0, 0.0, 0.0, -1.0]
@@ -550,7 +550,7 @@ async fn derives_transform_with_explicit_arrays_filter() {
     let arrays = ["temperature".to_string()];
     let arr = read_all(&uri, Some(&arrays)).await.unwrap();
 
-    let raster = RasterStructArray::new(&arr).get(0).unwrap();
+    let raster = RasterStructArray::try_new(&arr).unwrap().get(0).unwrap();
     assert_eq!(
         raster.transform().to_vec(),
         vec![9.5, 1.0, 0.0, 20.5, 0.0, -1.0]

--- a/rust/sedona-raster/src/array.rs
+++ b/rust/sedona-raster/src/array.rs
@@ -20,6 +20,11 @@ use arrow_array::{
     StringViewArray, StructArray, UInt32Array,
 };
 use arrow_schema::ArrowError;
+use datafusion_common::cast::{
+    as_binary_array, as_binary_view_array, as_float64_array, as_int64_array, as_list_array,
+    as_string_array, as_string_view_array, as_struct_array, as_uint32_array,
+};
+use datafusion_common::DataFusionError;
 
 use crate::traits::{BandRef, Bands, NdBuffer, RasterRef};
 use crate::view_entries::ViewEntry;
@@ -406,116 +411,58 @@ impl<'a> RasterStructArray<'a> {
     /// Returns an error if the array doesn't have the expected raster schema.
     #[inline]
     pub fn try_new(raster_array: &'a StructArray) -> Result<Self, ArrowError> {
-        // Helper macro for safe downcasting with descriptive errors
-        macro_rules! downcast {
-            ($array:expr, $type:ty, $field:expr) => {
-                $array.as_any().downcast_ref::<$type>().ok_or_else(|| {
-                    ArrowError::InvalidArgumentError(format!(
-                        "Raster schema mismatch: expected {} for field '{}'",
-                        stringify!($type),
-                        $field
-                    ))
-                })?
-            };
+        // Helper to convert DataFusionError to ArrowError
+        fn to_arrow_err(e: DataFusionError) -> ArrowError {
+            match e {
+                DataFusionError::ArrowError(arrow_err, _) => *arrow_err,
+                other => ArrowError::InvalidArgumentError(other.to_string()),
+            }
         }
 
         // Top-level fields
-        let crs_array = downcast!(
-            raster_array.column(raster_indices::CRS),
-            StringViewArray,
-            "crs"
-        );
-        let transform_list = downcast!(
-            raster_array.column(raster_indices::TRANSFORM),
-            ListArray,
-            "transform"
-        );
-        let transform_values = downcast!(transform_list.values(), Float64Array, "transform.values");
-        let spatial_dims_list = downcast!(
-            raster_array.column(raster_indices::SPATIAL_DIMS),
-            ListArray,
-            "spatial_dims"
-        );
-        let spatial_dims_values = downcast!(
-            spatial_dims_list.values(),
-            StringViewArray,
-            "spatial_dims.values"
-        );
-        let spatial_shape_list = downcast!(
-            raster_array.column(raster_indices::SPATIAL_SHAPE),
-            ListArray,
-            "spatial_shape"
-        );
-        let spatial_shape_values = downcast!(
-            spatial_shape_list.values(),
-            Int64Array,
-            "spatial_shape.values"
-        );
+        let crs_array =
+            as_string_view_array(raster_array.column(raster_indices::CRS)).map_err(to_arrow_err)?;
+        let transform_list =
+            as_list_array(raster_array.column(raster_indices::TRANSFORM)).map_err(to_arrow_err)?;
+        let transform_values = as_float64_array(transform_list.values()).map_err(to_arrow_err)?;
+        let spatial_dims_list = as_list_array(raster_array.column(raster_indices::SPATIAL_DIMS))
+            .map_err(to_arrow_err)?;
+        let spatial_dims_values =
+            as_string_view_array(spatial_dims_list.values()).map_err(to_arrow_err)?;
+        let spatial_shape_list = as_list_array(raster_array.column(raster_indices::SPATIAL_SHAPE))
+            .map_err(to_arrow_err)?;
+        let spatial_shape_values =
+            as_int64_array(spatial_shape_list.values()).map_err(to_arrow_err)?;
 
         // Bands list and nested struct
-        let bands_list = downcast!(
-            raster_array.column(raster_indices::BANDS),
-            ListArray,
-            "bands"
-        );
-        let bands_struct = downcast!(bands_list.values(), StructArray, "bands.values");
+        let bands_list =
+            as_list_array(raster_array.column(raster_indices::BANDS)).map_err(to_arrow_err)?;
+        let bands_struct = as_struct_array(bands_list.values()).map_err(to_arrow_err)?;
 
         // Band-level fields
-        let band_name_array = downcast!(
-            bands_struct.column(band_indices::NAME),
-            StringArray,
-            "bands.name"
-        );
-        let band_dim_names_list = downcast!(
-            bands_struct.column(band_indices::DIM_NAMES),
-            ListArray,
-            "bands.dim_names"
-        );
-        let band_dim_names_values = downcast!(
-            band_dim_names_list.values(),
-            StringArray,
-            "bands.dim_names.values"
-        );
-        let band_source_shape_list = downcast!(
-            bands_struct.column(band_indices::SOURCE_SHAPE),
-            ListArray,
-            "bands.source_shape"
-        );
-        let band_source_shape_values = downcast!(
-            band_source_shape_list.values(),
-            Int64Array,
-            "bands.source_shape.values"
-        );
-        let band_datatype_array = downcast!(
-            bands_struct.column(band_indices::DATA_TYPE),
-            UInt32Array,
-            "bands.data_type"
-        );
-        let band_nodata_array = downcast!(
-            bands_struct.column(band_indices::NODATA),
-            BinaryArray,
-            "bands.nodata"
-        );
-        let band_view_list = downcast!(
-            bands_struct.column(band_indices::VIEW),
-            ListArray,
-            "bands.view"
-        );
-        let band_outdb_uri_array = downcast!(
-            bands_struct.column(band_indices::OUTDB_URI),
-            StringArray,
-            "bands.outdb_uri"
-        );
-        let band_outdb_format_array = downcast!(
-            bands_struct.column(band_indices::OUTDB_FORMAT),
-            StringViewArray,
-            "bands.outdb_format"
-        );
-        let band_data_array = downcast!(
-            bands_struct.column(band_indices::DATA),
-            BinaryViewArray,
-            "bands.data"
-        );
+        let band_name_array =
+            as_string_array(bands_struct.column(band_indices::NAME)).map_err(to_arrow_err)?;
+        let band_dim_names_list =
+            as_list_array(bands_struct.column(band_indices::DIM_NAMES)).map_err(to_arrow_err)?;
+        let band_dim_names_values =
+            as_string_array(band_dim_names_list.values()).map_err(to_arrow_err)?;
+        let band_source_shape_list =
+            as_list_array(bands_struct.column(band_indices::SOURCE_SHAPE)).map_err(to_arrow_err)?;
+        let band_source_shape_values =
+            as_int64_array(band_source_shape_list.values()).map_err(to_arrow_err)?;
+        let band_datatype_array =
+            as_uint32_array(bands_struct.column(band_indices::DATA_TYPE)).map_err(to_arrow_err)?;
+        let band_nodata_array =
+            as_binary_array(bands_struct.column(band_indices::NODATA)).map_err(to_arrow_err)?;
+        let band_view_list =
+            as_list_array(bands_struct.column(band_indices::VIEW)).map_err(to_arrow_err)?;
+        let band_outdb_uri_array =
+            as_string_array(bands_struct.column(band_indices::OUTDB_URI)).map_err(to_arrow_err)?;
+        let band_outdb_format_array =
+            as_string_view_array(bands_struct.column(band_indices::OUTDB_FORMAT))
+                .map_err(to_arrow_err)?;
+        let band_data_array =
+            as_binary_view_array(bands_struct.column(band_indices::DATA)).map_err(to_arrow_err)?;
 
         Ok(Self {
             raster_array,

--- a/rust/sedona-raster/src/array.rs
+++ b/rust/sedona-raster/src/array.rs
@@ -402,115 +402,122 @@ pub struct RasterStructArray<'a> {
 
 impl<'a> RasterStructArray<'a> {
     /// Create a new RasterStructArray from an existing StructArray.
+    ///
+    /// Returns an error if the array doesn't have the expected raster schema.
     #[inline]
-    pub fn new(raster_array: &'a StructArray) -> Self {
+    pub fn try_new(raster_array: &'a StructArray) -> Result<Self, ArrowError> {
+        // Helper macro for safe downcasting with descriptive errors
+        macro_rules! downcast {
+            ($array:expr, $type:ty, $field:expr) => {
+                $array.as_any().downcast_ref::<$type>().ok_or_else(|| {
+                    ArrowError::InvalidArgumentError(format!(
+                        "Raster schema mismatch: expected {} for field '{}'",
+                        stringify!($type),
+                        $field
+                    ))
+                })?
+            };
+        }
+
         // Top-level fields
-        let crs_array = raster_array
-            .column(raster_indices::CRS)
-            .as_any()
-            .downcast_ref::<StringViewArray>()
-            .unwrap();
-        let transform_list = raster_array
-            .column(raster_indices::TRANSFORM)
-            .as_any()
-            .downcast_ref::<ListArray>()
-            .unwrap();
-        let transform_values = transform_list
-            .values()
-            .as_any()
-            .downcast_ref::<Float64Array>()
-            .unwrap();
-        let spatial_dims_list = raster_array
-            .column(raster_indices::SPATIAL_DIMS)
-            .as_any()
-            .downcast_ref::<ListArray>()
-            .unwrap();
-        let spatial_dims_values = spatial_dims_list
-            .values()
-            .as_any()
-            .downcast_ref::<StringViewArray>()
-            .unwrap();
-        let spatial_shape_list = raster_array
-            .column(raster_indices::SPATIAL_SHAPE)
-            .as_any()
-            .downcast_ref::<ListArray>()
-            .unwrap();
-        let spatial_shape_values = spatial_shape_list
-            .values()
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap();
+        let crs_array = downcast!(
+            raster_array.column(raster_indices::CRS),
+            StringViewArray,
+            "crs"
+        );
+        let transform_list = downcast!(
+            raster_array.column(raster_indices::TRANSFORM),
+            ListArray,
+            "transform"
+        );
+        let transform_values = downcast!(transform_list.values(), Float64Array, "transform.values");
+        let spatial_dims_list = downcast!(
+            raster_array.column(raster_indices::SPATIAL_DIMS),
+            ListArray,
+            "spatial_dims"
+        );
+        let spatial_dims_values = downcast!(
+            spatial_dims_list.values(),
+            StringViewArray,
+            "spatial_dims.values"
+        );
+        let spatial_shape_list = downcast!(
+            raster_array.column(raster_indices::SPATIAL_SHAPE),
+            ListArray,
+            "spatial_shape"
+        );
+        let spatial_shape_values = downcast!(
+            spatial_shape_list.values(),
+            Int64Array,
+            "spatial_shape.values"
+        );
 
         // Bands list and nested struct
-        let bands_list = raster_array
-            .column(raster_indices::BANDS)
-            .as_any()
-            .downcast_ref::<ListArray>()
-            .unwrap();
-        let bands_struct = bands_list
-            .values()
-            .as_any()
-            .downcast_ref::<StructArray>()
-            .unwrap();
+        let bands_list = downcast!(
+            raster_array.column(raster_indices::BANDS),
+            ListArray,
+            "bands"
+        );
+        let bands_struct = downcast!(bands_list.values(), StructArray, "bands.values");
 
         // Band-level fields
-        let band_name_array = bands_struct
-            .column(band_indices::NAME)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        let band_dim_names_list = bands_struct
-            .column(band_indices::DIM_NAMES)
-            .as_any()
-            .downcast_ref::<ListArray>()
-            .unwrap();
-        let band_dim_names_values = band_dim_names_list
-            .values()
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        let band_source_shape_list = bands_struct
-            .column(band_indices::SOURCE_SHAPE)
-            .as_any()
-            .downcast_ref::<ListArray>()
-            .unwrap();
-        let band_source_shape_values = band_source_shape_list
-            .values()
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap();
-        let band_datatype_array = bands_struct
-            .column(band_indices::DATA_TYPE)
-            .as_any()
-            .downcast_ref::<UInt32Array>()
-            .unwrap();
-        let band_nodata_array = bands_struct
-            .column(band_indices::NODATA)
-            .as_any()
-            .downcast_ref::<BinaryArray>()
-            .unwrap();
-        let band_view_list = bands_struct
-            .column(band_indices::VIEW)
-            .as_any()
-            .downcast_ref::<ListArray>()
-            .unwrap();
-        let band_outdb_uri_array = bands_struct
-            .column(band_indices::OUTDB_URI)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        let band_outdb_format_array = bands_struct
-            .column(band_indices::OUTDB_FORMAT)
-            .as_any()
-            .downcast_ref::<StringViewArray>()
-            .unwrap();
-        let band_data_array = bands_struct
-            .column(band_indices::DATA)
-            .as_any()
-            .downcast_ref::<BinaryViewArray>()
-            .unwrap();
+        let band_name_array = downcast!(
+            bands_struct.column(band_indices::NAME),
+            StringArray,
+            "bands.name"
+        );
+        let band_dim_names_list = downcast!(
+            bands_struct.column(band_indices::DIM_NAMES),
+            ListArray,
+            "bands.dim_names"
+        );
+        let band_dim_names_values = downcast!(
+            band_dim_names_list.values(),
+            StringArray,
+            "bands.dim_names.values"
+        );
+        let band_source_shape_list = downcast!(
+            bands_struct.column(band_indices::SOURCE_SHAPE),
+            ListArray,
+            "bands.source_shape"
+        );
+        let band_source_shape_values = downcast!(
+            band_source_shape_list.values(),
+            Int64Array,
+            "bands.source_shape.values"
+        );
+        let band_datatype_array = downcast!(
+            bands_struct.column(band_indices::DATA_TYPE),
+            UInt32Array,
+            "bands.data_type"
+        );
+        let band_nodata_array = downcast!(
+            bands_struct.column(band_indices::NODATA),
+            BinaryArray,
+            "bands.nodata"
+        );
+        let band_view_list = downcast!(
+            bands_struct.column(band_indices::VIEW),
+            ListArray,
+            "bands.view"
+        );
+        let band_outdb_uri_array = downcast!(
+            bands_struct.column(band_indices::OUTDB_URI),
+            StringArray,
+            "bands.outdb_uri"
+        );
+        let band_outdb_format_array = downcast!(
+            bands_struct.column(band_indices::OUTDB_FORMAT),
+            StringViewArray,
+            "bands.outdb_format"
+        );
+        let band_data_array = downcast!(
+            bands_struct.column(band_indices::DATA),
+            BinaryViewArray,
+            "bands.data"
+        );
 
-        Self {
+        Ok(Self {
             raster_array,
             crs_array,
             transform_list,
@@ -531,7 +538,7 @@ impl<'a> RasterStructArray<'a> {
             band_outdb_uri_array,
             band_outdb_format_array,
             band_data_array,
-        }
+        })
     }
 
     /// Get the total number of rasters in the array.
@@ -654,7 +661,7 @@ mod tests {
         let raster_array = builder.finish().unwrap();
 
         // Test the array
-        let rasters = RasterStructArray::new(&raster_array);
+        let rasters = RasterStructArray::try_new(&raster_array).unwrap();
 
         assert_eq!(rasters.len(), 1);
         assert!(!rasters.is_empty());
@@ -729,7 +736,7 @@ mod tests {
 
         let raster_array = builder.finish().unwrap();
 
-        let rasters = RasterStructArray::new(&raster_array);
+        let rasters = RasterStructArray::try_new(&raster_array).unwrap();
         let raster = rasters.get(0).unwrap();
         let bands = raster.bands();
 
@@ -770,7 +777,7 @@ mod tests {
     #[test]
     fn test_raster_is_null() {
         let raster_array = generate_test_rasters(2, Some(1)).unwrap();
-        let rasters = RasterStructArray::new(&raster_array);
+        let rasters = RasterStructArray::try_new(&raster_array).unwrap();
         assert_eq!(rasters.len(), 2);
         assert!(!rasters.is_null(0));
         assert!(rasters.is_null(1));
@@ -849,7 +856,7 @@ mod tests {
         let array = build_identity_raster();
         let bad_dtype: ArrayRef = Arc::new(UInt32Array::from(vec![0xFFu32]));
         let mutated = replace_band_column(&array, band_indices::DATA_TYPE, bad_dtype);
-        let rasters = RasterStructArray::new(&mutated);
+        let rasters = RasterStructArray::try_new(&mutated).unwrap();
         let r = rasters.get(0).unwrap();
         // band() surfaces the corruption through the standardized
         // SedonaDB-internal-error message routed via ArrowError::ExternalError.
@@ -884,7 +891,7 @@ mod tests {
             band_indices::SOURCE_SHAPE,
             Arc::new(empty_source_shape),
         );
-        let rasters = RasterStructArray::new(&mutated);
+        let rasters = RasterStructArray::try_new(&mutated).unwrap();
         let err = rasters.get(0).unwrap().band(0).err().unwrap();
         assert!(err.to_string().contains("SedonaDB internal error"));
         assert!(err.to_string().contains("empty source_shape"));
@@ -929,7 +936,7 @@ mod tests {
         builder.finish_band().unwrap();
         builder.finish_raster().unwrap();
         let array = builder.finish().unwrap();
-        let rasters = RasterStructArray::new(&array);
+        let rasters = RasterStructArray::try_new(&array).unwrap();
         let r = rasters.get(0).unwrap();
 
         // Bounds: out-of-range indices yield None on every fast path.
@@ -1044,7 +1051,7 @@ mod tests {
         builder.finish_raster().unwrap();
 
         let array = builder.finish().unwrap();
-        let rasters = RasterStructArray::new(&array);
+        let rasters = RasterStructArray::try_new(&array).unwrap();
 
         let r0 = rasters.get(0).unwrap();
         assert_eq!(r0.num_bands(), 3);
@@ -1138,7 +1145,7 @@ mod tests {
         builder.finish_raster().unwrap();
         builder.append_null().unwrap();
         let array = builder.finish().unwrap();
-        let rasters = RasterStructArray::new(&array);
+        let rasters = RasterStructArray::try_new(&array).unwrap();
 
         // Sanity: raster 0 still resolves correctly.
         let r0 = rasters.get(0).unwrap();
@@ -1183,7 +1190,7 @@ mod tests {
         builder.finish_raster().unwrap();
         let arr = builder.finish().unwrap();
 
-        let rasters = RasterStructArray::new(&arr);
+        let rasters = RasterStructArray::try_new(&arr).unwrap();
         let r = rasters.get(0).unwrap();
         let band = r.band(0).unwrap();
         assert!(

--- a/rust/sedona-raster/src/array.rs
+++ b/rust/sedona-raster/src/array.rs
@@ -24,7 +24,6 @@ use datafusion_common::cast::{
     as_binary_array, as_binary_view_array, as_float64_array, as_int64_array, as_list_array,
     as_string_array, as_string_view_array, as_struct_array, as_uint32_array,
 };
-use datafusion_common::DataFusionError;
 
 use crate::traits::{BandRef, Bands, NdBuffer, RasterRef};
 use crate::view_entries::ViewEntry;
@@ -411,58 +410,45 @@ impl<'a> RasterStructArray<'a> {
     /// Returns an error if the array doesn't have the expected raster schema.
     #[inline]
     pub fn try_new(raster_array: &'a StructArray) -> Result<Self, ArrowError> {
-        // Helper to convert DataFusionError to ArrowError
-        fn to_arrow_err(e: DataFusionError) -> ArrowError {
-            match e {
-                DataFusionError::ArrowError(arrow_err, _) => *arrow_err,
-                other => ArrowError::InvalidArgumentError(other.to_string()),
-            }
+        if raster_array.fields().len() != raster_indices::FIELD_COUNT {
+            return Err(ArrowError::SchemaError(
+                "Unexpected column count for raster array".to_string(),
+            ));
         }
 
         // Top-level fields
-        let crs_array =
-            as_string_view_array(raster_array.column(raster_indices::CRS)).map_err(to_arrow_err)?;
-        let transform_list =
-            as_list_array(raster_array.column(raster_indices::TRANSFORM)).map_err(to_arrow_err)?;
-        let transform_values = as_float64_array(transform_list.values()).map_err(to_arrow_err)?;
-        let spatial_dims_list = as_list_array(raster_array.column(raster_indices::SPATIAL_DIMS))
-            .map_err(to_arrow_err)?;
-        let spatial_dims_values =
-            as_string_view_array(spatial_dims_list.values()).map_err(to_arrow_err)?;
-        let spatial_shape_list = as_list_array(raster_array.column(raster_indices::SPATIAL_SHAPE))
-            .map_err(to_arrow_err)?;
-        let spatial_shape_values =
-            as_int64_array(spatial_shape_list.values()).map_err(to_arrow_err)?;
+        let crs_array = as_string_view_array(raster_array.column(raster_indices::CRS))?;
+        let transform_list = as_list_array(raster_array.column(raster_indices::TRANSFORM))?;
+        let transform_values = as_float64_array(transform_list.values())?;
+        let spatial_dims_list = as_list_array(raster_array.column(raster_indices::SPATIAL_DIMS))?;
+        let spatial_dims_values = as_string_view_array(spatial_dims_list.values())?;
+        let spatial_shape_list = as_list_array(raster_array.column(raster_indices::SPATIAL_SHAPE))?;
+        let spatial_shape_values = as_int64_array(spatial_shape_list.values())?;
 
         // Bands list and nested struct
-        let bands_list =
-            as_list_array(raster_array.column(raster_indices::BANDS)).map_err(to_arrow_err)?;
-        let bands_struct = as_struct_array(bands_list.values()).map_err(to_arrow_err)?;
+        let bands_list = as_list_array(raster_array.column(raster_indices::BANDS))?;
+        let bands_struct = as_struct_array(bands_list.values())?;
+
+        if bands_struct.fields().len() != band_indices::FIELD_COUNT {
+            return Err(ArrowError::SchemaError(
+                "Unexpected column count for band array".to_string(),
+            ));
+        }
 
         // Band-level fields
-        let band_name_array =
-            as_string_array(bands_struct.column(band_indices::NAME)).map_err(to_arrow_err)?;
-        let band_dim_names_list =
-            as_list_array(bands_struct.column(band_indices::DIM_NAMES)).map_err(to_arrow_err)?;
-        let band_dim_names_values =
-            as_string_array(band_dim_names_list.values()).map_err(to_arrow_err)?;
+        let band_name_array = as_string_array(bands_struct.column(band_indices::NAME))?;
+        let band_dim_names_list = as_list_array(bands_struct.column(band_indices::DIM_NAMES))?;
+        let band_dim_names_values = as_string_array(band_dim_names_list.values())?;
         let band_source_shape_list =
-            as_list_array(bands_struct.column(band_indices::SOURCE_SHAPE)).map_err(to_arrow_err)?;
-        let band_source_shape_values =
-            as_int64_array(band_source_shape_list.values()).map_err(to_arrow_err)?;
-        let band_datatype_array =
-            as_uint32_array(bands_struct.column(band_indices::DATA_TYPE)).map_err(to_arrow_err)?;
-        let band_nodata_array =
-            as_binary_array(bands_struct.column(band_indices::NODATA)).map_err(to_arrow_err)?;
-        let band_view_list =
-            as_list_array(bands_struct.column(band_indices::VIEW)).map_err(to_arrow_err)?;
-        let band_outdb_uri_array =
-            as_string_array(bands_struct.column(band_indices::OUTDB_URI)).map_err(to_arrow_err)?;
+            as_list_array(bands_struct.column(band_indices::SOURCE_SHAPE))?;
+        let band_source_shape_values = as_int64_array(band_source_shape_list.values())?;
+        let band_datatype_array = as_uint32_array(bands_struct.column(band_indices::DATA_TYPE))?;
+        let band_nodata_array = as_binary_array(bands_struct.column(band_indices::NODATA))?;
+        let band_view_list = as_list_array(bands_struct.column(band_indices::VIEW))?;
+        let band_outdb_uri_array = as_string_array(bands_struct.column(band_indices::OUTDB_URI))?;
         let band_outdb_format_array =
-            as_string_view_array(bands_struct.column(band_indices::OUTDB_FORMAT))
-                .map_err(to_arrow_err)?;
-        let band_data_array =
-            as_binary_view_array(bands_struct.column(band_indices::DATA)).map_err(to_arrow_err)?;
+            as_string_view_array(bands_struct.column(band_indices::OUTDB_FORMAT))?;
+        let band_data_array = as_binary_view_array(bands_struct.column(band_indices::DATA))?;
 
         Ok(Self {
             raster_array,

--- a/rust/sedona-raster/src/builder.rs
+++ b/rust/sedona-raster/src/builder.rs
@@ -815,7 +815,7 @@ mod tests {
         let raster_array = builder.finish().unwrap();
 
         // Test the iterator
-        let rasters = RasterStructArray::new(&raster_array);
+        let rasters = RasterStructArray::try_new(&raster_array).unwrap();
 
         assert_eq!(rasters.len(), 1);
         assert!(!rasters.is_empty());
@@ -890,7 +890,7 @@ mod tests {
 
         let raster_array = builder.finish().unwrap();
 
-        let rasters = RasterStructArray::new(&raster_array);
+        let rasters = RasterStructArray::try_new(&raster_array).unwrap();
         let raster = rasters.get(0).unwrap();
         let bands = raster.bands();
 
@@ -966,7 +966,7 @@ mod tests {
 
         // Create a new raster using metadata from the iterator
         let mut target_builder = RasterBuilder::new(10);
-        let iterator = RasterStructArray::new(&source_array);
+        let iterator = RasterStructArray::try_new(&source_array).unwrap();
         let source_raster = iterator.get(0).unwrap();
 
         target_builder
@@ -995,7 +995,7 @@ mod tests {
         let target_array = target_builder.finish().unwrap();
 
         // Verify the metadata was copied correctly
-        let target_iterator = RasterStructArray::new(&target_array);
+        let target_iterator = RasterStructArray::try_new(&target_array).unwrap();
         let target_raster = target_iterator.get(0).unwrap();
         let target_metadata = target_raster.metadata();
 
@@ -1122,7 +1122,7 @@ mod tests {
         let raster_array = builder.finish().unwrap();
 
         // Test the data type conversion for each band
-        let iterator = RasterStructArray::new(&raster_array);
+        let iterator = RasterStructArray::try_new(&raster_array).unwrap();
         let raster = iterator.get(0).unwrap();
         let bands = raster.bands();
 
@@ -1206,7 +1206,7 @@ mod tests {
         let raster_array = builder.finish().unwrap();
 
         // Verify the band metadata
-        let iterator = RasterStructArray::new(&raster_array);
+        let iterator = RasterStructArray::try_new(&raster_array).unwrap();
         let raster = iterator.get(0).unwrap();
         let bands = raster.bands();
 
@@ -1269,7 +1269,7 @@ mod tests {
         builder.finish_raster().unwrap();
 
         let raster_array = builder.finish().unwrap();
-        let iterator = RasterStructArray::new(&raster_array);
+        let iterator = RasterStructArray::try_new(&raster_array).unwrap();
         let raster = iterator.get(0).unwrap();
         let bands = raster.bands();
 
@@ -1319,7 +1319,7 @@ mod tests {
         builder.finish_raster().unwrap();
 
         let array = builder.finish().unwrap();
-        let rasters = RasterStructArray::new(&array);
+        let rasters = RasterStructArray::try_new(&array).unwrap();
         assert_eq!(rasters.len(), 1);
 
         let r = rasters.get(0).unwrap();
@@ -1368,7 +1368,7 @@ mod tests {
 
         builder.finish_raster().unwrap();
         let array = builder.finish().unwrap();
-        let rasters = RasterStructArray::new(&array);
+        let rasters = RasterStructArray::try_new(&array).unwrap();
         let r = rasters.get(0).unwrap();
 
         assert_eq!(r.num_bands(), 2);
@@ -1396,7 +1396,7 @@ mod tests {
         builder.append_null().unwrap();
 
         let array = builder.finish().unwrap();
-        let rasters = RasterStructArray::new(&array);
+        let rasters = RasterStructArray::try_new(&array).unwrap();
         assert_eq!(rasters.len(), 2);
         assert!(!rasters.is_null(0));
         assert!(rasters.is_null(1));
@@ -1428,7 +1428,7 @@ mod tests {
         builder.finish_raster().unwrap();
 
         let array = builder.finish().unwrap();
-        let rasters = RasterStructArray::new(&array);
+        let rasters = RasterStructArray::try_new(&array).unwrap();
         let r = rasters.get(0).unwrap();
 
         assert_eq!(r.band_name(0), Some("temperature"));
@@ -1477,7 +1477,7 @@ mod tests {
         builder.finish_raster().unwrap();
 
         let array = builder.finish().unwrap();
-        let rasters = RasterStructArray::new(&array);
+        let rasters = RasterStructArray::try_new(&array).unwrap();
         let r = rasters.get(0).unwrap();
 
         assert_eq!(r.x_dim(), "longitude");
@@ -1530,7 +1530,7 @@ mod tests {
 
         builder.finish_raster().unwrap();
         let array = builder.finish().unwrap();
-        let rasters = RasterStructArray::new(&array);
+        let rasters = RasterStructArray::try_new(&array).unwrap();
         let r = rasters.get(0).unwrap();
 
         assert_eq!(r.num_bands(), 2);
@@ -1575,7 +1575,7 @@ mod tests {
         builder.finish_raster().unwrap();
 
         let array = builder.finish().unwrap();
-        let rasters = RasterStructArray::new(&array);
+        let rasters = RasterStructArray::try_new(&array).unwrap();
         let r = rasters.get(0).unwrap();
         let band = r.band(0).unwrap();
 
@@ -1602,7 +1602,7 @@ mod tests {
         builder.finish_raster().unwrap();
 
         let array = builder.finish().unwrap();
-        let rasters = RasterStructArray::new(&array);
+        let rasters = RasterStructArray::try_new(&array).unwrap();
         let r = rasters.get(0).unwrap();
         let band = r.band(0).unwrap();
 
@@ -1675,7 +1675,7 @@ mod tests {
         builder.finish_raster().unwrap();
 
         let array = builder.finish().unwrap();
-        let rasters = RasterStructArray::new(&array);
+        let rasters = RasterStructArray::try_new(&array).unwrap();
 
         let r0 = rasters.get(0).unwrap();
         let b0 = r0.band(0).unwrap();
@@ -1703,7 +1703,7 @@ mod tests {
         builder.finish_raster().unwrap();
 
         let array = builder.finish().unwrap();
-        let rasters = RasterStructArray::new(&array);
+        let rasters = RasterStructArray::try_new(&array).unwrap();
         let r = rasters.get(0).unwrap();
 
         assert_eq!(r.num_bands(), 0);
@@ -1743,7 +1743,7 @@ mod tests {
 
         builder.finish_raster().unwrap();
         let array = builder.finish().unwrap();
-        let rasters = RasterStructArray::new(&array);
+        let rasters = RasterStructArray::try_new(&array).unwrap();
         let r = rasters.get(0).unwrap();
 
         assert_eq!(r.band_name(0), Some("temperature"));
@@ -1776,7 +1776,7 @@ mod tests {
         builder.finish_raster().unwrap();
 
         let array = builder.finish().unwrap();
-        let rasters = RasterStructArray::new(&array);
+        let rasters = RasterStructArray::try_new(&array).unwrap();
         let r = rasters.get(0).unwrap();
 
         assert_eq!(r.spatial_dims(), vec!["longitude", "latitude"]);
@@ -1799,7 +1799,7 @@ mod tests {
         builder.finish_raster().unwrap();
 
         let array = builder.finish().unwrap();
-        let rasters = RasterStructArray::new(&array);
+        let rasters = RasterStructArray::try_new(&array).unwrap();
         let r = rasters.get(0).unwrap();
 
         assert_eq!(r.num_bands(), 0);
@@ -1875,7 +1875,7 @@ mod tests {
         builder.finish_raster().unwrap();
 
         let array = builder.finish().unwrap();
-        let rasters = RasterStructArray::new(&array);
+        let rasters = RasterStructArray::try_new(&array).unwrap();
         let r = rasters.get(0).unwrap();
         let band = r.band(0).unwrap();
 
@@ -2044,7 +2044,7 @@ mod tests {
             "identity-view band must remain a null view row after IPC round-trip"
         );
 
-        let rasters = RasterStructArray::new(restored_struct);
+        let rasters = RasterStructArray::try_new(restored_struct).unwrap();
         let r0 = rasters.get(0).unwrap();
         assert_eq!(r0.band(0).unwrap().shape(), &[2, 3]);
     }
@@ -2085,7 +2085,7 @@ mod tests {
         builder.finish_raster().unwrap();
         let arr = builder.finish().unwrap();
 
-        let rasters = RasterStructArray::new(&arr);
+        let rasters = RasterStructArray::try_new(&arr).unwrap();
         let r = rasters.get(0).unwrap();
         let band = r.band(0).unwrap();
         let out = band.nd_buffer().unwrap().as_contiguous().unwrap();
@@ -2118,7 +2118,7 @@ mod tests {
         // Dedup: one shared data block, not two.
         assert_eq!(output_band_data(&arr).data_buffers().len(), 1);
 
-        let rasters = RasterStructArray::new(&arr);
+        let rasters = RasterStructArray::try_new(&arr).unwrap();
         let r = rasters.get(0).unwrap();
         assert_eq!(
             r.band(0)
@@ -2160,7 +2160,7 @@ mod tests {
         builder.finish_raster().unwrap();
         let arr = builder.finish().unwrap();
 
-        let rasters = RasterStructArray::new(&arr);
+        let rasters = RasterStructArray::try_new(&arr).unwrap();
         let r = rasters.get(0).unwrap();
         assert_eq!(
             r.band(0)
@@ -2211,7 +2211,7 @@ mod tests {
         builder.finish_raster().unwrap();
         let arr = builder.finish().unwrap();
 
-        let rasters = RasterStructArray::new(&arr);
+        let rasters = RasterStructArray::try_new(&arr).unwrap();
         let r = rasters.get(0).unwrap();
         let band = r.band(0).unwrap();
         let out = band.nd_buffer().unwrap().as_contiguous().unwrap();
@@ -2247,7 +2247,7 @@ mod tests {
         builder.finish_raster().unwrap();
         let arr = builder.finish().unwrap();
 
-        let rasters = RasterStructArray::new(&arr);
+        let rasters = RasterStructArray::try_new(&arr).unwrap();
         assert_eq!(
             rasters
                 .get(0)
@@ -2282,7 +2282,7 @@ mod tests {
         // Inline: no backing block attached.
         assert_eq!(output_band_data(&arr).data_buffers().len(), 0);
 
-        let rasters = RasterStructArray::new(&arr);
+        let rasters = RasterStructArray::try_new(&arr).unwrap();
         let r = rasters.get(0).unwrap();
         let band = r.band(0).unwrap();
         assert_eq!(

--- a/rust/sedona-raster/src/display.rs
+++ b/rust/sedona-raster/src/display.rs
@@ -126,7 +126,7 @@ mod tests {
         // i=0: w=1, h=2, scale=(0.1, -0.2), skew=(0, 0), CRS=OGC:CRS84
         // Bounds: xmin=1, ymin=1.6, xmax=1.1, ymax=2
         let rasters = generate_test_rasters(1, None).unwrap();
-        let raster_array = RasterStructArray::new(&rasters);
+        let raster_array = RasterStructArray::try_new(&rasters).unwrap();
         let raster = raster_array.get(0).unwrap();
 
         let display = format!("{}", RasterDisplay(&raster));
@@ -139,7 +139,7 @@ mod tests {
         // Corners: (3,4), (3.6,4.24), (3.84,2.64), (3.24,2.4)
         // AABB: xmin=3, ymin=2.4, xmax=3.84, ymax=4.24
         let rasters = generate_test_rasters(3, None).unwrap();
-        let raster_array = RasterStructArray::new(&rasters);
+        let raster_array = RasterStructArray::try_new(&rasters).unwrap();
         let raster = raster_array.get(2).unwrap();
 
         let display = format!("{}", RasterDisplay(&raster));
@@ -153,7 +153,7 @@ mod tests {
     fn display_write_to_fmt_write() {
         // Verify RasterDisplay works with any fmt::Write target (e.g., String)
         let rasters = generate_test_rasters(1, None).unwrap();
-        let raster_array = RasterStructArray::new(&rasters);
+        let raster_array = RasterStructArray::try_new(&rasters).unwrap();
         let raster = raster_array.get(0).unwrap();
 
         let mut buf = String::new();

--- a/rust/sedona-schema/src/raster.rs
+++ b/rust/sedona-schema/src/raster.rs
@@ -231,6 +231,7 @@ pub mod raster_indices {
     pub const SPATIAL_DIMS: usize = 2;
     pub const SPATIAL_SHAPE: usize = 3;
     pub const BANDS: usize = 4;
+    pub const FIELD_COUNT: usize = 5;
 }
 
 pub mod band_indices {
@@ -243,6 +244,7 @@ pub mod band_indices {
     pub const OUTDB_URI: usize = 6;
     pub const OUTDB_FORMAT: usize = 7;
     pub const DATA: usize = 8;
+    pub const FIELD_COUNT: usize = 9;
 }
 
 /// Field indices within the `view` struct (`(source_axis, start, step, steps)`).
@@ -251,6 +253,7 @@ pub mod band_view_indices {
     pub const START: usize = 1;
     pub const STEP: usize = 2;
     pub const STEPS: usize = 3;
+    pub const FIELD_COUNT: usize = 4;
 }
 
 /// Column name constants used throughout the raster schema definition.

--- a/rust/sedona-testing/src/benchmark_util.rs
+++ b/rust/sedona-testing/src/benchmark_util.rs
@@ -967,7 +967,7 @@ mod test {
         assert_eq!(data[0].data_type(), RASTER.storage_type());
 
         let raster_array = data[0].as_any().downcast_ref::<StructArray>().unwrap();
-        let rasters = RasterStructArray::new(raster_array);
+        let rasters = RasterStructArray::try_new(raster_array).unwrap();
         assert_eq!(rasters.len(), ROWS_PER_BATCH);
         let raster = rasters.get(0).unwrap();
         let metadata = raster.metadata();

--- a/rust/sedona-testing/src/compare.rs
+++ b/rust/sedona-testing/src/compare.rs
@@ -231,8 +231,8 @@ pub fn assert_scalar_equal(actual: &ScalarValue, expected: &ScalarValue) {
 
 fn assert_raster_structs_equal(actual: &StructArray, expected: &StructArray) {
     assert_raster_arrays_equal(
-        &RasterStructArray::new(actual),
-        &RasterStructArray::new(expected),
+        &RasterStructArray::try_new(actual).unwrap(),
+        &RasterStructArray::try_new(expected).unwrap(),
     );
 }
 

--- a/rust/sedona-testing/src/raster_spec.rs
+++ b/rust/sedona-testing/src/raster_spec.rs
@@ -419,8 +419,8 @@ pub fn assert_rasters_equal(actual: &ArrayRef, expected: &[Option<RasterSpec>]) 
         .expect("expected a raster StructArray result");
     let expected_struct = raster_array(expected.iter().cloned());
     assert_raster_arrays_equal(
-        &RasterStructArray::new(actual_struct),
-        &RasterStructArray::new(&expected_struct),
+        &RasterStructArray::try_new(actual_struct).unwrap(),
+        &RasterStructArray::try_new(&expected_struct).unwrap(),
     );
 }
 
@@ -431,8 +431,8 @@ pub fn assert_raster_scalar_equals(actual: &ScalarValue, expected: &RasterSpec) 
         ScalarValue::Struct(actual_struct) => {
             let expected_struct = expected.build();
             assert_raster_arrays_equal(
-                &RasterStructArray::new(actual_struct),
-                &RasterStructArray::new(&expected_struct),
+                &RasterStructArray::try_new(actual_struct).unwrap(),
+                &RasterStructArray::try_new(&expected_struct).unwrap(),
             );
         }
         other => panic!("expected a raster struct scalar, got {other:?}"),
@@ -484,7 +484,7 @@ pub fn list_i64_row(result: &ArrayRef, row: usize) -> Option<Vec<i64>> {
 pub fn band_pixels<T: PixelValue>(rasters: &StructArray, row: usize, band_number: usize) -> Vec<T> {
     use sedona_raster::traits::RasterRef;
 
-    let array = RasterStructArray::new(rasters);
+    let array = RasterStructArray::try_new(rasters).unwrap();
     assert!(!array.is_null(row), "raster row {row} is null");
     let raster = array.get(row).expect("raster row");
     let bands = raster.bands();
@@ -510,7 +510,7 @@ mod tests {
     #[test]
     fn d2_defaults() {
         let raster = RasterSpec::d2(4, 5).band(BandDataType::Float32).build();
-        let array = RasterStructArray::new(&raster);
+        let array = RasterStructArray::try_new(&raster).unwrap();
         assert_eq!(array.len(), 1);
         let raster_ref = array.get(0).unwrap();
         let metadata = raster_ref.metadata();
@@ -537,7 +537,7 @@ mod tests {
         let raster = RasterSpec::nd(&["time", "y", "x"], &[3, 4, 5])
             .band(BandDataType::Float32)
             .build();
-        let array = RasterStructArray::new(&raster);
+        let array = RasterStructArray::try_new(&raster).unwrap();
         let raster_ref = array.get(0).unwrap();
 
         // Raster-level spatial metadata is X-first, like the readers emit.
@@ -563,7 +563,7 @@ mod tests {
             .band_nd(&["y", "x"], &[4, 5], BandDataType::Float32)
             .band(BandDataType::Float32)
             .build();
-        let array = RasterStructArray::new(&mixed);
+        let array = RasterStructArray::try_new(&mixed).unwrap();
         let raster_ref = array.get(0).unwrap();
         assert_eq!(raster_ref.bands().len(), 2);
 
@@ -572,7 +572,7 @@ mod tests {
             .band(BandDataType::Float32)
             .band_nd(&["time", "y", "x"], &[7, 4, 5], BandDataType::Float32)
             .build();
-        let array = RasterStructArray::new(&conflicting);
+        let array = RasterStructArray::try_new(&conflicting).unwrap();
         let bands = array.get(0).unwrap();
         let bands = bands.bands();
         assert_eq!(bands.band(1).unwrap().shape(), &[3, 4, 5]);
@@ -586,7 +586,7 @@ mod tests {
             .nodata(0u16)
             .name("temperature")
             .build();
-        let array = RasterStructArray::new(&raster);
+        let array = RasterStructArray::try_new(&raster).unwrap();
         let raster_ref = array.get(0).unwrap();
         let bands = raster_ref.bands();
         let band = bands.band(1).unwrap();
@@ -607,7 +607,7 @@ mod tests {
             .band(BandDataType::Float32)
             .outdb("s3://bucket/raster.tif#band=2", None)
             .build();
-        let array = RasterStructArray::new(&raster);
+        let array = RasterStructArray::try_new(&raster).unwrap();
         let raster_ref = array.get(0).unwrap();
         let bands = raster_ref.bands();
         let band = bands.band(1).unwrap();
@@ -624,7 +624,7 @@ mod tests {
             None,
             Some(RasterSpec::d2(3, 3).band(BandDataType::UInt8)),
         ]);
-        let rasters = RasterStructArray::new(&array);
+        let rasters = RasterStructArray::try_new(&array).unwrap();
         assert_eq!(rasters.len(), 3);
         assert!(!rasters.is_null(0));
         assert!(rasters.is_null(1));

--- a/rust/sedona-testing/src/rasters.rs
+++ b/rust/sedona-testing/src/rasters.rs
@@ -540,7 +540,7 @@ mod tests {
     fn test_generate_test_rasters() {
         let count = 5;
         let struct_array = generate_test_rasters(count, None).unwrap();
-        let raster_array = RasterStructArray::new(&struct_array);
+        let raster_array = RasterStructArray::try_new(&struct_array).unwrap();
         assert_eq!(raster_array.len(), count);
 
         for i in 0..count {
@@ -585,7 +585,7 @@ mod tests {
         let data_type = BandDataType::UInt8;
         let struct_array =
             generate_tiled_rasters(tile_size, number_of_tiles, data_type, Some(43)).unwrap();
-        let raster_array = RasterStructArray::new(&struct_array);
+        let raster_array = RasterStructArray::try_new(&struct_array).unwrap();
         assert_eq!(raster_array.len(), 16); // 4x4 tiles
         for i in 0..16 {
             let raster = raster_array.get(i).unwrap();
@@ -610,7 +610,7 @@ mod tests {
     #[test]
     fn test_raster_arrays_equal() {
         let raster_array1 = generate_test_rasters(3, None).unwrap();
-        let raster_struct_array1 = RasterStructArray::new(&raster_array1);
+        let raster_struct_array1 = RasterStructArray::try_new(&raster_array1).unwrap();
         // Test that identical arrays are equal
         assert_raster_arrays_equal(&raster_struct_array1, &raster_struct_array1);
     }
@@ -626,8 +626,8 @@ mod tests {
             .band(BandDataType::UInt8)
             .build();
         let without_crs = RasterSpec::d2(2, 2).band(BandDataType::UInt8).build();
-        let a = RasterStructArray::new(&with_crs);
-        let b = RasterStructArray::new(&without_crs);
+        let a = RasterStructArray::try_new(&with_crs).unwrap();
+        let b = RasterStructArray::try_new(&without_crs).unwrap();
         assert_raster_arrays_equal(&a, &b);
     }
 
@@ -635,11 +635,11 @@ mod tests {
     #[should_panic = "Raster array lengths do not match"]
     fn test_raster_arrays_not_equal() {
         let raster_array1 = generate_test_rasters(3, None).unwrap();
-        let raster_struct_array1 = RasterStructArray::new(&raster_array1);
+        let raster_struct_array1 = RasterStructArray::try_new(&raster_array1).unwrap();
 
         // Test that arrays with different lengths are not equal
         let raster_array2 = generate_test_rasters(4, None).unwrap();
-        let raster_struct_array2 = RasterStructArray::new(&raster_array2);
+        let raster_struct_array2 = RasterStructArray::try_new(&raster_array2).unwrap();
         assert_raster_arrays_equal(&raster_struct_array1, &raster_struct_array2);
     }
 
@@ -647,7 +647,10 @@ mod tests {
     fn test_raster_equal() {
         let raster_array1 =
             generate_tiled_rasters((256, 256), (1, 1), BandDataType::UInt8, Some(43)).unwrap();
-        let raster1 = RasterStructArray::new(&raster_array1).get(0).unwrap();
+        let raster1 = RasterStructArray::try_new(&raster_array1)
+            .unwrap()
+            .get(0)
+            .unwrap();
 
         // Assert that the rasters are equal to themselves
         assert_raster_equal(&raster1, &raster1);
@@ -661,15 +664,21 @@ mod tests {
         let raster_array2 =
             generate_tiled_rasters((128, 128), (1, 1), BandDataType::UInt8, Some(47)).unwrap();
 
-        let raster1 = RasterStructArray::new(&raster_array1).get(0).unwrap();
-        let raster2 = RasterStructArray::new(&raster_array2).get(0).unwrap();
+        let raster1 = RasterStructArray::try_new(&raster_array1)
+            .unwrap()
+            .get(0)
+            .unwrap();
+        let raster2 = RasterStructArray::try_new(&raster_array2)
+            .unwrap()
+            .get(0)
+            .unwrap();
         assert_raster_equal(&raster1, &raster2);
     }
 
     #[test]
     fn test_generate_multi_band_raster() {
         let struct_array = generate_multi_band_raster();
-        let raster_array = RasterStructArray::new(&struct_array);
+        let raster_array = RasterStructArray::try_new(&struct_array).unwrap();
         assert_eq!(raster_array.len(), 1);
 
         let raster = raster_array.get(0).unwrap();
@@ -707,8 +716,14 @@ mod tests {
     fn test_raster_different_metadata() {
         let raster_array =
             generate_tiled_rasters((128, 128), (2, 1), BandDataType::UInt8, Some(43)).unwrap();
-        let raster1 = RasterStructArray::new(&raster_array).get(0).unwrap();
-        let raster2 = RasterStructArray::new(&raster_array).get(1).unwrap();
+        let raster1 = RasterStructArray::try_new(&raster_array)
+            .unwrap()
+            .get(0)
+            .unwrap();
+        let raster2 = RasterStructArray::try_new(&raster_array)
+            .unwrap()
+            .get(1)
+            .unwrap();
         assert_raster_equal(&raster1, &raster2);
     }
 }


### PR DESCRIPTION
Extracted from #916. Some code paths create a RasterStructArray from  data that hasn't yet been validated. Because the `new()` function paniced for unexpected child array types, this meant that malformed data could crash the process.

This PR updates the `new()` function to be `try_new()` and ensures it errors for unexpected input.