### PR TITLE
refactor(python/sedonadb): Extract common read functionality into read accessor

### DIFF
--- a/python/sedonadb-zarr/README.md
+++ b/python/sedonadb-zarr/README.md
@@ -22,15 +22,16 @@
 Zarr support for [SedonaDB](https://sedona.apache.org/) as an opt-in plugin package. Reads Zarr v3 groups (with sharding, vlen-utf8 dims, etc.) as a column of N-D rasters:
 
 ```python
-import sedonadb
-import sedonadb_zarr
+import sedona.db
+from sedonadb_zarr import ZarrExtension
 
-con = sedonadb.connect()
-con.read_format(sedonadb_zarr.ZarrFormatSpec(), "file:///path/to/foo.zarr").show()
+sd = sedona.db.connect()
+sd.register(ZarrExtension())
+con.read("file:///path/to/foo.zarr").show()
 ```
 
 The main `sedonadb` package does not bundle Zarr support — applications that don't import `sedonadb_zarr` pay no runtime cost.
 
 ## Architecture
 
-A maturin-built mixed Rust/Python package. The Rust side is a thin PyO3 shim around `sedona-raster-zarr` exposing `PyZarrChunkReader` (implementing `__arrow_c_stream__`). The Python side defines `ZarrFormatSpec(ExternalFormatSpec)`, which sedonadb consumes via `con.read_format(spec, uri)`. The same plugin shape applies to future formats (`sedonadb-cog`, `sedonadb-icechunk`, …).
+A maturin-built mixed Rust/Python package. The Rust side is a thin PyO3 shim around `sedona-raster-zarr` exposing `PyZarrChunkReader` (implementing `__arrow_c_stream__`).

--- a/python/sedonadb-zarr/README.md
+++ b/python/sedonadb-zarr/README.md
@@ -27,7 +27,7 @@ from sedonadb_zarr import ZarrExtension
 
 sd = sedona.db.connect()
 sd.register(ZarrExtension())
-con.read("file:///path/to/foo.zarr").show()
+sd.read("file:///path/to/foo.zarr").show()
 ```
 
 The main `sedonadb` package does not bundle Zarr support — applications that don't import `sedonadb_zarr` pay no runtime cost.

--- a/python/sedonadb-zarr/python/sedonadb_zarr/__init__.py
+++ b/python/sedonadb-zarr/python/sedonadb_zarr/__init__.py
@@ -18,6 +18,7 @@
 """Zarr support for SedonaDB.
 
 ```python
+import sedona.db
 from sedonadb_zarr import ZarrExtension
 
 sd = sedona.db.connect()

--- a/python/sedonadb-zarr/python/sedonadb_zarr/__init__.py
+++ b/python/sedonadb-zarr/python/sedonadb_zarr/__init__.py
@@ -18,10 +18,11 @@
 """Zarr support for SedonaDB.
 
 ```python
-from sedonadb_zarr import Zarr
+from sedonadb_zarr import ZarrExtension
 
 sd = sedona.db.connect()
-sd.read_format(Zarr(), "file:///path/to/foo.zarr").show()
+sd.register(ZarrExtension())
+sd.read("file:///path/to/foo.zarr").show()
 ```
 
 Importing `sedonadb_zarr` is opt-in — applications that don't import
@@ -53,7 +54,7 @@ class ZarrExtension:
         if kwargs:
             raise ValueError("Registration options not supported for ZarrExtension")
 
-        # Register the Zarr() format as a FileFormatFactory for SQL support
+        # Register the Zarr() format as a FileFormatFactory for SQL and .read(..., format="zarr")
         ctx.register(Zarr())
 
 
@@ -61,10 +62,11 @@ class Zarr(ExternalFormatSpec):
     """`ExternalFormatSpec` for Zarr groups.
 
     This is registered automatically when registering the module with a
-    SedonaContext. Use with `sd.read_format(spec, uri)`:
+    SedonaContext. Use with `sd.read(uri, format=Zarr())` or format="zarr"
+    after registering the extension:
 
     ```python
-    sd.read_format(Zarr(), "file:///path/to/foo.zarr")
+    sd.read("file:///path/to/foo.zarr", format="zarr")
     ```
 
     Args:

--- a/python/sedonadb-zarr/tests/conftest.py
+++ b/python/sedonadb-zarr/tests/conftest.py
@@ -51,7 +51,8 @@ def raster_con(zarr_group):
     Uses its own connection (not the shared module-level one) so the view
     doesn't leak into other tests.
     """
-    con = sedonadb.connect()
-    df = con.read_format(sedonadb_zarr.Zarr(), f"file://{zarr_group}")
+    sd = sedonadb.connect()
+    sd.register(sedonadb_zarr.ZarrExtension())
+    df = sd.read(f"file://{zarr_group}", format="zarr")
     df.to_view("rasters")
-    return con
+    return sd

--- a/python/sedonadb-zarr/tests/test_zarr.py
+++ b/python/sedonadb-zarr/tests/test_zarr.py
@@ -15,13 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Tests for the `sedonadb-zarr` plugin.
-
-Plugin surface: `ZarrFormatSpec(ExternalFormatSpec)` paired with
-`con.read_format(spec, uri)`. The SQL UDTF form (`sd_read_zarr`) is
-deferred to a follow-up PR.
-"""
-
 import numpy as np
 import pytest
 import sedonadb
@@ -48,9 +41,9 @@ def zarr_group(tmp_path):
     return tmp_path
 
 
-def test_format_spec_via_read_format(zarr_group):
+def test_format_spec_via_read(zarr_group):
     con = sedonadb.connect()
-    df = con.read_format(sedonadb_zarr.Zarr(), f"file://{zarr_group}")
+    df = con.read(f"file://{zarr_group}", format=sedonadb_zarr.Zarr())
     arrow_tab = df.to_arrow_table()
     assert arrow_tab.num_rows == 2
     assert arrow_tab.column_names == ["raster"]
@@ -99,7 +92,7 @@ def _zarr_with_attrs(tmp_path, group_attrs, *, dims=("y", "x")):
 def _envelope_bounds(con, path):
     """Read the single-chunk zarr and return RS_Envelope bounds of row 0."""
     shapely = pytest.importorskip("shapely")
-    df = con.read_format(sedonadb_zarr.Zarr(), f"file://{path}")
+    df = con.read(f"file://{path}", format=sedonadb_zarr.Zarr())
     raster = df.to_arrow_table()["raster"][0].as_py()
     wkt = (
         con.sql("SELECT ST_AsText(RS_Envelope($1)) AS wkt", params=(raster,))
@@ -182,7 +175,17 @@ def test_rs_envelope_honors_skew(tmp_path):
 def test_format_spec_with_arrays_option(zarr_group):
     con = sedonadb.connect()
     spec = sedonadb_zarr.Zarr().with_options({"arrays": ["temperature"]})
-    df = con.read_format(spec, f"file://{zarr_group}")
+
+    # Check via constructor options
+    df = con.read(f"file://{zarr_group}", format=spec)
+    assert df.to_arrow_table().num_rows == 2
+
+    # Check via read(..., options={...})
+    df = con.read(
+        f"file://{zarr_group}",
+        options={"arrays": ["temperature"]},
+        format=sedonadb_zarr.Zarr(),
+    )
     assert df.to_arrow_table().num_rows == 2
 
 
@@ -225,7 +228,7 @@ def test_dtype_mapping_roundtrips(tmp_path, numpy_dtype):
     arr[:] = np.ones((2, 2), dtype=numpy_dtype)
 
     con = sedonadb.connect()
-    df = con.read_format(sedonadb_zarr.Zarr(), f"file://{tmp_path}")
+    df = con.read(f"file://{tmp_path}", format=sedonadb_zarr.Zarr())
     tab = df.to_arrow_table()
     assert tab.num_rows == 2
 

--- a/python/sedonadb/python/sedonadb/context.py
+++ b/python/sedonadb/python/sedonadb/context.py
@@ -459,6 +459,11 @@ class SedonaContext:
             component.__sedonadb_extension__(self, **kwargs)
             return
 
+        # If this is an external format, register it so that sd.read(..., format="ext")
+        # works
+        if hasattr(component, "__sedonadb_external_format__") and component.extension:
+            self.read._register_external_format(component.extension, component)
+
         supported_interfaces = (
             "__sedonadb_internal_udf__",
             "__sedonadb_internal_aggregate_udf__",

--- a/python/sedonadb/python/sedonadb/context.py
+++ b/python/sedonadb/python/sedonadb/context.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import json
 import os
 import sys
 from functools import cached_property
@@ -33,7 +32,7 @@ from typing import (
 )
 
 if TYPE_CHECKING:
-    from sedonadb.datasource import ExternalFormatSpec
+    from sedonadb.read import Read
 
 from sedonadb._lib import (
     InternalContext,
@@ -44,6 +43,7 @@ from sedonadb._lib import (
 from sedonadb._options import Options
 from sedonadb.dataframe import DataFrame, _create_data_frame
 from sedonadb.functions import Functions
+
 from sedonadb.expr.expression import (
     Expr,
     col as col_expr,
@@ -193,6 +193,12 @@ class SedonaContext:
         """
         self._impl.drop_view(name)
 
+    @cached_property
+    def read(self) -> "Read":
+        from sedonadb.read import Read
+
+        return Read(self)
+
     def read_parquet(
         self,
         table_paths: Union[str, Path, Iterable[str]],
@@ -275,27 +281,12 @@ class SedonaContext:
             >>> sd.read_parquet(url)
             <sedonadb.dataframe.DataFrame object at ...>
         """
-        if isinstance(table_paths, (str, Path)):
-            table_paths = [table_paths]
-
-        if options is None:
-            options = {}
-
-        if geometry_columns is not None and not isinstance(geometry_columns, str):
-            geometry_columns = json.dumps(geometry_columns)
-
-        if isinstance(partitioning, str):
-            partitioning = [partitioning]
-
-        return DataFrame(
-            self,
-            self._impl.read_parquet(
-                [str(path) for path in table_paths],
-                options,
-                geometry_columns,
-                validate,
-                None if partitioning is None else list(partitioning),
-            ),
+        return self.read.parquet(
+            table_paths,
+            options=options,
+            geometry_columns=geometry_columns,
+            validate=validate,
+            partitioning=partitioning,
         )
 
     def read_pyogrio(
@@ -362,83 +353,8 @@ class SedonaContext:
             └──────────────┘
 
         """
-        from sedonadb.datasource import PyogrioFormatSpec
-
-        if isinstance(table_paths, (str, Path)):
-            table_paths = [table_paths]
-
-        spec = PyogrioFormatSpec(extension)
-        if options is not None:
-            spec = spec.with_options(options)
-
-        if isinstance(partitioning, str):
-            partitioning = [partitioning]
-
-        return DataFrame(
-            self,
-            self._impl.read_external_format(
-                spec,
-                [str(path) for path in table_paths],
-                False,
-                None if partitioning is None else list(partitioning),
-            ),
-        )
-
-    def read_format(
-        self,
-        spec: "ExternalFormatSpec",
-        table_paths: Union[str, Path, Iterable[str]],
-        check_extension: bool = False,
-        partitioning: Union[str, Iterable[str], None] = None,
-    ) -> DataFrame:
-        """Read one or more paths using a Python-defined `ExternalFormatSpec`.
-
-        This is the plugin entry point: a format-specific package (e.g.
-        `sedonadb-zarr`) defines an `ExternalFormatSpec` subclass and the
-        user reads through it via this method. Built-in formats have
-        their own dedicated readers (`read_parquet`, `read_pyogrio`).
-
-        Format-specific options are passed via the spec itself using
-        `spec.with_options({...})`, which returns a configured copy.
-        Unlike `read_pyogrio`, this method has no `options=` keyword —
-        each spec class documents its own supported keys.
-
-        Args:
-            spec: An `ExternalFormatSpec` instance describing how to open
-                the underlying source.
-            table_paths: A str, Path, or iterable of paths/URLs.
-            check_extension: When `True`, error if a non-collection path
-                doesn't end in the spec's `extension`. Defaults to `False`.
-            partitioning:
-                Optional list of column names for hive-style partitioning. When reading
-                from a directory with paths like `/col=value/file.ext`, partition
-                column names are auto-discovered by default (`partitioning=None`).
-                Explicitly specify column names (e.g., `["col"]`) to override
-                auto-discovery, or pass an empty list `[]` to disable partitioning
-                entirely.
-
-        Examples:
-            >>> import sedonadb_zarr  # doctest: +SKIP
-            >>> sd = sedona.db.connect()
-            >>> spec = sedonadb_zarr.ZarrFormatSpec().with_options(  # doctest: +SKIP
-            ...     {"arrays": ["temperature"]}
-            ... )
-            >>> sd.read_format(spec, "file:///path/to/foo.zarr").show()  # doctest: +SKIP
-        """
-        if isinstance(table_paths, (str, Path)):
-            table_paths = [table_paths]
-
-        if isinstance(partitioning, str):
-            partitioning = [partitioning]
-
-        return DataFrame(
-            self,
-            self._impl.read_external_format(
-                spec,
-                [str(path) for path in table_paths],
-                check_extension,
-                None if partitioning is None else list(partitioning),
-            ),
+        return self.read.pyogrio(
+            table_paths, options=options, extension=extension, partitioning=partitioning
         )
 
     def sql(

--- a/python/sedonadb/python/sedonadb/read.py
+++ b/python/sedonadb/python/sedonadb/read.py
@@ -1,0 +1,306 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import json
+from typing import Any, Dict, Iterable, Optional, Union
+
+from pathlib import Path
+
+from sedonadb.dataframe import DataFrame
+from sedonadb.utility import sedona  # noqa: F401
+from sedonadb.datasource import ExternalFormatSpec
+
+
+class Read:
+    """Read external data into SedonaDB
+
+    This class is the entrypoint to reading any path or URL as
+    a SedonaDB DataFrame.
+    """
+
+    def __init__(self, ctx):
+        self._ctx = ctx
+
+    def __call__(
+        self,
+        table_paths: Union[str, Path, Iterable[str]],
+        *,
+        options: Optional[Dict[str, Any]] = None,
+        partitioning: Union[str, Iterable[str], None] = None,
+        format: Union[str, "ExternalFormatSpec", None] = None,
+        check_extension: bool = False,
+    ) -> DataFrame:
+        """Read one or more paths
+
+        This is the generic read path, which guesses the appropriate format.
+        Format-specific methods like `.read.parquet()` provide type-specific
+        documentation for common format options.
+
+        Examples:
+            >>> sd = sedona.db.connect()
+            >>> spec = sedonadb_zarr.ZarrFormatSpec().with_options(  # doctest: +SKIP
+            ...     {"arrays": ["temperature"]}
+            ... )
+            >>> sd.read_format(spec, "file:///path/to/foo.zarr").show()  # doctest: +SKIP
+        """
+        if isinstance(table_paths, (str, Path)):
+            table_paths = [table_paths]
+
+        table_paths = [str(path) for path in table_paths]
+
+        if isinstance(partitioning, str):
+            partitioning = [partitioning]
+
+        if options is None:
+            options = {}
+
+        # If the format is a Python object, call with_options() on the Python objects
+        # to eliminate the serialization that would otherwise happen
+        if isinstance(format, ExternalFormatSpec):
+            return DataFrame(
+                self._ctx,
+                self._ctx._impl.read_external_format(
+                    format.with_options(options),
+                    table_paths,
+                    check_extension,
+                    None if partitioning is None else list(partitioning),
+                ),
+            )
+
+        # Special case a few format strings. It is theoretically possible to run these
+        # through a generic FileFormatFactory/ListingTable-based path, but for now we
+        # special-case some strings.
+        if format is None:
+            format = self._guess_format(table_paths)
+
+        if format in ("fgb", "gpkg", "shp"):
+            from sedonadb.datasource import PyogrioFormatSpec
+
+            return self(
+                table_paths,
+                options=options,
+                partitioning=partitioning,
+                check_extension=check_extension,
+                format=PyogrioFormatSpec(format),
+            )
+        elif format == "parquet":
+            geometry_columns = options.pop("geometry_columns", None)
+            validate = options.pop("validate", False)
+            return DataFrame(
+                self._ctx,
+                self._ctx._impl.read_parquet(
+                    table_paths,
+                    options,
+                    geometry_columns,
+                    validate,
+                    None if partitioning is None else list(partitioning),
+                ),
+            )
+        else:
+            raise ValueError(f"Can't guess file format for extension '{format}'")
+
+    def parquet(
+        self,
+        table_paths: Union[str, Path, Iterable[str]],
+        options: Optional[Dict[str, Any]] = None,
+        geometry_columns: Optional[Union[str, Dict[str, Any]]] = None,
+        validate: bool = False,
+        partitioning: Union[str, Iterable[str], None] = None,
+    ) -> DataFrame:
+        """Create a [DataFrame][sedonadb.dataframe.DataFrame] from one or more Parquet files
+
+        Args:
+            table_paths: A str, Path, or iterable of paths containing URLs to Parquet
+                files.
+            options: Optional dictionary of options to pass to the Parquet reader.
+                For S3 access, use {"aws.skip_signature": True, "aws.region": "us-west-2"} for anonymous access to public buckets.
+            geometry_columns: Optional JSON string or dict mapping column name to
+                GeoParquet column metadata (e.g.,
+                {"geom": {"encoding": "WKB"}}). Use this to mark binary WKB
+                columns as geometry columns or correct metadata such as the
+                column CRS.
+
+                Supported keys:
+                - encoding: "WKB" (required)
+                - crs: (e.g., "EPSG:4326")
+                - edges: "planar" (default) or "spherical"
+                - ...other supported keys
+                See the specification for details: https://geoparquet.org/releases/v1.1.0/
+
+                Useful for:
+                - Legacy Parquet files with Binary columns containing WKB payloads.
+                - Overriding GeoParquet metadata when fields like `crs` are missing.
+
+                Precedence:
+                - GeoParquet metadata is used to infer geometry columns first.
+                - geometry_columns then overrides the auto-inferred schema:
+                  - If a column is not geometry in metadata but appears in
+                    geometry_columns, it is treated as a geometry column.
+                  - If a column is geometry in metadata and also appears in
+                    geometry_columns, the provided metadata replaces the inferred
+                    metadata for that column. Missing optional fields are treated
+                    as absent/defaults.
+
+                Example:
+                - For `geo.parquet(geo1: geometry, geo2: geometry, geo3: binary)`,
+                  `read_parquet("geo.parquet", geometry_columns='{"geo2": {"encoding": "WKB"}, "geo3": {"encoding": "WKB"}}')`
+                  overrides `geo2` metadata and treats `geo3` as a geometry column.
+                - If `geo` inferred from metadata has:
+                  - `geo: {"encoding": "wkb", "crs": "EPSG:4326", ..}`
+                  and geometry_columns provides:
+                  - `geo: {"encoding": "wkb", "crs": "EPSG:3857"}`
+                  then the result is (full overwrite):
+                  - `geo: {"encoding": "wkb", "crs": "EPSG:3857", ..}` (other fields are defaulted)
+
+
+                Safety:
+                - Columns specified here can optionally be validated according to the
+                  `validate` option (e.g., WKB encoding checks). If validation is not
+                  enabled, inconsistent data may cause undefined behavior.
+            validate:
+                When set to `True`, geometry column contents are validated against
+                their metadata. Metadata can come from the source Parquet file or
+                the user-provided `geometry_columns` option.
+                Only supported properties are validated; unsupported properties are
+                ignored. If validation fails, execution stops with an error.
+
+                Currently the only property that is validated is the WKB of input geometry
+                columns.
+            partitioning:
+                Optional list of column names for hive-style partitioning. When reading
+                from a directory with paths like `/col=value/file.parquet`, partition
+                column names are auto-discovered by default (`partitioning=None`).
+                Explicitly specify column names (e.g., `["col"]`) to override
+                auto-discovery, or pass an empty list `[]` to disable partitioning
+                entirely.
+
+        Examples:
+
+            >>> sd = sedona.db.connect()
+            >>> url = "https://github.com/apache/sedona-testing/raw/refs/heads/main/data/parquet/geoparquet-1.1.0.parquet"
+            >>> sd.read.parquet(url)
+            <sedonadb.dataframe.DataFrame object at ...>
+        """
+        if options is None:
+            options = {}
+
+        if geometry_columns is not None and not isinstance(geometry_columns, str):
+            geometry_columns = json.dumps(geometry_columns)
+
+        options["geometry_columns"] = geometry_columns
+        options["validate"] = validate
+        return self(
+            table_paths, options=options, partitioning=partitioning, format="parquet"
+        )
+
+    def pyogrio(
+        self,
+        table_paths: Union[str, Path, Iterable[str]],
+        options: Optional[Dict[str, Any]] = None,
+        extension: str = "",
+        partitioning: Union[str, Iterable[str], None] = None,
+    ) -> DataFrame:
+        """Read spatial file formats using GDAL/OGR via pyogrio
+
+        Creates a DataFrame from one or more paths or URLs to a file supported by
+        [pyogrio](https://pyogrio.readthedocs.io/en/latest/), which is the same package
+        that powers `geopandas.read_file()` by default. Some common formats that can be
+        opened using GDAL/OGR are FlatGeoBuf, GeoPackage, Shapefile, GeoJSON, and many,
+        many more. See <https://gdal.org/en/stable/drivers/vector/index.html> for a list
+        of available vector drivers.
+
+        Like `read_parquet()`, globs and directories can be specified in addition to
+        individual file paths. Paths ending in `.zip` are automatically prepended with
+        `/vsizip/` (i.e., are automatically unzipped by GDAL). HTTP(s) URLs are
+        supported via `/vsicurl/`.
+
+        Args:
+            table_paths: A str, Path, or iterable of paths containing URLs or
+                paths. Globs (i.e., `path/*.gpkg`), directories, and zipped
+                versions of otherwise readable files are supported.
+            options: An optional mapping of key/value pairs passed to
+                pyogrio/GDAL. Supports pyogrio keyword arguments (e.g.,
+                ``layer``, ``where``, ``sql``, ``max_features``) as well
+                as GDAL driver-specific dataset open options. Additionally,
+                ``path_suffix`` can append a subpath to the resolved
+                GDAL source (e.g., ``{"path_suffix": "data.gdb"}`` for
+                a GDB stored inside a .zip file).
+            extension: An optional file extension (e.g., `"fgb"`) used when
+                `table_paths` specifies one or more directories or a glob
+                that does not enforce a file extension.
+            partitioning:
+                Optional list of column names for hive-style partitioning. When reading
+                from a directory with paths like `/col=value/file.fgb`, partition
+                column names are auto-discovered by default (`partitioning=None`).
+                Explicitly specify column names (e.g., `["col"]`) to override
+                auto-discovery, or pass an empty list `[]` to disable partitioning
+                entirely.
+
+        Examples:
+
+            >>> import geopandas
+            >>> import tempfile
+            >>> sd = sedona.db.connect()
+            >>> df = geopandas.GeoDataFrame({
+            ...     "geometry": geopandas.GeoSeries.from_wkt(["POINT (0 1)"], crs=3857)
+            ... })
+            >>>
+            >>> with tempfile.TemporaryDirectory() as td:
+            ...     df.to_file(f"{td}/df.fgb")
+            ...     sd.read.pyogrio(f"{td}/df.fgb").show()
+            ...
+            ┌──────────────┐
+            │ wkb_geometry │
+            │   geometry   │
+            ╞══════════════╡
+            │ POINT(0 1)   │
+            └──────────────┘
+
+        """
+        from sedonadb.datasource import PyogrioFormatSpec
+
+        return self(
+            table_paths,
+            options=options,
+            partitioning=partitioning,
+            format=PyogrioFormatSpec(extension),
+        )
+
+    def _guess_format(self, table_paths):
+        if not table_paths:
+            raise ValueError("Can't guess table paths from empty path list")
+
+        formats = set()
+        for path in table_paths:
+            try:
+                suffix = Path(path).suffix
+                if suffix:
+                    formats.add(suffix.strip("."))
+            except ValueError:
+                pass
+
+        if not formats:
+            raise ValueError(
+                "Can't guess format from paths where no item has an extension"
+            )
+
+        if len(formats) > 1:
+            raise ValueError(
+                f"Can't guess format where items have multiple extensions (got {sorted(formats)})"
+            )
+
+        return formats.pop()

--- a/python/sedonadb/python/sedonadb/read.py
+++ b/python/sedonadb/python/sedonadb/read.py
@@ -34,6 +34,7 @@ class Read:
 
     def __init__(self, ctx):
         self._ctx = ctx
+        self._registered_formats = {}
 
     def __call__(
         self,
@@ -44,18 +45,48 @@ class Read:
         format: Union[str, "ExternalFormatSpec", None] = None,
         check_extension: bool = False,
     ) -> DataFrame:
-        """Read one or more paths
+        """Read one or more paths as a DataFrame
 
-        This is the generic read path, which guesses the appropriate format.
-        Format-specific methods like `.read.parquet()` provide type-specific
+        This is the generic read path, which guesses the appropriate format
+        from the file extension when `format` is not specified. Format-specific
+        methods like `.read.parquet()` and `.read.pyogrio()` provide type-specific
         documentation for common format options.
 
+        Supported formats include:
+
+        - `"parquet"`: Parquet and GeoParquet files
+        - `"fgb"`, `"gpkg"`, `"shp"`: Spatial formats via pyogrio/GDAL
+        - Custom formats via `ExternalFormatSpec` objects registered at runtime
+
+        Args:
+            table_paths: A str, Path, or iterable of paths containing URLs or
+                local paths. Globs (e.g., `path/*.parquet`) and directories are
+                supported.
+            options: Optional dictionary of options to pass to the underlying
+                reader. Available options depend on the format being read.
+                For S3 access, use `{"aws.skip_signature": True, "aws.region": "us-west-2"}`
+                for anonymous access to public buckets.
+            partitioning: Optional list of column names for hive-style partitioning.
+                When reading from a directory with paths like `/col=value/file.parquet`,
+                partition column names are auto-discovered by default (`partitioning=None`).
+                Explicitly specify column names (e.g., `["col"]`) to override
+                auto-discovery, or pass an empty list `[]` to disable partitioning
+                entirely.
+            format: Explicit format specification. Can be a string (e.g., `"parquet"`,
+                `"fgb"`) or an `ExternalFormatSpec` object. If `None` (the default),
+                the format is guessed from the file extension.
+            check_extension: When `True`, validates that file extensions match the
+                specified format. Defaults to `False`.
+
         Examples:
+
             >>> sd = sedona.db.connect()
-            >>> spec = sedonadb_zarr.ZarrFormatSpec().with_options(  # doctest: +SKIP
-            ...     {"arrays": ["temperature"]}
-            ... )
-            >>> sd.read_format(spec, "file:///path/to/foo.zarr").show()  # doctest: +SKIP
+            >>> sd.read("path/to/file.parquet")  # doctest: +SKIP
+            <sedonadb.dataframe.DataFrame object at ...>
+
+            >>> sd.read("path/to/file.fgb")  # doctest: +SKIP
+            <sedonadb.dataframe.DataFrame object at ...>
+
         """
         if isinstance(table_paths, (str, Path)):
             table_paths = [table_paths]
@@ -87,7 +118,15 @@ class Read:
         if format is None:
             format = self._guess_format(table_paths)
 
-        if format in ("fgb", "gpkg", "shp"):
+        if format in self._registered_formats:
+            return self(
+                table_paths,
+                options=options,
+                partitioning=partitioning,
+                check_extension=check_extension,
+                format=self._registered_formats[format],
+            )
+        elif format in ("fgb", "gpkg", "shp"):
             from sedonadb.datasource import PyogrioFormatSpec
 
             return self(
@@ -279,6 +318,9 @@ class Read:
             partitioning=partitioning,
             format=PyogrioFormatSpec(extension),
         )
+
+    def _register_external_format(self, format: str, spec: ExternalFormatSpec):
+        self._registered_formats[format] = spec
 
     def _guess_format(self, table_paths):
         if not table_paths:

--- a/python/sedonadb/python/sedonadb/read.py
+++ b/python/sedonadb/python/sedonadb/read.py
@@ -102,10 +102,13 @@ class Read:
         # If the format is a Python object, call with_options() on the Python objects
         # to eliminate the serialization that would otherwise happen
         if isinstance(format, ExternalFormatSpec):
+            if options:
+                format = format.with_options(options)
+
             return DataFrame(
                 self._ctx,
                 self._ctx._impl.read_external_format(
-                    format.with_options(options),
+                    format,
                     table_paths,
                     check_extension,
                     None if partitioning is None else list(partitioning),
@@ -140,8 +143,13 @@ class Read:
             )
         elif format == "parquet":
             options = options.copy()
+
             geometry_columns = options.pop("geometry_columns", None)
+            if geometry_columns is not None and not isinstance(geometry_columns, str):
+                geometry_columns = json.dumps(geometry_columns)
+
             validate = options.pop("validate", False)
+
             return DataFrame(
                 self._ctx,
                 self._ctx._impl.read_parquet(
@@ -240,9 +248,7 @@ class Read:
         if options is None:
             options = {}
 
-        if geometry_columns is not None and not isinstance(geometry_columns, str):
-            geometry_columns = json.dumps(geometry_columns)
-
+        options = options.copy()
         options["geometry_columns"] = geometry_columns
         options["validate"] = validate
         return self(
@@ -326,20 +332,17 @@ class Read:
         self._registered_formats[format.lower()] = spec
 
     def _guess_format(self, table_paths):
-        """A heuristic to guess a format when not provided. This doesn't handle
-        URL suffixes like query strings or fragments (these types of inputs should
-        use an explicit format)."""
+        """A heuristic to guess a format when not provided."""
         if not table_paths:
             raise ValueError("Can't guess table paths from empty path list")
 
         formats = set()
         for path in table_paths:
-            try:
-                suffix = Path(path).suffix
-                if suffix:
-                    formats.add(suffix.strip(".").lower())
-            except ValueError:
-                pass
+            # Strip query strings and fragments before extracting suffix
+            path = path.split("?")[0].split("#")[0]
+            suffix = Path(path).suffix.strip(".").lower()
+            if suffix:
+                formats.add(suffix)
 
         if not formats:
             raise ValueError(

--- a/python/sedonadb/python/sedonadb/read.py
+++ b/python/sedonadb/python/sedonadb/read.py
@@ -118,6 +118,8 @@ class Read:
         if format is None:
             format = self._guess_format(table_paths)
 
+        format = format.lower()
+
         if format in self._registered_formats:
             return self(
                 table_paths,
@@ -137,6 +139,7 @@ class Read:
                 format=PyogrioFormatSpec(format),
             )
         elif format == "parquet":
+            options = options.copy()
             geometry_columns = options.pop("geometry_columns", None)
             validate = options.pop("validate", False)
             return DataFrame(
@@ -150,7 +153,7 @@ class Read:
                 ),
             )
         else:
-            raise ValueError(f"Can't guess file format for extension '{format}'")
+            raise ValueError(f"No format registered for extension '{format}'")
 
     def parquet(
         self,
@@ -320,9 +323,12 @@ class Read:
         )
 
     def _register_external_format(self, format: str, spec: ExternalFormatSpec):
-        self._registered_formats[format] = spec
+        self._registered_formats[format.lower()] = spec
 
     def _guess_format(self, table_paths):
+        """A heuristic to guess a format when not provided. This doesn't handle
+        URL suffixes like query strings or fragments (these types of inputs should
+        use an explicit format)."""
         if not table_paths:
             raise ValueError("Can't guess table paths from empty path list")
 
@@ -331,7 +337,7 @@ class Read:
             try:
                 suffix = Path(path).suffix
                 if suffix:
-                    formats.add(suffix.strip("."))
+                    formats.add(suffix.strip(".").lower())
             except ValueError:
                 pass
 

--- a/python/sedonadb/tests/test_context.py
+++ b/python/sedonadb/tests/test_context.py
@@ -228,6 +228,15 @@ def test_read_parquet_geometry_columns_roundtrip(con, tmp_path):
     ):
         df = con.read_parquet(src, geometry_columns=geometry_columns)
 
+    # Test 9: Ensure this works when passed via read(), not just read.parquet()
+    geometry_columns = {"geom": {"encoding": "WKB"}}
+    df = con.read(src, options={"geometry_columns": geometry_columns})
+    out_geo1 = tmp_path / "geo1.parquet"
+    df.to_parquet(out_geo1)
+
+    geom_meta = _geom_column_metadata(out_geo1)
+    assert geom_meta["encoding"] == "WKB"
+
 
 def test_read_parquet_geometry_columns_multiple_columns(con, tmp_path):
     # Write a regular Parquet table with two Binary WKB columns.

--- a/python/sedonadb/tests/test_read.py
+++ b/python/sedonadb/tests/test_read.py
@@ -19,6 +19,9 @@ import geopandas
 import geopandas.testing
 import pytest
 
+import sedonadb
+from sedonadb.datasource import ExternalFormatSpec
+
 
 def test_read_guess_format(con):
     read = con.read
@@ -73,3 +76,20 @@ def test_read_parquet_guessed(con, geoarrow_data):
     geopandas.testing.assert_geodataframe_equal(
         df.to_pandas(), con.read_parquet(parquet_path).sort("quadrangle_id").to_pandas()
     )
+
+
+class TestFormatSpec(ExternalFormatSpec):
+    @property
+    def extension(self):
+        return "foofy"
+
+    def with_options(self, options):
+        raise ValueError("test format spec!")
+
+
+def test_format_register():
+    sd = sedonadb.connect()
+    sd.register(TestFormatSpec())
+
+    with pytest.raises(ValueError, match="test format spec!"):
+        sd.read("test.foofy", options={"k": "v"})

--- a/python/sedonadb/tests/test_read.py
+++ b/python/sedonadb/tests/test_read.py
@@ -48,6 +48,12 @@ def test_read_guess_format(con):
     # Multiple files with same format works
     assert read._guess_format(["/a.parquet", "/b.parquet"]) == "parquet"
 
+    # URLs with query strings are handled correctly
+    assert read._guess_format(["https://example.com/file.parquet?token=abc"]) == "parquet"
+
+    # URLs with fragments are handled correctly
+    assert read._guess_format(["https://example.com/file.fgb#section"]) == "fgb"
+
 
 def test_read_pyogrio_guessed(con, tmp_path):
     # Create a test GeoDataFrame

--- a/python/sedonadb/tests/test_read.py
+++ b/python/sedonadb/tests/test_read.py
@@ -49,7 +49,9 @@ def test_read_guess_format(con):
     assert read._guess_format(["/a.parquet", "/b.parquet"]) == "parquet"
 
     # URLs with query strings are handled correctly
-    assert read._guess_format(["https://example.com/file.parquet?token=abc"]) == "parquet"
+    assert (
+        read._guess_format(["https://example.com/file.parquet?token=abc"]) == "parquet"
+    )
 
     # URLs with fragments are handled correctly
     assert read._guess_format(["https://example.com/file.fgb#section"]) == "fgb"

--- a/python/sedonadb/tests/test_read.py
+++ b/python/sedonadb/tests/test_read.py
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import geopandas
+import geopandas.testing
+import pytest
+
+
+def test_read_guess_format(con):
+    read = con.read
+
+    # Empty list raises ValueError
+    with pytest.raises(
+        ValueError, match="Can't guess table paths from empty path list"
+    ):
+        read._guess_format([])
+
+    # No extension raises ValueError
+    with pytest.raises(ValueError, match="no item has an extension"):
+        read._guess_format(["/path/to/file"])
+
+    # Multiple different extensions raises ValueError
+    with pytest.raises(ValueError, match="multiple extensions"):
+        read._guess_format(["/path/to/file.parquet", "/path/to/file.fgb"])
+
+    # Single format guesses correctly
+    assert read._guess_format(["/path/to/file.parquet"]) == "parquet"
+    assert read._guess_format(["/path/to/file.fgb"]) == "fgb"
+    assert read._guess_format(["/path/to/file.gpkg"]) == "gpkg"
+
+    # Multiple files with same format works
+    assert read._guess_format(["/a.parquet", "/b.parquet"]) == "parquet"
+
+
+def test_read_pyogrio_guessed(con, tmp_path):
+    # Create a test GeoDataFrame
+    gdf = geopandas.GeoDataFrame(
+        {"id": [1, 2, 3]},
+        geometry=geopandas.GeoSeries.from_wkt(
+            ["POINT (0 1)", "POINT (1 2)", "POINT (2 3)"], crs="EPSG:4326"
+        ),
+    )
+
+    # Write to FlatGeoBuf
+    fgb_path = tmp_path / "test.fgb"
+    gdf.to_file(fgb_path)
+
+    # Read using con.read() which should guess the format
+    df = con.read(fgb_path).select("id", geometry="wkb_geometry").sort("id")
+    geopandas.testing.assert_geodataframe_equal(df.to_pandas(), gdf)
+
+
+def test_read_parquet_guessed(con, geoarrow_data):
+    parquet_path = geoarrow_data / "quadrangles/files/quadrangles_100k_geo.parquet"
+
+    # Read using con.read() which should guess the format
+    df = con.read(parquet_path).sort("quadrangle_id")
+
+    geopandas.testing.assert_geodataframe_equal(
+        df.to_pandas(), con.read_parquet(parquet_path).sort("quadrangle_id").to_pandas()
+    )


### PR DESCRIPTION
This PR extracts common functionality between `read_format()`, `read_parquet()`, and `read_pyogrio()` into a `read` accessor that is easier to use:

```python
import sedona.db
import sedonadb_zarr

sd = sedona.db.connect()
sd.register(sedonadb_zarr.ZarrExtension())

t = sd.read(
    "https://atlantis-vis-o.s3-ext.jc.rl.ac.uk/hurricanes/era5/florence",
    options={"arrays": ["velocity"]},
    format="zarr",
)

t.select(t.raster.funcs.rs_envelope().geo.set_srid(0)).to_pandas().plot(
    facecolor="none", edgecolor="black"
)
```

<img width="543" height="315" alt="output" src="https://github.com/user-attachments/assets/070955f2-88c4-4712-8704-e6c5fb810427" />

I'd like to push some of this into Rust (using the session's FileFormatFactory) but that change is too disruptive for the pressing need, which is to solidify the read command for an externally registered format.