### PR TITLE
feat(rust/sedona,python/sedonadb): Support nested expressions in Python and SQL

### DIFF
--- a/python/sedonadb/python/sedonadb/expr/expression.py
+++ b/python/sedonadb/python/sedonadb/expr/expression.py
@@ -334,11 +334,12 @@ class Expr:
             # Python uses 0-based indexing; SQL uses 1-based indexing
             return self.funcs.array_extract(key + 1)
         elif isinstance(key, str):
-            return self.funcs.map_extract(key)
+            # get_field works for both structs and maps, returning a scalar
+            return self.funcs.get_field(key)
         else:
             raise ValueError(
                 "Expr keys are not yet supported. Use .funcs.array_extract() "
-                "or .funcs.map_extract() to extract with an expression key."
+                "or .funcs.get_field() to extract with an expression key."
             )
 
     def __getattr__(self, name: str) -> "Expr":

--- a/python/sedonadb/python/sedonadb/expr/expression.py
+++ b/python/sedonadb/python/sedonadb/expr/expression.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import TYPE_CHECKING, Any, Iterable, Optional
+from typing import TYPE_CHECKING, Any, Iterable, Optional, Union
 
 from sedonadb._lib import (
     InternalExpr as _InternalExpr,
@@ -327,6 +327,22 @@ class Expr:
             "Expr has no length. To count rows in a DataFrame, evaluate "
             "the Expr against a frame (e.g. `df.filter(expr).count()`)."
         )
+
+    # Nested expressions
+    def __getitem__(self, key: Union[int, str, "Expr"]) -> "Expr":
+        if isinstance(key, int):
+            # Python uses 0-based indexing; SQL uses 1-based indexing
+            return self.funcs.array_extract(key + 1)
+        elif isinstance(key, str):
+            return self.funcs.map_extract(key)
+        else:
+            raise ValueError(
+                "Expr keys are not yet supported. Use .funcs.array_extract() "
+                "or .funcs.map_extract() to extract with an expression key."
+            )
+
+    def __getattr__(self, name: str) -> "Expr":
+        return self.funcs.get_field(name)
 
 
 class SortExpr:

--- a/python/sedonadb/python/sedonadb/expr/expression.py
+++ b/python/sedonadb/python/sedonadb/expr/expression.py
@@ -329,9 +329,11 @@ class Expr:
         )
 
     # Nested expressions
-    def __getitem__(self, key: Union[int, str, "Expr"]) -> "Expr":
+    def __getitem__(self, key: Union[int, str]) -> "Expr":
         if isinstance(key, int):
             # Python uses 0-based indexing; SQL uses 1-based indexing
+            if key < 0:
+                raise ValueError("Can't index array expression with negative integer")
             return self.funcs.array_extract(key + 1)
         elif isinstance(key, str):
             # get_field works for both structs and maps, returning a scalar
@@ -341,9 +343,6 @@ class Expr:
                 "Expr keys are not yet supported. Use .funcs.array_extract() "
                 "or .funcs.get_field() to extract with an expression key."
             )
-
-    def __getattr__(self, name: str) -> "Expr":
-        return self.funcs.get_field(name)
 
 
 class SortExpr:

--- a/python/sedonadb/tests/expr/test_expression.py
+++ b/python/sedonadb/tests/expr/test_expression.py
@@ -362,16 +362,14 @@ def test_nested_expression_exec(con):
 
     t = con.create_data_frame(table)
     pd.testing.assert_frame_equal(
-        t.select(array0=t.array_col[1]).to_pandas(),
-        pd.DataFrame({"array0": [1, 4]})
+        t.select(array0=t.array_col[1]).to_pandas(), pd.DataFrame({"array0": [1, 4]})
     )
 
     pd.testing.assert_frame_equal(
-        t.select(a=t.struct_col.a).to_pandas(),
-        pd.DataFrame({"a": [1, 3]})
+        t.select(a=t.struct_col.a).to_pandas(), pd.DataFrame({"a": [1, 3]})
     )
 
     pd.testing.assert_frame_equal(
         t.select(foofy=t.map_col["foofy"]).to_pandas(),
-        pd.DataFrame({"foofy": ["foggy", "groggy"]}, dtype="object")
+        pd.DataFrame({"foofy": ["foggy", "groggy"]}, dtype="object"),
     )

--- a/python/sedonadb/tests/expr/test_expression.py
+++ b/python/sedonadb/tests/expr/test_expression.py
@@ -366,7 +366,7 @@ def test_nested_expression_exec(con):
     )
 
     pd.testing.assert_frame_equal(
-        t.select(a=t.struct_col.a).to_pandas(), pd.DataFrame({"a": [1, 3]})
+        t.select(a=t.struct_col["a"]).to_pandas(), pd.DataFrame({"a": [1, 3]})
     )
 
     pd.testing.assert_frame_equal(

--- a/python/sedonadb/tests/expr/test_expression.py
+++ b/python/sedonadb/tests/expr/test_expression.py
@@ -362,7 +362,7 @@ def test_nested_expression_exec(con):
 
     t = con.create_data_frame(table)
     pd.testing.assert_frame_equal(
-        t.select(array0=t.array_col[1]).to_pandas(), pd.DataFrame({"array0": [1, 4]})
+        t.select(array0=t.array_col[0]).to_pandas(), pd.DataFrame({"array0": [1, 4]})
     )
 
     pd.testing.assert_frame_equal(
@@ -371,5 +371,6 @@ def test_nested_expression_exec(con):
 
     pd.testing.assert_frame_equal(
         t.select(foofy=t.map_col["foofy"]).to_pandas(),
-        pd.DataFrame({"foofy": ["foggy", "groggy"]}, dtype="object"),
+        pd.DataFrame({"foofy": ["foggy", "groggy"]}),
+        check_dtype=False,
     )

--- a/python/sedonadb/tests/expr/test_expression.py
+++ b/python/sedonadb/tests/expr/test_expression.py
@@ -23,6 +23,7 @@
 # replacement check on `_impl.variant_name()` so the structural meaning is
 # still locked.
 
+import pandas as pd
 import pyarrow as pa
 import pytest
 
@@ -336,3 +337,41 @@ def test_ctx_propagation(con):
     assert bare_expr._ctx is None
     assert (e + bare_expr)._ctx is con
     assert (bare_expr + e)._ctx is con
+
+
+def test_nested_expression_exec(con):
+    table = pa.table(
+        {
+            "array_col": [[1, 2, 3], [4, 5, 6]],
+            "struct_col": [{"a": 1, "b": 2}, {"a": 3, "b": 4}],
+            "map_col": [
+                [{"key": "foofy", "value": "foggy"}],
+                [{"key": "foofy", "value": "groggy"}],
+            ],
+        },
+        schema=pa.schema(
+            {
+                "array_col": pa.list_(pa.int64()),
+                "struct_col": pa.struct(
+                    [pa.field("a", pa.int64()), pa.field("b", pa.int64())]
+                ),
+                "map_col": pa.map_(pa.string(), pa.string()),
+            }
+        ),
+    )
+
+    t = con.create_data_frame(table)
+    pd.testing.assert_frame_equal(
+        t.select(array0=t.array_col[1]).to_pandas(),
+        pd.DataFrame({"array0": [1, 4]})
+    )
+
+    pd.testing.assert_frame_equal(
+        t.select(a=t.struct_col.a).to_pandas(),
+        pd.DataFrame({"a": [1, 3]})
+    )
+
+    pd.testing.assert_frame_equal(
+        t.select(foofy=t.map_col["foofy"]).to_pandas(),
+        pd.DataFrame({"foofy": ["foggy", "groggy"]}, dtype="object")
+    )

--- a/rust/sedona/Cargo.toml
+++ b/rust/sedona/Cargo.toml
@@ -59,7 +59,7 @@ async-trait = { workspace = true }
 aws-config = { version = "1.5.17", optional = true }
 aws-credential-types = { version = "1.2.0", optional = true }
 comfy-table = { workspace = true }
-datafusion = { workspace = true, default_features = false, features = ["sql", "parquet"] }
+datafusion = { workspace = true, default_features = false, features = ["sql", "parquet", "nested_expressions"] }
 datafusion-common = { workspace = true }
 datafusion-expr = { workspace = true }
 datafusion-ffi = { workspace = true }

--- a/rust/sedona/src/context.rs
+++ b/rust/sedona/src/context.rs
@@ -823,6 +823,113 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn nested_expressions_sql() -> Result<()> {
+        let ctx = SedonaContext::new();
+
+        // Test get_field on a struct
+        let batches = ctx
+            .sql("SELECT get_field(named_struct('a', 1, 'b', 2), 'a') AS a")
+            .await?
+            .collect()
+            .await?;
+        #[rustfmt::skip]
+        assert_batches_eq!(
+            [
+                "+---+",
+                "| a |",
+                "+---+",
+                "| 1 |",
+                "+---+",
+            ],
+            &batches
+        );
+
+        // Test map_extract on a map
+        let batches = ctx
+            .sql("SELECT map_extract(map {'x': 10, 'y': 20}, 'x') AS x")
+            .await?
+            .collect()
+            .await?;
+        #[rustfmt::skip]
+        assert_batches_eq!(
+            [
+                "+------+",
+                "| x    |",
+                "+------+",
+                "| [10] |",
+                "+------+",
+            ],
+            &batches
+        );
+
+        // Test map bracket notation shorthand (returns scalar, not array)
+        let batches = ctx
+            .sql("SELECT map {'x': 10, 'y': 20}['x'] AS x")
+            .await?
+            .collect()
+            .await?;
+        #[rustfmt::skip]
+        assert_batches_eq!(
+            [
+                "+----+",
+                "| x  |",
+                "+----+",
+                "| 10 |",
+                "+----+",
+            ],
+            &batches
+        );
+
+        // Test struct dot notation and map bracket notation on table columns
+        ctx.sql(
+            "CREATE TABLE nested_test AS SELECT \
+             named_struct('a', 1, 'b', 2) AS s, \
+             map {'x': 10, 'y': 20} AS m",
+        )
+        .await?
+        .collect()
+        .await?;
+
+        // Struct field access via dot notation on column
+        let batches = ctx
+            .sql("SELECT s.a FROM nested_test")
+            .await?
+            .collect()
+            .await?;
+        #[rustfmt::skip]
+        assert_batches_eq!(
+            [
+                "+------------------+",
+                "| nested_test.s[a] |",
+                "+------------------+",
+                "| 1                |",
+                "+------------------+",
+            ],
+            &batches
+        );
+
+        // Map key access via bracket notation on column
+        let batches = ctx
+            .sql("SELECT m['x'] FROM nested_test")
+            .await?
+            .collect()
+            .await?;
+        #[rustfmt::skip]
+        assert_batches_eq!(
+            [
+                "+------------------+",
+                "| nested_test.m[x] |",
+                "+------------------+",
+                "| 10               |",
+                "+------------------+",
+            ],
+            &batches
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn show() {
         let ctx = SedonaContext::new();
         let tbl = ctx


### PR DESCRIPTION
The main issue here is that we didn't build datafusion with the nested expressions feature. This makes overture queries way nicer because they otherwise require a lot of ugly functions (which we didn't even have because they weren't compiled in with our feature set)

```python
import sedona.db

sd = sedona.db.connect()

overture = "s3://overturemaps-us-west-2/release/2026-05-20.0"
options = {"aws.skip_signature": True, "aws.region": "us-west-2"}
sd.read_parquet(f"{overture}/theme=places/type=place/", options=options).to_view(
    "places"
)
sd.read_parquet(
    f"{overture}/theme=divisions/type=division_area/", options=options
).to_view("divisions")

sd.sql("SELECT names.common['en'] FROM divisions WHERE names.common['en'] IS NOT NULL").show(3)
# ┌─────────────────────────────┐
# │ divisions.names[common][en] │
# │             utf8            │
# ╞═════════════════════════════╡
# │ Chapecó                     │
# ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
# │ Santa Catarina              │
# ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
# │ Paraná                      │
# └─────────────────────────────┘

t = sd.view("divisions")
t.select(common_name=t.names["common"]["en"]).filter(sd.col("common_name").is_not_null()).show(3)
# ┌────────────────┐
# │   common_name  │
# │      utf8      │
# ╞════════════════╡
# │ Chapecó        │
# ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
# │ Santa Catarina │
# ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
# │ Paraná         │
# └────────────────┘
```

Closes #701.