### PR TITLE
fix(rust/sedona-query-planner): recognize wrapped RS_EnsureLoaded in idempotency guard

### DIFF
--- a/rust/sedona-query-planner/src/ensure_loaded.rs
+++ b/rust/sedona-query-planner/src/ensure_loaded.rs
@@ -46,6 +46,8 @@ use sedona_common::sedona_internal_err;
 use sedona_expr::scalar_udf::SedonaScalarUDF;
 use sedona_schema::datatypes::SedonaType;
 
+use crate::restore_metadata::RESTORE_METADATA_NAME;
+
 /// `SedonaScalarUDF` metadata key marking a UDF whose kernels read raster
 /// pixel bytes. Duplicated from `sedona_raster_functions` (the owner),
 /// which this crate can't depend on — keep the literal in sync with
@@ -213,11 +215,22 @@ fn wrap_for_loading(arg: Expr, ensure_loaded_udf: &Arc<ScalarUDF>) -> Expr {
     })
 }
 
-/// True if `expr` is already wrapped with `rs_ensureloaded`, either
-/// directly or through an alias (e.g. `rs_ensureloaded(rast) AS loaded`).
+/// True if `expr` is already wrapped with `rs_ensureloaded`, looking
+/// through the wrappers that sit between this rule's fixpoint passes:
+///
+/// - an alias, e.g. `rs_ensureloaded(rast) AS loaded`;
+/// - the `sd_restore_metadata(...)` wrapper that [`WrapAsyncUdfRule`]
+///   stamps onto the async `rs_ensureloaded` call. That rule runs between
+///   our passes, so on the next pass the argument is no longer a bare
+///   `rs_ensureloaded(...)` but `sd_restore_metadata(rs_ensureloaded(...))`.
+///   Without seeing through it the guard would re-inject another wrapper
+///   every pass, producing a tower of unresolved async calls.
 fn is_loaded_wrap(expr: &Expr) -> bool {
     match expr {
-        Expr::ScalarFunction(sf) => sf.func.name() == "rs_ensureloaded",
+        Expr::ScalarFunction(sf) if sf.func.name() == "rs_ensureloaded" => true,
+        Expr::ScalarFunction(sf) if sf.func.name() == RESTORE_METADATA_NAME => {
+            sf.args.first().is_some_and(is_loaded_wrap)
+        }
         Expr::Alias(alias) => is_loaded_wrap(&alias.expr),
         _ => false,
     }
@@ -399,6 +412,39 @@ mod tests {
             count_ensure_loaded(&out_aliased),
             1,
             "aliased already-wrapped arg must not be wrapped again: {out_aliased:?}"
+        );
+    }
+
+    #[test]
+    fn idempotent_through_restore_metadata_wrapper() {
+        // Models the cross-rule fixpoint: after the first pass wraps the arg,
+        // WrapAsyncUdfRule re-stamps it as `sd_restore_metadata(rs_ensureloaded(rast))`
+        // (aliased back to the original name). A later pass must recognise this
+        // as already-loaded and not inject another wrapper — otherwise the
+        // async calls tower up and only the innermost is ever extracted, so the
+        // rest are invoked synchronously and the query fails at runtime.
+        use crate::restore_metadata::restore_metadata_udf;
+        use std::collections::HashMap;
+
+        let schema = raster_schema_named("rast");
+        let udf = fake_ensure_loaded_udf();
+
+        let restore = restore_metadata_udf(HashMap::new());
+        let wrapped = Expr::ScalarFunction(ScalarFunction {
+            func: restore,
+            args: vec![wrap_for_loading(col("rast"), &udf)],
+        })
+        .alias("rs_ensureloaded(rast)");
+
+        let call = Expr::ScalarFunction(ScalarFunction {
+            func: needs_bytes_udf("rs_mock"),
+            args: vec![wrapped],
+        });
+        let out = rewrite(call, &schema, &udf);
+        assert_eq!(
+            count_ensure_loaded(&out),
+            1,
+            "arg already wrapped as sd_restore_metadata(rs_ensureloaded(..)) must not be re-wrapped: {out:?}"
         );
     }
 


### PR DESCRIPTION
Theres 2 bugs here:

1. the new refactor from #969 causes the two rules to retrigger each other, stacking up 3 of each (datafusion runs the optimizer up to 3 times if things keep changing)
2. Datafusion has some bug with nested Async UDFs. will dig into this tomorrow to create a bug report for them.


This solves 1 so 2 doesnt trigger.

<details>
<summary>🤖 AI-generated description</summary>

### Summary

`EnsureLoadedOptimizerRule` wraps the raster arguments of `needs_pixels` UDFs (e.g. `RS_Slice`, `RS_DimBand`) with `RS_EnsureLoaded`, and `WrapAsyncUdfRule` re-stamps that async call as `sd_restore_metadata(RS_EnsureLoaded(...))` to preserve field metadata. Both rules run in the same logical-optimizer fixpoint loop. The idempotency guard `is_loaded_wrap` only recognized a bare `RS_EnsureLoaded`, not one already wrapped in `sd_restore_metadata`, so on every subsequent pass it failed to see the argument as already-loaded and injected another wrapper. DataFusion runs the rule list repeatedly until the plan stops changing or it hits `max_passes` (default 3), so the steady state is three nested `RS_EnsureLoaded` calls.

This regressed in #969, which split metadata handling into the separate `sd_restore_metadata` wrapper but did not teach the guard to look through it. It went unnoticed because there is no end-to-end execution test for `needs_pixels` functions — the Rust tests invoke kernels directly and never run a real query plan, and #969's own idempotency test runs only the single rule, never with `WrapAsyncUdfRule` in between.

### Why the nesting is fatal (a DataFusion limitation)

A redundant tower of an idempotent function would normally be harmless waste. It is fatal here because `RS_EnsureLoaded` is an async UDF, and DataFusion cannot evaluate an async UDF inside a synchronous expression. Instead it hoists each async call out into a dedicated `AsyncFuncExec` operator, computes it as a precomputed column (`__async_fn_N`), and rewrites the surrounding expression to reference that column.

That hoist does not correctly handle an async UDF nested as an argument to another async UDF call. `AsyncMapper::find_references` walks the expression pre-order and registers every nested async call as a separate `async_expr` (so it clearly intends to support nesting), but `AsyncMapper::map_expr` substitutes by whole-subtree structural equality and is applied bottom-up via `transform_up`. Substituting the innermost call mutates every enclosing subtree, so they no longer structurally match the `async_expr` registered for them, and only the innermost call is replaced with a column reference. The outer `RS_EnsureLoaded` calls remain literal inside the synchronous `ProjectionExec` and are invoked directly at runtime, failing with `Internal error: async functions should not be called directly`. The two halves of DataFusion's async extraction are thus mutually inconsistent under nesting — but this only surfaces when something generates nested async calls, which normal usage does not and the fixpoint regression above did.

### Fix

Teach `is_loaded_wrap` to see through the `sd_restore_metadata` wrapper so an already-loaded argument is recognized and left alone. The rule then reaches a fixpoint after the first pass and produces a single `RS_EnsureLoaded`, which the async hoister handles correctly. Adds a regression test exercising the cross-rule fixpoint that the existing single-rule idempotency test could not reproduce.

</details>
