### PR TITLE
chore: Ensure workspace can be built + verified under GDAL 3.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2888,6 +2888,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cceef1cc08a1f031c5717cb645bb361a3114470cc142cc96bc5e62b79695632e"
 dependencies = [
+ "bindgen",
  "pkg-config",
  "semver",
 ]

--- a/c/sedona-gdal/Cargo.toml
+++ b/c/sedona-gdal/Cargo.toml
@@ -37,6 +37,9 @@ thiserror = { workspace = true }
 [features]
 default = ["gdal-sys"]
 gdal-sys = ["dep:gdal-sys"]
+# Enable bindgen for GDAL versions without pre-built bindings (e.g., GDAL 3.13+).
+# Use: cargo build --features bindgen
+bindgen = ["gdal-sys/bindgen"]
 
 [dev-dependencies]
 sedona-testing = { workspace = true }

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -46,9 +46,11 @@ install the required dependencies:
 ```shell
 conda create -y --name verify-sedona-db
 conda activate verify-sedona-db
-conda install -y compilers curl gnupg geos proj openssl libabseil cmake make pkg-config
+conda install -y compilers curl gnupg geos proj openssl libabseil cmake make pkg-config "gdal<3.13"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$CONDA_PREFIX/lib"
 ```
+
+Note that GDAL 3.13 and greater is supported by SedonaDB; however, for the purposes of verifying a release candidate it is simpler to use an earlier version.
 
 When verifying via Docker or on a smaller machine it may be necessary to limit the
 number of parallel jobs to avoid running out of memory:
@@ -63,6 +65,13 @@ environment variable may be set.
 
 ```shell
 export MATURIN_PEP517_ARGS="--features s2geography"
+```
+
+Users with GDAL 3.13+ (which lacks pre-built bindings in the `gdal-sys` crate) can
+enable runtime binding generation:
+
+```shell
+export SEDONADB_CARGO_TEST_ARGS="--features bindgen"
 ```
 
 ## Pre-release

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -230,7 +230,7 @@ test_rust() {
   show_header "Build and test Rust libraries"
 
   pushd "${SEDONADB_SOURCE_DIR}"
-  cargo test --workspace --exclude sedona-s2geography
+  cargo test --workspace --exclude sedona-s2geography ${SEDONADB_CARGO_TEST_ARGS:-}
   popd
 }
 
@@ -259,13 +259,17 @@ test_python() {
 
   pushd "${SEDONADB_SOURCE_DIR}/python"
 
-  show_info "Installing Python package"
+  show_info "Installing Python packages"
   rm -rf "${SEDONADB_TMPDIR}/python"
 
+  pip install "sedonadb-expr/[test]" -v
   pip install "sedonadb/[test]" -v
+  pip install "sedonadb-zarr/[test]" -v
 
-  show_info "Testing Python package"
-  python -m pytest -vv
+  show_info "Testing Python packages"
+  python -m pytest -vv sedonadb-expr
+  python -m pytest -vv sedonadb
+  python -m pytest -vv sedonadb-zarr
 
   popd
 }

--- a/rust/sedona-raster-gdal/Cargo.toml
+++ b/rust/sedona-raster-gdal/Cargo.toml
@@ -47,6 +47,10 @@ sedona-raster-functions = { workspace = true }
 sedona-schema = { workspace = true }
 tokio = { workspace = true }
 
+[features]
+# Enable bindgen for GDAL versions without pre-built bindings (e.g., GDAL 3.13+).
+bindgen = ["sedona-gdal/bindgen"]
+
 [dev-dependencies]
 criterion = { workspace = true }
 sedona-gdal = { workspace = true, features = ["gdal-sys"] }

--- a/rust/sedona/Cargo.toml
+++ b/rust/sedona/Cargo.toml
@@ -42,6 +42,8 @@ http = ["object_store/http"]
 pointcloud = ["dep:sedona-pointcloud"]
 proj = ["sedona-proj/proj-sys"]
 gdal = ["sedona-gdal/gdal-sys"]
+# Enable bindgen for GDAL versions without pre-built bindings (e.g., GDAL 3.13+).
+bindgen = ["sedona-gdal/bindgen"]
 spatial-join = ["dep:sedona-spatial-join"]
 gpu = ["dep:sedona-spatial-join-gpu", "sedona-spatial-join-gpu/gpu"]
 s2geography = ["dep:sedona-s2geography", "dep:sedona-spatial-join-geography", "sedona-geoparquet/s2geography"]


### PR DESCRIPTION
GDAL 3.13 is now release + on package managers like hombrew and conda; however, gdal-sys doesn't support it and we depend on that for testing.

This PR adds a "bindgen" feature abd tweaks the verification script to suggest what to do in the event a verifier has GDAL 3.13 installed.

I also added the zarr Python package to Python verification while I was in that script.