### PR TITLE
feat(rust/sedona-raster-zarr): enable the zlib codec

### DIFF
--- a/rust/sedona-raster-zarr/Cargo.toml
+++ b/rust/sedona-raster-zarr/Cargo.toml
@@ -46,7 +46,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
-zarrs = { workspace = true, features = ["async", "gzip", "zstd", "blosc", "crc32c", "sharding", "transpose"] }
+zarrs = { workspace = true, features = ["async", "gzip", "zlib", "zstd", "blosc", "crc32c", "sharding", "transpose"] }
 zarrs_object_store = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Enables the zarrs `zlib` feature so Zarr V2 arrays compressed with zlib/deflate (a common numcodecs default) decode instead of failing with `codec zlib is not supported`. Verified end-to-end against a public zlib-compressed EPSG:3857 ERA5 pyramid.