### PR TITLE
chore(python/sedonadb-expr): Fix double include of generated files

### DIFF
--- a/python/sedonadb-expr/pyproject.toml
+++ b/python/sedonadb-expr/pyproject.toml
@@ -48,6 +48,9 @@ expression = "get_version()"
 
 [tool.hatch.build.targets.wheel]
 packages = ["python/sedonadb_expr"]
+# Exclude _generated and _version.py from packages since force-include handles them
+# (avoids duplicate file errors when building from sdist/tarball)
+exclude = ["python/sedonadb_expr/_generated", "python/sedonadb_expr/_version.py"]
 # Generated files are in .gitignore but must be included in the wheel
 force-include = { "python/sedonadb_expr/_generated" = "sedonadb_expr/_generated", "python/sedonadb_expr/_version.py" = "sedonadb_expr/_version.py" }
 


### PR DESCRIPTION
If building sedonadb-expr from a source tree that already has the generated files (e.g., local dev), the build fails with

```
  ValueError: A second file is being added to the wheel archive at the same path: `sedonadb_expr/_generated/__init__.py`.
```

Notably, this happens during verification from a source tarball built with the packaging workflow.
