### PR TITLE
chore(ci): Set development version on main before building/uploading sedonadb-expr wheel

### DIFF
--- a/.github/workflows/wheels-expr.yml
+++ b/.github/workflows/wheels-expr.yml
@@ -44,6 +44,16 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Set SedonaDB dev version
+        shell: bash
+        run: |
+          # Set the unique development version anywhere except a release branch
+          if [[ "${GITHUB_REF##*/}" =~ ^branch-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "On release branch - using version from Cargo.toml"
+          else
+            python ci/scripts/set_dev_version.py
+          fi
+
       - name: Install build tools
         run: pip install build
 


### PR DESCRIPTION
On main we see an error when uploading wheels because the dev version isn't set (so we are uploading a duplicate version, which is rejected by fury).

This PR duplicates the version setter from the other wheels so the upload succeeds.