### PR TITLE
chore(python/sedonadb): Error on attempt to convert a Raster array to Pandas for Pandas < 3.0

### DIFF
--- a/python/sedonadb/python/sedonadb/raster.py
+++ b/python/sedonadb/python/sedonadb/raster.py
@@ -339,6 +339,8 @@ class RasterArray(pa.ExtensionArray):
         """Convert to a Pandas Series of Raster objects (zero-copy where possible)."""
         import pandas as pd
 
+        _check_pandas_version()
+
         # Create Raster objects that reference the underlying storage directly
         rasters = [Raster(self.storage, i) for i in range(len(self))]
         return pd.array(rasters, dtype=object)
@@ -413,6 +415,8 @@ class RasterDtype:
         object wraps a slice of the Arrow array for zero-copy access.
         """
         import pandas as pd
+
+        _check_pandas_version()
 
         # Handle ChunkedArray by iterating over chunks
         if isinstance(arr, pa.ChunkedArray):
@@ -697,3 +701,24 @@ def _build_raster(
     raster_struct = raster_struct.cast(RASTER_STORAGE_TYPE)
 
     return Raster(raster_struct)
+
+
+def _check_pandas_version():
+    """Check that pandas version is >= 3.0 for raster to_pandas conversion.
+
+    Older Pandas versions have an issue with Arrow conversion for the
+    current strategy of Raster array -> Pandas conversion. This may
+    be able to be worked around (the original error was a BlockManager
+    error regarding a 1D/2D block).
+
+    Raises:
+        ImportError: If pandas version is less than 3.0.
+    """
+    import pandas as pd
+    from packaging.version import Version
+
+    if Version(pd.__version__) < Version("3.0"):
+        raise ImportError(
+            f"Converting raster columns to pandas requires pandas >= 3.0, "
+            f"but found pandas {pd.__version__}. Use .to_arrow_table() instead."
+        )

--- a/python/sedonadb/tests/test_raster.py
+++ b/python/sedonadb/tests/test_raster.py
@@ -146,6 +146,19 @@ def test_raster_zero_copy_access(con):
     # Verify the arrays are views, not copies (same base memory)
     assert np.shares_memory(arr, arr_from_tab)
 
+
+def test_raster_zero_copy_pandas(con):
+    # Earlier versions of Pandas seem to error with a BlockManager issue
+    # regarding a 1D/2D block. This may be workaroundable if we need to
+    # support older Python/Pandas.
+    pytest.importorskip("pandas", minversion="3.0")
+
+    t = con.sql("SELECT RS_Example() as raster")
+    tab = t.to_arrow_table()
+    r = Raster(tab["raster"], 0)
+    b = r.bands[0]
+    arr = b.to_numpy()
+
     # This should also be true of the collected Pandas DataFrame
     df = con.create_data_frame(tab).to_pandas()
 


### PR DESCRIPTION
After #999 we see

https://github.com/apache/sedona-db/actions/runs/28105750513/job/83219537111

```
2026-06-24T14:39:21.3012810Z =========================== short test summary info ============================
2026-06-24T14:39:21.3013560Z FAILED ../../../../../../../../../Users/runner/work/sedona-db/sedona-db/python/sedonadb/tests/test_raster.py::test_raster_zero_copy_access - AssertionError: Number of Block dimensions (1) must equal number of axes (2)
```

If we need to support old Python/Pandas when raster functionality is mature we can reevaluate how this work (e.g., a proper Pandas ExtensionaArray, perhaps shared between sedona spark and sedonadb).