### PR TITLE
feat(rust/sedona-raster-zarr): read CF spatial_ref GeoTransform georeferencing

### DIFF
--- a/rust/sedona-raster-zarr/src/geozarr.rs
+++ b/rust/sedona-raster-zarr/src/geozarr.rs
@@ -147,6 +147,62 @@ pub fn crs_from_cf_attributes(
     Ok(None)
 }
 
+/// Parse a CF `GeoTransform` attribute (as written by GDAL / rioxarray on a
+/// `spatial_ref` / grid-mapping variable) into a GDAL-order transform.
+///
+/// Unlike the GeoZarr `spatial:transform` (a JSON array in affine order, see
+/// [`parse_transform`]), the CF `GeoTransform` is a space-separated **string**
+/// already in GDAL GeoTransform order
+/// `[origin_x, scale_x, skew_x, origin_y, skew_y, scale_y]`, so it is used
+/// verbatim with no reordering. (Some writers store it as a JSON array of
+/// numbers instead; that form is accepted too.)
+///
+/// Returns `None` — so the caller falls back to other georeferencing sources —
+/// when the attribute is absent, and logs and returns `None` when it is present
+/// but malformed (not six numbers).
+pub fn geotransform_from_cf_attributes(
+    attrs: &serde_json::Map<String, serde_json::Value>,
+) -> Option<[f64; 6]> {
+    let raw = attrs.get("GeoTransform")?;
+
+    let values: Vec<f64> = if let Some(s) = raw.as_str() {
+        let mut out = Vec::with_capacity(6);
+        for token in s.split_whitespace() {
+            match token.parse::<f64>() {
+                Ok(v) => out.push(v),
+                Err(_) => {
+                    log::warn!("Zarr CF GeoTransform has a non-numeric value {token:?}; ignoring");
+                    return None;
+                }
+            }
+        }
+        out
+    } else if let Some(arr) = raw.as_array() {
+        match arr.iter().map(|v| v.as_f64()).collect::<Option<Vec<f64>>>() {
+            Some(out) => out,
+            None => {
+                log::warn!("Zarr CF GeoTransform array has a non-numeric element; ignoring");
+                return None;
+            }
+        }
+    } else {
+        log::warn!("Zarr CF GeoTransform attribute is neither a string nor an array; ignoring");
+        return None;
+    };
+
+    match <[f64; 6]>::try_from(values) {
+        // Already in GDAL GeoTransform order — no reordering.
+        Ok(transform) => Some(transform),
+        Err(values) => {
+            log::warn!(
+                "Zarr CF GeoTransform must have 6 values (GDAL order); got {}; ignoring",
+                values.len()
+            );
+            None
+        }
+    }
+}
+
 fn parse_transform(
     attrs: &serde_json::Map<String, serde_json::Value>,
 ) -> Result<Option<[f64; 6]>, ArrowError> {
@@ -363,6 +419,49 @@ mod tests {
         })))
         .unwrap();
         assert_eq!(g.crs.as_deref(), Some("PROJCS[\"a\"]"));
+    }
+
+    #[test]
+    fn cf_geotransform_string_parses_in_gdal_order() {
+        // The CF GeoTransform is already GDAL order [origin_x, scale_x, skew_x,
+        // origin_y, skew_y, scale_y] — used verbatim, no reordering. Values from
+        // a real rioxarray spatial_ref (EPSG:3857).
+        let attrs = map(json!({
+            "GeoTransform": "-8630308.0188 1.2874707 0 4772553.2794 0 -1.2874707"
+        }));
+        assert_eq!(
+            geotransform_from_cf_attributes(&attrs),
+            Some([-8630308.0188, 1.2874707, 0.0, 4772553.2794, 0.0, -1.2874707])
+        );
+    }
+
+    #[test]
+    fn cf_geotransform_array_form_parses() {
+        // Some writers store it as a JSON array of numbers rather than a string.
+        let attrs = map(json!({ "GeoTransform": [100.0, 2.0, 0.0, 200.0, 0.0, -3.0] }));
+        assert_eq!(
+            geotransform_from_cf_attributes(&attrs),
+            Some([100.0, 2.0, 0.0, 200.0, 0.0, -3.0])
+        );
+    }
+
+    #[test]
+    fn cf_geotransform_absent_is_none() {
+        assert_eq!(geotransform_from_cf_attributes(&map(json!({}))), None);
+    }
+
+    #[test]
+    fn cf_geotransform_malformed_is_none() {
+        // Wrong value count and a non-numeric token are both ignored (non-fatal):
+        // the loader falls back to other georeferencing sources.
+        assert_eq!(
+            geotransform_from_cf_attributes(&map(json!({ "GeoTransform": "1 2 3" }))),
+            None
+        );
+        assert_eq!(
+            geotransform_from_cf_attributes(&map(json!({ "GeoTransform": "a b c d e f" }))),
+            None
+        );
     }
 
     #[test]

--- a/rust/sedona-raster-zarr/src/loader.rs
+++ b/rust/sedona-raster-zarr/src/loader.rs
@@ -43,7 +43,7 @@ use zarrs::storage::{AsyncReadableListableStorage, AsyncReadableListableStorageT
 
 use crate::coords;
 use crate::dtype::zarr_to_band_data_type;
-use crate::geozarr::{crs_from_cf_attributes, GroupGeoMetadata};
+use crate::geozarr::{crs_from_cf_attributes, geotransform_from_cf_attributes, GroupGeoMetadata};
 use crate::source_uri::build_chunk_anchor;
 
 /// Streaming reader over the chunk grid of a Zarr group.
@@ -336,15 +336,22 @@ async fn open_and_validate(
         }
     };
 
-    // CF / rioxarray groups declare their CRS on a separate scalar
-    // grid-mapping variable (commonly `spatial_ref`) rather than in the group
-    // attributes. When the group attributes didn't already yield a CRS,
-    // consult that variable before we drop the open array handles.
-    if geo.crs.is_none() {
-        if let Some(crs) = crs_from_grid_mapping_variable(&storage, &arrays).await {
-            geo.crs = Some(crs);
+    // CF / rioxarray groups declare their CRS — and often the affine
+    // `GeoTransform` — on a separate scalar grid-mapping variable (commonly
+    // `spatial_ref`) rather than in the group attributes. When the group
+    // attributes left either unresolved, consult that variable before we drop
+    // the open array handles.
+    let cf_transform = if geo.crs.is_none() || geo.transform.is_none() {
+        let cf = cf_georeference_from_grid_mapping(&storage, &arrays).await;
+        if geo.crs.is_none() {
+            geo.crs = cf.crs;
         }
-    }
+        // Only relevant when the group declared no `spatial:transform`; otherwise
+        // the explicit group transform wins in `resolve_group_transform`.
+        geo.transform.is_none().then_some(cf.transform).flatten()
+    } else {
+        None
+    };
 
     let array_infos = collect_array_infos(arrays)?;
     validate_group_constraints(&array_infos)?;
@@ -360,13 +367,15 @@ async fn open_and_validate(
     let spatial_dim_indices =
         resolve_spatial_dim_indices(&array_infos[0].dim_names, geo.spatial_dims.as_deref())?;
 
-    // Effective transform + CRS. An explicit GeoZarr `spatial:transform` wins;
-    // failing that a `spatial:bbox`; failing that the spatial coordinate arrays
-    // (the common CF / non-GeoZarr case); failing that identity pixel coords.
+    // Effective transform + CRS. An explicit transform wins (GeoZarr
+    // `spatial:transform`, then the CF `GeoTransform`); failing that a
+    // `spatial:bbox`; failing that the spatial coordinate arrays (the common
+    // CF / non-GeoZarr case); failing that identity pixel coords.
     let group_transform = resolve_group_transform(
         &storage,
         group_uri,
         &mut geo,
+        cf_transform,
         &array_infos,
         &spatial_dim_indices,
     )
@@ -405,10 +414,20 @@ async fn resolve_group_transform(
     storage: &AsyncReadableListableStorage,
     group_uri: &str,
     geo: &mut GroupGeoMetadata,
+    cf_transform: Option<[f64; 6]>,
     array_infos: &[ArrayInfo],
     spatial_dim_indices: &[usize],
 ) -> Result<[f64; 6], ArrowError> {
+    // An explicit transform wins, GeoZarr `spatial:transform` first and then the
+    // CF `GeoTransform` from the grid-mapping variable (both already GDAL order).
     if let Some(t) = geo.transform {
+        return Ok(t);
+    }
+    if let Some(t) = cf_transform {
+        log::debug!(
+            "Zarr group at {group_uri} has no `spatial:transform`; using the CF \
+             `GeoTransform` from the grid-mapping variable"
+        );
         return Ok(t);
     }
     // spatial_dim_indices is validated upstream to be [y_index, x_index].
@@ -580,46 +599,64 @@ async fn open_named_arrays(
     Ok(out)
 }
 
-/// Resolve a CRS from a CF / rioxarray grid-mapping variable.
+/// CRS and/or affine transform read from a CF grid-mapping variable.
+#[derive(Default)]
+struct CfGeoreference {
+    crs: Option<String>,
+    transform: Option<[f64; 6]>,
+}
+
+/// Resolve the CRS and affine `GeoTransform` from a CF / rioxarray grid-mapping
+/// variable.
 ///
-/// rioxarray writes the CRS to a scalar variable (conventionally
-/// `spatial_ref`, sometimes `crs`) carrying a `crs_wkt` / `spatial_ref`
-/// attribute, linked from each data variable via the CF `grid_mapping`
-/// attribute — or, as rioxarray does, listed in the data variable's
-/// `coordinates` attribute. That variable is a 0-D scalar, so it never
-/// appears among the rank ≥ 2 data arrays and must be opened on its own.
+/// rioxarray writes the CRS (and usually the `GeoTransform`) to a scalar
+/// variable (conventionally `spatial_ref`, sometimes `crs`) carrying `crs_wkt` /
+/// `spatial_ref` and `GeoTransform` attributes, linked from each data variable
+/// via the CF `grid_mapping` attribute — or, as rioxarray does, listed in the
+/// data variable's `coordinates` attribute. That variable is a 0-D scalar, so it
+/// never appears among the rank ≥ 2 data arrays and must be opened on its own.
 ///
 /// Candidate names are gathered in priority order — `grid_mapping` targets
 /// first, then `coordinates` tokens, then the conventional `spatial_ref` /
-/// `crs` — and the first that opens and yields a CRS wins. A candidate that
-/// is missing, unreadable, or carries no CRS attribute is skipped, so a group
-/// without a grid-mapping variable simply stays CRS-less.
-async fn crs_from_grid_mapping_variable(
+/// `crs` — and the first candidate that opens and carries either a CRS or a
+/// `GeoTransform` wins (both are read from that one variable). A candidate that
+/// is missing, unreadable, or carries neither is skipped, so a group without a
+/// grid-mapping variable simply stays unreferenced.
+async fn cf_georeference_from_grid_mapping(
     storage: &AsyncReadableListableStorage,
     data_arrays: &[Array<dyn AsyncReadableListableStorageTraits>],
-) -> Option<String> {
+) -> CfGeoreference {
     let candidates = cf_crs_candidate_names(data_arrays.iter().map(|a| a.attributes()));
     for name in candidates {
         let path = format!("/{}", name.trim_start_matches('/'));
         let array = match Array::async_open(storage.clone(), &path).await {
             Ok(array) => array,
             // An absent candidate and a transient/permission failure look
-            // alike here; CRS is optional so we keep trying, but leave a
-            // breadcrumb so a genuinely broken store stays traceable.
+            // alike here; georeferencing is optional so we keep trying, but
+            // leave a breadcrumb so a genuinely broken store stays traceable.
             Err(e) => {
                 log::debug!("Zarr grid-mapping candidate {name:?}: open failed: {e}");
                 continue;
             }
         };
-        match crs_from_cf_attributes(array.attributes()) {
-            Ok(Some(crs)) => return Some(crs),
-            Ok(None) => continue,
+        let attrs = array.attributes();
+        let crs = match crs_from_cf_attributes(attrs) {
+            Ok(crs) => crs,
             // A malformed CRS attribute on a candidate variable shouldn't take
-            // the whole read offline; log and keep looking.
-            Err(e) => log::warn!("Zarr grid-mapping variable {name:?}: ignoring CRS: {e}"),
+            // the whole read offline; log and treat it as absent.
+            Err(e) => {
+                log::warn!("Zarr grid-mapping variable {name:?}: ignoring CRS: {e}");
+                None
+            }
+        };
+        let transform = geotransform_from_cf_attributes(attrs);
+        // The first variable that carries either is the grid-mapping variable;
+        // both come from it, so stop here.
+        if crs.is_some() || transform.is_some() {
+            return CfGeoreference { crs, transform };
         }
     }
-    None
+    CfGeoreference::default()
 }
 
 /// Gather candidate grid-mapping variable names from the data arrays'

--- a/rust/sedona-raster-zarr/tests/zarr_roundtrip.rs
+++ b/rust/sedona-raster-zarr/tests/zarr_roundtrip.rs
@@ -682,3 +682,72 @@ async fn derives_transform_with_explicit_arrays_filter() {
     );
     assert_eq!(raster.crs(), Some("EPSG:4326"));
 }
+
+// A real EPSG:3857 WKT (carries the embedded authority), as rioxarray writes to
+// the `spatial_ref` variable's `crs_wkt` attribute.
+const WKT_3857: &str = "PROJCS[\"WGS 84 / Pseudo-Mercator\",GEOGCS[\"WGS 84\",\
+DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],\
+PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433]],\
+PROJECTION[\"Mercator_1SP\"],PARAMETER[\"central_meridian\",0],\
+PARAMETER[\"scale_factor\",1],PARAMETER[\"false_easting\",0],\
+PARAMETER[\"false_northing\",0],UNIT[\"metre\",1],AUTHORITY[\"EPSG\",\"3857\"]]";
+
+/// CF / rioxarray group: no `proj:`/`spatial:` group attributes; georeferencing
+/// lives on a scalar `spatial_ref` variable (linked via `grid_mapping`) carrying
+/// `crs_wkt` + a GDAL-order `GeoTransform` string.
+fn build_cf_spatial_ref_fixture() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    let store = Arc::new(FilesystemStore::new(tmp.path()).unwrap());
+
+    GroupBuilder::new()
+        .build(store.clone(), "/")
+        .unwrap()
+        .store_metadata()
+        .unwrap();
+
+    // Data variable, linked to the grid-mapping variable by name.
+    let mut data_attrs = serde_json::Map::new();
+    data_attrs.insert("grid_mapping".into(), serde_json::json!("spatial_ref"));
+    ArrayBuilder::new(vec![4u64, 4u64], vec![2u64, 2u64], data_type::uint8(), 0u8)
+        .dimension_names(Some(["y", "x"]))
+        .attributes(data_attrs)
+        .build(store.clone(), "/variables")
+        .unwrap()
+        .store_metadata()
+        .unwrap();
+
+    // Scalar grid-mapping variable: crs_wkt + GeoTransform (already GDAL order).
+    let mut sr_attrs = serde_json::Map::new();
+    sr_attrs.insert("crs_wkt".into(), serde_json::json!(WKT_3857));
+    sr_attrs.insert(
+        "GeoTransform".into(),
+        serde_json::json!("-8630308.0188 1.2874707 0 4772553.2794 0 -1.2874707"),
+    );
+    ArrayBuilder::new(vec![1u64], vec![1u64], data_type::uint8(), 0u8)
+        .attributes(sr_attrs)
+        .build(store.clone(), "/spatial_ref")
+        .unwrap()
+        .store_metadata()
+        .unwrap();
+
+    tmp
+}
+
+#[tokio::test]
+async fn cf_spatial_ref_georeferences_from_crs_wkt_and_geotransform() {
+    // The rioxarray/CF convention: CRS + affine on a `spatial_ref` variable, not
+    // in group attributes. The reader resolves the CRS from `crs_wkt` and uses
+    // the `GeoTransform` verbatim (GDAL order, no reorder). First chunk row sits
+    // at the grid origin, so its transform equals the GeoTransform.
+    let tmp = build_cf_spatial_ref_fixture();
+    let uri = format!("file://{}", tmp.path().display());
+    let arr = read_all(&uri, None).await.unwrap();
+
+    let raster = RasterStructArray::try_new(&arr).unwrap().get(0).unwrap();
+    assert_eq!(
+        raster.transform().to_vec(),
+        vec![-8630308.0188, 1.2874707, 0.0, 4772553.2794, 0.0, -1.2874707]
+    );
+    let crs = raster.crs().expect("CRS resolved from spatial_ref crs_wkt");
+    assert!(crs.contains("3857"), "expected EPSG:3857 WKT, got: {crs}");
+}


### PR DESCRIPTION
Read CF / rioxarray georeferencing from a Zarr scalar grid-mapping variable (commonly `spatial_ref`): the reader already resolved the CRS from `crs_wkt` there; this also reads its `GeoTransform` and uses it as the group transform.

The CF `GeoTransform` is a space-separated string **already in GDAL order** `[origin_x, scale_x, skew_x, origin_y, skew_y, scale_y]`, so it's used verbatim — no affine reorder (unlike GeoZarr `spatial:transform`). Priority: explicit `spatial:transform` → CF `GeoTransform` → `spatial:bbox` → coordinate arrays → identity.

This closes the last open Zarr georeferencing source (GeoZarr transform, bbox, and CF coordinate arrays already landed). Covered by a synthetic `spatial_ref` round-trip fixture; the real-world cloud dataset is not public so it isn't included as a test.
