### PR TITLE
feat(python/sedonadb): add DataFrame.mutate and rename

### DIFF
--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Literal, Optional, 
 from sedonadb.expr import Expr, SortExpr
 from sedonadb.expr import Literal as _SedonaLit
 from sedonadb.expr import col as _col
-from sedonadb.expr.expression import _to_expr
+from sedonadb.expr.expression import collect_exprs
 from sedonadb.utility import sedona  # noqa: F401
 
 if TYPE_CHECKING:
@@ -337,38 +337,8 @@ class DataFrame:
         if not exprs and not kwargs:
             raise ValueError("select() requires at least one column or expression")
 
-        coerced = []
-        for e in exprs:
-            if isinstance(e, Expr):
-                coerced.append(e._impl)
-            elif isinstance(e, str):
-                coerced.append(_col(e)._impl)
-            elif isinstance(e, _SedonaLit):
-                # `lit(value)` returns Literal; route it through the same
-                # coercion path operators use so the resulting Expr lands
-                # in the plan with metadata preserved.
-                coerced.append(_to_expr(e)._impl)
-            else:
-                raise TypeError(
-                    f"select() expects str, Expr, or Literal arguments, "
-                    f"got {type(e).__name__}"
-                )
-
-        # Process keyword arguments: alias each value with its key
-        for name, e in kwargs.items():
-            if isinstance(e, Expr):
-                coerced.append(e.alias(name)._impl)
-            elif isinstance(e, str):
-                coerced.append(_col(e).alias(name)._impl)
-            elif isinstance(e, _SedonaLit):
-                coerced.append(_to_expr(e).alias(name)._impl)
-            else:
-                raise TypeError(
-                    f"select() expects str, Expr, or Literal keyword arguments, "
-                    f"got {type(e).__name__} for '{name}'"
-                )
-
-        return DataFrame(self._ctx, self._impl.select(coerced))
+        coerced = collect_exprs("select", exprs, kwargs)
+        return DataFrame(self._ctx, self._impl.select([e._impl for e in coerced]))
 
     def filter(self, *exprs: Expr) -> "DataFrame":
         """Filter rows by one or more boolean expressions.
@@ -1066,6 +1036,130 @@ class DataFrame:
         """
         self._check_set_op_compatible(other, "except_distinct")
         return DataFrame(self._ctx, self._impl.except_distinct(other._impl))
+
+    def mutate(
+        self,
+        *exprs: Union[Expr, str, _SedonaLit],
+        **named_exprs: Union[Expr, str, _SedonaLit],
+    ) -> "DataFrame":
+        """Add or replace columns, keeping all existing ones.
+
+        Adds each given column (Ibis / dplyr `mutate`). Positional and
+        keyword arguments follow the same rules as `select`: a positional
+        value is used as-is (its own output name applies), a keyword value
+        is aliased to the keyword. A column whose output name matches an
+        existing column replaces it in place; genuinely new columns are
+        appended in the order given. Unlike `select`, you don't re-list the
+        columns you want to keep — `mutate` keeps them all.
+
+        Args:
+            *exprs: Positional column definitions (`Expr` / column-name
+                `str` / `lit()` literal), used with their own output names.
+            **named_exprs: Keyword column definitions, aliased to the key.
+                At least one positional or keyword argument is required.
+
+        Examples:
+
+            >>> sd = sedona.db.connect()
+            >>> df = sd.sql("SELECT 1 AS a, 2 AS b")
+            >>> df.mutate(c=df.a + df.b, b=df.b * 10).show()
+            ┌───────┬───────┬───────┐
+            │   a   ┆   b   ┆   c   │
+            │ int64 ┆ int64 ┆ int64 │
+            ╞═══════╪═══════╪═══════╡
+            │     1 ┆    20 ┆     3 │
+            └───────┴───────┴───────┘
+        """
+        if not exprs and not named_exprs:
+            raise ValueError("mutate() requires at least one column")
+
+        # Coerce with the same rules as select, then key each result by its
+        # output name so an existing column can be replaced in place.
+        coerced = collect_exprs("mutate", exprs, named_exprs)
+        by_name: Dict[str, Expr] = {}
+        order: List[str] = []
+        for e in coerced:
+            name = e._output_name()
+            if name not in by_name:
+                order.append(name)
+            by_name[name] = e
+
+        # Single projection: existing columns (replaced in place where a
+        # mutation matches the name), then the new columns in input order.
+        current = self._impl.columns()
+        projection = [by_name[c] if c in by_name else _col(c) for c in current]
+        projection += [by_name[name] for name in order if name not in current]
+
+        return DataFrame(self._ctx, self._impl.select([e._impl for e in projection]))
+
+    def rename(self, *args: Any, **new_to_old: str) -> "DataFrame":
+        """Rename columns, keeping all others and their order.
+
+        Follows the Ibis / dplyr convention: each keyword is the **new**
+        name and its value is the existing (**old**) name — i.e.
+        `df.rename(new_name="old_name")`. This is the reverse of pandas /
+        Polars, which map old→new; passing a dict raises a clear error
+        pointing at the keyword form.
+
+        Args:
+            **new_to_old: `new_name="old_name"` pairs. At least one is
+                required.
+
+        Raises:
+            KeyError: If an old column name doesn't exist (the message
+                lists the available columns).
+
+        Examples:
+
+            >>> sd = sedona.db.connect()
+            >>> df = sd.sql("SELECT 1 AS a, 2 AS b")
+            >>> df.rename(c="b").show()
+            ┌───────┬───────┐
+            │   a   ┆   c   │
+            │ int64 ┆ int64 │
+            ╞═══════╪═══════╡
+            │     1 ┆     2 │
+            └───────┴───────┘
+        """
+        # The common pandas/Polars habit is `rename({"old": "new"})`; catch a
+        # positional (dict) argument and redirect to the keyword form. A clear,
+        # actionable message so it's an easy fix (including for LLMs iterating).
+        if args:
+            hint = ""
+            if len(args) == 1 and isinstance(args[0], dict):
+                pairs = ", ".join(f'{v}="{k}"' for k, v in args[0].items())
+                hint = f" Rewrite {args[0]!r} as rename({pairs})."
+            raise TypeError(
+                'rename() takes new_name="old_name" keyword arguments '
+                "(Ibis/dplyr style), not positional/dict arguments — this is "
+                "the reverse of the pandas/Polars {old: new} mapping." + hint
+            )
+
+        if not new_to_old:
+            raise ValueError('rename() requires at least one new_name="old_name" pair')
+
+        old_to_new: Dict[str, str] = {}
+        for new_name, old_name in new_to_old.items():
+            if not isinstance(old_name, str):
+                raise TypeError(
+                    'rename() takes new_name="old_name" keyword pairs '
+                    "(the value is the existing column name as a str); got "
+                    f"{type(old_name).__name__} for '{new_name}'"
+                )
+            old_to_new[old_name] = new_name
+
+        columns = self._impl.columns()
+        missing = [old for old in old_to_new if old not in columns]
+        if missing:
+            raise KeyError(
+                f"Column(s) {missing} not found. Available columns: {columns}"
+            )
+
+        projection = [
+            _col(c).alias(old_to_new[c]) if c in old_to_new else _col(c)
+            for c in columns
+        ]
+        return DataFrame(self._ctx, self._impl.select([e._impl for e in projection]))
 
     def limit(self, n: Optional[int], /, *, offset: int = 0) -> "DataFrame":
         """Limit result to n rows starting at offset

--- a/python/sedonadb/python/sedonadb/expr/expression.py
+++ b/python/sedonadb/python/sedonadb/expr/expression.py
@@ -106,6 +106,14 @@ class Expr:
         """
         return Expr(self._impl.alias(name), self._ctx)
 
+    def _output_name(self) -> str:
+        """The output column name this expression would produce.
+
+        Internal helper: `mutate()` uses it to match positional
+        expressions against existing columns for in-place replacement.
+        """
+        return self._impl.output_name()
+
     def cast(self, target) -> "Expr":
         """Cast the expression to the given Arrow type.
 
@@ -526,3 +534,36 @@ def _binary(op: str, lhs: Any, rhs: Any) -> Expr:
     rhs_expr = _to_expr(rhs)
     ctx = lhs_expr._ctx if lhs_expr._ctx is not None else rhs_expr._ctx
     return Expr(_expr_binary(op, lhs_expr._impl, rhs_expr._impl), ctx)
+
+
+def collect_exprs(caller: str, exprs, named_exprs) -> "list[Expr]":
+    """Coerce positional + keyword column expressions to a list of `Expr`.
+
+    Shared by `DataFrame.select` and `DataFrame.mutate`, which accept the
+    same kinds of input: positional column-name `str`s / `Expr`s / `Literal`s
+    used as-is, plus keyword arguments aliased to their key. `caller` names
+    the calling method for error messages.
+    """
+
+    def coerce(value: Any, kw_name: Optional[str] = None) -> Expr:
+        if isinstance(value, Expr):
+            expr = value
+        elif isinstance(value, str):
+            expr = col(value)
+        elif isinstance(value, Literal):
+            expr = _to_expr(value)
+        elif kw_name is None:
+            raise TypeError(
+                f"{caller}() expects str, Expr, or Literal arguments, "
+                f"got {type(value).__name__}"
+            )
+        else:
+            raise TypeError(
+                f"{caller}() expects str, Expr, or Literal keyword arguments, "
+                f"got {type(value).__name__} for '{kw_name}'"
+            )
+        return expr.alias(kw_name) if kw_name is not None else expr
+
+    coerced = [coerce(e) for e in exprs]
+    coerced += [coerce(e, name) for name, e in named_exprs.items()]
+    return coerced

--- a/python/sedonadb/src/expr.rs
+++ b/python/sedonadb/src/expr.rs
@@ -88,6 +88,13 @@ impl PyExpr {
         self.inner.variant_name().to_string()
     }
 
+    /// The output column name this expression would produce (its alias if
+    /// aliased, the column name if a bare column, etc.). Used to match
+    /// positional `mutate()` expressions against existing columns.
+    fn output_name(&self) -> String {
+        self.inner.schema_name().to_string()
+    }
+
     /// Wrap this expression in `Expr::Alias { name }`.
     ///
     /// We use DataFusion's `alias_if_changed` helper so that aliasing an

--- a/python/sedonadb/tests/expr/test_dataframe_mutate.py
+++ b/python/sedonadb/tests/expr/test_dataframe_mutate.py
@@ -1,0 +1,151 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pandas as pd
+import pandas.testing as pdt
+import pytest
+
+from sedonadb.dataframe import DataFrame
+
+
+def test_mutate_appends_new_column(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1, 2], "b": [10, 20]}))
+    out = df.mutate(c=df["a"] + df["b"]).to_pandas()
+    pdt.assert_frame_equal(
+        out,
+        pd.DataFrame({"a": [1, 2], "b": [10, 20], "c": [11, 22]}),
+    )
+
+
+def test_mutate_replaces_in_place(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1, 2], "b": [10, 20]}))
+    out = df.mutate(b=df["b"] * 2).to_pandas()
+    # b is replaced where it was; column order preserved.
+    pdt.assert_frame_equal(out, pd.DataFrame({"a": [1, 2], "b": [20, 40]}))
+
+
+def test_mutate_multiple_columns_mixed(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1, 2], "b": [10, 20]}))
+    # One replacement (b, in place) and one new column (c, appended).
+    out = df.mutate(b=df["b"] * 10, c=df["a"] + df["b"]).to_pandas()
+    pdt.assert_frame_equal(
+        out,
+        pd.DataFrame({"a": [1, 2], "b": [100, 200], "c": [11, 22]}),
+    )
+
+
+def test_mutate_from_str_copies_column(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1, 2]}))
+    out = df.mutate(a_copy="a").to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"a": [1, 2], "a_copy": [1, 2]}))
+
+
+def test_mutate_from_literal(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1, 2]}))
+    out = df.mutate(k=con.lit(9)).to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"a": [1, 2], "k": [9, 9]}))
+
+
+def test_mutate_from_context_col(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1, 2]}))
+    out = df.mutate(b=con.col("a") + 1).to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"a": [1, 2], "b": [2, 3]}))
+
+
+def test_mutate_preserves_column_order(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1], "b": [2], "c": [3]}))
+    out = df.mutate(b=con.col("b") * 100, d=con.lit(0))
+    assert out.columns == ["a", "b", "c", "d"]
+
+
+def test_mutate_positional_expr(con):
+    # Positional aliased Expr: name comes from the expr; replaces in place.
+    df = con.create_data_frame(pd.DataFrame({"a": [1, 2], "b": [10, 20]}))
+    out = df.mutate((con.col("a") + con.col("b")).alias("b")).to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"a": [1, 2], "b": [11, 22]}))
+
+
+def test_mutate_positional_and_keyword_mixed(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1, 2]}))
+    out = df.mutate((con.col("a") * 2).alias("d"), c=con.col("a") + 1).to_pandas()
+    pdt.assert_frame_equal(
+        out,
+        pd.DataFrame({"a": [1, 2], "d": [2, 4], "c": [2, 3]}),
+    )
+
+
+def test_mutate_returns_lazy_dataframe(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1]}))
+    assert isinstance(df.mutate(b=con.col("a")), DataFrame)
+
+
+def test_mutate_empty_raises(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1]}))
+    with pytest.raises(ValueError, match="at least one column"):
+        df.mutate()
+
+
+def test_mutate_bad_value_type_raises(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1]}))
+    with pytest.raises(TypeError, match="mutate\\(\\) expects str, Expr, or Literal"):
+        df.mutate(b=123)
+
+
+def test_rename_kwargs_new_from_old(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1, 2], "b": [10, 20]}))
+    out = df.rename(c="b").to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"a": [1, 2], "c": [10, 20]}))
+
+
+def test_rename_multiple_preserves_order(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1], "b": [2], "c": [3]}))
+    out = df.rename(x="a", z="c")
+    assert out.columns == ["x", "b", "z"]
+
+
+def test_rename_returns_lazy_dataframe(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1]}))
+    assert isinstance(df.rename(b="a"), DataFrame)
+
+
+def test_rename_empty_raises(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1]}))
+    with pytest.raises(ValueError, match="at least one"):
+        df.rename()
+
+
+def test_rename_unknown_old_raises_keyerror(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1], "b": [2]}))
+    with pytest.raises(KeyError, match="nonexistent") as exc:
+        df.rename(x="nonexistent")
+    assert "a" in exc.value.args[0]
+    assert "b" in exc.value.args[0]
+
+
+def test_rename_dict_raises_helpful_error(con):
+    # pandas/Polars habit: rename({"old": "new"}). Redirect to kwargs form.
+    df = con.create_data_frame(pd.DataFrame({"a": [1], "b": [2]}))
+    with pytest.raises(TypeError, match="keyword arguments") as exc:
+        df.rename({"a": "x"})
+    # The message should show the corrected call.
+    assert 'rename(x="a")' in str(exc.value)
+
+
+def test_rename_value_not_str_raises(con):
+    df = con.create_data_frame(pd.DataFrame({"a": [1]}))
+    with pytest.raises(TypeError, match="existing column name as a str"):
+        df.rename(x=123)


### PR DESCRIPTION
Adds two relational column operations to the Python `DataFrame`, in the engine-neutral (Spark/Polars) naming, continuing the Ibis/DuckDB-style relational surface.

## API

```python
df.with_column("c", df.a + df.b)     # add a column
df.with_column("b", df.b * 2)        # replace an existing column in place
df.with_column("k", lit(9))          # constant column
df.with_column("a_copy", "a")        # copy a column by name
df.with_column_renamed("b", "c")     # rename one column
```

- `with_column(name, expr)` — add a column, or replace the existing column of that name in place (order preserved). `expr` accepts an `Expr`, a column-name `str` (copied), or a `lit()` literal. For building several columns at once, `select(..., **kwargs)` is usually more convenient.
- `with_column_renamed(old, new)` — rename a single column, preserving order and all other columns.

## Footgun guard

DataFusion's `with_column_renamed` **silently no-ops** when the source column doesn't exist, which hides typos. The Python wrapper validates the source name and raises a `KeyError` listing the available columns — same pattern already used by `drop`.

## Implementation

| File | Change |
|---|---|
| `python/sedonadb/src/dataframe.rs` | `InternalDataFrame::with_column` / `with_column_renamed` — thin wrappers over DataFusion. |
| `python/sedonadb/python/sedonadb/dataframe.py` | `DataFrame.with_column` (Expr/str/Literal coercion + name-type check) and `with_column_renamed` (KeyError guard). |

## Test plan

`tests/expr/test_dataframe_with_column.py`:
- `with_column`: append; in-place replace (order preserved); from a column-name str; from a literal; bad name type; bad value type; lazy return.
- `with_column_renamed`: rename; order preservation; unknown-column `KeyError` (listing available columns); lazy return.

Local: 11 unit + 33 doctests + expr suite + `ruff` + `cargo fmt --check` + `clippy -Dwarnings` all clean.
