### PR TITLE
Normalize expected geometry WKT in Python tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ __pycache__
 
 # .env file for release management
 dev/release/.env
+.mcp.env
 
 /.luarc.json
 .positai
+
+.venv/*

--- a/python/sedonadb/python/sedonadb/testing.py
+++ b/python/sedonadb/python/sedonadb/testing.py
@@ -225,6 +225,31 @@ class DBEngine:
 
         return list(zip(*columns))
 
+    def normalize_expected_tuples(
+        self, result, expected, *, wkt_precision=None, **kwargs
+    ) -> List[Tuple[str]]:
+        """Normalize expected WKT cells using the result geometry columns."""
+        tab = self.result_to_table(result)
+        geometry_col_indices = {
+            i for i, type in enumerate(tab.schema.types) if _type_is_geoarrow(type)
+        }
+
+        rows = []
+        for row in expected:
+            normalized_row = []
+            for i, value in enumerate(row):
+                if i in geometry_col_indices and value is not None:
+                    try:
+                        value = ga.format_wkt(
+                            ga.as_wkb([value]), precision=wkt_precision
+                        ).to_pylist()[0]
+                    except Exception:
+                        pass
+                normalized_row.append(value)
+            rows.append(tuple(normalized_row))
+
+        return rows
+
     def assert_result(self, result, expected, **kwargs) -> "DBEngine":
         """Assert a result against an expected target
 
@@ -293,9 +318,10 @@ class DBEngine:
             pandas.testing.assert_frame_equal(result_pandas, expected, **kwargs)
         elif isinstance(expected, list):
             result_tuples = self.result_to_tuples(result, **kwargs)
-            if result_tuples != expected:
+            expected_tuples = self.normalize_expected_tuples(result, expected, **kwargs)
+            if result_tuples != expected_tuples:
                 raise AssertionError(
-                    f"Expected:\n  {expected}\nGot:\n  {result_tuples}"
+                    f"Expected:\n  {expected_tuples}\nGot:\n  {result_tuples}"
                 )
         elif isinstance(expected, tuple):
             self.assert_result(result, [expected], **kwargs)

--- a/python/sedonadb/tests/test_testing.py
+++ b/python/sedonadb/tests/test_testing.py
@@ -91,6 +91,24 @@ def test_assert_result_spatial(eng):
             wkt_precision=1,
         )
         eng.assert_query_result(
+            "SELECT "
+            "ST_GeomFromText("
+            "'POLYGON Z ((0 0 5, 0 1 5, 1 1 5, 1 0 5, 0 0 5))'"
+            ") as geom",
+            "POLYGON Z ((0 0 5,0 1 5,1 1 5,1 0 5,0 0 5))",
+        )
+        eng.assert_query_result(
+            "SELECT "
+            "ST_GeomFromText("
+            "'POLYGON Z ((0 0 5, 0 1 5, 1 1 5, 1 0 5, 0 0 5))'"
+            ") as geom, "
+            "'POLYGON Z ((0 0 5,0 1 5,1 1 5,1 0 5,0 0 5))' as txt",
+            (
+                "POLYGON Z ((0 0 5,0 1 5,1 1 5,1 0 5,0 0 5))",
+                "POLYGON Z ((0 0 5,0 1 5,1 1 5,1 0 5,0 0 5))",
+            ),
+        )
+        eng.assert_query_result(
             q,
             geopandas.GeoDataFrame(
                 {"geom": geopandas.GeoSeries.from_wkt(["POINT (0 1)"])}


### PR DESCRIPTION
Closes #815.

## Summary

- Normalize expected WKT values for geometry result columns before tuple/list comparisons in the Python test harness.
- Use the same `geoarrow.pyarrow.format_wkt()` path for expected geometry strings that the harness already uses for actual geometry results.
- Keep ordinary string columns as exact string comparisons, so mixed geometry/text result assertions still catch real text differences.
- Leave expected strings unchanged when GeoArrow cannot parse them, preserving existing expectations for known GeoArrow rendering artifacts.

## Why

Some tests failed only because the expected WKT used compact formatting while GeoArrow rendered the actual geometry with spaces after commas. For example, these represent the same geometry but previously compared as different strings:

```text
POLYGON Z ((0 0 5,0 1 5,1 1 5,1 0 5,0 0 5))
POLYGON Z ((0 0 5, 0 1 5, 1 1 5, 1 0 5, 0 0 5))
```

This change makes geometry assertions compare against the harness' normalized WKT representation instead of failing on formatting-only differences.

## Verification

- `PYTHONPYCACHEPREFIX=/private/tmp/sedona-pycache .venv/bin/python -m py_compile python/sedonadb/python/sedonadb/testing.py python/sedonadb/tests/test_testing.py`
- `.venv/bin/python -m pytest python/sedonadb/tests/test_testing.py`
