### PR TITLE
fix(rust/sedona): accept aws.allow_http / aws.session_token; reject dead AWS options

### DIFF
--- a/rust/sedona-geoparquet/src/provider.rs
+++ b/rust/sedona-geoparquet/src/provider.rs
@@ -393,8 +393,13 @@ mod test {
         ] {
             let mut opts = HashMap::new();
             opts.insert(rejected.to_string(), "x".to_string());
-            let err =
-                GeoParquetReadOptions::from_table_options(opts).expect_err(rejected);
+            // Avoid `expect_err`/`unwrap_err`: they require `Debug` on the
+            // `Ok` type, but `GeoParquetReadOptions` (via `ParquetReadOptions`)
+            // does not implement `Debug`.
+            let err = match GeoParquetReadOptions::from_table_options(opts) {
+                Ok(_) => panic!("{rejected} should be rejected"),
+                Err(e) => e,
+            };
             assert!(
                 err.contains("Unknown AWS option"),
                 "{rejected} should be rejected, got: {err}"

--- a/rust/sedona-geoparquet/src/provider.rs
+++ b/rust/sedona-geoparquet/src/provider.rs
@@ -125,16 +125,23 @@ impl GeoParquetReadOptions<'_> {
     pub fn from_table_options(options: HashMap<String, String>) -> Result<Self, String> {
         for key in options.keys() {
             if key.starts_with("aws.") {
+                // Keep this list in sync with the options consumed by
+                // `AwsOptions::set` in `sedona::object_storage`. The previous
+                // list accepted several options (`aws.bucket_name`,
+                // `aws.use_ssl`, `aws.force_path_style`, `aws.nosign`) that are
+                // never consumed there -- they passed validation here but were
+                // silently dropped by `to_listing_options`, so a user setting
+                // them got no effect and no error. Conversely it rejected
+                // `aws.allow_http` and `aws.session_token`, which _are_
+                // consumed. The list below now matches the consumer exactly.
                 let common_aws_options = [
                     "aws.access_key_id",
                     "aws.secret_access_key",
+                    "aws.session_token",
                     "aws.region",
                     "aws.endpoint",
+                    "aws.allow_http",
                     "aws.skip_signature",
-                    "aws.nosign",
-                    "aws.bucket_name",
-                    "aws.use_ssl",
-                    "aws.force_path_style",
                 ];
 
                 if !common_aws_options.contains(&key.as_str()) {
@@ -357,6 +364,43 @@ mod test {
     use crate::format::GeoParquetFormatFactory;
 
     use super::*;
+
+    #[test]
+    fn aws_option_allowlist_matches_consumer() {
+        // Options consumed by AwsOptions::set in sedona::object_storage must be
+        // accepted here; options NOT consumed there must be rejected (otherwise
+        // they are silently dropped in to_listing_options and mislead users).
+        for accepted in [
+            "aws.access_key_id",
+            "aws.secret_access_key",
+            "aws.session_token",
+            "aws.region",
+            "aws.endpoint",
+            "aws.allow_http",
+            "aws.skip_signature",
+        ] {
+            let mut opts = HashMap::new();
+            opts.insert(accepted.to_string(), "x".to_string());
+            GeoParquetReadOptions::from_table_options(opts)
+                .unwrap_or_else(|e| panic!("{accepted} should be accepted, got: {e}"));
+        }
+
+        for rejected in [
+            "aws.bucket_name",
+            "aws.use_ssl",
+            "aws.force_path_style",
+            "aws.nosign",
+        ] {
+            let mut opts = HashMap::new();
+            opts.insert(rejected.to_string(), "x".to_string());
+            let err =
+                GeoParquetReadOptions::from_table_options(opts).expect_err(rejected);
+            assert!(
+                err.contains("Unknown AWS option"),
+                "{rejected} should be rejected, got: {err}"
+            );
+        }
+    }
 
     #[tokio::test]
     async fn listing_table() {


### PR DESCRIPTION
## Problem

`read_parquet()` can't read from HTTP-only S3 endpoints (MinIO, LocalStack, `s3s`). Setting `aws.endpoint` to `http://...` fails:

```
HTTP is not allowed for S3 endpoints. To allow HTTP, set 'aws.allow_http' to true
```

…but `aws.allow_http` is itself rejected before it gets there:

```
Unknown AWS option 'aws.allow_http'. Valid options are: aws.access_key_id, aws.secret_access_key, aws.region, aws.endpoint, aws.skip_signature, aws.nosign, aws.bucket_name, aws.use_ssl, aws.force_path_style
```

## Root cause

`GeoParquetReadOptions::from_table_options()` hard-codes an `aws.*` allowlist that drifted out of sync with `AwsOptions::set` (the actual consumer in `sedona::object_storage`). Two mismatches:

- **Rejected but consumed:** `aws.allow_http`, `aws.session_token` — both applied by `AwsOptions` but blocked by the allowlist.
- **Accepted but never consumed:** `aws.bucket_name`, `aws.use_ssl`, `aws.force_path_style`, `aws.nosign` — pass validation, then hit the `_` arm of `AwsOptions::set` and are silently dropped.

## Fix

Align the allowlist with `AwsOptions::set` exactly:

| option | before | after |
| --- | --- | --- |
| `aws.allow_http` | rejected | **accepted** |
| `aws.session_token` | rejected | **accepted** |
| `aws.bucket_name` | silently ignored | **rejected** |
| `aws.use_ssl` | silently ignored | **rejected** |
| `aws.force_path_style` | silently ignored | **rejected** |
| `aws.nosign` | silently ignored | **rejected** |

The four newly-rejected options never worked, so erroring surfaces the misconfiguration instead of hiding it. Azure already had `azure.allow_http`; this brings AWS to parity.

## Test

Rust unit test pinning the accepted vs. rejected set against `from_table_options`.