### PR TITLE
chore(python/sedonadb,python/sedonadb-zarr): Update pyo3 to 0.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3669,15 +3669,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4131,15 +4122,6 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mimalloc"
@@ -4854,35 +4836,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -4890,9 +4869,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -4902,13 +4881,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.117",
 ]
@@ -7212,12 +7190,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "unsafe_cell_slice"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ parking_lot = "0.12"
 parquet = { version = "57.1.0", default-features = false, features = ["arrow", "async", "geospatial", "object_store"] }
 parquet-geospatial = { version = "57.1.0" }
 pin-project-lite = "0.2"
+pyo3 = { version = "0.29.0" }
 rand = "0.10"
 regex = "1.12"
 rstest = "0.26.1"

--- a/python/sedonadb-zarr/Cargo.toml
+++ b/python/sedonadb-zarr/Cargo.toml
@@ -31,7 +31,7 @@ doc = false
 arrow-array = { workspace = true, features = ["ffi"] }
 arrow-buffer = { workspace = true }
 object_store = { workspace = true, features = ["aws", "http"] }
-pyo3 = { version = "0.26.0" }
+pyo3 = { workspace = true }
 sedona-raster = { workspace = true }
 sedona-raster-zarr = { workspace = true }
 sedona-schema = { workspace = true }

--- a/python/sedonadb-zarr/src/lib.rs
+++ b/python/sedonadb-zarr/src/lib.rs
@@ -21,7 +21,7 @@
 //! - `ZarrRasterLoader`: a Python class implementing the raster loader interface
 //!   that can be registered with `sedonadb` via `py_raster_loader`.
 
-use std::ffi::{c_int, CString};
+use std::ffi::c_int;
 use std::sync::{Mutex, OnceLock};
 
 use arrow_array::ffi_stream::FFI_ArrowArrayStream;
@@ -99,9 +99,7 @@ impl PyZarrChunkReader {
                 )
             })?;
         let ffi_stream = FFI_ArrowArrayStream::new(Box::new(reader));
-        let capsule_name = CString::new("arrow_array_stream")
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
-        PyCapsule::new(py, ffi_stream, Some(capsule_name))
+        PyCapsule::new_with_value(py, ffi_stream, c"arrow_array_stream")
     }
 }
 
@@ -224,7 +222,7 @@ impl ZarrLoadResult {
 }
 
 /// View entry for Zarr load results.
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 #[derive(Clone, Copy)]
 pub struct ZarrViewEntry {
     #[pyo3(get)]

--- a/python/sedonadb/Cargo.toml
+++ b/python/sedonadb/Cargo.toml
@@ -46,7 +46,7 @@ datafusion-execution = { workspace = true }
 datafusion-expr = { workspace = true }
 datafusion-ffi = { workspace = true }
 futures = { workspace = true }
-pyo3 = { version = "0.26.0" }
+pyo3 = { workspace = true }
 sedona = { workspace = true }
 sedona-adbc = { workspace = true }
 sedona-datasource = { workspace = true }

--- a/python/sedonadb/src/dataframe.rs
+++ b/python/sedonadb/src/dataframe.rs
@@ -15,7 +15,6 @@ use std::collections::{HashMap, HashSet};
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-use std::ffi::CString;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -50,7 +49,7 @@ use crate::runtime::wait_for_future;
 use crate::schema::PySedonaSchema;
 
 #[pyclass]
-#[derive(Clone)]
+
 pub struct InternalDataFrame {
     pub inner: DataFrame,
     pub runtime: Arc<Runtime>,
@@ -671,7 +670,6 @@ impl InternalDataFrame {
         &self,
         py: Python<'py>,
     ) -> Result<Bound<'py, PyCapsule>, PySedonaError> {
-        let name = cr"datafusion_table_provider".into();
         let provider = self.inner.clone().into_view();
         let ctx = Arc::new(SessionContext::new()) as Arc<dyn TaskContextProvider>;
         let ffi_provider = FFI_TableProvider::new(
@@ -681,7 +679,11 @@ impl InternalDataFrame {
             &ctx,
             None,
         );
-        Ok(PyCapsule::new(py, ffi_provider, Some(name))?)
+        Ok(PyCapsule::new_with_value(
+            py,
+            ffi_provider,
+            c"datafusion_table_provider",
+        )?)
     }
 }
 
@@ -708,8 +710,11 @@ impl Batches {
         let reader: Box<dyn RecordBatchReader + Send> = Box::new(reader);
 
         let ffi_stream = FFI_ArrowArrayStream::new(reader);
-        let stream_capsule_name = CString::new("arrow_array_stream").unwrap();
-        Ok(PyCapsule::new(py, ffi_stream, Some(stream_capsule_name))?)
+        Ok(PyCapsule::new_with_value(
+            py,
+            ffi_stream,
+            c"arrow_array_stream",
+        )?)
     }
 }
 
@@ -736,8 +741,11 @@ impl StreamingResult {
         if let Some(reader) = reader_opt.take() {
             check_py_requested_schema(requested_schema, &reader.schema())?;
             let ffi_stream = FFI_ArrowArrayStream::new(reader);
-            let stream_capsule_name = CString::new("arrow_array_stream").unwrap();
-            Ok(PyCapsule::new(py, ffi_stream, Some(stream_capsule_name))?)
+            Ok(PyCapsule::new_with_value(
+                py,
+                ffi_stream,
+                c"arrow_array_stream",
+            )?)
         } else {
             Err(PySedonaError::SedonaPython(
                 "SedonaDB DataFrame streaming result may only be consumed once".to_string(),

--- a/python/sedonadb/src/datasource.rs
+++ b/python/sedonadb/src/datasource.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::{collections::HashMap, ffi::CString, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 
 use arrow_array::{ffi_stream::FFI_ArrowArrayStream, RecordBatch, RecordBatchReader};
 use arrow_schema::{ArrowError, Schema, SchemaRef};
@@ -43,7 +43,7 @@ use crate::{
 ///
 /// The main purpose of this object is to implement [ExternalFormatSpec] such
 /// that it can be used by SedonaDB/DataFusion internals.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug)]
 pub struct PyExternalFormat {
     extension: String,
@@ -218,7 +218,7 @@ impl ExternalFormatSpec for PyExternalFormat {
 /// Currently this only exposes `to_url()`; however, we can and should expose
 /// the ability to read portions of files using the underlying object_store.
 #[pyclass]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct PyDataSourceObject {
     pub inner: Object,
 }
@@ -233,7 +233,7 @@ impl PyDataSourceObject {
 /// Wrapper around the [OpenReaderArgs] such that the [PyExternalFormat] can pass
 /// required information into Python method calls
 #[pyclass]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct PyOpenReaderArgs {
     pub inner: OpenReaderArgs,
 }
@@ -385,8 +385,11 @@ impl PyProjectedRecordBatchReader {
         };
 
         let ffi_stream = FFI_ArrowArrayStream::new(Box::new(reader));
-        let stream_capsule_name = CString::new("arrow_array_stream").unwrap();
-        Ok(PyCapsule::new(py, ffi_stream, Some(stream_capsule_name))?)
+        Ok(PyCapsule::new_with_value(
+            py,
+            ffi_stream,
+            c"arrow_array_stream",
+        )?)
     }
 }
 

--- a/python/sedonadb/src/error.rs
+++ b/python/sedonadb/src/error.rs
@@ -16,6 +16,7 @@
 // under the License.
 use arrow_schema::ArrowError;
 use datafusion_common::DataFusionError;
+use pyo3::pyclass::PyClassGuardError;
 use pyo3::{create_exception, PyErr};
 
 use thiserror::Error;
@@ -66,5 +67,11 @@ impl From<PyErr> for PySedonaError {
 impl From<ArrowError> for PySedonaError {
     fn from(other: ArrowError) -> Self {
         PySedonaError::DF(Box::new(DataFusionError::ArrowError(Box::new(other), None)))
+    }
+}
+
+impl From<PyClassGuardError<'_, '_>> for PySedonaError {
+    fn from(other: PyClassGuardError) -> Self {
+        PySedonaError::SedonaPython(other.to_string())
     }
 }

--- a/python/sedonadb/src/expr.rs
+++ b/python/sedonadb/src/expr.rs
@@ -55,7 +55,7 @@ use crate::import_from::{import_arrow_field, import_arrow_scalar};
 /// The `inner` field is intentionally `pub` so that other PyO3 modules in
 /// this crate (e.g. `dataframe.rs`) can take `Vec<PyExpr>` arguments and
 /// move the inner `Expr` out without going through accessor methods.
-#[pyclass(name = "InternalExpr")]
+#[pyclass(name = "InternalExpr", from_py_object)]
 #[derive(Clone)]
 pub struct PyExpr {
     pub inner: Expr,
@@ -197,7 +197,7 @@ impl PyExpr {
 /// (the common case, with `nulls_first` defaulting to false), or via
 /// `sedonadb.expr.sort_expr(expr, asc=..., nulls_first=...)` for full
 /// control. They are consumed by `DataFrame.sort(*keys)`.
-#[pyclass(name = "InternalSortExpr")]
+#[pyclass(name = "InternalSortExpr", from_py_object)]
 #[derive(Clone)]
 pub struct PySortExpr {
     pub inner: SortExpr,

--- a/python/sedonadb/src/import_from.rs
+++ b/python/sedonadb/src/import_from.rs
@@ -77,8 +77,7 @@ pub fn import_arrow_array_stream<'py>(
     let capsule = if let Some(requested_schema) = requested_schema {
         let schema = import_arrow_schema(requested_schema)?;
         let ffi_schema = FFI_ArrowSchema::try_from(schema)?;
-        let ffi_schema_capsule =
-            PyCapsule::new(py, ffi_schema, Some(CString::new("arrow_schema").unwrap()))?;
+        let ffi_schema_capsule = PyCapsule::new_with_value(py, ffi_schema, c"arrow_schema")?;
 
         obj.getattr("__arrow_c_stream__")?
             .call1((ffi_schema_capsule,))?
@@ -175,24 +174,14 @@ pub fn import_arrow_schema(obj: &Bound<PyAny>) -> Result<Schema, PySedonaError> 
 
 pub fn check_pycapsule(obj: &Bound<PyAny>, name: &str) -> Result<*mut c_void, PySedonaError> {
     let capsule = obj
-        .downcast::<PyCapsule>()
+        .cast::<PyCapsule>()
         .map_err(|e| PySedonaError::SedonaPython(e.to_string()))?;
 
-    let actual_name = capsule
-        .name()?
-        .map(|obj| obj.to_string_lossy().to_string())
-        .unwrap_or("<unnamed>".to_string());
-    if actual_name != name {
-        return Err(PySedonaError::SedonaPython(format!(
-            "Expected PyCapsule with name '{name}' but got PyCapsule with name '{actual_name}'"
-        )));
-    }
+    // Validate name and get pointer in one step
+    let name_cstr = CString::new(name).map_err(|e| PySedonaError::SedonaPython(e.to_string()))?;
+    let pointer = capsule
+        .pointer_checked(Some(&name_cstr))
+        .map_err(|e| PySedonaError::SedonaPython(e.to_string()))?;
 
-    if capsule.pointer().is_null() {
-        return Err(PySedonaError::SedonaPython(format!(
-            "PyCapsule with name '{name}' is NULL"
-        )));
-    }
-
-    Ok(capsule.pointer())
+    Ok(pointer.as_ptr())
 }

--- a/python/sedonadb/src/raster_loader.rs
+++ b/python/sedonadb/src/raster_loader.rs
@@ -126,7 +126,7 @@ impl AsyncRasterLoader for PyRasterLoader {
                     .call(py, (py_requests_list,), None)
                     .map_err(py_err)?;
                 let result_list: &pyo3::Bound<'_, PyList> =
-                    result.bind(py).downcast().map_err(py_err)?;
+                    result.bind(py).cast().map_err(py_err)?;
 
                 // Extract results
                 let mut results = Vec::new();
@@ -144,8 +144,7 @@ impl AsyncRasterLoader for PyRasterLoader {
                         .extract()
                         .map_err(py_err)?;
                     let view_attr = item.getattr("view").map_err(py_err)?;
-                    let view_list: &pyo3::Bound<'_, PyList> =
-                        view_attr.downcast().map_err(py_err)?;
+                    let view_list: &pyo3::Bound<'_, PyList> = view_attr.cast().map_err(py_err)?;
 
                     let mut view = Vec::new();
                     for v in view_list.iter() {
@@ -291,7 +290,6 @@ impl AsRef<[u8]> for PyBufferWrapper {
 
 /// Python-visible raster load request
 #[pyclass]
-#[derive(Clone)]
 pub struct PyRasterLoadRequest {
     #[pyo3(get)]
     pub uri: String,
@@ -316,7 +314,7 @@ impl PyRasterLoadRequest {
 }
 
 /// Python-visible view entry
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone, Copy)]
 pub struct PyViewEntry {
     #[pyo3(get)]
@@ -372,7 +370,7 @@ impl From<PyViewEntry> for ViewEntry {
 }
 
 /// Python-visible band data type wrapper
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 #[derive(Clone, Copy)]
 pub struct PyBandDataType(pub BandDataType);
 
@@ -406,7 +404,6 @@ impl PyBandDataType {
 
 /// Python-visible raster load result
 #[pyclass]
-#[derive(Clone)]
 pub struct PyRasterLoadResult {
     #[pyo3(get, set)]
     pub bytes: Vec<u8>,
@@ -459,7 +456,7 @@ pub fn py_raster_loader(
 }
 
 /// Wrapper to expose PyRasterLoader to Python for registration
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyRasterLoaderWrapper {
     pub inner: Arc<PyRasterLoader>,

--- a/python/sedonadb/src/schema.rs
+++ b/python/sedonadb/src/schema.rs
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-use std::ffi::CString;
 
 use arrow_array::ffi::FFI_ArrowSchema;
 use arrow_schema::{Field, Schema};
@@ -47,9 +46,8 @@ impl PySedonaSchema {
         &self,
         py: Python<'py>,
     ) -> Result<Bound<'py, PyCapsule>, PySedonaError> {
-        let schema_capsule_name = CString::new("arrow_schema").unwrap();
         let ffi_schema = FFI_ArrowSchema::try_from(self.inner.clone())?;
-        Ok(PyCapsule::new(py, ffi_schema, Some(schema_capsule_name))?)
+        Ok(PyCapsule::new_with_value(py, ffi_schema, c"arrow_schema")?)
     }
 
     fn field_by_index(&self, i: usize) -> PySedonaField {
@@ -182,9 +180,8 @@ impl PySedonaField {
         &self,
         py: Python<'py>,
     ) -> Result<Bound<'py, PyCapsule>, PySedonaError> {
-        let schema_capsule_name = CString::new("arrow_schema").unwrap();
         let ffi_schema = FFI_ArrowSchema::try_from(self.inner.clone())?;
-        Ok(PyCapsule::new(py, ffi_schema, Some(schema_capsule_name))?)
+        Ok(PyCapsule::new_with_value(py, ffi_schema, c"arrow_schema")?)
     }
 
     fn __repr__(&self) -> String {
@@ -192,7 +189,7 @@ impl PySedonaField {
     }
 }
 
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 #[derive(Clone, Debug)]
 pub struct PySedonaType {
     pub inner: SedonaType,
@@ -247,10 +244,9 @@ impl PySedonaType {
         &self,
         py: Python<'py>,
     ) -> Result<Bound<'py, PyCapsule>, PySedonaError> {
-        let schema_capsule_name = CString::new("arrow_schema").unwrap();
         let field = self.inner.to_storage_field("", true)?;
         let ffi_schema = FFI_ArrowSchema::try_from(field)?;
-        Ok(PyCapsule::new(py, ffi_schema, Some(schema_capsule_name))?)
+        Ok(PyCapsule::new_with_value(py, ffi_schema, c"arrow_schema")?)
     }
 
     fn __repr__(&self) -> String {

--- a/python/sedonadb/src/udf.rs
+++ b/python/sedonadb/src/udf.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::{ffi::CString, iter::zip, sync::Arc};
+use std::{iter::zip, sync::Arc};
 
 use arrow_array::{
     ffi::{FFI_ArrowArray, FFI_ArrowSchema},
@@ -51,7 +51,7 @@ use crate::{
 /// implement overloading such that registration adds to existing overloads instead
 /// of replacing a function with a given name. This struct is primarily used to
 /// generate an Expr scalar function call.
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 #[derive(Clone)]
 pub struct PyScalarUdf {
     pub inner: Arc<ScalarUDF>,
@@ -77,9 +77,12 @@ impl PyScalarUdf {
         &self,
         py: Python<'py>,
     ) -> Result<Bound<'py, PyCapsule>, PySedonaError> {
-        let capsule_name = CString::new("datafusion_scalar_udf").unwrap();
         let ffi_scalar_udf = FFI_ScalarUDF::from(self.inner.clone());
-        Ok(PyCapsule::new(py, ffi_scalar_udf, Some(capsule_name))?)
+        Ok(PyCapsule::new_with_value(
+            py,
+            ffi_scalar_udf,
+            c"datafusion_scalar_udf",
+        )?)
     }
 }
 
@@ -89,7 +92,7 @@ impl PyScalarUdf {
 /// implement overloading such that registration adds to existing overloads instead
 /// of replacing a function with a given name. This struct is primarily used to
 /// generate an Expr aggregate function call.
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 #[derive(Clone)]
 pub struct PyAggregateUdf {
     pub inner: Arc<AggregateUDF>,
@@ -118,7 +121,7 @@ impl PyAggregateUdf {
 /// UDFs implement overloading such that multiple implementations of a single function
 /// can be combined instead of replaced. This struct is primarily used to represent
 /// a Python-implemented user-defined function before registration.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PySedonaScalarUdf {
     pub inner: SedonaScalarUDF,
@@ -145,10 +148,13 @@ impl PySedonaScalarUdf {
         &self,
         py: Python<'py>,
     ) -> Result<Bound<'py, PyCapsule>, PySedonaError> {
-        let capsule_name = CString::new("datafusion_scalar_udf").unwrap();
         let scalar_udf: ScalarUDF = self.inner.clone().into();
         let ffi_scalar_udf = FFI_ScalarUDF::from(Arc::new(scalar_udf));
-        Ok(PyCapsule::new(py, ffi_scalar_udf, Some(capsule_name))?)
+        Ok(PyCapsule::new_with_value(
+            py,
+            ffi_scalar_udf,
+            c"datafusion_scalar_udf",
+        )?)
     }
 }
 
@@ -396,10 +402,9 @@ impl PySedonaValue {
         &self,
         py: Python<'py>,
     ) -> Result<Bound<'py, PyCapsule>, PySedonaError> {
-        let schema_capsule_name = CString::new("arrow_schema").unwrap();
         let storage_field = self.sedona_type.inner.to_storage_field("", true)?;
         let ffi_schema = FFI_ArrowSchema::try_from(storage_field)?;
-        Ok(PyCapsule::new(py, ffi_schema, Some(schema_capsule_name))?)
+        Ok(PyCapsule::new_with_value(py, ffi_schema, c"arrow_schema")?)
     }
 
     #[pyo3(signature = (requested_schema=None))]
@@ -421,11 +426,9 @@ impl PySedonaValue {
             }
         }
 
-        let schema_capsule_name = CString::new("arrow_schema").unwrap();
         let field = self.sedona_type.inner.to_storage_field("", true)?;
         let ffi_schema = FFI_ArrowSchema::try_from(&field)?;
 
-        let array_capsule_name = CString::new("arrow_array").unwrap();
         let out_size = match &self.value {
             ColumnarValue::Array(array) => array.len(),
             ColumnarValue::Scalar(_) => 1,
@@ -434,8 +437,8 @@ impl PySedonaValue {
         let ffi_array = FFI_ArrowArray::new(&array.to_data());
 
         Ok((
-            PyCapsule::new(py, ffi_schema, Some(schema_capsule_name))?,
-            PyCapsule::new(py, ffi_array, Some(array_capsule_name))?,
+            PyCapsule::new_with_value(py, ffi_schema, c"arrow_schema")?,
+            PyCapsule::new_with_value(py, ffi_array, c"arrow_array")?,
         ))
     }
 
@@ -458,7 +461,7 @@ impl PySedonaValue {
 /// Python class which produces accumulator instances. Registration goes
 /// through `__sedona_internal_udf__()` on the Python side; `InternalContext`
 /// recognizes the capsule and routes to `insert_aggregate_udf`.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PySedonaAggregateUdf {
     pub inner: SedonaAggregateUDF,
@@ -638,8 +641,8 @@ impl Accumulator for PySedonaAccumulator {
     fn state(&mut self) -> Result<Vec<ScalarValue>> {
         let scalars = Python::attach(|py| -> Result<Vec<ScalarValue>, PySedonaError> {
             let result = self.instance.call_method0(py, "state")?;
-            let result_bound = result.bind(py);
-            let tuple = result_bound.downcast::<PyTuple>().map_err(|_| {
+            let result_bound = result.into_bound(py);
+            let tuple = result_bound.cast::<PyTuple>().map_err(|_| {
                 PySedonaError::SedonaPython(
                     "Expected aggregate UDF state() to return a tuple".to_string(),
                 )


### PR DESCRIPTION
Quick follow-up to #1012 (which took care of the hard part of enabling free threading) and taking care of the harder upgrade...this updates to the latest version fixes compile errors in the process.

Closes #949.