### PR TITLE
ci(dependabot): group object_store with the datafusion/arrow/parquet bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,8 +40,9 @@ updates:
         patterns:
           - "datafusion*"
           - "arrow*"
-          - "parquet"
-          - "objstore"
+          - "parquet*"
+          - "object_store"
+          - "zarrs_object_store"
       wasm-bindgen:
         applies-to: version-updates
         patterns:


### PR DESCRIPTION
The `datafusion-arrow-parquet` Dependabot group listed `"objstore"`, which matches no crate — the crate is `object_store`. So `object_store` updates escaped the group and arrived as standalone PRs (e.g. #1015) that fail to build: `object_store`'s version is locked to what DataFusion re-exports (`datafusion::object_store`), so bumping it alone produces two incompatible versions in the tree.

These arrow-rs companion crates can only move in lockstep with `datafusion`/`arrow`, so they're grouped:

- **`object_store`** — re-exported as `datafusion::object_store`; fixes the `objstore` typo.
- **`parquet*`** (widened from exact `parquet`) — now also catches **`parquet-geospatial`**, which is the companion to the `parquet` crate and shares the GeoParquet statistics contract with it. Bumping it alone (#960) desyncs the `GeometryBounder` from `parquet::geospatial::GeospatialStatistics` and pulls a duplicate `arrow-schema`, so it must track `parquet`.
- **`zarrs_object_store`** — tracks `object_store`.

These now bump together with `datafusion`/`arrow`, and only when a compatible DataFusion release exists, instead of fragmenting into individually-broken PRs.
