### PR TITLE
build(deps): bump adbc to 0.23 and adapt Statement::execute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "adbc_core"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dbe031527c9856a1e2df5e82aa8e568ffaab3be897f70d874477fb42a783bb"
+checksum = "46b169525a7c41670fe95874103c7c6ce713ac699123f81a200bc31f9ad3b02e"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -62,9 +62,9 @@ dependencies = [
 
 [[package]]
 name = "adbc_ffi"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3600ae9aec2907516d088189e3b863029280f1953dd0eab903c7f4c862a0ce81"
+checksum = "e6851c2ab953511cf7a244aadcbc0586442fd3c67dfe371457369048880dd513"
 dependencies = [
  "adbc_core",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,8 +67,8 @@ keywords = ["geospatial", "gis", "spatial", "datafusion", "arrow"]
 categories = ["science::geo", "database"]
 
 [workspace.dependencies]
-adbc_core = ">=0.22.0"
-adbc_ffi = ">=0.22.0"
+adbc_core = ">=0.23.0"
+adbc_ffi = ">=0.23.0"
 approx = "0.5"
 arrow = { version = "57.1.0", features = ["prettyprint", "ffi", "chrono-tz"] }
 arrow-array = { version = "57.1.0" }

--- a/rust/sedona-adbc/src/statement.rs
+++ b/rust/sedona-adbc/src/statement.rs
@@ -93,7 +93,7 @@ impl Statement for SedonaStatement {
         }
     }
 
-    fn execute(&mut self) -> Result<impl RecordBatchReader> {
+    fn execute(&mut self) -> Result<Box<dyn RecordBatchReader + Send + 'static>> {
         if let Some(query) = self.sql_query.clone() {
             self.runtime.block_on(async {
                 let df = self.ctx.sql(&query).await.map_err(from_datafusion_error)?;


### PR DESCRIPTION
`adbc_core` 0.23 changed `Statement::execute` to return `Box<dyn RecordBatchReader + Send + 'static>` instead of `impl RecordBatchReader` (our impl body already produced the boxed reader, so it's a one-line signature change). Bumps the `adbc_core`/`adbc_ffi` floor to `>=0.23.0` to match.

Supersedes #892 (the Dependabot bump), which couldn't build without this code change.
