### PR TITLE
fix(c/sedona-tg): Fix polygon hole containment predicates

### DIFF
--- a/c/sedona-tg/src/tg.rs
+++ b/c/sedona-tg/src/tg.rs
@@ -306,12 +306,22 @@ mod test {
 
         test_predicate::<Contains>("POLYGON ((0 0, 5 0, 0 5, 0 0))", "POINT (1 1)", true);
         test_predicate::<Contains>("POLYGON ((0 0, 5 0, 0 5, 0 0))", "POINT (-1 -1)", false);
+        test_predicate::<Contains>(
+            "POLYGON ((0 0, 3 0, 3 3, 0 3, 0 0), (1 1, 1 2, 2 1, 1 1))",
+            "POLYGON ((1 1, 1 2, 2 1, 1 1))",
+            false,
+        );
 
         test_predicate::<Within>("POINT (1 1)", "POLYGON ((0 0, 5 0, 0 5, 0 0))", true);
         test_predicate::<Within>("POINT (-1 -1)", "POLYGON ((0 0, 5 0, 0 5, 0 0))", false);
 
         test_predicate::<Covers>("POLYGON ((0 0, 5 0, 0 5, 0 0))", "POINT (1 1)", true);
         test_predicate::<Covers>("POLYGON ((0 0, 5 0, 0 5, 0 0))", "POINT (-1 -1)", false);
+        test_predicate::<Covers>(
+            "POLYGON ((0 0, 3 0, 3 3, 0 3, 0 0), (1 1, 1 2, 2 1, 1 1))",
+            "POLYGON ((1 1, 1 2, 2 1, 1 1))",
+            false,
+        );
 
         test_predicate::<CoveredBy>("POINT (1 1)", "POLYGON ((0 0, 5 0, 0 5, 0 0))", true);
         test_predicate::<CoveredBy>("POINT (-1 -1)", "POLYGON ((0 0, 5 0, 0 5, 0 0))", false);

--- a/c/sedona-tg/src/tg/tg.c
+++ b/c/sedona-tg/src/tg/tg.c
@@ -4067,10 +4067,12 @@ bool tg_poly_covers_poly(const struct tg_poly *a, const struct tg_poly *b) {
     if (!tg_ring_contains_ring(a_exterior, b_exterior, true)) {
         return false;
     }
-    // 2) ring cannot intersect poly holes
+    // 2) ring cannot intersect or be contained by poly holes
     bool covers = true;
     for (int i = 0; i < a_nholes; i++) {
-        if (tg_ring_intersects_ring(a_holes[i], b_exterior, false)) {
+        if (tg_ring_contains_ring(a_holes[i], b_exterior, true) ||
+            tg_ring_intersects_ring(a_holes[i], b_exterior, false))
+        {
             covers = false;
             // 3) unless the poly hole is contain inside of a other hole
             for (int j = 0; j < b_nholes; j++) {

--- a/python/sedonadb/tests/functions/test_predicates.py
+++ b/python/sedonadb/tests/functions/test_predicates.py
@@ -36,6 +36,11 @@ from sedonadb.testing import geom_or_null, PostGIS, SedonaDB, val_or_null
             False,
         ),
         (
+            "POLYGON ((0 0, 3 0, 3 3, 0 3, 0 0), (1 1, 1 2, 2 1, 1 1))",
+            "POLYGON ((1 1, 1 2, 2 1, 1 1))",
+            False,
+        ),
+        (
             "POINT (1 1)",
             "GEOMETRYCOLLECTION (POINT (0 0), POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)), LINESTRING (0 0, 1 1))",
             False,
@@ -97,6 +102,11 @@ def test_st_covered_by(eng, geom1, geom2, expected):
         (
             "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))",
             "POLYGON ((5 5, 6 5, 6 6, 5 6, 5 5))",
+            False,
+        ),
+        (
+            "POLYGON ((0 0, 3 0, 3 3, 0 3, 0 0), (1 1, 1 2, 2 1, 1 1))",
+            "POLYGON ((1 1, 1 2, 2 1, 1 1))",
             False,
         ),
         (


### PR DESCRIPTION
## Summary
- Fix tg polygon containment so ST_Covers/ST_Contains return false when the child polygon is identical to a parent polygon hole
- Add Rust and Python predicate regressions for the issue case

## Tests
- cargo test -p sedona-tg
- cargo fmt --check
- .venv/bin/python -m pytest -q python/sedonadb/tests/functions/test_predicates.py::test_st_contains python/sedonadb/tests/functions/test_predicates.py::test_st_covers

Fixes #709