### PR TITLE
feat: parameterize S2_CoveringCellIds (min_level, max_level, max_cells)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,7 +19,9 @@
 	url = https://github.com/geoarrow/geoarrow-data.git
 [submodule "c/sedona-s2geography/s2geography"]
 	path = c/sedona-s2geography/s2geography
-	url = https://github.com/paleolimbot/s2geography.git
+	# TEMPORARY: points at a fork branch pending paleolimbot/s2geography#123.
+	# Revert to https://github.com/paleolimbot/s2geography.git once merged.
+	url = https://github.com/ajaypadwal73/s2geography.git
 [submodule "c/sedona-s2geography/s2geometry"]
 	path = c/sedona-s2geography/s2geometry
 	url = https://github.com/google/s2geometry.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,9 +19,7 @@
 	url = https://github.com/geoarrow/geoarrow-data.git
 [submodule "c/sedona-s2geography/s2geography"]
 	path = c/sedona-s2geography/s2geography
-	# TEMPORARY: points at a fork branch pending paleolimbot/s2geography#123.
-	# Revert to https://github.com/paleolimbot/s2geography.git once merged.
-	url = https://github.com/ajaypadwal73/s2geography.git
+	url = https://github.com/paleolimbot/s2geography.git
 [submodule "c/sedona-s2geography/s2geometry"]
 	path = c/sedona-s2geography/s2geometry
 	url = https://github.com/google/s2geometry.git

--- a/c/sedona-s2geography/src/kernels.rs
+++ b/c/sedona-s2geography/src/kernels.rs
@@ -32,11 +32,7 @@ use sedona_schema::{
 use crate::{s2geog_check, s2geography_c_bindgen::*};
 
 fn covering_cell_ids_type() -> SedonaType {
-    SedonaType::Arrow(DataType::List(Arc::new(arrow_schema::Field::new(
-        "item",
-        DataType::Int64,
-        true,
-    ))))
+    SedonaType::Arrow(DataType::new_list(DataType::Int64, true))
 }
 
 pub fn s2_scalar_kernels() -> Result<Vec<(String, ScalarKernelRef)>> {

--- a/c/sedona-s2geography/src/kernels.rs
+++ b/c/sedona-s2geography/src/kernels.rs
@@ -31,6 +31,14 @@ use sedona_schema::{
 
 use crate::{s2geog_check, s2geography_c_bindgen::*};
 
+fn covering_cell_ids_type() -> SedonaType {
+    SedonaType::Arrow(DataType::List(Arc::new(arrow_schema::Field::new(
+        "item",
+        DataType::Int64,
+        true,
+    ))))
+}
+
 pub fn s2_scalar_kernels() -> Result<Vec<(String, ScalarKernelRef)>> {
     let mut ffi_scalar_kernels = Vec::<SedonaCScalarKernel>::new();
     ffi_scalar_kernels.resize_with(unsafe { S2GeogNumKernels() }, Default::default);
@@ -235,13 +243,62 @@ pub fn s2_scalar_kernels() -> Result<Vec<(String, ScalarKernelRef)>> {
         "s2_coveringcellids".to_string(),
         Arc::new(NullKernelHelper::new(ArgMatcher::new(
             vec![ArgMatcher::is_null()],
-            SedonaType::Arrow(DataType::List(Arc::new(arrow_schema::Field::new(
-                "item",
-                DataType::Int64,
-                true,
-            )))),
+            covering_cell_ids_type(),
         ))),
     ));
+
+    // s2_coveringcellids(NULL, ...), s2_coveringcellids(geography, NULL, ...)
+    for matchers in [
+        vec![ArgMatcher::is_null(), ArgMatcher::is_integer()],
+        vec![ArgMatcher::is_geography(), ArgMatcher::is_null()],
+        vec![
+            ArgMatcher::is_null(),
+            ArgMatcher::is_integer(),
+            ArgMatcher::is_integer(),
+        ],
+        vec![
+            ArgMatcher::is_geography(),
+            ArgMatcher::is_null(),
+            ArgMatcher::is_integer(),
+        ],
+        vec![
+            ArgMatcher::is_geography(),
+            ArgMatcher::is_integer(),
+            ArgMatcher::is_null(),
+        ],
+        vec![
+            ArgMatcher::is_null(),
+            ArgMatcher::is_integer(),
+            ArgMatcher::is_integer(),
+            ArgMatcher::is_integer(),
+        ],
+        vec![
+            ArgMatcher::is_geography(),
+            ArgMatcher::is_null(),
+            ArgMatcher::is_integer(),
+            ArgMatcher::is_integer(),
+        ],
+        vec![
+            ArgMatcher::is_geography(),
+            ArgMatcher::is_integer(),
+            ArgMatcher::is_null(),
+            ArgMatcher::is_integer(),
+        ],
+        vec![
+            ArgMatcher::is_geography(),
+            ArgMatcher::is_integer(),
+            ArgMatcher::is_integer(),
+            ArgMatcher::is_null(),
+        ],
+    ] {
+        kernels.push((
+            "s2_coveringcellids".to_string(),
+            Arc::new(NullKernelHelper::new(ArgMatcher::new(
+                matchers,
+                covering_cell_ids_type(),
+            ))),
+        ));
+    }
 
     Ok(kernels)
 }
@@ -303,6 +360,28 @@ mod test {
     fn test_s2_scalar_kernels() {
         let kernels = s2_scalar_kernels().unwrap();
         assert!(!kernels.is_empty());
+    }
+
+    #[test]
+    fn covering_cell_ids_return_type() {
+        let udf = s2_udf("s2_coveringcellids");
+        let int64 = SedonaType::Arrow(DataType::Int64);
+        let null = SedonaType::Arrow(DataType::Null);
+
+        for arg_types in [
+            vec![WKB_GEOGRAPHY],
+            vec![WKB_GEOGRAPHY, int64.clone()],
+            vec![WKB_GEOGRAPHY, int64.clone(), int64.clone()],
+            vec![WKB_GEOGRAPHY, int64.clone(), int64.clone(), int64.clone()],
+            vec![null.clone()],
+            vec![null.clone(), int64.clone()],
+            vec![WKB_GEOGRAPHY, null.clone(), int64.clone()],
+            vec![WKB_GEOGRAPHY, int64.clone(), null.clone(), int64.clone()],
+            vec![WKB_GEOGRAPHY, int64.clone(), int64.clone(), null.clone()],
+        ] {
+            let tester = ScalarUdfTester::new(udf.clone().into(), arg_types);
+            assert_eq!(tester.return_type().unwrap(), covering_cell_ids_type());
+        }
     }
 
     fn s2_udf(name: &str) -> SedonaScalarUDF {

--- a/docs/reference/sql/s2_coveringcellids.qmd
+++ b/docs/reference/sql/s2_coveringcellids.qmd
@@ -22,11 +22,32 @@ kernels:
   - returns: array
     args: [geography]
   - returns: array
-    args: [geography, int64]
+    args:
+    - geography
+    - name: min_level
+      type: int64
+      description: Minimum S2 cell level to return. Must be between 0 and 30. Defaults to 0.
   - returns: array
-    args: [geography, int64, int64]
+    args:
+    - geography
+    - name: min_level
+      type: int64
+      description: Minimum S2 cell level to return. Must be between 0 and 30. Defaults to 0.
+    - name: max_level
+      type: int64
+      description: Maximum S2 cell level to return. Must be between 0 and 30. Defaults to 30.
   - returns: array
-    args: [geography, int64, int64, int64]
+    args:
+    - geography
+    - name: min_level
+      type: int64
+      description: Minimum S2 cell level to return. Must be between 0 and 30. Defaults to 0.
+    - name: max_level
+      type: int64
+      description: Maximum S2 cell level to return. Must be between 0 and 30. Defaults to 30.
+    - name: max_cells
+      type: int64
+      description: Maximum number of cells to return. Must be greater than 0. Defaults to 8.
 ---
 
 ## Description
@@ -34,14 +55,6 @@ kernels:
 Returns an array of 64-bit S2 cell IDs that form a covering of the given geography. A covering is a set of cells that completely contains the geography with minimal overlap. For a point, returns an array with a single cell ID. For empty geometries, returns an empty array.
 
 This is useful for spatial indexing and efficient spatial queries. The returned cells may be at different S2 levels depending on the size and shape of the geography.
-
-Optional positional arguments can control the covering:
-
-| Argument | Description | Default |
-| --- | --- | --- |
-| `min_level` | Minimum S2 cell level to return. Must be between 0 and 30. | 0 |
-| `max_level` | Maximum S2 cell level to return. Must be between 0 and 30. | 30 |
-| `max_cells` | Maximum number of cells to return. Must be greater than 0. | 8 |
 
 ## Examples
 

--- a/docs/reference/sql/s2_coveringcellids.qmd
+++ b/docs/reference/sql/s2_coveringcellids.qmd
@@ -32,7 +32,6 @@ kernels:
     - geography
     - name: min_level
       type: int64
-      description: Minimum S2 cell level to return. Must be between 0 and 30. Defaults to 0.
     - name: max_level
       type: int64
       description: Maximum S2 cell level to return. Must be between 0 and 30. Defaults to 30.
@@ -41,10 +40,8 @@ kernels:
     - geography
     - name: min_level
       type: int64
-      description: Minimum S2 cell level to return. Must be between 0 and 30. Defaults to 0.
     - name: max_level
       type: int64
-      description: Maximum S2 cell level to return. Must be between 0 and 30. Defaults to 30.
     - name: max_cells
       type: int64
       description: Maximum number of cells to return. Must be greater than 0. Defaults to 8.

--- a/docs/reference/sql/s2_coveringcellids.qmd
+++ b/docs/reference/sql/s2_coveringcellids.qmd
@@ -21,6 +21,12 @@ description: Returns an array of S2 cell IDs that cover the given geography.
 kernels:
   - returns: array
     args: [geography]
+  - returns: array
+    args: [geography, int64]
+  - returns: array
+    args: [geography, int64, int64]
+  - returns: array
+    args: [geography, int64, int64, int64]
 ---
 
 ## Description
@@ -29,8 +35,20 @@ Returns an array of 64-bit S2 cell IDs that form a covering of the given geograp
 
 This is useful for spatial indexing and efficient spatial queries. The returned cells may be at different S2 levels depending on the size and shape of the geography.
 
+Optional positional arguments can control the covering:
+
+| Argument | Description | Default |
+| --- | --- | --- |
+| `min_level` | Minimum S2 cell level to return. Must be between 0 and 30. | 0 |
+| `max_level` | Maximum S2 cell level to return. Must be between 0 and 30. | 30 |
+| `max_cells` | Maximum number of cells to return. Must be greater than 0. | 8 |
+
 ## Examples
 
 ```sql
 SELECT S2_CoveringCellIds(ST_GeogFromWKT('LINESTRING (0 0, 1 1)'));
+```
+
+```sql
+SELECT S2_CoveringCellIds(ST_GeogFromWKT('LINESTRING (0 0, 1 1)'), 10, 12, 16);
 ```

--- a/python/sedonadb/tests/geography/test_geog_s2.py
+++ b/python/sedonadb/tests/geography/test_geog_s2.py
@@ -105,18 +105,19 @@ def test_s2_coveringcellids_parameters(eng):
     eng = eng.create_or_skip()
     geog = "ST_GeogFromText('LINESTRING (0 0, 100 50)')"
     cases = [
-        (f"S2_CoveringCellIds({geog})", 0, 30, 8),
-        (f"S2_CoveringCellIds({geog}, 4)", 4, 30, 8),
-        (f"S2_CoveringCellIds({geog}, 4, 6)", 4, 6, 8),
+        (f"S2_CoveringCellIds({geog})", 0, 30, None),
+        (f"S2_CoveringCellIds({geog}, 4)", 4, 30, None),
+        (f"S2_CoveringCellIds({geog}, 4, 6)", 4, 6, None),
         (f"S2_CoveringCellIds({geog}, 4, 6, 2)", 4, 6, 2),
     ]
 
-    for expr, min_level, max_level, max_cells in cases:
+    for expr, min_level, max_level, expected_max_cells in cases:
         result = eng.execute_and_collect(f"SELECT {expr}")
         df = eng.result_to_pandas(result)
         cells = df.iloc[0, 0]
         levels = [_s2_cell_level(cell_id) for cell_id in cells]
 
         assert len(cells) > 0
-        assert len(cells) <= max_cells
+        if expected_max_cells is not None:
+            assert len(cells) <= expected_max_cells
         assert all(min_level <= level <= max_level for level in levels)

--- a/python/sedonadb/tests/geography/test_geog_s2.py
+++ b/python/sedonadb/tests/geography/test_geog_s2.py
@@ -23,6 +23,12 @@ if "s2geography" not in sedonadb.__features__:
     pytest.skip("Python package built without s2geography", allow_module_level=True)
 
 
+def _s2_cell_level(cell_id):
+    # The least significant set bit encodes the S2 cell level.
+    marker_bit_index = (int(cell_id) & -int(cell_id)).bit_length() - 1
+    return 30 - (marker_bit_index // 2)
+
+
 # S2_CellIdFromPoint tests - returns the S2 cell ID containing a point
 @pytest.mark.parametrize("eng", [SedonaDB, BigQuery])
 @pytest.mark.parametrize(
@@ -97,9 +103,20 @@ def test_s2_coveringcellids(eng, geog, expected):
 @pytest.mark.parametrize("eng", [SedonaDB])
 def test_s2_coveringcellids_parameters(eng):
     eng = eng.create_or_skip()
-    result = eng.execute_and_collect(
-        "SELECT S2_CoveringCellIds("
-        "ST_GeogFromText('LINESTRING (0 0, 100 50)'), 0, 30, 2)"
-    )
-    df = eng.result_to_pandas(result)
-    assert len(df.iloc[0, 0]) <= 2
+    geog = "ST_GeogFromText('LINESTRING (0 0, 100 50)')"
+    cases = [
+        (f"S2_CoveringCellIds({geog})", 0, 30, 8),
+        (f"S2_CoveringCellIds({geog}, 4)", 4, 30, 8),
+        (f"S2_CoveringCellIds({geog}, 4, 6)", 4, 6, 8),
+        (f"S2_CoveringCellIds({geog}, 4, 6, 2)", 4, 6, 2),
+    ]
+
+    for expr, min_level, max_level, max_cells in cases:
+        result = eng.execute_and_collect(f"SELECT {expr}")
+        df = eng.result_to_pandas(result)
+        cells = df.iloc[0, 0]
+        levels = [_s2_cell_level(cell_id) for cell_id in cells]
+
+        assert len(cells) > 0
+        assert len(cells) <= max_cells
+        assert all(min_level <= level <= max_level for level in levels)

--- a/python/sedonadb/tests/geography/test_geog_s2.py
+++ b/python/sedonadb/tests/geography/test_geog_s2.py
@@ -92,3 +92,14 @@ def test_s2_coveringcellids(eng, geog, expected):
     )
     df = eng.result_to_pandas(result)
     assert len(df.iloc[0, 0]) == len(expected)
+
+
+@pytest.mark.parametrize("eng", [SedonaDB])
+def test_s2_coveringcellids_parameters(eng):
+    eng = eng.create_or_skip()
+    result = eng.execute_and_collect(
+        "SELECT S2_CoveringCellIds("
+        "ST_GeogFromText('LINESTRING (0 0, 100 50)'), 0, 30, 2)"
+    )
+    df = eng.result_to_pandas(result)
+    assert len(df.iloc[0, 0]) <= 2

--- a/python/sedonadb/tests/geography/test_geog_s2.py
+++ b/python/sedonadb/tests/geography/test_geog_s2.py
@@ -108,7 +108,7 @@ def test_s2_coveringcellids_parameters(eng):
         (f"S2_CoveringCellIds({geog})", 0, 30, None),
         (f"S2_CoveringCellIds({geog}, 4)", 4, 30, None),
         (f"S2_CoveringCellIds({geog}, 4, 6)", 4, 6, None),
-        (f"S2_CoveringCellIds({geog}, 4, 6, 2)", 4, 6, 2),
+        (f"S2_CoveringCellIds({geog}, 0, 30, 2)", 0, 30, 2),
     ]
 
     for expr, min_level, max_level, expected_max_cells in cases:


### PR DESCRIPTION
## Summary
- Adds optional `min_level`, `max_level`, `max_cells` positional args to `S2_CoveringCellIds`, matching BigQuery's S2 covering signature.
- Adds NULL-argument overloads so `S2_CoveringCellIds` returns NULL (rather than failing to resolve) when any parameter is a literal NULL.
- Documents the new parameters and defaults (`min_level=0`, `max_level=30`, `max_cells=8`, unchanged from prior hardcoded behavior).

Closes #920

## Submodule status
The `s2geography` C++ change backing this lives in [paleolimbot/s2geography#123](https://github.com/paleolimbot/s2geography/pull/123). Until that merges, `.gitmodules` temporarily points the submodule at my fork (`ajaypadwal73/s2geography`) so CI can resolve the pinned commit. Once #123 merges upstream, this PR needs a follow-up commit reverting `.gitmodules` to `paleolimbot/s2geography` and re-pinning the submodule to the merged commit.

## Test plan
- [x] Rust unit test (`covering_cell_ids_return_type`) covers return-type resolution for all arg-count/NULL-position combinations.
- [x] Python test exercises the 4-arg form end-to-end (`test_s2_coveringcellids_parameters`).
- [x] C++ unit tests (`coverings_test.cc`) cover the new kernels, level-fixing, point-parent, and max_cells behavior.
- [x] Revert `.gitmodules` to upstream `s2geography` once paleolimbot/s2geography#123 merges.