### PR TITLE
Add probe chunk parallel refinement

### DIFF
--- a/rust/sedona-common/src/option.rs
+++ b/rust/sedona-common/src/option.rs
@@ -125,6 +125,12 @@ config_namespace! {
         /// for small datasets, while lower values enable more fine-grained parallelism.
         pub parallel_refinement_chunk_size: usize, default = 8192
 
+        /// The number of probe rows per spawned task when parallelizing spatial join refinement
+        /// across probe rows. Specify 0 to disable probe-row parallelism. This is useful for
+        /// skewed workloads where many probe rows each have moderate candidate counts that do not
+        /// individually trigger `parallel_refinement_chunk_size`.
+        pub parallel_probe_chunk_size: usize, default = 0
+
         /// Options for debugging or testing spatial join
         pub debug : SpatialJoinDebugOptions, default = SpatialJoinDebugOptions::default()
     }

--- a/rust/sedona-spatial-join/Cargo.toml
+++ b/rust/sedona-spatial-join/Cargo.toml
@@ -77,7 +77,7 @@ datafusion = { workspace = true, features = ["sql"] }
 rstest = { workspace = true }
 sedona-testing = { workspace = true }
 wkt = { workspace = true }
-tokio = { workspace = true, features = ["macros"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 rand = { workspace = true }
 env_logger = { workspace = true }
 
@@ -104,6 +104,11 @@ harness = false
 [[bench]]
 name = "external_evaluated_batch_stream"
 path = "bench/evaluated_batch/external_evaluated_batch_stream.rs"
+harness = false
+
+[[bench]]
+name = "query_batch_parallel"
+path = "bench/query_batch_parallel.rs"
 harness = false
 
 [[bench]]

--- a/rust/sedona-spatial-join/bench/query_batch_parallel.rs
+++ b/rust/sedona-spatial-join/bench/query_batch_parallel.rs
@@ -1,0 +1,306 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Benchmarks for query_batch probe-row parallelism.
+//!
+//! The uniform workload keeps candidate counts low and spread across the indexed extent.
+//! The skewed workload gives many probe rows a moderate candidate count, which is the case
+//! `parallel_probe_chunk_size` is intended to help when per-row refinement does not trigger.
+
+use std::hint::black_box;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use arrow_array::RecordBatch;
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use datafusion_common::Result;
+use datafusion_expr::JoinType;
+use datafusion_physical_expr::expressions::Column;
+use futures::Stream;
+use sedona_expr::statistics::GeoStatistics;
+use sedona_schema::datatypes::WKB_GEOMETRY;
+use sedona_spatial_join::evaluated_batch::evaluated_batch_stream::{
+    EvaluatedBatchStream, SendableEvaluatedBatchStream,
+};
+use sedona_spatial_join::evaluated_batch::EvaluatedBatch;
+use sedona_spatial_join::index::default_spatial_index_builder::DefaultSpatialIndexBuilder;
+use sedona_spatial_join::index::spatial_index::SpatialIndexRef;
+use sedona_spatial_join::index::spatial_index_builder::{
+    SpatialIndexBuilder, SpatialJoinBuildMetrics,
+};
+use sedona_spatial_join::operand_evaluator::EvaluatedGeometryArray;
+use sedona_spatial_join::spatial_predicate::{RelationPredicate, SpatialRelationType};
+use sedona_spatial_join::{SpatialJoinOptions, SpatialPredicate};
+use sedona_testing::create::create_array;
+
+const GRID_SIZE: usize = 100;
+const PROBE_ROWS: usize = 8_192;
+const BUILD_HALF_SIZE: f64 = 0.10;
+const PROBE_PADDING: f64 = 0.20;
+const UNIFORM_BLOCK: usize = 2;
+const HOTSPOT_BLOCK: usize = 10;
+const PROBE_CHUNK_SIZES: [usize; 5] = [0, 64, 256, 1024, 4096];
+
+struct SingleBatchStream {
+    batch: Option<EvaluatedBatch>,
+    schema: SchemaRef,
+}
+
+impl SingleBatchStream {
+    fn new(batch: EvaluatedBatch, schema: SchemaRef) -> Self {
+        Self {
+            batch: Some(batch),
+            schema,
+        }
+    }
+}
+
+impl Stream for SingleBatchStream {
+    type Item = Result<EvaluatedBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Poll::Ready(self.batch.take().map(Ok))
+    }
+}
+
+impl EvaluatedBatchStream for SingleBatchStream {
+    fn is_external(&self) -> bool {
+        false
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum WorkloadKind {
+    Uniform,
+    Skewed,
+}
+
+impl WorkloadKind {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Uniform => "uniform",
+            Self::Skewed => "skewed",
+        }
+    }
+
+    fn probe_block_size(self) -> usize {
+        match self {
+            Self::Uniform => UNIFORM_BLOCK,
+            Self::Skewed => HOTSPOT_BLOCK,
+        }
+    }
+}
+
+struct QueryBatchWorkload {
+    kind: WorkloadKind,
+    probe_batch: Arc<EvaluatedBatch>,
+    expected_count: usize,
+}
+
+fn spatial_predicate() -> SpatialPredicate {
+    SpatialPredicate::Relation(RelationPredicate::new(
+        Arc::new(Column::new("probe", 0)),
+        Arc::new(Column::new("build", 0)),
+        SpatialRelationType::Intersects,
+    ))
+}
+
+fn geometry_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![Field::new(
+        "geom",
+        DataType::Binary,
+        true,
+    )]))
+}
+
+fn square_wkt(min_x: f64, min_y: f64, max_x: f64, max_y: f64) -> String {
+    format!(
+        "POLYGON (({min_x} {min_y}, {max_x} {min_y}, {max_x} {max_y}, {min_x} {max_y}, {min_x} {min_y}))"
+    )
+}
+
+fn block_probe_wkt(x_start: usize, y_start: usize, block_size: usize) -> String {
+    let min_x = x_start as f64 - PROBE_PADDING;
+    let min_y = y_start as f64 - PROBE_PADDING;
+    let max_x = (x_start + block_size - 1) as f64 + PROBE_PADDING;
+    let max_y = (y_start + block_size - 1) as f64 + PROBE_PADDING;
+    square_wkt(min_x, min_y, max_x, max_y)
+}
+
+fn build_side_wkts() -> Vec<String> {
+    let mut wkts = Vec::with_capacity(GRID_SIZE * GRID_SIZE);
+    for x in 0..GRID_SIZE {
+        for y in 0..GRID_SIZE {
+            let x = x as f64;
+            let y = y as f64;
+            wkts.push(square_wkt(
+                x - BUILD_HALF_SIZE,
+                y - BUILD_HALF_SIZE,
+                x + BUILD_HALF_SIZE,
+                y + BUILD_HALF_SIZE,
+            ));
+        }
+    }
+    wkts
+}
+
+fn probe_wkts(kind: WorkloadKind) -> Vec<String> {
+    let block_size = kind.probe_block_size();
+    let max_start = GRID_SIZE - block_size;
+    let mut wkts = Vec::with_capacity(PROBE_ROWS);
+
+    for i in 0..PROBE_ROWS {
+        let (x_start, y_start) = match kind {
+            WorkloadKind::Uniform => ((i * 17) % max_start, (i * 37) % max_start),
+            WorkloadKind::Skewed => {
+                let hotspot_x = (GRID_SIZE - block_size) / 2;
+                let hotspot_y = (GRID_SIZE - block_size) / 2;
+                (hotspot_x + (i % 4), hotspot_y + ((i / 4) % 4))
+            }
+        };
+        wkts.push(block_probe_wkt(x_start, y_start, block_size));
+    }
+
+    wkts
+}
+
+fn make_evaluated_batch(wkts: &[String]) -> EvaluatedBatch {
+    let schema = geometry_schema();
+    let wkt_refs = wkts
+        .iter()
+        .map(|wkt| Some(wkt.as_str()))
+        .collect::<Vec<_>>();
+    let geom_array = create_array(&wkt_refs, &WKB_GEOMETRY);
+    let batch = RecordBatch::try_new(schema, vec![Arc::new(geom_array.clone())])
+        .expect("failed to create benchmark record batch");
+    let geom_array = EvaluatedGeometryArray::try_new(geom_array, &WKB_GEOMETRY)
+        .expect("failed to evaluate benchmark geometry array");
+    EvaluatedBatch { batch, geom_array }
+}
+
+async fn build_index(options: SpatialJoinOptions) -> SpatialIndexRef {
+    let schema = geometry_schema();
+    let build_batch = make_evaluated_batch(&build_side_wkts());
+    let mut builder = DefaultSpatialIndexBuilder::new(
+        Arc::clone(&schema),
+        spatial_predicate(),
+        options,
+        JoinType::Inner,
+        1,
+        SpatialJoinBuildMetrics::default(),
+    )
+    .expect("failed to create spatial index builder");
+
+    let stream: SendableEvaluatedBatchStream =
+        Box::pin(SingleBatchStream::new(build_batch, schema));
+    builder
+        .add_stream(stream, GeoStatistics::empty())
+        .await
+        .expect("failed to add benchmark build batch");
+    builder.finish().expect("failed to finish benchmark index")
+}
+
+fn make_workload(kind: WorkloadKind) -> QueryBatchWorkload {
+    let probe_batch = Arc::new(make_evaluated_batch(&probe_wkts(kind)));
+    let expected_count = PROBE_ROWS * kind.probe_block_size() * kind.probe_block_size();
+    QueryBatchWorkload {
+        kind,
+        probe_batch,
+        expected_count,
+    }
+}
+
+fn chunk_label(chunk_size: usize) -> String {
+    if chunk_size == 0 {
+        "off".to_string()
+    } else {
+        chunk_size.to_string()
+    }
+}
+
+fn query_batch_parallel(c: &mut Criterion) {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(
+            std::thread::available_parallelism()
+                .map(|parallelism| parallelism.get())
+                .unwrap_or(8),
+        )
+        .build()
+        .expect("failed to create benchmark runtime");
+
+    for kind in [WorkloadKind::Uniform, WorkloadKind::Skewed] {
+        let workload = make_workload(kind);
+        let mut group = c.benchmark_group(format!("query_batch_parallel/{}", workload.kind.name()));
+        group.throughput(Throughput::Elements(PROBE_ROWS as u64));
+
+        for chunk_size in PROBE_CHUNK_SIZES {
+            let options = SpatialJoinOptions {
+                parallel_probe_chunk_size: chunk_size,
+                ..Default::default()
+            };
+            let index = runtime.block_on(build_index(options));
+            let probe_batch = Arc::clone(&workload.probe_batch);
+            let expected_count = workload.expected_count;
+
+            group.bench_with_input(
+                BenchmarkId::from_parameter(chunk_label(chunk_size)),
+                &chunk_size,
+                |b, _| {
+                    b.iter_batched(
+                        || {
+                            (
+                                Vec::with_capacity(expected_count),
+                                Vec::with_capacity(expected_count),
+                            )
+                        },
+                        |(mut build_batch_positions, mut probe_indices)| {
+                            let (metrics, next_idx) = runtime
+                                .block_on(index.query_batch(
+                                    &probe_batch,
+                                    0..PROBE_ROWS,
+                                    usize::MAX,
+                                    &mut build_batch_positions,
+                                    &mut probe_indices,
+                                ))
+                                .expect("query_batch failed in benchmark");
+
+                            assert_eq!(next_idx, PROBE_ROWS);
+                            assert_eq!(metrics.count, expected_count);
+                            assert_eq!(build_batch_positions.len(), expected_count);
+                            assert_eq!(probe_indices.len(), expected_count);
+                            black_box(metrics.candidate_count);
+                            black_box(build_batch_positions);
+                            black_box(probe_indices);
+                        },
+                        BatchSize::SmallInput,
+                    )
+                },
+            );
+        }
+
+        group.finish();
+    }
+}
+
+criterion_group!(query_batch_parallel_group, query_batch_parallel);
+criterion_main!(query_batch_parallel_group);

--- a/rust/sedona-spatial-join/bench/query_batch_parallel.rs
+++ b/rust/sedona-spatial-join/bench/query_batch_parallel.rs
@@ -232,9 +232,9 @@ fn make_workload(kind: WorkloadKind) -> QueryBatchWorkload {
 
 fn chunk_label(chunk_size: usize) -> String {
     if chunk_size == 0 {
-        "off".to_string()
+        "before".to_string()
     } else {
-        chunk_size.to_string()
+        format!("after_chunk_{chunk_size}")
     }
 }
 

--- a/rust/sedona-spatial-join/src/index/default_spatial_index.rs
+++ b/rust/sedona-spatial-join/src/index/default_spatial_index.rs
@@ -110,6 +110,25 @@ pub(crate) struct DefaultSpatialIndex {
     inner: Arc<DefaultSpatialIndexInner>,
 }
 
+struct QueryBatchRowOutput {
+    row_idx: usize,
+    metrics: QueryResultMetrics,
+    build_batch_positions: Vec<(i32, i32)>,
+}
+
+impl QueryBatchRowOutput {
+    fn empty(row_idx: usize) -> Self {
+        Self {
+            row_idx,
+            metrics: QueryResultMetrics {
+                count: 0,
+                candidate_count: 0,
+            },
+            build_batch_positions: Vec::new(),
+        }
+    }
+}
+
 impl DefaultSpatialIndex {
     pub(crate) fn empty(
         spatial_predicate: SpatialPredicate,
@@ -176,6 +195,250 @@ impl DefaultSpatialIndex {
             &self.inner.indexed_batches,
             &self.inner.data_id_to_batch_pos,
             knn_components,
+        ))
+    }
+
+    async fn query_batch_row(
+        &self,
+        evaluated_batch: &Arc<EvaluatedBatch>,
+        row_idx: usize,
+    ) -> Result<QueryBatchRowOutput> {
+        let rects = evaluated_batch.geom_array.rects();
+        let dist = evaluated_batch.geom_array.distance();
+
+        let probe_rect = &rects[row_idx];
+        if probe_rect.is_empty() {
+            return Ok(QueryBatchRowOutput::empty(row_idx));
+        }
+
+        let mut candidates = if let Some(wraparound) = &self.inner.wraparound {
+            let (left, right) = probe_rect.split(wraparound);
+            if left.is_empty() {
+                return sedona_internal_err!("Probe rectangle split produced empty left split");
+            }
+
+            let (x, y) = left.into_inner();
+            let mut candidates = self.inner.rtree.search(x.0, y.0, x.1, y.1);
+            if !right.is_empty() {
+                let (x, y) = right.into_inner();
+                candidates.extend(self.inner.rtree.search(x.0, y.0, x.1, y.1));
+            }
+
+            candidates
+        } else {
+            let (x, y) = probe_rect.clone().into_inner();
+            self.inner.rtree.search(x.0, y.0, x.1, y.1)
+        };
+
+        if candidates.is_empty() {
+            return Ok(QueryBatchRowOutput::empty(row_idx));
+        }
+
+        // Deduplicate the data_idx themselves. This can happen if the same build rectangle
+        // intersects both the left and right probe rectangles.
+        if probe_rect.is_wraparound() {
+            candidates.sort_unstable();
+            candidates.dedup();
+        }
+
+        // Deduplicate candidates arising from distinct data_idx in candidates that resolve
+        // to the same build batch positions due to multiple rectangles for the same item
+        // in the tree.
+        if self.inner.wraparound.is_some() {
+            let mut indexed_candidates: Vec<_> = candidates
+                .iter()
+                .map(|&data_idx| (self.inner.data_id_to_batch_pos[data_idx as usize], data_idx))
+                .collect();
+            indexed_candidates.sort_unstable_by_key(|(pos, _)| *pos);
+            indexed_candidates.dedup_by_key(|(pos, _)| *pos);
+            candidates = indexed_candidates
+                .into_iter()
+                .map(|(_, data_idx)| data_idx)
+                .collect();
+        }
+
+        let distance = match dist {
+            Some(dist_array) => distance_value_at(dist_array, row_idx)?,
+            None => None,
+        };
+
+        // Refine the candidates retrieved from the r-tree index by evaluating the actual spatial predicate
+        let refine_chunk_size = self.inner.options.parallel_refinement_chunk_size;
+        let (metrics, build_batch_positions) =
+            if refine_chunk_size == 0 || candidates.len() < refine_chunk_size * 2 {
+                let Some(probe_wkb) = evaluated_batch.geom_array.wkb(row_idx) else {
+                    return sedona_internal_err!(
+                        "Failed to get WKB for row {} in evaluated batch",
+                        row_idx
+                    );
+                };
+
+                // For small candidate sets, use refine synchronously
+                let mut build_batch_positions = Vec::new();
+                let metrics = self.refine(
+                    probe_wkb,
+                    &candidates,
+                    &distance,
+                    &mut build_batch_positions,
+                )?;
+                (metrics, build_batch_positions)
+            } else {
+                // For large candidate sets, spawn several tasks to parallelize refinement
+                self.refine_concurrently(
+                    evaluated_batch,
+                    row_idx,
+                    &candidates,
+                    distance,
+                    refine_chunk_size,
+                )
+                .await?
+            };
+
+        Ok(QueryBatchRowOutput {
+            row_idx,
+            metrics,
+            build_batch_positions,
+        })
+    }
+
+    fn append_query_batch_row(
+        row_output: QueryBatchRowOutput,
+        max_result_size: usize,
+        build_batch_positions: &mut Vec<(i32, i32)>,
+        probe_indices: &mut Vec<u32>,
+        total_count: &mut usize,
+        total_candidates_count: &mut usize,
+    ) -> bool {
+        let QueryBatchRowOutput {
+            row_idx,
+            metrics,
+            build_batch_positions: row_build_batch_positions,
+        } = row_output;
+
+        debug_assert_eq!(row_build_batch_positions.len(), metrics.count);
+
+        let count = metrics.count;
+        let candidate_count = metrics.candidate_count;
+        build_batch_positions.extend(row_build_batch_positions);
+        probe_indices.extend(std::iter::repeat_n(row_idx as u32, count));
+        *total_count += count;
+        *total_candidates_count += candidate_count;
+
+        candidate_count > 0 && *total_count >= max_result_size
+    }
+
+    async fn query_batch_sequential(
+        &self,
+        evaluated_batch: &Arc<EvaluatedBatch>,
+        range: Range<usize>,
+        max_result_size: usize,
+        build_batch_positions: &mut Vec<(i32, i32)>,
+        probe_indices: &mut Vec<u32>,
+    ) -> Result<(QueryResultMetrics, usize)> {
+        let mut total_candidates_count = 0;
+        let mut total_count = 0;
+        let mut current_row_idx = range.start;
+
+        for row_idx in range {
+            current_row_idx = row_idx;
+            let row_output = self.query_batch_row(evaluated_batch, row_idx).await?;
+            if Self::append_query_batch_row(
+                row_output,
+                max_result_size,
+                build_batch_positions,
+                probe_indices,
+                &mut total_count,
+                &mut total_candidates_count,
+            ) {
+                break;
+            }
+        }
+
+        let end_idx = current_row_idx + 1;
+        Ok((
+            QueryResultMetrics {
+                count: total_count,
+                candidate_count: total_candidates_count,
+            },
+            end_idx,
+        ))
+    }
+
+    async fn query_batch_probe_chunks(
+        &self,
+        evaluated_batch: &Arc<EvaluatedBatch>,
+        range: Range<usize>,
+        max_result_size: usize,
+        build_batch_positions: &mut Vec<(i32, i32)>,
+        probe_indices: &mut Vec<u32>,
+        probe_chunk_size: usize,
+    ) -> Result<(QueryResultMetrics, usize)> {
+        let mut join_set = JoinSet::new();
+        for (chunk_idx, chunk_start) in (range.start..range.end)
+            .step_by(probe_chunk_size)
+            .enumerate()
+        {
+            let chunk_end = (chunk_start + probe_chunk_size).min(range.end);
+            let cloned_evaluated_batch = Arc::clone(evaluated_batch);
+            let index_owned = self.clone();
+            join_set.spawn(async move {
+                let mut row_results = Vec::with_capacity(chunk_end - chunk_start);
+                for row_idx in chunk_start..chunk_end {
+                    let row_result = index_owned
+                        .query_batch_row(&cloned_evaluated_batch, row_idx)
+                        .await;
+                    row_results.push((row_idx, row_result));
+                }
+                (chunk_idx, row_results)
+            });
+        }
+
+        // Collect chunks by chunk index so rows can be committed in global probe-row order.
+        let mut chunk_results: Vec<Option<Vec<(usize, Result<QueryBatchRowOutput>)>>> =
+            Vec::with_capacity(join_set.len());
+        chunk_results.resize_with(join_set.len(), || None);
+        while let Some(res) = join_set.join_next().await {
+            let (chunk_idx, row_results) =
+                res.map_err(|e| DataFusionError::External(Box::new(e)))?;
+            chunk_results[chunk_idx] = Some(row_results);
+        }
+
+        let mut total_candidates_count = 0;
+        let mut total_count = 0;
+        let mut current_row_idx = range.start;
+
+        for chunk_result in chunk_results {
+            let row_results = chunk_result.expect("All chunks should be processed");
+            for (row_idx, row_result) in row_results {
+                current_row_idx = row_idx;
+                let row_output = row_result?;
+                if Self::append_query_batch_row(
+                    row_output,
+                    max_result_size,
+                    build_batch_positions,
+                    probe_indices,
+                    &mut total_count,
+                    &mut total_candidates_count,
+                ) {
+                    let end_idx = current_row_idx + 1;
+                    return Ok((
+                        QueryResultMetrics {
+                            count: total_count,
+                            candidate_count: total_candidates_count,
+                        },
+                        end_idx,
+                    ));
+                }
+            }
+        }
+
+        let end_idx = current_row_idx + 1;
+        Ok((
+            QueryResultMetrics {
+                count: total_count,
+                candidate_count: total_candidates_count,
+            },
+            end_idx,
         ))
     }
 
@@ -525,115 +788,27 @@ impl SpatialIndex for DefaultSpatialIndex {
             ));
         }
 
-        let rects = evaluated_batch.geom_array.rects();
-        let dist = evaluated_batch.geom_array.distance();
-        let mut total_candidates_count = 0;
-        let mut total_count = 0;
-        let mut current_row_idx = range.start;
-        for row_idx in range {
-            current_row_idx = row_idx;
-            let probe_rect = &rects[row_idx];
-            if probe_rect.is_empty() {
-                continue;
-            }
-
-            let mut candidates = if let Some(wraparound) = &self.inner.wraparound {
-                let (left, right) = probe_rect.split(wraparound);
-                if left.is_empty() {
-                    return sedona_internal_err!("Probe rectangle split produced empty left split");
-                }
-
-                let (x, y) = left.into_inner();
-                let mut candidates = self.inner.rtree.search(x.0, y.0, x.1, y.1);
-                if !right.is_empty() {
-                    let (x, y) = right.into_inner();
-                    candidates.extend(self.inner.rtree.search(x.0, y.0, x.1, y.1));
-                }
-
-                candidates
-            } else {
-                let (x, y) = probe_rect.clone().into_inner();
-                self.inner.rtree.search(x.0, y.0, x.1, y.1)
-            };
-
-            if candidates.is_empty() {
-                continue;
-            }
-
-            // Deduplicate the data_idx themselves. This can happen if the same build rectangle
-            // intersects both the left and right probe rectangles.
-            if probe_rect.is_wraparound() {
-                candidates.sort_unstable();
-                candidates.dedup();
-            }
-
-            // Deduplicate candidates arising from distinct data_idx in candidates that resolve
-            // to the same build batch positions due to multiple rectangles for the same item
-            // in the tree.
-            if self.inner.wraparound.is_some() {
-                let mut indexed_candidates: Vec<_> = candidates
-                    .iter()
-                    .map(|&data_idx| (self.inner.data_id_to_batch_pos[data_idx as usize], data_idx))
-                    .collect();
-                indexed_candidates.sort_unstable_by_key(|(pos, _)| *pos);
-                indexed_candidates.dedup_by_key(|(pos, _)| *pos);
-                candidates = indexed_candidates
-                    .into_iter()
-                    .map(|(_, data_idx)| data_idx)
-                    .collect();
-            }
-
-            let Some(probe_wkb) = evaluated_batch.geom_array.wkb(row_idx) else {
-                return sedona_internal_err!(
-                    "Failed to get WKB for row {} in evaluated batch",
-                    row_idx
-                );
-            };
-
-            let distance = match dist {
-                Some(dist_array) => distance_value_at(dist_array, row_idx)?,
-                None => None,
-            };
-
-            // Refine the candidates retrieved from the r-tree index by evaluating the actual spatial predicate
-            let refine_chunk_size = self.inner.options.parallel_refinement_chunk_size;
-            if refine_chunk_size == 0 || candidates.len() < refine_chunk_size * 2 {
-                // For small candidate sets, use refine synchronously
-                let metrics =
-                    self.refine(probe_wkb, &candidates, &distance, build_batch_positions)?;
-                probe_indices.extend(std::iter::repeat_n(row_idx as u32, metrics.count));
-                total_count += metrics.count;
-                total_candidates_count += metrics.candidate_count;
-            } else {
-                // For large candidate sets, spawn several tasks to parallelize refinement
-                let (metrics, positions) = self
-                    .refine_concurrently(
-                        evaluated_batch,
-                        row_idx,
-                        &candidates,
-                        distance,
-                        refine_chunk_size,
-                    )
-                    .await?;
-                build_batch_positions.extend(positions);
-                probe_indices.extend(std::iter::repeat_n(row_idx as u32, metrics.count));
-                total_count += metrics.count;
-                total_candidates_count += metrics.candidate_count;
-            }
-
-            if total_count >= max_result_size {
-                break;
-            }
+        let probe_chunk_size = self.inner.options.parallel_probe_chunk_size;
+        if probe_chunk_size == 0 || range.len() < probe_chunk_size.saturating_mul(2) {
+            self.query_batch_sequential(
+                evaluated_batch,
+                range,
+                max_result_size,
+                build_batch_positions,
+                probe_indices,
+            )
+            .await
+        } else {
+            self.query_batch_probe_chunks(
+                evaluated_batch,
+                range,
+                max_result_size,
+                build_batch_positions,
+                probe_indices,
+                probe_chunk_size,
+            )
+            .await
         }
-
-        let end_idx = current_row_idx + 1;
-        Ok((
-            QueryResultMetrics {
-                count: total_count,
-                candidate_count: total_candidates_count,
-            },
-            end_idx,
-        ))
     }
 
     fn need_more_probe_stats(&self) -> bool {
@@ -680,6 +855,7 @@ mod tests {
     use crate::index::spatial_index::SpatialIndexRef;
     use crate::index::spatial_index_builder::{SpatialIndexBuilder, SpatialJoinBuildMetrics};
     use crate::index::DefaultSpatialIndexBuilder;
+    use crate::utils::bounds::Bounds2D;
     use arrow_array::RecordBatch;
     use arrow_schema::{DataType, Field};
     use datafusion_common::JoinSide;
@@ -688,7 +864,10 @@ mod tests {
     use futures::Stream;
     use geo_traits::Dimensions;
     use sedona_common::option::{ExecutionMode, SpatialJoinOptions};
-    use sedona_geometry::wkb_factory::write_wkb_empty_point;
+    use sedona_geometry::{
+        interval::{IntervalTrait, WraparoundInterval},
+        wkb_factory::write_wkb_empty_point,
+    };
     use sedona_schema::datatypes::WKB_GEOMETRY;
     use sedona_testing::create::create_array;
 
@@ -1805,6 +1984,31 @@ mod tests {
         })
     }
 
+    fn create_probe_batch_with_rects(
+        probe_geoms: &[Option<&str>],
+        rects: Vec<Bounds2D>,
+    ) -> Arc<EvaluatedBatch> {
+        let geom_array = create_array(probe_geoms, &WKB_GEOMETRY);
+        let batch = RecordBatch::try_new(
+            Arc::new(arrow_schema::Schema::new(vec![Field::new(
+                "geom",
+                DataType::Binary,
+                true,
+            )])),
+            vec![Arc::new(geom_array.clone())],
+        )
+        .unwrap();
+        Arc::new(EvaluatedBatch {
+            batch,
+            geom_array: EvaluatedGeometryArray::try_new_with_rects(
+                geom_array,
+                rects,
+                &WKB_GEOMETRY,
+            )
+            .unwrap(),
+        })
+    }
+
     #[tokio::test]
     async fn test_query_batch_empty_results() {
         let build_geoms = &[Some("POINT (0 0)"), Some("POINT (1 1)")];
@@ -2026,5 +2230,187 @@ mod tests {
         assert!(result.is_ok());
         let (metrics, _) = result.unwrap();
         assert_eq!(metrics.count, 3);
+    }
+
+    #[tokio::test]
+    async fn test_query_batch_parallel_probe_chunks_matches_sequential() {
+        let build_geoms = &[
+            Some("POINT (0 0)"),
+            Some("POINT (1 1)"),
+            Some("POINT (2 2)"),
+            Some("POINT (5 5)"),
+        ];
+        let sequential_index =
+            setup_index_for_batch_test(build_geoms, SpatialJoinOptions::default()).await;
+        let parallel_index = setup_index_for_batch_test(
+            build_geoms,
+            SpatialJoinOptions {
+                parallel_probe_chunk_size: 1,
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let probe_geoms = &[
+            Some("POLYGON ((-1 -1, 1.5 -1, 1.5 1.5, -1 1.5, -1 -1))"),
+            Some("POINT (5 5)"),
+            None,
+            Some("POINT (2 2)"),
+        ];
+        let probe_batch = create_probe_batch(probe_geoms);
+
+        let mut sequential_build_positions = Vec::new();
+        let mut sequential_probe_indices = Vec::new();
+        let (sequential_metrics, sequential_next_idx) = sequential_index
+            .query_batch(
+                &probe_batch,
+                0..probe_geoms.len(),
+                usize::MAX,
+                &mut sequential_build_positions,
+                &mut sequential_probe_indices,
+            )
+            .await
+            .unwrap();
+
+        let mut parallel_build_positions = Vec::new();
+        let mut parallel_probe_indices = Vec::new();
+        let (parallel_metrics, parallel_next_idx) = parallel_index
+            .query_batch(
+                &probe_batch,
+                0..probe_geoms.len(),
+                usize::MAX,
+                &mut parallel_build_positions,
+                &mut parallel_probe_indices,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(parallel_metrics.count, sequential_metrics.count);
+        assert_eq!(
+            parallel_metrics.candidate_count,
+            sequential_metrics.candidate_count
+        );
+        assert_eq!(parallel_next_idx, sequential_next_idx);
+        assert_eq!(parallel_build_positions, sequential_build_positions);
+        assert_eq!(parallel_probe_indices, sequential_probe_indices);
+    }
+
+    #[tokio::test]
+    async fn test_query_batch_parallel_probe_chunks_max_result_size() {
+        let build_geoms = &[
+            Some("POINT (0 0)"),
+            Some("POINT (0 0)"),
+            Some("POINT (0 0)"),
+        ];
+        let index = setup_index_for_batch_test(
+            build_geoms,
+            SpatialJoinOptions {
+                parallel_probe_chunk_size: 1,
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let probe_geoms = &[Some("POINT (0 0)"), Some("POINT (0 0)")];
+        let probe_batch = create_probe_batch(probe_geoms);
+
+        let mut build_batch_positions = Vec::new();
+        let mut probe_indices = Vec::new();
+        let (metrics, next_idx) = index
+            .query_batch(
+                &probe_batch,
+                0..2,
+                2,
+                &mut build_batch_positions,
+                &mut probe_indices,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(metrics.count, 3);
+        assert_eq!(next_idx, 1);
+        assert_eq!(build_batch_positions.len(), 3);
+        assert_eq!(probe_indices, vec![0, 0, 0]);
+    }
+
+    #[tokio::test]
+    async fn test_query_batch_parallel_probe_chunks_wraparound_deduplicates() {
+        let metrics = SpatialJoinBuildMetrics::default();
+        let spatial_predicate = SpatialPredicate::Relation(RelationPredicate::new(
+            Arc::new(Column::new("left", 0)),
+            Arc::new(Column::new("right", 0)),
+            SpatialRelationType::Intersects,
+        ));
+        let schema = Arc::new(arrow_schema::Schema::new(vec![Field::new(
+            "geom",
+            DataType::Binary,
+            true,
+        )]));
+        let options = SpatialJoinOptions {
+            parallel_probe_chunk_size: 1,
+            ..Default::default()
+        };
+
+        let builder = DefaultSpatialIndexBuilder::new(
+            schema.clone(),
+            spatial_predicate,
+            options,
+            JoinType::Inner,
+            1,
+            metrics,
+        )
+        .unwrap()
+        .with_wraparound((-180.0, 180.0));
+
+        let build_geoms = &[Some("POINT (179 0)")];
+        let build_geom_array = create_array(build_geoms, &WKB_GEOMETRY);
+        let build_batch = RecordBatch::try_new(
+            Arc::new(arrow_schema::Schema::new(vec![Field::new(
+                "geom",
+                DataType::Binary,
+                true,
+            )])),
+            vec![Arc::new(build_geom_array.clone())],
+        )
+        .unwrap();
+        let build_evaluated_batch = EvaluatedBatch {
+            batch: build_batch,
+            geom_array: EvaluatedGeometryArray::try_new_with_rects(
+                build_geom_array,
+                vec![Bounds2D::new(
+                    WraparoundInterval::new(170.0, -170.0),
+                    (-1.0, 1.0),
+                )],
+                &WKB_GEOMETRY,
+            )
+            .unwrap(),
+        };
+        let index = build_index(builder, build_evaluated_batch, schema).await;
+
+        let probe_batch = create_probe_batch_with_rects(
+            &[Some("POINT (179 0)"), Some("POINT (0 0)")],
+            vec![
+                Bounds2D::new(WraparoundInterval::new(175.0, -175.0), (-1.0, 1.0)),
+                Bounds2D::new((0.0, 0.0), (0.0, 0.0)),
+            ],
+        );
+
+        let mut build_batch_positions = Vec::new();
+        let mut probe_indices = Vec::new();
+        let (metrics, next_idx) = index
+            .query_batch(
+                &probe_batch,
+                0..2,
+                usize::MAX,
+                &mut build_batch_positions,
+                &mut probe_indices,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(metrics.count, 1);
+        assert_eq!(next_idx, 2);
+        assert_eq!(build_batch_positions, vec![(0, 0)]);
+        assert_eq!(probe_indices, vec![0]);
     }
 }

--- a/rust/sedona-spatial-join/src/index/default_spatial_index.rs
+++ b/rust/sedona-spatial-join/src/index/default_spatial_index.rs
@@ -129,6 +129,9 @@ impl QueryBatchRowOutput {
     }
 }
 
+/// Row results of one probe chunk, keyed by the global probe-row index.
+type ProbeChunkRowResults = Vec<(usize, Result<QueryBatchRowOutput>)>;
+
 impl DefaultSpatialIndex {
     pub(crate) fn empty(
         spatial_predicate: SpatialPredicate,
@@ -394,7 +397,7 @@ impl DefaultSpatialIndex {
         }
 
         // Collect chunks by chunk index so rows can be committed in global probe-row order.
-        let mut chunk_results: Vec<Option<Vec<(usize, Result<QueryBatchRowOutput>)>>> =
+        let mut chunk_results: Vec<Option<ProbeChunkRowResults>> =
             Vec::with_capacity(join_set.len());
         chunk_results.resize_with(join_set.len(), || None);
         while let Some(res) = join_set.join_next().await {

--- a/rust/sedona-spatial-join/tests/spatial_join_integration.rs
+++ b/rust/sedona-spatial-join/tests/spatial_join_integration.rs
@@ -817,6 +817,29 @@ async fn test_full_outer_join() -> Result<()> {
     Ok(())
 }
 
+#[rstest]
+#[tokio::test]
+async fn test_probe_chunk_parallel_join_types(
+    #[values(
+        JoinType::Inner,
+        JoinType::Left,
+        JoinType::Right,
+        JoinType::Full,
+        JoinType::LeftSemi,
+        JoinType::LeftAnti,
+        JoinType::RightSemi,
+        JoinType::RightAnti
+    )]
+    join_type: JoinType,
+) -> Result<()> {
+    let options = SpatialJoinOptions {
+        parallel_probe_chunk_size: 1,
+        ..Default::default()
+    };
+    test_with_join_types(join_type, options, 30).await?;
+    Ok(())
+}
+
 #[tokio::test]
 async fn test_geography_join_is_not_optimized() -> Result<()> {
     let options = SpatialJoinOptions::default();


### PR DESCRIPTION
## Summary
- add opt-in parallel_probe_chunk_size for spatial join query_batch
- preserve row-major commit and early-exit semantics while running probe row chunks concurrently
- add correctness coverage and a Criterion benchmark for uniform/skewed workloads

## Verification
- cargo test -p sedona-spatial-join query_batch --lib
- cargo test -p sedona-spatial-join test_probe_chunk_parallel_join_types --test spatial_join_integration
- cargo test -p sedona-spatial-join
- cargo test -p sedona-spatial-join --bench query_batch_parallel --no-run
- cargo bench -p sedona-spatial-join --bench query_batch_parallel
- cargo clippy -p sedona-spatial-join --all-targets -- -D warnings

## Benchmark Results
Full Criterion run (100 samples per case) on a 10-core Apple M5 MacBook Air (4 performance cores, 6 efficiency cores).

| Workload | Before: probe chunks off | After: best probe chunk setting | Speedup |
| --- | ---: | ---: | ---: |
| Skewed | 109.9 ms | 38.8 ms (`parallel_probe_chunk_size=64`) | ~2.8x faster |
| Uniform | 7.6 ms | 2.7 ms (`parallel_probe_chunk_size=256`) | ~2.8x faster |

Chunk-size sweep (mean times):

| Workload | off / before | 64 | 256 | 1024 | 4096 |
| --- | ---: | ---: | ---: | ---: | ---: |
| Skewed | 109.9 ms | 38.8 ms | 41.3 ms | 45.1 ms | 67.2 ms |
| Uniform | 7.6 ms | 3.1 ms | 2.7 ms | 3.1 ms | 5.0 ms |

The option remains default-off. Small chunk sizes (64-256) are the useful starting points; very large chunks leave too little parallel work.

### Scope of the speedup
This benchmark drives `query_batch` on a single index directly, so there is no partition-level parallelism competing for cores. In full queries where DataFusion partitions already saturate the CPU, the uniform-workload gain will shrink accordingly. The improvement primarily targets cases partition parallelism cannot address: skewed data (one dense partition dominating wall time), under-partitioned inputs, and the end-of-query drain when only a few partitions remain.


@james-willis this touches the spatial join refinement path; I’d value your take on whether probe-row chunking is the right layer for this or whether you’d prefer a different interface/placement.

@paleolimbot I’d also appreciate your view on the API/config shape. I used an explicit default-off `parallel_probe_chunk_size` knob for clarity and benchmarking, but I’m happy to make this internal/automatic or adjust the interface if that fits SedonaDB better.
