### PR TITLE
feat(sedona-raster-functions): add RS_Values

### DIFF
--- a/docs/reference/sql/rs_value.qmd
+++ b/docs/reference/sql/rs_value.qmd
@@ -56,5 +56,5 @@ sampled pixel equals the band's nodata value. Only 2-D rasters are supported.
 ## Examples
 
 ```sql
-SELECT RS_Value(RS_Example(), ST_Point(74.58, 110.57, 'OGC:CRS84'));
+SELECT RS_Value(RS_Example(), ST_Point(74.58, 110.57, 'OGC:CRS84'), 1);
 ```

--- a/docs/reference/sql/rs_value.qmd
+++ b/docs/reference/sql/rs_value.qmd
@@ -43,6 +43,10 @@ kernels:
         is ambiguous and raises an error.
 ---
 
+::: callout-warning
+**Experimental.** This function is experimental; its behavior may change without notice.
+:::
+
 ## Description
 
 `RS_Value` samples one pixel of a raster. The location is given as a point

--- a/docs/reference/sql/rs_value.qmd
+++ b/docs/reference/sql/rs_value.qmd
@@ -37,14 +37,18 @@ kernels:
       type: geometry
     - name: band
       type: int
-      description: Band index (1-based). Defaults to 1 if not specified.
+      description: >
+        Band index (1-based). When omitted, defaults to band 1, but only for a
+        single-band raster; sampling an unspecified band of a multiband raster
+        is ambiguous and raises an error.
 ---
 
 ## Description
 
 `RS_Value` samples one pixel of a raster. The location is given as a point
 geometry — the value of the pixel that contains the point is returned, with no
-interpolation. The band defaults to 1.
+interpolation. The band defaults to 1 when omitted, but only for a single-band
+raster; on a multiband raster the band must be given explicitly.
 
 The result is `NULL` when the point falls outside the raster, or when the
 sampled pixel equals the band's nodata value. Only 2-D rasters are supported.

--- a/docs/reference/sql/rs_values.qmd
+++ b/docs/reference/sql/rs_values.qmd
@@ -38,15 +38,21 @@ kernels:
       type: geometry
     - name: band
       type: int
-      description: Band index (1-based). Defaults to 1 if not specified.
+      description: >
+        Band index (1-based). When omitted, defaults to band 1, but only for a
+        single-band raster; sampling an unspecified band of a multiband raster
+        is ambiguous and raises an error.
 ---
 
 ## Description
 
 `RS_Values` is the plural form of [`RS_Value`](rs_value.qmd): it samples one
 pixel per point of a MultiPoint and returns the values as a list of doubles, in
-the same order as the input points. The band defaults to 1. A single Point is
-accepted as well and produces a one-element list.
+the same order as the input points. A single Point is accepted as well and
+produces a one-element list.
+
+The band defaults to 1 when omitted, but only for a single-band raster; on a
+multiband raster the band is ambiguous and must be given explicitly.
 
 Each list element is `NULL` when its point falls outside the raster or the
 sampled pixel equals the band's nodata value; the whole result is `NULL` when
@@ -58,6 +64,7 @@ list. Only 2-D rasters are supported.
 ```sql
 SELECT RS_Values(
   RS_Example(),
-  ST_SetCRS(ST_GeomFromText('MULTIPOINT (74.58 110.57, 500 500)'), 'OGC:CRS84')
+  ST_GeomFromText('MULTIPOINT (74.58 110.57, 500 500)', 'OGC:CRS84'),
+  1
 );
 ```

--- a/docs/reference/sql/rs_values.qmd
+++ b/docs/reference/sql/rs_values.qmd
@@ -1,0 +1,63 @@
+---
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+title: RS_Values
+description: >
+  Returns the pixel values under each point of a MultiPoint geometry as a list
+  of doubles, one element per point. An element is null where the point falls
+  outside the raster or the pixel holds the band's nodata value.
+kernels:
+  - returns: list
+    args:
+    - raster
+    - name: points
+      type: geometry
+      description: >
+        The pixel that contains each sub-point is sampled (no resampling).
+        Reprojected into the raster CRS when both carry one. A single Point is
+        also accepted and yields a one-element list.
+  - returns: list
+    args:
+    - raster
+    - name: points
+      type: geometry
+    - name: band
+      type: int
+      description: Band index (1-based). Defaults to 1 if not specified.
+---
+
+## Description
+
+`RS_Values` is the plural form of [`RS_Value`](rs_value.qmd): it samples one
+pixel per point of a MultiPoint and returns the values as a list of doubles, in
+the same order as the input points. The band defaults to 1. A single Point is
+accepted as well and produces a one-element list.
+
+Each list element is `NULL` when its point falls outside the raster or the
+sampled pixel equals the band's nodata value; the whole result is `NULL` when
+the raster, geometry, or band is `NULL`. An empty MultiPoint yields an empty
+list. Only 2-D rasters are supported.
+
+## Examples
+
+```sql
+SELECT RS_Values(
+  RS_Example(),
+  ST_SetCRS(ST_GeomFromText('MULTIPOINT (74.58 110.57, 500 500)'), 'OGC:CRS84')
+);
+```

--- a/docs/reference/sql/rs_values.qmd
+++ b/docs/reference/sql/rs_values.qmd
@@ -44,6 +44,10 @@ kernels:
         is ambiguous and raises an error.
 ---
 
+::: callout-warning
+**Experimental.** This function is experimental; its behavior may change without notice.
+:::
+
 ## Description
 
 `RS_Values` is the plural form of [`RS_Value`](rs_value.qmd): it samples one

--- a/python/sedonadb/python/sedonadb/testing.py
+++ b/python/sedonadb/python/sedonadb/testing.py
@@ -213,6 +213,11 @@ class DBEngine:
         This option strips away fine-grained type information but is helpful for
         generally asserting a query result or verifying results between engines
         that have (e.g.) differing integer handling.
+
+        Geometry columns are rendered as WKT strings. List columns (e.g. the
+        `List<Double>` returned by `RS_Values`) can't be cast to string, so they
+        pass through as Python lists and are compared by value — assert them with
+        an expected cell that is itself a list, e.g. ``[([1.0, None],)]``.
         """
         tab = self.result_to_table(result)
         columns = []
@@ -220,6 +225,8 @@ class DBEngine:
             # isinstance() does not always work with pyarrow in pytest
             if _type_is_geoarrow(col.type):
                 columns.append(ga.format_wkt(col, precision=wkt_precision).to_pylist())
+            elif pa.types.is_list(col.type) or pa.types.is_large_list(col.type):
+                columns.append(col.to_pylist())
             else:
                 columns.append(col.cast(pa.string()).to_pylist())
 

--- a/python/sedonadb/tests/functions/test_raster_functions.py
+++ b/python/sedonadb/tests/functions/test_raster_functions.py
@@ -326,6 +326,48 @@ def test_rs_values_default_band_requires_single_band(con):
         ).to_arrow_table()
 
 
+def test_rs_values_ensureloaded_outdb(con, sedona_testing):
+    """RS_Values over an OutDb raster exercises the needs_pixels ->
+    RS_EnsureLoaded planner path end to end: the raster from RS_FromPath carries
+    no pixels, so the planner must materialise it before the kernel samples.
+
+    sentinel2.tif's top-left pixel holds 2324 (see test_rs_ensureloaded); its
+    world center is derived from the raster's own georeference so the test does
+    not hard-code the file's geotransform.
+    """
+    path = sedona_testing / "data/raster/sentinel2.tif"
+    t = con.sql("SELECT RS_FromPath($1) AS raster", params=(str(path),))
+    view = "test_rs_values_ensureloaded_outdb_raster"
+    t.to_view(view)
+    try:
+        meta = con.sql(
+            f"SELECT RS_GeoReference(raster) AS georef, RS_SRID(raster) AS srid FROM {view}"
+        ).to_arrow_table()
+        georef = [float(v) for v in meta["georef"][0].as_py().split()]
+        scale_x, skew_y, skew_x, scale_y, ul_x, ul_y = georef
+        srid = meta["srid"][0].as_py()
+        # World center of pixel (0, 0): upper-left corner + half a pixel step.
+        cx = ul_x + 0.5 * scale_x + 0.5 * skew_x
+        cy = ul_y + 0.5 * skew_y + 0.5 * scale_y
+
+        result = (
+            con.sql(
+                f"""
+            SELECT RS_Values(
+                raster,
+                ST_GeomFromText('MULTIPOINT ({cx} {cy})', 'EPSG:{srid}'),
+                1
+            ) AS v FROM {view}
+            """
+            )
+            .to_arrow_table()["v"][0]
+            .as_py()
+        )
+        assert result == [2324.0]
+    finally:
+        con.drop_view(view)
+
+
 def test_rs_values_matches_rasterio(con):
     """Cross-check RS_Values against rasterio on a random raster.
 

--- a/python/sedonadb/tests/functions/test_raster_functions.py
+++ b/python/sedonadb/tests/functions/test_raster_functions.py
@@ -108,33 +108,42 @@ def test_rs_ensureloaded(con, sedona_testing):
 # the top-left pixel which is set to the nodata value (127). (74.58, 110.57) is
 # the centroid of pixel (10, 10) (0-based) in the raster's OGC:CRS84 space; the
 # point and raster share a CRS so no reprojection happens. A point far outside
-# the footprint yields NULL. (The `needs_pixels` -> RS_EnsureLoaded planner path
-# is covered against a real OutDb raster by `test_rs_ensureloaded`.)
+# the footprint yields NULL. RS_Example is multiband, so the band is given
+# explicitly. (The `needs_pixels` -> RS_EnsureLoaded planner path is covered
+# against a real OutDb raster by `test_rs_ensureloaded`.)
 @pytest.mark.parametrize(
     ("expr", "expected"),
     [
         (
-            "RS_Value(RS_Example(), ST_SetCRS(ST_Point(74.58, 110.57), 'OGC:CRS84'))",
+            "RS_Value(RS_Example(), ST_Point(74.58, 110.57, 'OGC:CRS84'), 1)",
             1.0,
         ),
         (
-            "RS_Value(RS_Example(), ST_SetCRS(ST_Point(74.58, 110.57), 'OGC:CRS84'), 2)",
+            "RS_Value(RS_Example(), ST_Point(74.58, 110.57, 'OGC:CRS84'), 2)",
             2.0,
         ),
         (
-            "RS_Value(RS_Example(), ST_SetCRS(ST_Point(74.58, 110.57), 'OGC:CRS84'), 3)",
+            "RS_Value(RS_Example(), ST_Point(74.58, 110.57, 'OGC:CRS84'), 3)",
             3.0,
         ),
-        ("RS_Value(RS_Example(), ST_SetCRS(ST_Point(0.0, 0.0), 'OGC:CRS84'))", None),
+        ("RS_Value(RS_Example(), ST_Point(0.0, 0.0, 'OGC:CRS84'), 1)", None),
         # POINT EMPTY has no location to sample -> NULL (not an error).
         (
-            "RS_Value(RS_Example(), ST_SetCRS(ST_GeomFromText('POINT EMPTY'), 'OGC:CRS84'))",
+            "RS_Value(RS_Example(), ST_GeomFromText('POINT EMPTY', 'OGC:CRS84'), 1)",
             None,
         ),
     ],
 )
 def test_rs_value_point(expr, expected):
     SedonaDB().assert_query_result(f"SELECT {expr}", expected)
+
+
+def test_rs_value_default_band_requires_single_band(con):
+    # RS_Example has 3 bands, so omitting the band is ambiguous and errors.
+    with pytest.raises(Exception, match="specify which band"):
+        con.sql(
+            "SELECT RS_Value(RS_Example(), ST_Point(74.58, 110.57, 'OGC:CRS84'))"
+        ).to_arrow_table()
 
 
 def test_rs_value_matches_rasterio(con):
@@ -279,34 +288,42 @@ def test_rs_setbandnodatavalue_two_arg_requires_single_band():
 @pytest.mark.parametrize(
     ("expr", "expected"),
     [
-        # Default band: two in-bounds points + one outside.
+        # Two in-bounds points + one outside, on band 1.
         (
-            "RS_Values(RS_Example(), ST_SetCRS(ST_GeomFromText('MULTIPOINT (74.58 110.57, 74.58 110.57, 0 0)'), 'OGC:CRS84'))",
+            "RS_Values(RS_Example(), ST_GeomFromText('MULTIPOINT (74.58 110.57, 74.58 110.57, 0 0)', 'OGC:CRS84'), 1)",
             [1.0, 1.0, None],
         ),
         # Explicit band selects the plane; nodata corner and outside are NULL.
         (
-            "RS_Values(RS_Example(), ST_SetCRS(ST_GeomFromText('MULTIPOINT (74.58 110.57, 44.58 80.57, 0 0)'), 'OGC:CRS84'), 2)",
+            "RS_Values(RS_Example(), ST_GeomFromText('MULTIPOINT (74.58 110.57, 44.58 80.57, 0 0)', 'OGC:CRS84'), 2)",
             [2.0, None, None],
         ),
         (
-            "RS_Values(RS_Example(), ST_SetCRS(ST_GeomFromText('MULTIPOINT (74.58 110.57)'), 'OGC:CRS84'), 3)",
+            "RS_Values(RS_Example(), ST_GeomFromText('MULTIPOINT (74.58 110.57)', 'OGC:CRS84'), 3)",
             [3.0],
         ),
         # A bare Point is accepted and yields a one-element list.
         (
-            "RS_Values(RS_Example(), ST_SetCRS(ST_Point(74.58, 110.57), 'OGC:CRS84'))",
+            "RS_Values(RS_Example(), ST_Point(74.58, 110.57, 'OGC:CRS84'), 1)",
             [1.0],
         ),
         # An empty MultiPoint is an empty list (not NULL).
         (
-            "RS_Values(RS_Example(), ST_SetCRS(ST_GeomFromText('MULTIPOINT EMPTY'), 'OGC:CRS84'))",
+            "RS_Values(RS_Example(), ST_GeomFromText('MULTIPOINT EMPTY', 'OGC:CRS84'), 1)",
             [],
         ),
     ],
 )
 def test_rs_values_multipoint(expr, expected):
     SedonaDB().assert_query_result(f"SELECT {expr}", [(expected,)])
+
+
+def test_rs_values_default_band_requires_single_band(con):
+    # RS_Example has 3 bands, so omitting the band is ambiguous and errors.
+    with pytest.raises(Exception, match="specify which band"):
+        con.sql(
+            "SELECT RS_Values(RS_Example(), ST_GeomFromText('MULTIPOINT (74.58 110.57)', 'OGC:CRS84'))"
+        ).to_arrow_table()
 
 
 def test_rs_values_matches_rasterio(con):

--- a/python/sedonadb/tests/functions/test_raster_functions.py
+++ b/python/sedonadb/tests/functions/test_raster_functions.py
@@ -168,9 +168,17 @@ def test_rs_value_matches_rasterio(con):
     height, width = 7, 5
     data = rng.random((height, width)) * 1000.0
 
-    # GDAL-order geotransform: origin (100, 500), 2-wide pixels, -3 tall
-    # (north-up), no skew. Shared verbatim by both engines.
-    gdal_transform = (100.0, 2.0, 0.0, 500.0, 0.0, -3.0)
+    # Raster spans world bbox x[100, 110], y[479, 500] as 5 cols x 7 rows
+    # (2-wide, 3-tall north-up pixels, no skew). Shared verbatim by both engines.
+    xmin, ymin, xmax, ymax = 100.0, 479.0, 110.0, 500.0
+    gdal_transform = (
+        xmin,
+        (xmax - xmin) / width,
+        0.0,
+        ymax,
+        0.0,
+        -(ymax - ymin) / height,
+    )
     affine = Affine.from_gdal(*gdal_transform)
 
     # Sample points in pixel space (col_frac, row_frac).
@@ -229,7 +237,7 @@ def test_rs_value_matches_rasterio(con):
     finally:
         con.drop_view(view)
 
-    assert got == pytest.approx(expected)
+    assert got == expected
 
 
 def test_rs_setgeoreference_roundtrips_with_getter():
@@ -393,21 +401,25 @@ def test_rs_values_matches_rasterio(con):
     call returns a list that must match rasterio's per-point reads element for
     element, in order.
     """
-    import numpy as np
-
     pytest.importorskip("rasterio")
     from rasterio.io import MemoryFile
     from rasterio.transform import Affine
-
-    from sedonadb.raster import Raster
 
     rng = np.random.default_rng(42)
     height, width = 7, 5
     data = rng.random((height, width)) * 1000.0
 
-    # GDAL-order geotransform: origin (100, 500), 2-wide pixels, -3 tall
-    # (north-up), no skew. Shared verbatim by both engines.
-    gdal_transform = (100.0, 2.0, 0.0, 500.0, 0.0, -3.0)
+    # Raster spans world bbox x[100, 110], y[479, 500] as 5 cols x 7 rows
+    # (2-wide, 3-tall north-up pixels, no skew). Shared verbatim by both engines.
+    xmin, ymin, xmax, ymax = 100.0, 479.0, 110.0, 500.0
+    gdal_transform = (
+        xmin,
+        (xmax - xmin) / width,
+        0.0,
+        ymax,
+        0.0,
+        -(ymax - ymin) / height,
+    )
     affine = Affine.from_gdal(*gdal_transform)
 
     # Sample points in pixel space (col_frac, row_frac): every pixel center plus
@@ -463,7 +475,7 @@ def test_rs_values_matches_rasterio(con):
         .to_pylist()[0]
     )
 
-    assert got == pytest.approx(expected)
+    assert got == expected
 
 
 # RS_AsGeoTiff smoke coverage: the GDAL-backed export is tested in depth in

--- a/python/sedonadb/tests/functions/test_raster_functions.py
+++ b/python/sedonadb/tests/functions/test_raster_functions.py
@@ -340,17 +340,24 @@ def test_rs_values_ensureloaded_outdb(con, sedona_testing):
     view = "test_rs_values_ensureloaded_outdb_raster"
     t.to_view(view)
     try:
-        meta = con.sql(
-            f"SELECT RS_GeoReference(raster) AS georef, RS_SRID(raster) AS srid FROM {view}"
-        ).to_arrow_table()
-        georef = [float(v) for v in meta["georef"][0].as_py().split()]
+        # `.to_pylist()` converts the whole (one-row) table in one pass;
+        # indexing a column with `[0]` first would force a chunk-combining
+        # copy in pyarrow.
+        meta = (
+            con.sql(
+                f"SELECT RS_GeoReference(raster) AS georef, RS_SRID(raster) AS srid FROM {view}"
+            )
+            .to_arrow_table()
+            .to_pylist()[0]
+        )
+        georef = [float(v) for v in meta["georef"].split()]
         scale_x, skew_y, skew_x, scale_y, ul_x, ul_y = georef
-        srid = meta["srid"][0].as_py()
+        srid = meta["srid"]
         # World center of pixel (0, 0): upper-left corner + half a pixel step.
         cx = ul_x + 0.5 * scale_x + 0.5 * skew_x
         cy = ul_y + 0.5 * skew_y + 0.5 * scale_y
 
-        result = (
+        values = (
             con.sql(
                 f"""
             SELECT RS_Values(
@@ -360,10 +367,10 @@ def test_rs_values_ensureloaded_outdb(con, sedona_testing):
             ) AS v FROM {view}
             """
             )
-            .to_arrow_table()["v"][0]
-            .as_py()
+            .to_arrow_table()["v"]
+            .to_pylist()
         )
-        assert result == [2324.0]
+        assert values == [[2324.0]]
     finally:
         con.drop_view(view)
 

--- a/python/sedonadb/tests/functions/test_raster_functions.py
+++ b/python/sedonadb/tests/functions/test_raster_functions.py
@@ -268,3 +268,123 @@ def test_rs_setbandnodatavalue_two_arg_requires_single_band():
         SedonaDB().assert_query_result(
             "SELECT RS_SetBandNoDataValue(RS_Example(), 0)", None
         )
+
+
+# RS_Values samples one pixel per sub-point and returns a List<Double> in input
+# order. Same raster facts as `test_rs_value_point`: band `b` is filled with `b`,
+# (74.58, 110.57) is the centroid of pixel (10, 10), and (44.58, 80.57) is the
+# centroid of the top-left pixel (0, 0), which is set to nodata. A point far
+# outside the footprint yields a NULL element; the whole result is never NULL
+# here because the geometry is non-null.
+@pytest.mark.parametrize(
+    ("expr", "expected"),
+    [
+        # Default band: two in-bounds points + one outside.
+        (
+            "RS_Values(RS_Example(), ST_SetCRS(ST_GeomFromText('MULTIPOINT (74.58 110.57, 74.58 110.57, 0 0)'), 'OGC:CRS84'))",
+            [1.0, 1.0, None],
+        ),
+        # Explicit band selects the plane; nodata corner and outside are NULL.
+        (
+            "RS_Values(RS_Example(), ST_SetCRS(ST_GeomFromText('MULTIPOINT (74.58 110.57, 44.58 80.57, 0 0)'), 'OGC:CRS84'), 2)",
+            [2.0, None, None],
+        ),
+        (
+            "RS_Values(RS_Example(), ST_SetCRS(ST_GeomFromText('MULTIPOINT (74.58 110.57)'), 'OGC:CRS84'), 3)",
+            [3.0],
+        ),
+        # A bare Point is accepted and yields a one-element list.
+        (
+            "RS_Values(RS_Example(), ST_SetCRS(ST_Point(74.58, 110.57), 'OGC:CRS84'))",
+            [1.0],
+        ),
+        # An empty MultiPoint is an empty list (not NULL).
+        (
+            "RS_Values(RS_Example(), ST_SetCRS(ST_GeomFromText('MULTIPOINT EMPTY'), 'OGC:CRS84'))",
+            [],
+        ),
+    ],
+)
+def test_rs_values_multipoint(expr, expected):
+    SedonaDB().assert_query_result(f"SELECT {expr}", [(expected,)])
+
+
+def test_rs_values_matches_rasterio(con):
+    """Cross-check RS_Values against rasterio on a random raster.
+
+    The plural counterpart of `test_rs_value_matches_rasterio`: the same dense
+    set of sample points is passed as a single MultiPoint, so one `RS_Values`
+    call returns a list that must match rasterio's per-point reads element for
+    element, in order.
+    """
+    import numpy as np
+
+    pytest.importorskip("rasterio")
+    from rasterio.io import MemoryFile
+    from rasterio.transform import Affine
+
+    from sedonadb.raster import Raster
+
+    rng = np.random.default_rng(42)
+    height, width = 7, 5
+    data = rng.random((height, width)) * 1000.0
+
+    # GDAL-order geotransform: origin (100, 500), 2-wide pixels, -3 tall
+    # (north-up), no skew. Shared verbatim by both engines.
+    gdal_transform = (100.0, 2.0, 0.0, 500.0, 0.0, -3.0)
+    affine = Affine.from_gdal(*gdal_transform)
+
+    # Sample points in pixel space (col_frac, row_frac): every pixel center plus
+    # four off-center positions (kept inside the pixel to avoid floor ambiguity),
+    # then a batch of random interior points.
+    pixel_points = []
+    for row in range(height):
+        for col in range(width):
+            for du, dv in [
+                (0.5, 0.5),
+                (0.25, 0.25),
+                (0.75, 0.75),
+                (0.25, 0.75),
+                (0.75, 0.25),
+            ]:
+                pixel_points.append((col + du, row + dv))
+    n_random = 150
+    rand_cols = rng.integers(0, width, n_random)
+    rand_rows = rng.integers(0, height, n_random)
+    pixel_points.extend(
+        zip(
+            rand_cols + rng.uniform(0.1, 0.9, n_random),
+            rand_rows + rng.uniform(0.1, 0.9, n_random),
+        )
+    )
+
+    # Map pixel-space positions to world coordinates via the shared affine.
+    xs, ys = zip(*(affine * (u, v) for u, v in pixel_points))
+
+    # rasterio reference: a real GDAL read of the same array (no CRS).
+    with MemoryFile() as mem:
+        with mem.open(
+            driver="GTiff",
+            height=height,
+            width=width,
+            count=1,
+            dtype="float64",
+            transform=affine,
+        ) as dst:
+            dst.write(data, 1)
+        with mem.open() as src:
+            expected = [vals[0] for vals in src.sample(list(zip(xs, ys)))]
+
+    # sedonadb: sample every point in one MultiPoint via a single RS_Values call.
+    raster = Raster.from_numpy(data, transform=gdal_transform)
+    wkt = "MULTIPOINT (" + ", ".join(f"{x} {y}" for x, y in zip(xs, ys)) + ")"
+    got = (
+        con.sql(
+            "SELECT RS_Values($1, ST_GeomFromText($2)) AS v",
+            params=(raster, wkt),
+        )
+        .to_arrow_table()["v"]
+        .to_pylist()[0]
+    )
+
+    assert got == pytest.approx(expected)

--- a/rust/sedona-geometry/src/transform.rs
+++ b/rust/sedona-geometry/src/transform.rs
@@ -415,6 +415,57 @@ where
     Ok(())
 }
 
+/// Visit each point of a Point/MultiPoint geometry as `Some((x, y))` — or
+/// `None` for an empty (sub-)point — optionally transforming each coordinate
+/// with `trans` before visiting.
+///
+/// Compared to [`transform`], which writes a transformed WKB copy, this hands
+/// the caller each coordinate directly, so point-sampling consumers can
+/// transform and consume in one pass with no intermediate geometry
+/// materialisation. Any other geometry type is an error.
+pub fn visit_point_coords<F>(
+    geom: impl GeometryTrait<T = f64>,
+    trans: Option<&dyn CrsTransform>,
+    mut visit: F,
+) -> Result<(), SedonaGeometryError>
+where
+    F: FnMut(Option<(f64, f64)>) -> Result<(), SedonaGeometryError>,
+{
+    fn visit_one<P, F>(
+        point: &P,
+        trans: Option<&dyn CrsTransform>,
+        visit: &mut F,
+    ) -> Result<(), SedonaGeometryError>
+    where
+        P: PointTrait<T = f64>,
+        F: FnMut(Option<(f64, f64)>) -> Result<(), SedonaGeometryError>,
+    {
+        match point.coord() {
+            Some(coord) => {
+                let mut xy = (coord.x(), coord.y());
+                if let Some(trans) = trans {
+                    trans.transform_coord(&mut xy)?;
+                }
+                visit(Some(xy))
+            }
+            None => visit(None),
+        }
+    }
+
+    match geom.as_type() {
+        GeometryType::Point(point) => visit_one(point, trans, &mut visit),
+        GeometryType::MultiPoint(multi_point) => {
+            for point in multi_point.points() {
+                visit_one(&point, trans, &mut visit)?;
+            }
+            Ok(())
+        }
+        _ => Err(SedonaGeometryError::Invalid(
+            "expected a Point or MultiPoint geometry".to_string(),
+        )),
+    }
+}
+
 fn transform_and_write_coords<'a, C, I>(
     buf: &mut impl Write,
     trans: &dyn CrsTransform,
@@ -514,6 +565,86 @@ mod test {
             coord.1 += 20.0;
             Ok(())
         }
+    }
+
+    /// Collect what `visit_point_coords` hands the callback for `wkt`.
+    fn visited(wkt: &str, trans: Option<&dyn CrsTransform>) -> Vec<Option<(f64, f64)>> {
+        let geom = Wkt::<f64>::from_str(wkt).unwrap();
+        let mut out = Vec::new();
+        visit_point_coords(&geom, trans, |xy| {
+            out.push(xy);
+            Ok(())
+        })
+        .unwrap();
+        out
+    }
+
+    #[test]
+    fn visit_point_coords_visits_each_point_in_order() {
+        assert_eq!(visited("POINT (1 2)", None), vec![Some((1.0, 2.0))]);
+        assert_eq!(
+            visited("MULTIPOINT (1 2, 3 4)", None),
+            vec![Some((1.0, 2.0)), Some((3.0, 4.0))]
+        );
+        assert_eq!(visited("MULTIPOINT EMPTY", None), vec![]);
+        assert_eq!(visited("POINT EMPTY", None), vec![None]);
+    }
+
+    #[test]
+    fn visit_point_coords_transforms_before_visiting() {
+        let trans = MockTransform {};
+        assert_eq!(
+            visited("MULTIPOINT (1 2, 3 4)", Some(&trans)),
+            vec![Some((11.0, 22.0)), Some((13.0, 24.0))]
+        );
+        // An empty point has no coordinate to transform; it is visited as None.
+        assert_eq!(visited("POINT EMPTY", Some(&trans)), vec![None]);
+    }
+
+    #[test]
+    fn visit_point_coords_visits_empty_sub_point_as_none() {
+        // MULTIPOINT (1 2, EMPTY, 3 4): the wkt parser cannot express an EMPTY
+        // sub-point, so splice one (a NaN-NaN point, the WKB encoding) between
+        // two real sub-points by hand.
+        let mut wkb = vec![1u8, 0x04, 0, 0, 0, 3, 0, 0, 0];
+        for xy in [Some((1.0f64, 2.0f64)), None, Some((3.0, 4.0))] {
+            wkb.push(1);
+            wkb.extend(1u32.to_le_bytes());
+            let (x, y) = xy.unwrap_or((f64::NAN, f64::NAN));
+            wkb.extend(x.to_le_bytes());
+            wkb.extend(y.to_le_bytes());
+        }
+        let geom = read_wkb(&wkb).unwrap();
+        let mut out = Vec::new();
+        visit_point_coords(&geom, None, |xy| {
+            out.push(xy);
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(out, vec![Some((1.0, 2.0)), None, Some((3.0, 4.0))]);
+    }
+
+    #[test]
+    fn visit_point_coords_rejects_non_point_geometry() {
+        let geom = Wkt::<f64>::from_str("LINESTRING (0 0, 1 1)").unwrap();
+        let err = visit_point_coords(&geom, None, |_| Ok(())).unwrap_err();
+        assert!(
+            err.to_string().contains("Point or MultiPoint"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn visit_point_coords_propagates_callback_error() {
+        let geom = Wkt::<f64>::from_str("MULTIPOINT (1 2, 3 4)").unwrap();
+        let mut count = 0;
+        let err = visit_point_coords(&geom, None, |_| {
+            count += 1;
+            Err(SedonaGeometryError::Invalid("stop".to_string()))
+        })
+        .unwrap_err();
+        assert_eq!(count, 1, "the error should halt iteration");
+        assert!(err.to_string().contains("stop"));
     }
 
     #[derive(Debug)]

--- a/rust/sedona-geometry/src/transform.rs
+++ b/rust/sedona-geometry/src/transform.rs
@@ -415,14 +415,17 @@ where
     Ok(())
 }
 
-/// Visit each point of a Point/MultiPoint geometry as `Some((x, y))` — or
-/// `None` for an empty (sub-)point — optionally transforming each coordinate
-/// with `trans` before visiting.
+/// Visit each point of a point geometry as `Some((x, y))` — or `None` for an
+/// empty (sub-)point — optionally transforming each coordinate with `trans`
+/// before visiting. Accepts a `Point`, a `MultiPoint`, or a
+/// `GeometryCollection` whose members are themselves point geometries
+/// (recursively); points are visited in geometry order.
 ///
 /// Compared to [`transform`], which writes a transformed WKB copy, this hands
 /// the caller each coordinate directly, so point-sampling consumers can
 /// transform and consume in one pass with no intermediate geometry
-/// materialisation. Any other geometry type is an error.
+/// materialisation. Any non-point geometry (or a collection containing one) is
+/// an error.
 pub fn visit_point_coords<F>(
     geom: impl GeometryTrait<T = f64>,
     trans: Option<&dyn CrsTransform>,
@@ -452,18 +455,36 @@ where
         }
     }
 
-    match geom.as_type() {
-        GeometryType::Point(point) => visit_one(point, trans, &mut visit),
-        GeometryType::MultiPoint(multi_point) => {
-            for point in multi_point.points() {
-                visit_one(&point, trans, &mut visit)?;
+    fn visit_geom<G, F>(
+        geom: &G,
+        trans: Option<&dyn CrsTransform>,
+        visit: &mut F,
+    ) -> Result<(), SedonaGeometryError>
+    where
+        G: GeometryTrait<T = f64>,
+        F: FnMut(Option<(f64, f64)>) -> Result<(), SedonaGeometryError>,
+    {
+        match geom.as_type() {
+            GeometryType::Point(point) => visit_one(point, trans, visit),
+            GeometryType::MultiPoint(multi_point) => {
+                for point in multi_point.points() {
+                    visit_one(&point, trans, visit)?;
+                }
+                Ok(())
             }
-            Ok(())
+            GeometryType::GeometryCollection(collection) => {
+                for member in collection.geometries() {
+                    visit_geom(&member, trans, visit)?;
+                }
+                Ok(())
+            }
+            _ => Err(SedonaGeometryError::Invalid(
+                "expected a Point, MultiPoint, or GeometryCollection of points".to_string(),
+            )),
         }
-        _ => Err(SedonaGeometryError::Invalid(
-            "expected a Point or MultiPoint geometry".to_string(),
-        )),
     }
+
+    visit_geom(&geom, trans, &mut visit)
 }
 
 fn transform_and_write_coords<'a, C, I>(
@@ -629,7 +650,42 @@ mod test {
         let geom = Wkt::<f64>::from_str("LINESTRING (0 0, 1 1)").unwrap();
         let err = visit_point_coords(&geom, None, |_| Ok(())).unwrap_err();
         assert!(
-            err.to_string().contains("Point or MultiPoint"),
+            err.to_string()
+                .contains("Point, MultiPoint, or GeometryCollection"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn visit_point_coords_visits_geometry_collection_of_points() {
+        // Point and multipoint members flatten in geometry order.
+        assert_eq!(
+            visited(
+                "GEOMETRYCOLLECTION (POINT (1 2), MULTIPOINT (3 4, 5 6))",
+                None
+            ),
+            vec![Some((1.0, 2.0)), Some((3.0, 4.0)), Some((5.0, 6.0))]
+        );
+        // Nested collections recurse.
+        assert_eq!(
+            visited(
+                "GEOMETRYCOLLECTION (POINT (1 2), GEOMETRYCOLLECTION (POINT (3 4)))",
+                None
+            ),
+            vec![Some((1.0, 2.0)), Some((3.0, 4.0))]
+        );
+        // An empty collection visits nothing.
+        assert_eq!(visited("GEOMETRYCOLLECTION EMPTY", None), vec![]);
+    }
+
+    #[test]
+    fn visit_point_coords_rejects_non_point_in_collection() {
+        let geom = Wkt::<f64>::from_str("GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (0 0, 1 1))")
+            .unwrap();
+        let err = visit_point_coords(&geom, None, |_| Ok(())).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Point, MultiPoint, or GeometryCollection"),
             "unexpected error: {err}"
         );
     }

--- a/rust/sedona-raster-functions/Cargo.toml
+++ b/rust/sedona-raster-functions/Cargo.toml
@@ -37,6 +37,7 @@ arrow-buffer = { workspace = true }
 async-trait = { workspace = true }
 datafusion-common = { workspace = true }
 datafusion-expr = { workspace = true }
+geo-traits = { workspace = true }
 sedona-common = { workspace = true }
 sedona-expr = { workspace = true }
 sedona-geometry = { workspace = true }
@@ -49,7 +50,6 @@ wkb = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
-geo-traits = { workspace = true }
 sedona-testing = { workspace = true, features = ["criterion"] }
 sedona-proj = { workspace = true, features = ["proj-sys"] }
 rstest = { workspace = true }

--- a/rust/sedona-raster-functions/benches/native-raster-functions.rs
+++ b/rust/sedona-raster-functions/benches/native-raster-functions.rs
@@ -256,6 +256,34 @@ fn criterion_benchmark(c: &mut Criterion) {
         ),
     );
 
+    // RS_Values(raster, points, band) — array raster (a distinct raster per
+    // row), four sub-points per MultiPoint.
+    benchmark::scalar(
+        c,
+        &f,
+        "native-raster",
+        "rs_values",
+        BenchmarkArgs::ArrayArrayScalar(
+            Raster(64, 64),
+            Transformed(Box::new(MultiPoint(4)), sd_apply_default_crs_udf().into()),
+            Int32(1, 2),
+        ),
+    );
+    // RS_Values(raster, points, band) — scalar raster (one raster, many
+    // MultiPoints). This is the shape the hoisted fast path serves: per-row
+    // CRS/affine/band resolution collapses to once per batch.
+    benchmark::scalar(
+        c,
+        &f,
+        "native-raster",
+        "rs_values",
+        BenchmarkArgs::ScalarArrayScalar(
+            Raster(64, 64),
+            Transformed(Box::new(MultiPoint(4)), sd_apply_default_crs_udf().into()),
+            Int32(1, 2),
+        ),
+    );
+
     // RS_Intersects(raster, geometry) - point
     benchmark::scalar(
         c,

--- a/rust/sedona-raster-functions/benches/native-raster-functions.rs
+++ b/rust/sedona-raster-functions/benches/native-raster-functions.rs
@@ -214,31 +214,36 @@ fn criterion_benchmark(c: &mut Criterion) {
         ),
     );
 
-    // RS_Value(raster, point) — array raster (a distinct raster per row).
+    // RS_Value(raster, point, band) — array raster (a distinct raster per row).
+    // The band is explicit because the benchmark raster is multiband (band is
+    // only optional for single-band rasters).
     benchmark::scalar(
         c,
         &f,
         "native-raster",
         "rs_value",
-        BenchmarkArgs::ArrayArray(
+        BenchmarkArgs::ArrayArrayScalar(
             Raster(64, 64),
             Transformed(Box::new(Point), sd_apply_default_crs_udf().into()),
+            Int32(1, 2),
         ),
     );
-    // RS_Value(raster, point) — scalar raster (one raster, many points). This
-    // is the case where per-point band/nodata/buffer resolution can be hoisted
-    // out of the sample loop, so it is the primary target for optimization.
+    // RS_Value(raster, point, band) — scalar raster (one raster, many points).
+    // This is the case where per-point band/nodata/buffer resolution can be
+    // hoisted out of the sample loop, so it is the primary target for
+    // optimization.
     benchmark::scalar(
         c,
         &f,
         "native-raster",
         "rs_value",
-        BenchmarkArgs::ScalarArray(
+        BenchmarkArgs::ScalarArrayScalar(
             Raster(64, 64),
             Transformed(Box::new(Point), sd_apply_default_crs_udf().into()),
+            Int32(1, 2),
         ),
     );
-    // RS_Value(raster, point, band)
+    // RS_Value(raster, point, band) — band column
     benchmark::scalar(
         c,
         &f,

--- a/rust/sedona-raster-functions/src/crs_utils.rs
+++ b/rust/sedona-raster-functions/src/crs_utils.rs
@@ -15,10 +15,31 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use datafusion_common::config::ConfigOptions;
 use datafusion_common::{exec_datafusion_err, DataFusionError, Result};
+use sedona_common::option::SedonaOptions;
 use sedona_geometry::transform::{transform, CrsEngine};
+use sedona_proj::transform::with_global_proj_engine;
 use sedona_schema::crs::{deserialize_crs, CoordinateReferenceSystem, Crs};
 use wkb::reader::read_wkb;
+
+/// Run `f` with the session's CRS engine: the [`SedonaOptions`] runtime engine
+/// when config options are available (the query path), falling back to the
+/// process-global PROJ engine otherwise (e.g. direct `invoke_batch` calls).
+pub(crate) fn with_crs_engine<T>(
+    config_options: Option<&ConfigOptions>,
+    f: impl FnOnce(&dyn CrsEngine) -> Result<T>,
+) -> Result<T> {
+    if let Some(options) = config_options.and_then(|o| o.extensions.get::<SedonaOptions>()) {
+        f(options.runtime.crs_engine().as_ref())
+    } else {
+        let mut f = Some(f);
+        with_global_proj_engine(|engine| {
+            let f = f.take().expect("engine closure runs once");
+            f(engine)
+        })
+    }
+}
 
 /// Resolve an optional CRS string to a concrete CRS object.
 ///

--- a/rust/sedona-raster-functions/src/lib.rs
+++ b/rust/sedona-raster-functions/src/lib.rs
@@ -41,4 +41,6 @@ pub mod rs_slice;
 pub mod rs_spatial_predicates;
 pub mod rs_srid;
 pub mod rs_value;
+pub mod rs_values;
 pub mod rs_worldcoordinate;
+mod sampling;

--- a/rust/sedona-raster-functions/src/register.rs
+++ b/rust/sedona-raster-functions/src/register.rs
@@ -80,6 +80,7 @@ pub fn default_function_set() -> FunctionSet {
         crate::rs_srid::rs_crs_udf,
         crate::rs_srid::rs_srid_udf,
         crate::rs_value::rs_value_udf,
+        crate::rs_values::rs_values_udf,
         crate::rs_worldcoordinate::rs_rastertoworldcoord_udf,
         crate::rs_worldcoordinate::rs_rastertoworldcoordx_udf,
         crate::rs_worldcoordinate::rs_rastertoworldcoordy_udf,

--- a/rust/sedona-raster-functions/src/rs_value.rs
+++ b/rust/sedona-raster-functions/src/rs_value.rs
@@ -37,23 +37,23 @@ use std::sync::Arc;
 use arrow_array::{builder::Float64Builder, Array, ArrayRef, Float64Array, StructArray};
 use arrow_schema::DataType;
 use datafusion_common::cast::as_int32_array;
+use datafusion_common::config::ConfigOptions;
 use datafusion_common::{exec_datafusion_err, exec_err, Result, ScalarValue};
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
+use sedona_geometry::transform::CrsTransform;
 use sedona_geometry::wkb_header::read_point_xy;
-use sedona_proj::transform::with_global_proj_engine;
 use sedona_raster::affine_transformation::AffineMatrix;
 use sedona_raster::array::RasterStructArray;
 use sedona_raster::traits::RasterRef;
-use sedona_schema::crs::CrsRef;
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
 
-use crate::crs_utils::resolve_crs;
+use crate::crs_utils::{resolve_crs, with_crs_engine};
 use crate::executor::RasterExecutor;
 use crate::rs_ensure_loaded::NEEDS_PIXELS_METADATA_KEY;
 use crate::sampling::{
-    column_reproject_decision, default_band, int32_array_arg, next_band, read_pixel, reproject_wkb,
-    xy_to_pixel,
+    column_point_crs_transform, default_band, int32_array_arg, next_band, point_crs_transform,
+    read_pixel, xy_to_pixel,
 };
 
 /// `RS_Value()` scalar UDF — sample a pixel value at a point.
@@ -95,13 +95,35 @@ impl SedonaScalarKernel for RsValuePoint {
         arg_types: &[SedonaType],
         args: &[ColumnarValue],
     ) -> Result<ColumnarValue> {
+        self.invoke(arg_types, args, None)
+    }
+
+    fn invoke_batch_from_args(
+        &self,
+        arg_types: &[SedonaType],
+        args: &[ColumnarValue],
+        _return_type: &SedonaType,
+        _num_rows: usize,
+        config_options: Option<&ConfigOptions>,
+    ) -> Result<ColumnarValue> {
+        self.invoke(arg_types, args, config_options)
+    }
+}
+
+impl RsValuePoint {
+    fn invoke(
+        &self,
+        arg_types: &[SedonaType],
+        args: &[ColumnarValue],
+        config_options: Option<&ConfigOptions>,
+    ) -> Result<ColumnarValue> {
         // Fast path: a constant (scalar) raster lets us resolve the affine
         // transform and CRS once for the whole batch instead of per point — the
         // common RS_Value(raster_expr, point_column[, band]) shape. The band
         // argument does not change this: a constant band also hoists its buffer,
         // and only a band *column* falls back to per-row band resolution.
         if let ColumnarValue::Scalar(ScalarValue::Struct(raster_struct)) = &args[0] {
-            return self.invoke_scalar_raster(arg_types, args, raster_struct.as_ref());
+            return self.invoke_scalar_raster(arg_types, args, config_options, raster_struct);
         }
 
         let executor = RasterExecutor::new(arg_types, args);
@@ -119,8 +141,8 @@ impl SedonaScalarKernel for RsValuePoint {
         let band_array = band_arr.as_ref().map(|a| as_int32_array(a)).transpose()?;
         let mut band_iter = band_array.map(|a| a.iter());
 
-        // Reprojecting the point into the raster CRS needs a PROJ engine.
-        with_global_proj_engine(|engine| {
+        // Reprojecting the point into the raster CRS needs a CRS engine.
+        with_crs_engine(config_options, |engine| {
             executor.execute_raster_wkb_crs_void(|raster_opt, wkb_opt, point_crs| {
                 // Advance the band column every row so it stays in lockstep with
                 // the row index (a no-op when there is no band argument).
@@ -150,9 +172,9 @@ impl SedonaScalarKernel for RsValuePoint {
                 // Parse the point and bring it into the raster's CRS. Null/empty
                 // points (and non-finite coordinates) have no location to sample.
                 let raster_crs = resolve_crs(raster.crs())?;
-                let Some((x, y)) =
-                    resolve_point_xy(point_wkb, point_crs, raster_crs.as_deref(), false, engine)?
-                else {
+                let trans =
+                    point_crs_transform("RS_Value", point_crs, raster_crs.as_deref(), engine)?;
+                let Some((x, y)) = resolve_point_xy(point_wkb, trans.as_deref())? else {
                     builder.append_null();
                     return Ok(());
                 };
@@ -192,6 +214,7 @@ impl RsValuePoint {
         &self,
         arg_types: &[SedonaType],
         args: &[ColumnarValue],
+        config_options: Option<&ConfigOptions>,
         raster_struct: &StructArray,
     ) -> Result<ColumnarValue> {
         let executor = RasterExecutor::new(arg_types, args);
@@ -239,12 +262,6 @@ impl RsValuePoint {
         // Affine transform and raster CRS, resolved once for all points.
         let affine = AffineMatrix::from_metadata(&raster.metadata());
         let raster_crs = resolve_crs(raster.crs())?;
-        // Decide reprojection once when the point CRS is column-level (the common
-        // case). This skips a per-point `crs_equals`, which allocates a String —
-        // ~15 ns/point, uniform across CRS types.
-        let needs_reproject =
-            column_reproject_decision("RS_Value", &arg_types[1], raster_crs.as_deref())?;
-        let skip_reproject = needs_reproject == Some(false);
 
         let mut geom = executor.make_geom_wkb_crs_accessor(1)?;
 
@@ -253,7 +270,17 @@ impl RsValuePoint {
         // reprojected into the raster CRS. Skipped rows stay NULL in the output.
         let mut selection: Vec<(usize, f64, f64, usize)> = Vec::with_capacity(n);
         let mut band_iter = band_array.map(|a| a.iter());
-        with_global_proj_engine(|engine| {
+        with_crs_engine(config_options, |engine| {
+            // Resolve the raster-CRS transform once when the point CRS is
+            // column-level (the common case). This skips both a per-point
+            // `crs_equals` (which allocates a String, ~15 ns/point) and a
+            // per-point transform lookup.
+            let hoisted_trans = column_point_crs_transform(
+                "RS_Value",
+                &arg_types[1],
+                raster_crs.as_deref(),
+                engine,
+            )?;
             for i in 0..n {
                 // Advance the band column in lockstep with the row index; a NULL
                 // band element leaves the row NULL (matching the general path).
@@ -268,13 +295,14 @@ impl RsValuePoint {
                 let Some(point_wkb) = wkb_opt else {
                     continue;
                 };
-                if let Some((x, y)) = resolve_point_xy(
-                    point_wkb,
-                    point_crs,
-                    raster_crs.as_deref(),
-                    skip_reproject,
-                    engine,
-                )? {
+                // A per-item point CRS (hoisted_trans == None) resolves per row.
+                let trans = match &hoisted_trans {
+                    Some(trans) => trans.clone(),
+                    None => {
+                        point_crs_transform("RS_Value", point_crs, raster_crs.as_deref(), engine)?
+                    }
+                };
+                if let Some((x, y)) = resolve_point_xy(point_wkb, trans.as_deref())? {
                     selection.push((i, x, y, band_num));
                 }
             }
@@ -336,35 +364,25 @@ impl RsValuePoint {
 /// Parse a Point WKB and return its `(x, y)` in the raster's CRS, or `None` when
 /// there is nothing to sample (the point is empty — both ordinates NaN).
 ///
-/// `skip_reproject` is the hoisted column-level decision: when `true` the
-/// original coordinates are returned without consulting [`reproject_wkb`] (and
-/// its per-point `crs_equals`); when `false` reprojection is decided per point.
+/// `trans` is the transform into the raster CRS resolved by the caller (via
+/// [`point_crs_transform`]/[`column_point_crs_transform`]); `None` samples the
+/// original coordinates. The coordinate is transformed in place — no
+/// reprojected-WKB materialisation.
 fn resolve_point_xy(
     point_wkb: &[u8],
-    point_crs: CrsRef<'_>,
-    raster_crs: CrsRef<'_>,
-    skip_reproject: bool,
-    engine: &dyn sedona_geometry::transform::CrsEngine,
+    trans: Option<&dyn CrsTransform>,
 ) -> Result<Option<(f64, f64)>> {
-    let Some((px, py)) =
+    let Some(mut xy) =
         read_point_xy(point_wkb).map_err(|e| exec_datafusion_err!("RS_Value: {e}"))?
     else {
         return Ok(None);
     };
-    if skip_reproject {
-        return Ok(Some((px, py)));
+    if let Some(trans) = trans {
+        trans
+            .transform_coord(&mut xy)
+            .map_err(|e| exec_datafusion_err!("RS_Value: {e}"))?;
     }
-    // A reprojection only happens when both sides carry a (differing) CRS;
-    // otherwise the original coordinates are sampled directly.
-    match reproject_wkb("RS_Value", point_wkb, point_crs, raster_crs, engine)? {
-        Some(reprojected) => {
-            let xy = read_point_xy(&reprojected)
-                .map_err(|e| exec_datafusion_err!("RS_Value: {e}"))?
-                .ok_or_else(|| exec_datafusion_err!("RS_Value: reprojected point is empty"))?;
-            Ok(Some(xy))
-        }
-        None => Ok(Some((px, py))),
-    }
+    Ok(Some(xy))
 }
 
 /// Sample band `band_num` (1-based) at 0-based pixel `(col, row)` as `f64`.
@@ -404,6 +422,7 @@ mod tests {
     use super::*;
     use arrow_array::{Array, Float64Array, Int32Array};
     use datafusion_expr::ScalarUDF;
+    use sedona_proj::transform::with_global_proj_engine;
     use sedona_raster::array::RasterStructArray;
     use sedona_schema::crs::lnglat;
     use sedona_schema::datatypes::{Edges, RASTER};
@@ -604,7 +623,7 @@ mod tests {
         let raster = || {
             RasterSpec::d2(2, 2)
                 .band_values(&[1u8, 2, 3, 4])
-                .transform([0.0, 1.0, 0.0, 10.0, 0.0, -1.0])
+                .bbox(0.0, 8.0, 2.0, 10.0)
                 .build()
         };
 
@@ -625,6 +644,21 @@ mod tests {
         assert_eq!(arr.value(0), 1.0);
     }
 
+    /// North-up 2x2 raster spanning world bbox (0, 8)–(2, 10) with 1x1 pixels,
+    /// band values row-major `[1, 2, 3, 4]`: pixel (0, 0) covers x∈[0,1),
+    /// y∈[9,10) and holds 1; pixel (1, 1) holds 4.
+    fn raster_2x2_spec() -> RasterSpec {
+        RasterSpec::d2(2, 2)
+            .band_values(&[1u8, 2, 3, 4])
+            .bbox(0.0, 8.0, 2.0, 10.0)
+    }
+
+    /// Two-band variant of [`raster_2x2_spec`] (band 2 holds `[10, 20, 30, 40]`),
+    /// used to exercise the default-band ambiguity error.
+    fn two_band_raster_spec() -> RasterSpec {
+        raster_2x2_spec().band_values(&[10u8, 20, 30, 40])
+    }
+
     #[test]
     fn scalar_raster_samples_via_fast_path() {
         // A constant (scalar) raster with the default band takes the optimized
@@ -632,39 +666,12 @@ mod tests {
         // out-of-bounds, matching the general (array-raster) path.
         let udf: ScalarUDF = rs_value_udf().into();
         let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
-        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
+        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type]);
 
-        // North-up 2x2 raster, origin (0, 10), 1x1 pixels; row-major [1,2 / 3,4].
-        let raster = RasterSpec::d2(2, 2)
-            .band_values(&[1u8, 2, 3, 4])
-            .transform([0.0, 1.0, 0.0, 10.0, 0.0, -1.0])
-            .build();
-
-        let sample = |wkt: &str| -> Option<f64> {
-            let geoms = create_geom_array(&[Some(wkt)], &geom_type);
-            let result = tester
-                .invoke(vec![
-                    ColumnarValue::Scalar(ScalarValue::Struct(Arc::new(raster.clone()))),
-                    ColumnarValue::Array(geoms),
-                ])
-                .unwrap();
-            let arr = result.into_array(1).unwrap();
-            let arr = arr.as_any().downcast_ref::<Float64Array>().unwrap();
-            (!arr.is_null(0)).then(|| arr.value(0))
-        };
-
-        assert_eq!(sample("POINT (0.5 9.5)"), Some(1.0)); // pixel (0, 0)
-        assert_eq!(sample("POINT (1.5 8.5)"), Some(4.0)); // pixel (1, 1)
-        assert_eq!(sample("POINT (100 100)"), None); // outside the footprint
-    }
-
-    /// A two-band raster used to exercise the default-band ambiguity error.
-    fn two_band_raster() -> StructArray {
-        RasterSpec::d2(2, 2)
-            .band_values(&[1u8, 2, 3, 4])
-            .band_values(&[10u8, 20, 30, 40])
-            .transform([0.0, 1.0, 0.0, 10.0, 0.0, -1.0])
-            .build()
+        let sample = |wkt: &str| tester.invoke_scalar_scalar(raster_2x2_spec(), wkt).unwrap();
+        tester.assert_scalar_result_equals(sample("POINT (0.5 9.5)"), 1.0); // pixel (0, 0)
+        tester.assert_scalar_result_equals(sample("POINT (1.5 8.5)"), 4.0); // pixel (1, 1)
+        tester.assert_scalar_result_equals(sample("POINT (100 100)"), ScalarValue::Float64(None));
     }
 
     #[test]
@@ -676,7 +683,7 @@ mod tests {
         let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
         let geoms = create_geom_array(&[Some("POINT (0.5 9.5)")], &geom_type);
         let err = tester
-            .invoke_arrays(vec![Arc::new(two_band_raster()), geoms])
+            .invoke_arrays(vec![Arc::new(two_band_raster_spec().build()), geoms])
             .unwrap_err()
             .to_string();
         assert!(
@@ -690,13 +697,9 @@ mod tests {
         // Same ambiguity on the scalar-raster fast path.
         let udf: ScalarUDF = rs_value_udf().into();
         let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
-        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
-        let geoms = create_geom_array(&[Some("POINT (0.5 9.5)")], &geom_type);
+        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type]);
         let err = tester
-            .invoke(vec![
-                ColumnarValue::Scalar(ScalarValue::Struct(Arc::new(two_band_raster()))),
-                ColumnarValue::Array(geoms),
-            ])
+            .invoke_scalar_scalar(two_band_raster_spec(), "POINT (0.5 9.5)")
             .unwrap_err()
             .to_string();
         assert!(
@@ -717,7 +720,7 @@ mod tests {
         let geoms = create_geom_array(&[None, None], &geom_type);
         let result = tester
             .invoke(vec![
-                ColumnarValue::Scalar(ScalarValue::Struct(Arc::new(two_band_raster()))),
+                ColumnarValue::Scalar(two_band_raster_spec().scalar()),
                 ColumnarValue::Array(geoms),
             ])
             .unwrap();
@@ -734,29 +737,12 @@ mod tests {
         let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
         let tester = ScalarUdfTester::new(
             udf,
-            vec![
-                RASTER,
-                geom_type.clone(),
-                SedonaType::Arrow(DataType::Int32),
-            ],
+            vec![RASTER, geom_type, SedonaType::Arrow(DataType::Int32)],
         );
-        // North-up 2x2, two bands: band 1 [1,2,3,4], band 2 [10,20,30,40].
-        let raster = RasterSpec::d2(2, 2)
-            .band_values(&[1u8, 2, 3, 4])
-            .band_values(&[10u8, 20, 30, 40])
-            .transform([0.0, 1.0, 0.0, 10.0, 0.0, -1.0])
-            .build();
-        let geoms = create_geom_array(&[Some("POINT (0.5 9.5)")], &geom_type); // pixel (0, 0)
         let result = tester
-            .invoke(vec![
-                ColumnarValue::Scalar(ScalarValue::Struct(Arc::new(raster))),
-                ColumnarValue::Array(geoms),
-                ColumnarValue::Scalar(ScalarValue::Int32(Some(2))),
-            ])
+            .invoke_scalar_scalar_scalar(two_band_raster_spec(), "POINT (0.5 9.5)", 2)
             .unwrap();
-        let arr = result.into_array(1).unwrap();
-        let arr = arr.as_any().downcast_ref::<Float64Array>().unwrap();
-        assert_eq!(arr.value(0), 10.0); // band 2, pixel (0, 0)
+        tester.assert_scalar_result_equals(result, 10.0); // band 2, pixel (0, 0)
     }
 
     #[test]
@@ -776,7 +762,7 @@ mod tests {
         let raster = RasterSpec::d2(2, 2)
             .band_values(&[1u8, 2, 3, 4])
             .band_values(&[10u8, 20, 30, 40])
-            .transform([0.0, 1.0, 0.0, 10.0, 0.0, -1.0])
+            .bbox(0.0, 8.0, 2.0, 10.0)
             .build();
         // Three points at pixel (0, 0), sampling band 1, band 2, then a NULL band.
         let geoms = create_geom_array(
@@ -836,7 +822,7 @@ mod tests {
         // saturating cast turns it into pixel column 0, silently sampling a value.
         let raster = RasterSpec::d2(2, 2)
             .band_values(&[1u8, 2, 3, 4])
-            .transform([0.0, 1.0, 0.0, 10.0, 0.0, -1.0])
+            .bbox(0.0, 8.0, 2.0, 10.0)
             .build();
         let rasters = RasterStructArray::try_new(&raster).unwrap();
         let affine = AffineMatrix::from_metadata(&rasters.get(0).unwrap().metadata());
@@ -899,18 +885,24 @@ mod tests {
     #[test]
     fn crs_decision_equal_crs_skips_reproject() {
         // The common case: a lng/lat point CRS and a lng/lat raster are detected
-        // as equal, so the per-point reproject (and its crs_equals) is skipped.
-        // This is what the B1 hoist relies on — if it returned Some(true) the
+        // as equal, so no per-point transform is applied. This is what the
+        // column-level hoist relies on — if it resolved a transform here the
         // optimization would silently no-op.
         let raster = RasterSpec::d2(2, 2).band(BandDataType::UInt8).build(); // default lng/lat
         let rasters = RasterStructArray::try_new(&raster).unwrap();
         let raster_crs = resolve_crs(rasters.get(0).unwrap().crs()).unwrap();
         let point_type = SedonaType::Wkb(Edges::Planar, lnglat());
-        assert_eq!(
-            column_reproject_decision("RS_Value", &point_type, raster_crs.as_deref()).unwrap(),
-            Some(false),
-            "lng/lat point + lng/lat raster must be detected as equal (skip reproject)"
-        );
+        with_global_proj_engine(|engine| {
+            let hoisted =
+                column_point_crs_transform("RS_Value", &point_type, raster_crs.as_deref(), engine)
+                    .unwrap();
+            assert!(
+                matches!(hoisted, Some(None)),
+                "lng/lat point + lng/lat raster must be detected as equal (no transform)"
+            );
+            Ok(())
+        })
+        .unwrap();
     }
 
     #[test]
@@ -923,11 +915,17 @@ mod tests {
         let rasters = RasterStructArray::try_new(&raster).unwrap();
         let raster_crs = resolve_crs(rasters.get(0).unwrap().crs()).unwrap();
         let point_type = SedonaType::Wkb(Edges::Planar, deserialize_crs("EPSG:3857").unwrap());
-        assert_eq!(
-            column_reproject_decision("RS_Value", &point_type, raster_crs.as_deref()).unwrap(),
-            Some(true),
-            "EPSG:3857 point + EPSG:4326 raster must require reprojection"
-        );
+        with_global_proj_engine(|engine| {
+            let hoisted =
+                column_point_crs_transform("RS_Value", &point_type, raster_crs.as_deref(), engine)
+                    .unwrap();
+            assert!(
+                matches!(hoisted, Some(Some(_))),
+                "EPSG:3857 point + EPSG:4326 raster must resolve a transform"
+            );
+            Ok(())
+        })
+        .unwrap();
     }
 
     #[test]
@@ -939,6 +937,16 @@ mod tests {
         let rasters = RasterStructArray::try_new(&raster).unwrap();
         let raster_crs = resolve_crs(rasters.get(0).unwrap().crs()).unwrap();
         let point_type = SedonaType::Wkb(Edges::Planar, lnglat());
-        assert!(column_reproject_decision("RS_Value", &point_type, raster_crs.as_deref()).is_err());
+        with_global_proj_engine(|engine| {
+            assert!(column_point_crs_transform(
+                "RS_Value",
+                &point_type,
+                raster_crs.as_deref(),
+                engine
+            )
+            .is_err());
+            Ok(())
+        })
+        .unwrap();
     }
 }

--- a/rust/sedona-raster-functions/src/rs_value.rs
+++ b/rust/sedona-raster-functions/src/rs_value.rs
@@ -158,7 +158,7 @@ impl SedonaScalarKernel for RsValuePoint {
                 };
 
                 let affine = AffineMatrix::from_metadata(&raster.metadata());
-                match xy_to_pixel(&affine, x, y)? {
+                match xy_to_pixel("RS_Value", &affine, x, y)? {
                     Some((col, row)) => match sample_pixel(raster, col, row, band_num)? {
                         Some(value) => builder.append_value(value),
                         None => builder.append_null(),
@@ -184,9 +184,10 @@ impl RsValuePoint {
     ///
     /// Sampling behaviour matches the general path: it uses the same
     /// [`resolve_point_xy`]/[`xy_to_pixel`] helpers, so null/empty/non-finite
-    /// points yield NULL identically. Band resolution (and its 2-D check) is
-    /// deferred until at least one point needs sampling, so an all-null/all-empty
-    /// batch returns NULL without touching the band — as the general path does.
+    /// points yield NULL identically. Band resolution — including the
+    /// default-band ambiguity check and the 2-D check — is deferred until at
+    /// least one point needs sampling, so an all-null/all-empty batch returns
+    /// NULL without touching the band — as the general path does.
     fn invoke_scalar_raster(
         &self,
         arg_types: &[SedonaType],
@@ -206,7 +207,11 @@ impl RsValuePoint {
         // Band selection: a missing band argument (default band 1, single-band
         // rasters only) or a scalar band is constant for the batch and lets us
         // hoist the band buffer; a band column is resolved per row. A NULL scalar
-        // band makes every output NULL.
+        // band makes every output NULL. With no band argument the default-band
+        // ambiguity check is deferred until a point needs sampling (below), so an
+        // all-null/all-empty batch over a multiband raster stays NULL rather than
+        // erroring — matching the general path, which only resolves the band on
+        // rows that actually have a point.
         let mut const_band: Option<usize> = None;
         let mut band_values: Option<ArrayRef> = None;
         if self.with_band {
@@ -225,9 +230,6 @@ impl RsValuePoint {
                 }
                 other => band_values = Some(int32_array_arg(other, n)?),
             }
-        } else {
-            // No band argument: default to band 1 only for a single-band raster.
-            const_band = Some(default_band("RS_Value", raster.num_bands())?);
         }
         let band_array = band_values
             .as_ref()
@@ -240,7 +242,8 @@ impl RsValuePoint {
         // Decide reprojection once when the point CRS is column-level (the common
         // case). This skips a per-point `crs_equals`, which allocates a String —
         // ~15 ns/point, uniform across CRS types.
-        let needs_reproject = column_reproject_decision(&arg_types[1], raster_crs.as_deref())?;
+        let needs_reproject =
+            column_reproject_decision("RS_Value", &arg_types[1], raster_crs.as_deref())?;
         let skip_reproject = needs_reproject == Some(false);
 
         let mut geom = executor.make_geom_wkb_crs_accessor(1)?;
@@ -283,6 +286,15 @@ impl RsValuePoint {
             return executor.finish(Arc::new(Float64Array::from(out)));
         }
 
+        // At least one point needs sampling, so the deferred default-band
+        // resolution (band 1, single-band rasters only) can now run — and error
+        // on a multiband raster, exactly as the general path would for this row.
+        let const_band = if self.with_band {
+            const_band
+        } else {
+            Some(default_band("RS_Value", raster.num_bands())?)
+        };
+
         // Phase 2 — sample. A constant band resolves its buffer/nodata once (now
         // that we know a point needs sampling); a band column resolves per row.
         match const_band {
@@ -303,14 +315,14 @@ impl RsValuePoint {
                     .nodata_as_f64()
                     .map_err(|e| exec_datafusion_err!("RS_Value: {e}"))?;
                 for (i, x, y, _band) in selection {
-                    if let Some((col, row)) = xy_to_pixel(&affine, x, y)? {
-                        out[i] = read_pixel(&buffer, nodata, col, row)?;
+                    if let Some((col, row)) = xy_to_pixel("RS_Value", &affine, x, y)? {
+                        out[i] = read_pixel("RS_Value", &buffer, nodata, col, row)?;
                     }
                 }
             }
             None => {
                 for (i, x, y, band_num) in selection {
-                    if let Some((col, row)) = xy_to_pixel(&affine, x, y)? {
+                    if let Some((col, row)) = xy_to_pixel("RS_Value", &affine, x, y)? {
                         out[i] = sample_pixel(&raster, col, row, band_num)?;
                     }
                 }
@@ -344,7 +356,7 @@ fn resolve_point_xy(
     }
     // A reprojection only happens when both sides carry a (differing) CRS;
     // otherwise the original coordinates are sampled directly.
-    match reproject_wkb(point_wkb, point_crs, raster_crs, engine)? {
+    match reproject_wkb("RS_Value", point_wkb, point_crs, raster_crs, engine)? {
         Some(reprojected) => {
             let xy = read_point_xy(&reprojected)
                 .map_err(|e| exec_datafusion_err!("RS_Value: {e}"))?
@@ -384,7 +396,7 @@ fn sample_pixel(
     let nodata = band
         .nodata_as_f64()
         .map_err(|e| exec_datafusion_err!("RS_Value: {e}"))?;
-    read_pixel(&buffer, nodata, col, row)
+    read_pixel("RS_Value", &buffer, nodata, col, row)
 }
 
 #[cfg(test)]
@@ -526,7 +538,7 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(
-            err.contains("raster has a CRS but the point does not"),
+            err.contains("raster has a CRS but the geometry does not"),
             "unexpected error: {err}"
         );
 
@@ -543,7 +555,7 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(
-            err.contains("point has a CRS but the raster does not"),
+            err.contains("geometry has a CRS but the raster does not"),
             "unexpected error: {err}"
         );
     }
@@ -694,6 +706,27 @@ mod tests {
     }
 
     #[test]
+    fn scalar_all_null_points_defer_default_band_check() {
+        // The scalar fast path defers the default-band ambiguity check until a
+        // point needs sampling: an all-NULL point column over a multiband raster
+        // returns NULL rather than erroring — matching the general path, which
+        // only resolves the band on rows that actually have a point.
+        let udf: ScalarUDF = rs_value_udf().into();
+        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
+        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
+        let geoms = create_geom_array(&[None, None], &geom_type);
+        let result = tester
+            .invoke(vec![
+                ColumnarValue::Scalar(ScalarValue::Struct(Arc::new(two_band_raster()))),
+                ColumnarValue::Array(geoms),
+            ])
+            .unwrap();
+        let arr = result.into_array(2).unwrap();
+        let arr = arr.as_any().downcast_ref::<Float64Array>().unwrap();
+        assert!(arr.is_null(0) && arr.is_null(1));
+    }
+
+    #[test]
     fn scalar_raster_constant_band_uses_fast_path() {
         // A scalar raster with a constant (scalar) band argument takes the same
         // hoisted fast path as the 2-arg default-band case, just on that band.
@@ -808,11 +841,23 @@ mod tests {
         let rasters = RasterStructArray::try_new(&raster).unwrap();
         let affine = AffineMatrix::from_metadata(&rasters.get(0).unwrap().metadata());
 
-        assert_eq!(xy_to_pixel(&affine, f64::NAN, 5.0).unwrap(), None);
-        assert_eq!(xy_to_pixel(&affine, 5.0, f64::NAN).unwrap(), None);
-        assert_eq!(xy_to_pixel(&affine, f64::INFINITY, 5.0).unwrap(), None);
+        assert_eq!(
+            xy_to_pixel("RS_Value", &affine, f64::NAN, 5.0).unwrap(),
+            None
+        );
+        assert_eq!(
+            xy_to_pixel("RS_Value", &affine, 5.0, f64::NAN).unwrap(),
+            None
+        );
+        assert_eq!(
+            xy_to_pixel("RS_Value", &affine, f64::INFINITY, 5.0).unwrap(),
+            None
+        );
         // A finite in-bounds point still maps to a real pixel.
-        assert_eq!(xy_to_pixel(&affine, 0.5, 9.5).unwrap(), Some((0, 0)));
+        assert_eq!(
+            xy_to_pixel("RS_Value", &affine, 0.5, 9.5).unwrap(),
+            Some((0, 0))
+        );
     }
 
     #[test]
@@ -862,7 +907,7 @@ mod tests {
         let raster_crs = resolve_crs(rasters.get(0).unwrap().crs()).unwrap();
         let point_type = SedonaType::Wkb(Edges::Planar, lnglat());
         assert_eq!(
-            column_reproject_decision(&point_type, raster_crs.as_deref()).unwrap(),
+            column_reproject_decision("RS_Value", &point_type, raster_crs.as_deref()).unwrap(),
             Some(false),
             "lng/lat point + lng/lat raster must be detected as equal (skip reproject)"
         );
@@ -879,7 +924,7 @@ mod tests {
         let raster_crs = resolve_crs(rasters.get(0).unwrap().crs()).unwrap();
         let point_type = SedonaType::Wkb(Edges::Planar, deserialize_crs("EPSG:3857").unwrap());
         assert_eq!(
-            column_reproject_decision(&point_type, raster_crs.as_deref()).unwrap(),
+            column_reproject_decision("RS_Value", &point_type, raster_crs.as_deref()).unwrap(),
             Some(true),
             "EPSG:3857 point + EPSG:4326 raster must require reprojection"
         );
@@ -894,6 +939,6 @@ mod tests {
         let rasters = RasterStructArray::try_new(&raster).unwrap();
         let raster_crs = resolve_crs(rasters.get(0).unwrap().crs()).unwrap();
         let point_type = SedonaType::Wkb(Edges::Planar, lnglat());
-        assert!(column_reproject_decision(&point_type, raster_crs.as_deref()).is_err());
+        assert!(column_reproject_decision("RS_Value", &point_type, raster_crs.as_deref()).is_err());
     }
 }

--- a/rust/sedona-raster-functions/src/rs_value.rs
+++ b/rust/sedona-raster-functions/src/rs_value.rs
@@ -52,7 +52,8 @@ use crate::crs_utils::resolve_crs;
 use crate::executor::RasterExecutor;
 use crate::rs_ensure_loaded::NEEDS_PIXELS_METADATA_KEY;
 use crate::sampling::{
-    column_reproject_decision, int32_array_arg, next_band, read_pixel, reproject_wkb, xy_to_pixel,
+    column_reproject_decision, default_band, int32_array_arg, next_band, read_pixel, reproject_wkb,
+    xy_to_pixel,
 };
 
 /// `RS_Value()` scalar UDF — sample a pixel value at a point.
@@ -121,16 +122,30 @@ impl SedonaScalarKernel for RsValuePoint {
         // Reprojecting the point into the raster CRS needs a PROJ engine.
         with_global_proj_engine(|engine| {
             executor.execute_raster_wkb_crs_void(|raster_opt, wkb_opt, point_crs| {
-                let (raster, point_wkb, band_num) =
-                    match (raster_opt, wkb_opt, next_band(&mut band_iter)) {
-                        (Some(raster), Some(point_wkb), Some(band_num)) => {
-                            (raster, point_wkb, band_num)
-                        }
-                        _ => {
+                // Advance the band column every row so it stays in lockstep with
+                // the row index (a no-op when there is no band argument).
+                let band_arg = next_band(&mut band_iter);
+                let (raster, point_wkb) = match (raster_opt, wkb_opt) {
+                    (Some(raster), Some(point_wkb)) => (raster, point_wkb),
+                    _ => {
+                        builder.append_null();
+                        return Ok(());
+                    }
+                };
+                // An explicit band column drives the band (a NULL element yields a
+                // NULL row); with no band argument it defaults to band 1, but only
+                // for a single-band raster.
+                let band_num = if self.with_band {
+                    match band_arg {
+                        Some(band_num) => band_num,
+                        None => {
                             builder.append_null();
                             return Ok(());
                         }
-                    };
+                    }
+                } else {
+                    default_band("RS_Value", raster.num_bands())?
+                };
 
                 // Parse the point and bring it into the raster's CRS. Null/empty
                 // points (and non-finite coordinates) have no location to sample.
@@ -188,9 +203,10 @@ impl RsValuePoint {
         }
         let raster = rasters.get(0)?;
 
-        // Band selection: a missing band argument (default 1) or a scalar band is
-        // constant for the batch and lets us hoist the band buffer; a band column
-        // is resolved per row. A NULL scalar band makes every output NULL.
+        // Band selection: a missing band argument (default band 1, single-band
+        // rasters only) or a scalar band is constant for the batch and lets us
+        // hoist the band buffer; a band column is resolved per row. A NULL scalar
+        // band makes every output NULL.
         let mut const_band: Option<usize> = None;
         let mut band_values: Option<ArrayRef> = None;
         if self.with_band {
@@ -210,7 +226,8 @@ impl RsValuePoint {
                 other => band_values = Some(int32_array_arg(other, n)?),
             }
         } else {
-            const_band = Some(1);
+            // No band argument: default to band 1 only for a single-band raster.
+            const_band = Some(default_band("RS_Value", raster.num_bands())?);
         }
         let band_array = band_values
             .as_ref()
@@ -627,6 +644,53 @@ mod tests {
         assert_eq!(sample("POINT (0.5 9.5)"), Some(1.0)); // pixel (0, 0)
         assert_eq!(sample("POINT (1.5 8.5)"), Some(4.0)); // pixel (1, 1)
         assert_eq!(sample("POINT (100 100)"), None); // outside the footprint
+    }
+
+    /// A two-band raster used to exercise the default-band ambiguity error.
+    fn two_band_raster() -> StructArray {
+        RasterSpec::d2(2, 2)
+            .band_values(&[1u8, 2, 3, 4])
+            .band_values(&[10u8, 20, 30, 40])
+            .transform([0.0, 1.0, 0.0, 10.0, 0.0, -1.0])
+            .build()
+    }
+
+    #[test]
+    fn default_band_requires_single_band_raster_array_path() {
+        // No band argument + multiband raster is ambiguous -> error (general,
+        // array-raster path) rather than silently sampling band 1.
+        let udf: ScalarUDF = rs_value_udf().into();
+        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
+        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
+        let geoms = create_geom_array(&[Some("POINT (0.5 9.5)")], &geom_type);
+        let err = tester
+            .invoke_arrays(vec![Arc::new(two_band_raster()), geoms])
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("specify which band"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn default_band_requires_single_band_raster_scalar_path() {
+        // Same ambiguity on the scalar-raster fast path.
+        let udf: ScalarUDF = rs_value_udf().into();
+        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
+        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
+        let geoms = create_geom_array(&[Some("POINT (0.5 9.5)")], &geom_type);
+        let err = tester
+            .invoke(vec![
+                ColumnarValue::Scalar(ScalarValue::Struct(Arc::new(two_band_raster()))),
+                ColumnarValue::Array(geoms),
+            ])
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("specify which band"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/rust/sedona-raster-functions/src/rs_value.rs
+++ b/rust/sedona-raster-functions/src/rs_value.rs
@@ -44,13 +44,16 @@ use sedona_geometry::wkb_header::read_point_xy;
 use sedona_proj::transform::with_global_proj_engine;
 use sedona_raster::affine_transformation::AffineMatrix;
 use sedona_raster::array::RasterStructArray;
-use sedona_raster::traits::{nodata_bytes_to_f64_lossless, NdBuffer, RasterRef};
+use sedona_raster::traits::RasterRef;
 use sedona_schema::crs::CrsRef;
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
 
-use crate::crs_utils::{crs_transform_wkb, resolve_crs};
+use crate::crs_utils::resolve_crs;
 use crate::executor::RasterExecutor;
 use crate::rs_ensure_loaded::NEEDS_PIXELS_METADATA_KEY;
+use crate::sampling::{
+    column_reproject_decision, int32_array_arg, next_band, read_pixel, reproject_wkb, xy_to_pixel,
+};
 
 /// `RS_Value()` scalar UDF — sample a pixel value at a point.
 pub fn rs_value_udf() -> SedonaScalarUDF {
@@ -301,101 +304,11 @@ impl RsValuePoint {
     }
 }
 
-/// Materialise an integer argument as an owned `Int32` [`ArrayRef`] for the
-/// batch. Callers keep the returned `ArrayRef` alive and borrow a typed
-/// `&Int32Array` view from it (via `as_int32_array`) rather than cloning the
-/// typed array.
-fn int32_array_arg(arg: &ColumnarValue, num_iterations: usize) -> Result<ArrayRef> {
-    arg.clone()
-        .cast_to(&DataType::Int32, None)?
-        .into_array(num_iterations)
-}
-
-/// Advance the optional band-number iterator one row, yielding the 1-based band
-/// to sample. A missing band argument defaults to band 1; a NULL band element
-/// returns `None`, which the caller propagates to a NULL result. Band 0 and
-/// negative values map to 0 so [`Bands::band`](sedona_raster::traits::Bands::band)
-/// rejects them as not 1-based rather than being silently coerced.
-fn next_band(
-    band_iter: &mut Option<arrow_array::iterator::ArrayIter<&arrow_array::Int32Array>>,
-) -> Option<usize> {
-    match band_iter.as_mut() {
-        None => Some(1),
-        Some(iter) => iter.next().flatten().map(|b| b.max(0) as usize),
-    }
-}
-
-/// Reproject `point_wkb` from its CRS into the raster CRS, returning the
-/// transformed WKB only when a reprojection actually happened (so the caller
-/// can sample the original bytes otherwise — no allocation in the common case).
-///
-/// Errors if exactly one of the point / raster carries a CRS: sampling across a
-/// known and an unknown CRS would silently mislocate the point.
-///
-/// Unlike the spatial predicates (`RS_Intersects` et al.), which fall back to a
-/// WGS84 pivot when a direct transform between two CRSes fails, a failed
-/// transform here is propagated as an error. Sampling has to land the point in
-/// the raster's own CRS — that is the only space its affine/pixel grid is
-/// defined in — so there is no neutral CRS to fall back to: a WGS84 pivot would
-/// silently sample the wrong pixel rather than compare geometries in a shared
-/// space.
-fn reproject_point(
-    point_wkb: &[u8],
-    point_crs: CrsRef<'_>,
-    raster_crs: CrsRef<'_>,
-    engine: &dyn sedona_geometry::transform::CrsEngine,
-) -> Result<Option<Vec<u8>>> {
-    match (point_crs, raster_crs) {
-        (Some(point_crs), Some(raster_crs)) => {
-            if point_crs.crs_equals(raster_crs) {
-                Ok(None)
-            } else {
-                Ok(Some(crs_transform_wkb(
-                    point_wkb, point_crs, raster_crs, engine,
-                )?))
-            }
-        }
-        (None, None) => Ok(None),
-        (Some(_), None) => {
-            exec_err!("RS_Value: point has a CRS but the raster does not")
-        }
-        (None, Some(_)) => {
-            exec_err!("RS_Value: raster has a CRS but the point does not")
-        }
-    }
-}
-
-/// For a **column-level** point CRS, decide once whether sampling needs a
-/// reprojection into the raster CRS:
-/// - `Some(true)`  — CRSes differ, reproject each point;
-/// - `Some(false)` — CRSes match (or both absent), sample original coordinates;
-/// - `None`        — the point CRS is carried per row, so decide per point.
-///
-/// Errors when exactly one side carries a CRS. Hoisting this out of the per-point
-/// loop avoids a per-point `crs_equals`, whose `to_authority_code()` allocates a
-/// `String` every call (~15 ns/point, uniform across CRS types).
-fn column_reproject_decision(
-    point_type: &SedonaType,
-    raster_crs: CrsRef<'_>,
-) -> Result<Option<bool>> {
-    let point_crs = match point_type {
-        SedonaType::Wkb(_, c) | SedonaType::WkbView(_, c) => c.as_deref(),
-        // A per-item CRS varies by row; the caller decides per point.
-        _ => return Ok(None),
-    };
-    match (point_crs, raster_crs) {
-        (Some(p), Some(r)) => Ok(Some(!p.crs_equals(r))),
-        (None, None) => Ok(Some(false)),
-        (Some(_), None) => exec_err!("RS_Value: point has a CRS but the raster does not"),
-        (None, Some(_)) => exec_err!("RS_Value: raster has a CRS but the point does not"),
-    }
-}
-
 /// Parse a Point WKB and return its `(x, y)` in the raster's CRS, or `None` when
 /// there is nothing to sample (the point is empty — both ordinates NaN).
 ///
 /// `skip_reproject` is the hoisted column-level decision: when `true` the
-/// original coordinates are returned without consulting [`reproject_point`] (and
+/// original coordinates are returned without consulting [`reproject_wkb`] (and
 /// its per-point `crs_equals`); when `false` reprojection is decided per point.
 fn resolve_point_xy(
     point_wkb: &[u8],
@@ -414,7 +327,7 @@ fn resolve_point_xy(
     }
     // A reprojection only happens when both sides carry a (differing) CRS;
     // otherwise the original coordinates are sampled directly.
-    match reproject_point(point_wkb, point_crs, raster_crs, engine)? {
+    match reproject_wkb(point_wkb, point_crs, raster_crs, engine)? {
         Some(reprojected) => {
             let xy = read_point_xy(&reprojected)
                 .map_err(|e| exec_datafusion_err!("RS_Value: {e}"))?
@@ -423,28 +336,6 @@ fn resolve_point_xy(
         }
         None => Ok(Some((px, py))),
     }
-}
-
-/// Map a coordinate in the raster's CRS to a 0-based `(col, row)` pixel index,
-/// or `None` when the point has no location to sample.
-///
-/// A non-finite coordinate (a Point with a NaN/Inf ordinate, e.g. `POINT(NaN 5)`)
-/// returns `None`: without this guard a NaN would survive `inv_transform` and the
-/// saturating `f64 -> i64` cast would turn it into 0 (in bounds), silently
-/// sampling pixel column 0 rather than yielding NULL.
-fn xy_to_pixel(affine: &AffineMatrix, x: f64, y: f64) -> Result<Option<(i64, i64)>> {
-    if !x.is_finite() || !y.is_finite() {
-        return Ok(None);
-    }
-    let (raster_x, raster_y) = affine
-        .inv_transform(x, y)
-        .map_err(|e| exec_datafusion_err!("RS_Value: {e}"))?;
-    // Floor (not truncate toward zero) so a point just outside the top/left edge
-    // maps to a negative index and is rejected as out of bounds, rather than
-    // truncating to 0 and sampling an edge pixel. The `f64 -> i64` cast saturates
-    // (never panics); the bounds check in `read_pixel`/`sample_pixel` rejects an
-    // out-of-range index as NULL.
-    Ok(Some((raster_x.floor() as i64, raster_y.floor() as i64)))
 }
 
 /// Sample band `band_num` (1-based) at 0-based pixel `(col, row)` as `f64`.
@@ -477,54 +368,6 @@ fn sample_pixel(
         .nodata_as_f64()
         .map_err(|e| exec_datafusion_err!("RS_Value: {e}"))?;
     read_pixel(&buffer, nodata, col, row)
-}
-
-/// Read pixel `(col, row)` from an already-resolved band buffer and nodata
-/// value. Returns `None` for an out-of-bounds pixel or one that equals nodata.
-/// Hoisting the band resolution out of this function lets callers sample many
-/// points from one buffer without re-resolving per point.
-fn read_pixel(buffer: &NdBuffer, nodata: Option<f64>, col: i64, row: i64) -> Result<Option<f64>> {
-    let (height, width) = (buffer.shape[0], buffer.shape[1]);
-    if row < 0 || row >= height || col < 0 || col >= width {
-        return Ok(None);
-    }
-
-    // Byte offset of the (row, col) pixel via the band's own strides, so the
-    // read stays correct for any layout the producer hands us. Checked
-    // arithmetic throughout: `row`/`col` are already in bounds, but a corrupt
-    // stride or offset must surface as an error, never an i64 overflow panic.
-    let size = buffer.data_type.byte_size() as i64;
-    let byte_offset = row
-        .checked_mul(buffer.strides[0])
-        .zip(col.checked_mul(buffer.strides[1]))
-        .and_then(|(r, c)| r.checked_add(c))
-        .and_then(|rc| rc.checked_add(buffer.offset as i64))
-        .ok_or_else(|| exec_datafusion_err!("RS_Value: pixel byte offset overflow"))?;
-    let end_offset = byte_offset
-        .checked_add(size)
-        .ok_or_else(|| exec_datafusion_err!("RS_Value: pixel byte offset overflow"))?;
-    let start = usize::try_from(byte_offset)
-        .map_err(|_| exec_datafusion_err!("RS_Value: negative pixel byte offset"))?;
-    let end = usize::try_from(end_offset)
-        .map_err(|_| exec_datafusion_err!("RS_Value: pixel byte offset overflow"))?;
-    let bytes = buffer.buffer.get(start..end).ok_or_else(|| {
-        exec_datafusion_err!("RS_Value: pixel is out of the band's buffer bounds")
-    })?;
-
-    // Decode the pixel to f64. The lossless converter errors (rather than
-    // silently rounding) on Int64/UInt64 values beyond f64's exact-integer
-    // range (2^53) — RS_Value returns a Double, so such a pixel can't be
-    // represented faithfully; failing loudly is preferred over a wrong value.
-    let value = nodata_bytes_to_f64_lossless(bytes, &buffer.data_type)
-        .map_err(|e| exec_datafusion_err!("RS_Value: {e}"))?;
-
-    if let Some(nodata) = nodata {
-        if value == nodata || (value.is_nan() && nodata.is_nan()) {
-            return Ok(None);
-        }
-    }
-
-    Ok(Some(value))
 }
 
 #[cfg(test)]

--- a/rust/sedona-raster-functions/src/rs_values.rs
+++ b/rust/sedona-raster-functions/src/rs_values.rs
@@ -18,7 +18,7 @@
 //! `RS_Values` — sample a raster's pixel value at each point of a MultiPoint.
 //!
 //! ```text
-//! RS_Values(raster, points)        -> List<Double>  -- band defaults to 1
+//! RS_Values(raster, points)        -> List<Double>  -- single-band rasters only
 //! RS_Values(raster, points, band)  -> List<Double>
 //! ```
 //!
@@ -55,7 +55,9 @@ use wkb::reader::read_wkb;
 use crate::crs_utils::resolve_crs;
 use crate::executor::RasterExecutor;
 use crate::rs_ensure_loaded::NEEDS_PIXELS_METADATA_KEY;
-use crate::sampling::{int32_array_arg, next_band, read_pixel, reproject_wkb, xy_to_pixel};
+use crate::sampling::{
+    default_band, int32_array_arg, next_band, read_pixel, reproject_wkb, xy_to_pixel,
+};
 
 /// The `List<Float64>` output type, matching what a default
 /// `ListBuilder<Float64Builder>` produces (field "item", nullable).
@@ -120,17 +122,34 @@ impl SedonaScalarKernel for RsValues {
         // Reprojecting the points into the raster CRS needs a PROJ engine.
         with_global_proj_engine(|engine| {
             executor.execute_raster_wkb_crs_void(|raster_opt, wkb_opt, geom_crs| {
-                let (raster, geom_wkb, band_num) =
-                    match (raster_opt, wkb_opt, next_band(&mut band_iter)) {
-                        (Some(raster), Some(geom_wkb), Some(band_num)) => {
-                            (raster, geom_wkb, band_num)
-                        }
-                        // A NULL raster, geometry, or band yields a NULL row.
-                        _ => {
+                // Advance the band column every row so it stays in lockstep with
+                // the row index (a no-op when there is no band argument).
+                let band_arg = next_band(&mut band_iter);
+                let (raster, geom_wkb) = match (raster_opt, wkb_opt) {
+                    (Some(raster), Some(geom_wkb)) => (raster, geom_wkb),
+                    // A NULL raster or geometry yields a NULL row.
+                    _ => {
+                        list_builder.append_null();
+                        return Ok(());
+                    }
+                };
+
+                // Resolve the band to sample. An explicit band column drives it
+                // (a NULL element yields a NULL row); with no band argument it
+                // defaults to band 1, but only for a single-band raster — sampling
+                // an unspecified band of a multiband raster is ambiguous, so it
+                // errors rather than silently picking band 1.
+                let band_num = if self.with_band {
+                    match band_arg {
+                        Some(band_num) => band_num,
+                        None => {
                             list_builder.append_null();
                             return Ok(());
                         }
-                    };
+                    }
+                } else {
+                    default_band("RS_Values", raster.num_bands())?
+                };
 
                 // Resolve the band buffer, nodata, and affine transform once for
                 // this row, then sample every sub-point against them.
@@ -405,6 +424,29 @@ mod tests {
             .invoke_arrays(vec![Arc::new(raster), geoms, bands])
             .unwrap();
         assert_eq!(row(&result, 0), vec![Some(10.0)]);
+    }
+
+    #[test]
+    fn default_band_requires_single_band_raster() {
+        // With no band argument, a multiband raster is ambiguous and errors
+        // rather than silently sampling band 1 (matches RS_SetBandNoDataValue).
+        let udf: ScalarUDF = rs_values_udf().into();
+        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
+        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
+        let raster = RasterSpec::d2(2, 2)
+            .band_values(&[1u8, 2, 3, 4])
+            .band_values(&[10u8, 20, 30, 40])
+            .transform([0.0, 1.0, 0.0, 10.0, 0.0, -1.0])
+            .build();
+        let geoms = create_geom_array(&[Some("MULTIPOINT (0.5 9.5)")], &geom_type);
+        let err = tester
+            .invoke_arrays(vec![Arc::new(raster), geoms])
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("specify which band"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/rust/sedona-raster-functions/src/rs_values.rs
+++ b/rust/sedona-raster-functions/src/rs_values.rs
@@ -40,15 +40,17 @@
 use std::sync::Arc;
 
 use arrow_array::builder::{Float64Builder, ListBuilder};
+use arrow_array::{Array, ArrayRef, StructArray};
 use arrow_schema::{DataType, Field};
 use datafusion_common::cast::as_int32_array;
-use datafusion_common::{exec_datafusion_err, exec_err, Result};
+use datafusion_common::{exec_datafusion_err, exec_err, Result, ScalarValue};
 use datafusion_expr::{ColumnarValue, Volatility};
 use geo_traits::{CoordTrait, GeometryTrait, GeometryType, MultiPointTrait, PointTrait};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_proj::transform::with_global_proj_engine;
 use sedona_raster::affine_transformation::AffineMatrix;
-use sedona_raster::traits::{NdBuffer, RasterRef};
+use sedona_raster::array::RasterStructArray;
+use sedona_raster::traits::{BandRef, NdBuffer, RasterRef};
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
 use wkb::reader::read_wkb;
 
@@ -56,7 +58,8 @@ use crate::crs_utils::resolve_crs;
 use crate::executor::RasterExecutor;
 use crate::rs_ensure_loaded::NEEDS_PIXELS_METADATA_KEY;
 use crate::sampling::{
-    default_band, int32_array_arg, next_band, read_pixel, reproject_wkb, xy_to_pixel,
+    column_reproject_decision, default_band, int32_array_arg, next_band, read_pixel, reproject_wkb,
+    xy_to_pixel,
 };
 
 /// The `List<Float64>` output type, matching what a default
@@ -104,9 +107,20 @@ impl SedonaScalarKernel for RsValues {
         arg_types: &[SedonaType],
         args: &[ColumnarValue],
     ) -> Result<ColumnarValue> {
+        // Fast path: a constant (scalar) raster lets us resolve the affine
+        // transform, CRS, and band buffer once for the whole batch instead of
+        // per row — the common RS_Values(raster_expr, points_column[, band])
+        // shape. Only a band *column* falls back to per-row band resolution.
+        if let ColumnarValue::Scalar(ScalarValue::Struct(raster_struct)) = &args[0] {
+            return self.invoke_scalar_raster(arg_types, args, raster_struct.as_ref());
+        }
+
         let executor = RasterExecutor::new(arg_types, args);
         let num_iterations = executor.num_iterations();
         let mut list_builder = ListBuilder::new(Float64Builder::new());
+        // Per-row scratch for the parsed sub-point coordinates, reused across
+        // rows so the parse does not allocate per row.
+        let mut points_scratch: Vec<Option<(f64, f64)>> = Vec::new();
 
         // The optional band argument, materialised once as an Int32 array. Held
         // as an `ArrayRef` so the typed view below borrows it instead of cloning
@@ -154,15 +168,7 @@ impl SedonaScalarKernel for RsValues {
                 // Resolve the band buffer, nodata, and affine transform once for
                 // this row, then sample every sub-point against them.
                 let raster_crs = resolve_crs(raster.crs())?;
-                let band = raster
-                    .bands()
-                    .band(band_num)
-                    .map_err(|e| exec_datafusion_err!("RS_Values: {e}"))?;
-                if !band.is_spatial_2d() {
-                    return exec_err!(
-                        "RS_Values supports 2-D rasters only; band is not a 2-D (y, x) grid"
-                    );
-                }
+                let band = resolve_band_2d(raster, band_num)?;
                 let buffer = band
                     .nd_buffer()
                     .map_err(|e| exec_datafusion_err!("RS_Values: {e}"))?;
@@ -173,10 +179,20 @@ impl SedonaScalarKernel for RsValues {
 
                 // Reproject the whole geometry into the raster CRS (a no-op that
                 // borrows the original bytes when the CRSes match or are absent).
-                let reprojected = reproject_wkb(geom_wkb, geom_crs, raster_crs.as_deref(), engine)?;
+                let reprojected = reproject_wkb(
+                    "RS_Values",
+                    geom_wkb,
+                    geom_crs,
+                    raster_crs.as_deref(),
+                    engine,
+                )?;
                 let effective = reprojected.as_deref().unwrap_or(geom_wkb);
 
-                sample_points_into_list(effective, &affine, &buffer, nodata, &mut list_builder)?;
+                points_scratch.clear();
+                collect_point_xys(effective, &mut points_scratch)?;
+                for xy in &points_scratch {
+                    append_sample(*xy, &affine, &buffer, nodata, &mut list_builder)?;
+                }
                 list_builder.append(true);
                 Ok(())
             })
@@ -186,34 +202,225 @@ impl SedonaScalarKernel for RsValues {
     }
 }
 
-/// Sample each sub-point of a Point/MultiPoint WKB into one list row.
-///
-/// The WKB is assumed to already be in the raster's CRS (reprojected by the
-/// caller). Each sub-point contributes one list element: its sampled value, or
-/// `NULL` when the sub-point is empty, non-finite, out of bounds, or nodata. A
+impl RsValues {
+    /// Optimized path for a constant (scalar) raster: the affine transform and
+    /// raster CRS are resolved once for the whole batch, and the per-row work
+    /// reduces to parsing the points and reading pixels. This serves every band
+    /// shape:
+    /// - no band argument or a constant band → the band buffer is hoisted too;
+    /// - a band *column* → the band buffer is resolved per row (its `NdBuffer`
+    ///   borrows from the band, which can't be cached across distinct bands),
+    ///   but the affine/CRS/reproject work is still hoisted.
+    ///
+    /// Sampling behaviour matches the general path: it uses the same
+    /// [`collect_point_xys`]/[`append_sample`] helpers, so per-element and
+    /// per-row NULL semantics are identical. Band resolution — including the
+    /// default-band ambiguity check and the 2-D check — is deferred until at
+    /// least one row has a geometry to sample, so an all-null batch returns
+    /// NULL without touching the band — as the general path does.
+    fn invoke_scalar_raster(
+        &self,
+        arg_types: &[SedonaType],
+        args: &[ColumnarValue],
+        raster_struct: &StructArray,
+    ) -> Result<ColumnarValue> {
+        let executor = RasterExecutor::new(arg_types, args);
+        let n = executor.num_iterations();
+
+        let all_null = |executor: &RasterExecutor| {
+            let mut builder = ListBuilder::new(Float64Builder::new());
+            for _ in 0..n {
+                builder.append_null();
+            }
+            executor.finish(Arc::new(builder.finish()))
+        };
+
+        let rasters = RasterStructArray::try_new(raster_struct)?;
+        if rasters.is_null(0) {
+            // A NULL raster makes every output NULL.
+            return all_null(&executor);
+        }
+        let raster = rasters.get(0)?;
+
+        // Band selection: a missing band argument (default band 1, single-band
+        // rasters only) or a scalar band is constant for the batch and lets us
+        // hoist the band buffer; a band column is resolved per row. A NULL scalar
+        // band makes every output NULL. With no band argument the default-band
+        // ambiguity check is deferred until a row needs sampling (below), so an
+        // all-null batch over a multiband raster stays NULL rather than erroring
+        // — matching the general path, which only resolves the band on rows that
+        // actually have a geometry.
+        let mut const_band: Option<usize> = None;
+        let mut band_values: Option<ArrayRef> = None;
+        if self.with_band {
+            match &args[2] {
+                ColumnarValue::Scalar(scalar) => {
+                    let arr = ColumnarValue::Scalar(scalar.clone())
+                        .cast_to(&DataType::Int32, None)?
+                        .into_array(1)?;
+                    let arr = as_int32_array(&arr)?;
+                    if arr.is_null(0) {
+                        return all_null(&executor);
+                    }
+                    // Match `next_band`: clamp to 0 so band 0/negative surface as a
+                    // not-1-based error from `Bands::band` rather than being coerced.
+                    const_band = Some(arr.value(0).max(0) as usize);
+                }
+                other => band_values = Some(int32_array_arg(other, n)?),
+            }
+        }
+        let band_array = band_values
+            .as_ref()
+            .map(|a| as_int32_array(a))
+            .transpose()?;
+
+        // Affine transform and raster CRS, resolved once for all rows. Decide
+        // reprojection once when the geometry CRS is column-level (the common
+        // case), skipping a per-row `crs_equals` and its String allocation.
+        let affine = AffineMatrix::from_metadata(&raster.metadata());
+        let raster_crs = resolve_crs(raster.crs())?;
+        let needs_reproject =
+            column_reproject_decision("RS_Values", &arg_types[1], raster_crs.as_deref())?;
+        let skip_reproject = needs_reproject == Some(false);
+
+        let mut geom = executor.make_geom_wkb_crs_accessor(1)?;
+
+        // Phase 1 — parse each row's Point/MultiPoint (reprojected into the
+        // raster CRS) into owned sub-point coordinates. All rows share one
+        // coordinate arena with per-row (start, len, band) spans; a `None` row
+        // is NULL output (NULL geometry or band element).
+        let mut coords: Vec<Option<(f64, f64)>> = Vec::new();
+        let mut rows: Vec<Option<(usize, usize, usize)>> = Vec::with_capacity(n);
+        let mut band_iter = band_array.map(|a| a.iter());
+        with_global_proj_engine(|engine| {
+            for i in 0..n {
+                // Advance the band column in lockstep with the row index; with
+                // no band argument this yields a placeholder that the hoisted
+                // constant band supersedes below.
+                let band_num = match const_band {
+                    Some(b) => Some(b),
+                    None => next_band(&mut band_iter),
+                };
+                let (wkb_opt, geom_crs) = geom.get(i)?;
+                let (Some(geom_wkb), Some(band_num)) = (wkb_opt, band_num) else {
+                    rows.push(None);
+                    continue;
+                };
+                let reprojected = if skip_reproject {
+                    None
+                } else {
+                    reproject_wkb(
+                        "RS_Values",
+                        geom_wkb,
+                        geom_crs,
+                        raster_crs.as_deref(),
+                        engine,
+                    )?
+                };
+                let effective = reprojected.as_deref().unwrap_or(geom_wkb);
+                let start = coords.len();
+                collect_point_xys(effective, &mut coords)?;
+                rows.push(Some((start, coords.len() - start, band_num)));
+            }
+            Ok(())
+        })?;
+
+        let mut list_builder = ListBuilder::new(Float64Builder::new());
+        if rows.iter().all(|r| r.is_none()) {
+            // No row has anything to sample, so band resolution (and the
+            // default-band ambiguity check) never runs — as in the general path.
+            return all_null(&executor);
+        }
+
+        // At least one row samples, so the deferred default-band resolution
+        // (band 1, single-band rasters only) can now run — and error on a
+        // multiband raster, exactly as the general path would for that row.
+        let const_band = if self.with_band {
+            const_band
+        } else {
+            Some(default_band("RS_Values", raster.num_bands())?)
+        };
+
+        // Phase 2 — sample. A constant band resolves its buffer/nodata/2-D
+        // check once; a band column resolves them per row.
+        match const_band {
+            Some(band_num) => {
+                let band = resolve_band_2d(&raster, band_num)?;
+                let buffer = band
+                    .nd_buffer()
+                    .map_err(|e| exec_datafusion_err!("RS_Values: {e}"))?;
+                let nodata = band
+                    .nodata_as_f64()
+                    .map_err(|e| exec_datafusion_err!("RS_Values: {e}"))?;
+                for row in &rows {
+                    let Some((start, len, _band)) = row else {
+                        list_builder.append_null();
+                        continue;
+                    };
+                    for xy in &coords[*start..*start + *len] {
+                        append_sample(*xy, &affine, &buffer, nodata, &mut list_builder)?;
+                    }
+                    list_builder.append(true);
+                }
+            }
+            None => {
+                for row in &rows {
+                    let Some((start, len, band_num)) = row else {
+                        list_builder.append_null();
+                        continue;
+                    };
+                    let band = resolve_band_2d(&raster, *band_num)?;
+                    let buffer = band
+                        .nd_buffer()
+                        .map_err(|e| exec_datafusion_err!("RS_Values: {e}"))?;
+                    let nodata = band
+                        .nodata_as_f64()
+                        .map_err(|e| exec_datafusion_err!("RS_Values: {e}"))?;
+                    for xy in &coords[*start..*start + *len] {
+                        append_sample(*xy, &affine, &buffer, nodata, &mut list_builder)?;
+                    }
+                    list_builder.append(true);
+                }
+            }
+        }
+
+        executor.finish(Arc::new(list_builder.finish()))
+    }
+}
+
+/// Collect each sub-point of a Point/MultiPoint WKB as an owned `(x, y)`,
+/// appending to `out` in input order. An empty sub-point contributes `None`. A
 /// non-Point/MultiPoint geometry is an error.
-fn sample_points_into_list(
-    wkb: &[u8],
-    affine: &AffineMatrix,
-    buffer: &NdBuffer,
-    nodata: Option<f64>,
-    list_builder: &mut ListBuilder<Float64Builder>,
-) -> Result<()> {
+fn collect_point_xys(wkb: &[u8], out: &mut Vec<Option<(f64, f64)>>) -> Result<()> {
     let geom = read_wkb(wkb).map_err(|e| exec_datafusion_err!("RS_Values: {e}"))?;
     match geom.as_type() {
         GeometryType::Point(point) => {
-            let xy = point.coord().map(|c| (c.x(), c.y()));
-            append_sample(xy, affine, buffer, nodata, list_builder)?;
+            out.push(point.coord().map(|c| (c.x(), c.y())));
         }
         GeometryType::MultiPoint(multi_point) => {
             for point in multi_point.points() {
-                let xy = point.coord().map(|c| (c.x(), c.y()));
-                append_sample(xy, affine, buffer, nodata, list_builder)?;
+                out.push(point.coord().map(|c| (c.x(), c.y())));
             }
         }
         _ => return exec_err!("RS_Values expects a Point or MultiPoint geometry"),
     }
     Ok(())
+}
+
+/// Resolve 1-based band `band_num` of `raster`, requiring a spatial 2-D
+/// (y, x) grid — the only shape the sampling affine is defined for.
+fn resolve_band_2d<'a>(
+    raster: &'a dyn RasterRef,
+    band_num: usize,
+) -> Result<Box<dyn BandRef + 'a>> {
+    let band = raster
+        .bands()
+        .band(band_num)
+        .map_err(|e| exec_datafusion_err!("RS_Values: {e}"))?;
+    if !band.is_spatial_2d() {
+        return exec_err!("RS_Values supports 2-D rasters only; band is not a 2-D (y, x) grid");
+    }
+    Ok(band)
 }
 
 /// Append one sampled value (or NULL) to the current list row for a sub-point's
@@ -227,8 +434,8 @@ fn append_sample(
     list_builder: &mut ListBuilder<Float64Builder>,
 ) -> Result<()> {
     let sample = match xy {
-        Some((x, y)) => match xy_to_pixel(affine, x, y)? {
-            Some((col, row)) => read_pixel(buffer, nodata, col, row)?,
+        Some((x, y)) => match xy_to_pixel("RS_Values", affine, x, y)? {
+            Some((col, row)) => read_pixel("RS_Values", buffer, nodata, col, row)?,
             None => None,
         },
         None => None,
@@ -260,6 +467,22 @@ mod tests {
         RasterSpec::d2(2, 2)
             .band_values(&[1u8, 2, 3, 4])
             .transform([0.0, 1.0, 0.0, 10.0, 0.0, -1.0])
+    }
+
+    /// Build MultiPoint WKB by hand: the test WKT parser cannot express an
+    /// EMPTY sub-point, which WKB encodes as a point with NaN ordinates.
+    fn multipoint_wkb(points: &[Option<(f64, f64)>]) -> Vec<u8> {
+        let mut out = vec![1u8]; // little-endian
+        out.extend(4u32.to_le_bytes()); // MultiPoint
+        out.extend((points.len() as u32).to_le_bytes());
+        for point in points {
+            out.push(1);
+            out.extend(1u32.to_le_bytes()); // Point
+            let (x, y) = point.unwrap_or((f64::NAN, f64::NAN));
+            out.extend(x.to_le_bytes());
+            out.extend(y.to_le_bytes());
+        }
+        out
     }
 
     /// Extract one list row as a `Vec<Option<f64>>`.
@@ -482,7 +705,7 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(
-            err.contains("raster has a CRS but the point does not"),
+            err.contains("raster has a CRS but the geometry does not"),
             "unexpected error: {err}"
         );
     }
@@ -502,5 +725,232 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("2-D"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn empty_sub_point_yields_null_element() {
+        // A MultiPoint containing an EMPTY sub-point (`MULTIPOINT (0.5 9.5,
+        // EMPTY, 1.5 8.5)`): the empty sub-point has no location to sample, so
+        // it contributes a NULL element while its neighbours sample normally.
+        let udf: ScalarUDF = rs_values_udf().into();
+        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
+        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
+
+        let wkb = multipoint_wkb(&[Some((0.5, 9.5)), None, Some((1.5, 8.5))]);
+        let geoms: arrow_array::ArrayRef =
+            Arc::new(arrow_array::BinaryArray::from(vec![Some(wkb.as_slice())]));
+        let result = tester
+            .invoke_arrays(vec![Arc::new(raster_2x2().build()), geoms])
+            .unwrap();
+        assert_eq!(row(&result, 0), vec![Some(1.0), None, Some(4.0)]);
+    }
+
+    #[test]
+    fn scalar_raster_samples_via_fast_path() {
+        // A constant (scalar) raster takes the optimized hoisted path; verify
+        // the per-element semantics match the general (array-raster) path:
+        // in-bounds points sample, out-of-bounds and empty sub-points are NULL.
+        let udf: ScalarUDF = rs_values_udf().into();
+        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
+        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
+
+        // MULTIPOINT (0.5 9.5, 1.5 8.5, 100 100, EMPTY), NULL, MULTIPOINT EMPTY
+        let full = multipoint_wkb(&[
+            Some((0.5, 9.5)),
+            Some((1.5, 8.5)),
+            Some((100.0, 100.0)),
+            None,
+        ]);
+        let empty = multipoint_wkb(&[]);
+        let geoms: arrow_array::ArrayRef = Arc::new(arrow_array::BinaryArray::from(vec![
+            Some(full.as_slice()),
+            None,
+            Some(empty.as_slice()),
+        ]));
+        let result = tester
+            .invoke(vec![
+                ColumnarValue::Scalar(ScalarValue::Struct(Arc::new(raster_2x2().build()))),
+                ColumnarValue::Array(geoms),
+            ])
+            .unwrap();
+        let result = result.into_array(3).unwrap();
+        assert_eq!(
+            row(&result, 0),
+            vec![Some(1.0), Some(4.0), None, None],
+            "in-bounds points sample; out-of-bounds and EMPTY are NULL elements"
+        );
+        let list = result.as_any().downcast_ref::<ListArray>().unwrap();
+        assert!(list.is_null(1), "NULL geometry is a NULL list");
+        assert!(!list.is_null(2), "empty MultiPoint is an empty list");
+        assert_eq!(row(&result, 2), Vec::<Option<f64>>::new());
+    }
+
+    #[test]
+    fn scalar_raster_constant_band_uses_fast_path() {
+        // A scalar raster with a constant (scalar) band hoists that band's
+        // buffer for the whole batch.
+        let udf: ScalarUDF = rs_values_udf().into();
+        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
+        let tester = ScalarUdfTester::new(
+            udf,
+            vec![
+                RASTER,
+                geom_type.clone(),
+                SedonaType::Arrow(DataType::Int32),
+            ],
+        );
+        let raster = RasterSpec::d2(2, 2)
+            .band_values(&[1u8, 2, 3, 4])
+            .band_values(&[10u8, 20, 30, 40])
+            .transform([0.0, 1.0, 0.0, 10.0, 0.0, -1.0])
+            .build();
+        let geoms = create_geom_array(&[Some("MULTIPOINT (0.5 9.5, 1.5 8.5)")], &geom_type);
+        let result = tester
+            .invoke(vec![
+                ColumnarValue::Scalar(ScalarValue::Struct(Arc::new(raster))),
+                ColumnarValue::Array(geoms),
+                ColumnarValue::Scalar(ScalarValue::Int32(Some(2))),
+            ])
+            .unwrap();
+        let result = result.into_array(1).unwrap();
+        assert_eq!(row(&result, 0), vec![Some(10.0), Some(40.0)]);
+    }
+
+    #[test]
+    fn scalar_raster_band_column_resolves_per_row() {
+        // A scalar raster with a band *column* still hoists affine/CRS/reproject
+        // but resolves the band buffer per row; a NULL band element -> NULL row.
+        let udf: ScalarUDF = rs_values_udf().into();
+        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
+        let tester = ScalarUdfTester::new(
+            udf,
+            vec![
+                RASTER,
+                geom_type.clone(),
+                SedonaType::Arrow(DataType::Int32),
+            ],
+        );
+        let raster = RasterSpec::d2(2, 2)
+            .band_values(&[1u8, 2, 3, 4])
+            .band_values(&[10u8, 20, 30, 40])
+            .transform([0.0, 1.0, 0.0, 10.0, 0.0, -1.0])
+            .build();
+        let geoms = create_geom_array(
+            &[
+                Some("MULTIPOINT (0.5 9.5)"),
+                Some("MULTIPOINT (0.5 9.5)"),
+                Some("MULTIPOINT (0.5 9.5)"),
+            ],
+            &geom_type,
+        );
+        let bands: arrow_array::ArrayRef = Arc::new(Int32Array::from(vec![Some(1), Some(2), None]));
+        let result = tester
+            .invoke(vec![
+                ColumnarValue::Scalar(ScalarValue::Struct(Arc::new(raster))),
+                ColumnarValue::Array(geoms),
+                ColumnarValue::Array(bands),
+            ])
+            .unwrap();
+        let result = result.into_array(3).unwrap();
+        assert_eq!(row(&result, 0), vec![Some(1.0)]); // band 1
+        assert_eq!(row(&result, 1), vec![Some(10.0)]); // band 2
+        let list = result.as_any().downcast_ref::<ListArray>().unwrap();
+        assert!(list.is_null(2), "NULL band element is a NULL list");
+    }
+
+    #[test]
+    fn scalar_raster_null_scalar_band_is_all_null() {
+        // A NULL scalar band makes every output NULL without touching the band.
+        let udf: ScalarUDF = rs_values_udf().into();
+        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
+        let tester = ScalarUdfTester::new(
+            udf,
+            vec![
+                RASTER,
+                geom_type.clone(),
+                SedonaType::Arrow(DataType::Int32),
+            ],
+        );
+        let geoms = create_geom_array(&[Some("MULTIPOINT (0.5 9.5)")], &geom_type);
+        let result = tester
+            .invoke(vec![
+                ColumnarValue::Scalar(ScalarValue::Struct(Arc::new(raster_2x2().build()))),
+                ColumnarValue::Array(geoms),
+                ColumnarValue::Scalar(ScalarValue::Int32(None)),
+            ])
+            .unwrap();
+        let result = result.into_array(1).unwrap();
+        let list = result.as_any().downcast_ref::<ListArray>().unwrap();
+        assert!(list.is_null(0), "NULL scalar band should yield a NULL list");
+    }
+
+    #[test]
+    fn default_band_requires_single_band_raster_scalar_path() {
+        // Same default-band ambiguity error on the scalar-raster fast path.
+        let udf: ScalarUDF = rs_values_udf().into();
+        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
+        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
+        let raster = RasterSpec::d2(2, 2)
+            .band_values(&[1u8, 2, 3, 4])
+            .band_values(&[10u8, 20, 30, 40])
+            .transform([0.0, 1.0, 0.0, 10.0, 0.0, -1.0])
+            .build();
+        let geoms = create_geom_array(&[Some("MULTIPOINT (0.5 9.5)")], &geom_type);
+        let err = tester
+            .invoke(vec![
+                ColumnarValue::Scalar(ScalarValue::Struct(Arc::new(raster))),
+                ColumnarValue::Array(geoms),
+            ])
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("specify which band"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn scalar_all_null_geometry_defers_band_resolution() {
+        // The scalar fast path defers the default-band ambiguity check until a
+        // row has a geometry to sample: an all-NULL geometry column over a
+        // multiband raster returns NULL rather than erroring — matching the
+        // general path, which only resolves the band on rows with a geometry.
+        let udf: ScalarUDF = rs_values_udf().into();
+        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
+        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
+        let raster = RasterSpec::d2(2, 2)
+            .band_values(&[1u8, 2, 3, 4])
+            .band_values(&[10u8, 20, 30, 40])
+            .transform([0.0, 1.0, 0.0, 10.0, 0.0, -1.0])
+            .build();
+        let geoms = create_geom_array(&[None, None], &geom_type);
+        let result = tester
+            .invoke(vec![
+                ColumnarValue::Scalar(ScalarValue::Struct(Arc::new(raster))),
+                ColumnarValue::Array(geoms),
+            ])
+            .unwrap();
+        let result = result.into_array(2).unwrap();
+        let list = result.as_any().downcast_ref::<ListArray>().unwrap();
+        assert!(list.is_null(0) && list.is_null(1));
+    }
+
+    #[test]
+    fn scalar_null_raster_is_all_null() {
+        // A NULL scalar raster makes every row NULL.
+        let udf: ScalarUDF = rs_values_udf().into();
+        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
+        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
+        let raster = generate_test_rasters(1, Some(0)).unwrap();
+        let geoms = create_geom_array(&[Some("MULTIPOINT (0.5 9.5)")], &geom_type);
+        let result = tester
+            .invoke(vec![
+                ColumnarValue::Scalar(ScalarValue::Struct(Arc::new(raster))),
+                ColumnarValue::Array(geoms),
+            ])
+            .unwrap();
+        let result = result.into_array(1).unwrap();
+        let list = result.as_any().downcast_ref::<ListArray>().unwrap();
+        assert!(list.is_null(0));
     }
 }

--- a/rust/sedona-raster-functions/src/rs_values.rs
+++ b/rust/sedona-raster-functions/src/rs_values.rs
@@ -628,7 +628,7 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(
-            err.contains("expected a Point or MultiPoint"),
+            err.contains("expected a Point, MultiPoint, or GeometryCollection"),
             "unexpected error: {err}"
         );
     }

--- a/rust/sedona-raster-functions/src/rs_values.rs
+++ b/rust/sedona-raster-functions/src/rs_values.rs
@@ -41,31 +41,29 @@ use std::sync::Arc;
 
 use arrow_array::builder::{Float64Builder, ListBuilder};
 use arrow_array::{Array, ArrayRef, StructArray};
-use arrow_schema::{DataType, Field};
+use arrow_schema::DataType;
 use datafusion_common::cast::as_int32_array;
+use datafusion_common::config::ConfigOptions;
 use datafusion_common::{exec_datafusion_err, exec_err, Result, ScalarValue};
 use datafusion_expr::{ColumnarValue, Volatility};
-use geo_traits::{CoordTrait, GeometryTrait, GeometryType, MultiPointTrait, PointTrait};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
-use sedona_proj::transform::with_global_proj_engine;
 use sedona_raster::affine_transformation::AffineMatrix;
 use sedona_raster::array::RasterStructArray;
 use sedona_raster::traits::{BandRef, NdBuffer, RasterRef};
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
-use wkb::reader::read_wkb;
 
-use crate::crs_utils::resolve_crs;
+use crate::crs_utils::{resolve_crs, with_crs_engine};
 use crate::executor::RasterExecutor;
 use crate::rs_ensure_loaded::NEEDS_PIXELS_METADATA_KEY;
 use crate::sampling::{
-    column_reproject_decision, default_band, int32_array_arg, next_band, read_pixel, reproject_wkb,
-    xy_to_pixel,
+    column_point_crs_transform, default_band, int32_array_arg, next_band, point_crs_transform,
+    read_pixel, visit_points, xy_to_pixel,
 };
 
 /// The `List<Float64>` output type, matching what a default
 /// `ListBuilder<Float64Builder>` produces (field "item", nullable).
 fn list_float64_type() -> DataType {
-    DataType::List(Arc::new(Field::new("item", DataType::Float64, true)))
+    DataType::new_list(DataType::Float64, true)
 }
 
 /// `RS_Values()` scalar UDF — sample pixel values at each point of a MultiPoint.
@@ -107,20 +105,39 @@ impl SedonaScalarKernel for RsValues {
         arg_types: &[SedonaType],
         args: &[ColumnarValue],
     ) -> Result<ColumnarValue> {
+        self.invoke(arg_types, args, None)
+    }
+
+    fn invoke_batch_from_args(
+        &self,
+        arg_types: &[SedonaType],
+        args: &[ColumnarValue],
+        _return_type: &SedonaType,
+        _num_rows: usize,
+        config_options: Option<&ConfigOptions>,
+    ) -> Result<ColumnarValue> {
+        self.invoke(arg_types, args, config_options)
+    }
+}
+
+impl RsValues {
+    fn invoke(
+        &self,
+        arg_types: &[SedonaType],
+        args: &[ColumnarValue],
+        config_options: Option<&ConfigOptions>,
+    ) -> Result<ColumnarValue> {
         // Fast path: a constant (scalar) raster lets us resolve the affine
         // transform, CRS, and band buffer once for the whole batch instead of
         // per row — the common RS_Values(raster_expr, points_column[, band])
         // shape. Only a band *column* falls back to per-row band resolution.
         if let ColumnarValue::Scalar(ScalarValue::Struct(raster_struct)) = &args[0] {
-            return self.invoke_scalar_raster(arg_types, args, raster_struct.as_ref());
+            return self.invoke_scalar_raster(arg_types, args, config_options, raster_struct);
         }
 
         let executor = RasterExecutor::new(arg_types, args);
         let num_iterations = executor.num_iterations();
         let mut list_builder = ListBuilder::new(Float64Builder::new());
-        // Per-row scratch for the parsed sub-point coordinates, reused across
-        // rows so the parse does not allocate per row.
-        let mut points_scratch: Vec<Option<(f64, f64)>> = Vec::new();
 
         // The optional band argument, materialised once as an Int32 array. Held
         // as an `ArrayRef` so the typed view below borrows it instead of cloning
@@ -133,8 +150,8 @@ impl SedonaScalarKernel for RsValues {
         let band_array = band_arr.as_ref().map(|a| as_int32_array(a)).transpose()?;
         let mut band_iter = band_array.map(|a| a.iter());
 
-        // Reprojecting the points into the raster CRS needs a PROJ engine.
-        with_global_proj_engine(|engine| {
+        // Reprojecting the points into the raster CRS needs a CRS engine.
+        with_crs_engine(config_options, |engine| {
             executor.execute_raster_wkb_crs_void(|raster_opt, wkb_opt, geom_crs| {
                 // Advance the band column every row so it stays in lockstep with
                 // the row index (a no-op when there is no band argument).
@@ -177,22 +194,14 @@ impl SedonaScalarKernel for RsValues {
                     .map_err(|e| exec_datafusion_err!("RS_Values: {e}"))?;
                 let affine = AffineMatrix::from_metadata(&raster.metadata());
 
-                // Reproject the whole geometry into the raster CRS (a no-op that
-                // borrows the original bytes when the CRSes match or are absent).
-                let reprojected = reproject_wkb(
-                    "RS_Values",
-                    geom_wkb,
-                    geom_crs,
-                    raster_crs.as_deref(),
-                    engine,
-                )?;
-                let effective = reprojected.as_deref().unwrap_or(geom_wkb);
-
-                points_scratch.clear();
-                collect_point_xys(effective, &mut points_scratch)?;
-                for xy in &points_scratch {
-                    append_sample(*xy, &affine, &buffer, nodata, &mut list_builder)?;
-                }
+                // Sample each sub-point in one pass: the visitor transforms
+                // each coordinate into the raster CRS in place, so there is no
+                // reprojected-WKB copy and no coordinate scratch buffer.
+                let trans =
+                    point_crs_transform("RS_Values", geom_crs, raster_crs.as_deref(), engine)?;
+                visit_points("RS_Values", geom_wkb, trans.as_deref(), |xy| {
+                    append_sample(xy, &affine, &buffer, nodata, &mut list_builder)
+                })?;
                 list_builder.append(true);
                 Ok(())
             })
@@ -200,9 +209,6 @@ impl SedonaScalarKernel for RsValues {
 
         executor.finish(Arc::new(list_builder.finish()))
     }
-}
-
-impl RsValues {
     /// Optimized path for a constant (scalar) raster: the affine transform and
     /// raster CRS are resolved once for the whole batch, and the per-row work
     /// reduces to parsing the points and reading pixels. This serves every band
@@ -213,7 +219,7 @@ impl RsValues {
     ///   but the affine/CRS/reproject work is still hoisted.
     ///
     /// Sampling behaviour matches the general path: it uses the same
-    /// [`collect_point_xys`]/[`append_sample`] helpers, so per-element and
+    /// [`visit_points`]/[`append_sample`] helpers, so per-element and
     /// per-row NULL semantics are identical. Band resolution — including the
     /// default-band ambiguity check and the 2-D check — is deferred until at
     /// least one row has a geometry to sample, so an all-null batch returns
@@ -222,6 +228,7 @@ impl RsValues {
         &self,
         arg_types: &[SedonaType],
         args: &[ColumnarValue],
+        config_options: Option<&ConfigOptions>,
         raster_struct: &StructArray,
     ) -> Result<ColumnarValue> {
         let executor = RasterExecutor::new(arg_types, args);
@@ -229,9 +236,7 @@ impl RsValues {
 
         let all_null = |executor: &RasterExecutor| {
             let mut builder = ListBuilder::new(Float64Builder::new());
-            for _ in 0..n {
-                builder.append_null();
-            }
+            builder.append_nulls(n);
             executor.finish(Arc::new(builder.finish()))
         };
 
@@ -274,25 +279,30 @@ impl RsValues {
             .map(|a| as_int32_array(a))
             .transpose()?;
 
-        // Affine transform and raster CRS, resolved once for all rows. Decide
-        // reprojection once when the geometry CRS is column-level (the common
-        // case), skipping a per-row `crs_equals` and its String allocation.
+        // Affine transform and raster CRS, resolved once for all rows.
         let affine = AffineMatrix::from_metadata(&raster.metadata());
         let raster_crs = resolve_crs(raster.crs())?;
-        let needs_reproject =
-            column_reproject_decision("RS_Values", &arg_types[1], raster_crs.as_deref())?;
-        let skip_reproject = needs_reproject == Some(false);
 
         let mut geom = executor.make_geom_wkb_crs_accessor(1)?;
 
-        // Phase 1 — parse each row's Point/MultiPoint (reprojected into the
-        // raster CRS) into owned sub-point coordinates. All rows share one
-        // coordinate arena with per-row (start, len, band) spans; a `None` row
-        // is NULL output (NULL geometry or band element).
+        // Phase 1 — parse each row's Point/MultiPoint into owned sub-point
+        // coordinates, transformed into the raster CRS in place by the visitor
+        // (no reprojected-WKB copy). All rows share one coordinate arena with
+        // per-row (start, len, band) spans; a `None` row is NULL output (NULL
+        // geometry or band element).
         let mut coords: Vec<Option<(f64, f64)>> = Vec::new();
         let mut rows: Vec<Option<(usize, usize, usize)>> = Vec::with_capacity(n);
         let mut band_iter = band_array.map(|a| a.iter());
-        with_global_proj_engine(|engine| {
+        with_crs_engine(config_options, |engine| {
+            // Resolve the raster-CRS transform once when the geometry CRS is
+            // column-level (the common case), skipping a per-row `crs_equals`
+            // (and its String allocation) and a per-row transform lookup.
+            let hoisted_trans = column_point_crs_transform(
+                "RS_Values",
+                &arg_types[1],
+                raster_crs.as_deref(),
+                engine,
+            )?;
             for i in 0..n {
                 // Advance the band column in lockstep with the row index; with
                 // no band argument this yields a placeholder that the hoisted
@@ -306,20 +316,18 @@ impl RsValues {
                     rows.push(None);
                     continue;
                 };
-                let reprojected = if skip_reproject {
-                    None
-                } else {
-                    reproject_wkb(
-                        "RS_Values",
-                        geom_wkb,
-                        geom_crs,
-                        raster_crs.as_deref(),
-                        engine,
-                    )?
+                // A per-item geometry CRS (hoisted_trans == None) resolves per row.
+                let trans = match &hoisted_trans {
+                    Some(trans) => trans.clone(),
+                    None => {
+                        point_crs_transform("RS_Values", geom_crs, raster_crs.as_deref(), engine)?
+                    }
                 };
-                let effective = reprojected.as_deref().unwrap_or(geom_wkb);
                 let start = coords.len();
-                collect_point_xys(effective, &mut coords)?;
+                visit_points("RS_Values", geom_wkb, trans.as_deref(), |xy| {
+                    coords.push(xy);
+                    Ok(())
+                })?;
                 rows.push(Some((start, coords.len() - start, band_num)));
             }
             Ok(())
@@ -388,25 +396,6 @@ impl RsValues {
     }
 }
 
-/// Collect each sub-point of a Point/MultiPoint WKB as an owned `(x, y)`,
-/// appending to `out` in input order. An empty sub-point contributes `None`. A
-/// non-Point/MultiPoint geometry is an error.
-fn collect_point_xys(wkb: &[u8], out: &mut Vec<Option<(f64, f64)>>) -> Result<()> {
-    let geom = read_wkb(wkb).map_err(|e| exec_datafusion_err!("RS_Values: {e}"))?;
-    match geom.as_type() {
-        GeometryType::Point(point) => {
-            out.push(point.coord().map(|c| (c.x(), c.y())));
-        }
-        GeometryType::MultiPoint(multi_point) => {
-            for point in multi_point.points() {
-                out.push(point.coord().map(|c| (c.x(), c.y())));
-            }
-        }
-        _ => return exec_err!("RS_Values expects a Point or MultiPoint geometry"),
-    }
-    Ok(())
-}
-
 /// Resolve 1-based band `band_num` of `raster`, requiring a spatial 2-D
 /// (y, x) grid — the only shape the sampling affine is defined for.
 fn resolve_band_2d<'a>(
@@ -450,39 +439,53 @@ fn append_sample(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_array::{Array, Float64Array, Int32Array, ListArray};
+    use arrow_array::{Array, BinaryArray, Float64Array, Int32Array, ListArray};
     use datafusion_expr::ScalarUDF;
     use sedona_schema::crs::lnglat;
-    use sedona_schema::datatypes::{Edges, RASTER};
+    use sedona_schema::datatypes::{Edges, RASTER, WKB_GEOMETRY};
     use sedona_schema::raster::BandDataType;
-    use sedona_testing::create::create_array as create_geom_array;
+    use sedona_testing::create::{create_array as create_geom_array, make_multipoint_wkb};
     use sedona_testing::raster_spec::RasterSpec;
     use sedona_testing::rasters::generate_test_rasters;
     use sedona_testing::testers::ScalarUdfTester;
 
-    /// North-up 2x2 raster, origin (0, 10), 1x1 pixels, band values row-major
-    /// `[1, 2, 3, 4]` (row0 = [1, 2], row1 = [3, 4]). Pixel (0, 0) covers world
-    /// x∈[0,1), y∈[9,10) and holds 1; pixel (1, 1) holds 4.
+    /// The lng/lat geometry argument type shared by most tests.
+    fn geom_type() -> SedonaType {
+        SedonaType::Wkb(Edges::Planar, lnglat())
+    }
+
+    /// Tester for `RS_Values(raster, points)` with a lng/lat geometry column.
+    fn tester() -> ScalarUdfTester {
+        ScalarUdfTester::new(rs_values_udf().into(), vec![RASTER, geom_type()])
+    }
+
+    /// Tester for `RS_Values(raster, points, band)`.
+    fn tester_with_band() -> ScalarUdfTester {
+        ScalarUdfTester::new(
+            rs_values_udf().into(),
+            vec![RASTER, geom_type(), SedonaType::Arrow(DataType::Int32)],
+        )
+    }
+
+    /// North-up 2x2 raster spanning world bbox (0, 8)–(2, 10) with 1x1 pixels,
+    /// band values row-major `[1, 2, 3, 4]` (row0 = [1, 2], row1 = [3, 4]).
+    /// Pixel (0, 0) covers x∈[0,1), y∈[9,10) and holds 1; pixel (1, 1) holds 4.
     fn raster_2x2() -> RasterSpec {
         RasterSpec::d2(2, 2)
             .band_values(&[1u8, 2, 3, 4])
-            .transform([0.0, 1.0, 0.0, 10.0, 0.0, -1.0])
+            .bbox(0.0, 8.0, 2.0, 10.0)
     }
 
-    /// Build MultiPoint WKB by hand: the test WKT parser cannot express an
-    /// EMPTY sub-point, which WKB encodes as a point with NaN ordinates.
-    fn multipoint_wkb(points: &[Option<(f64, f64)>]) -> Vec<u8> {
-        let mut out = vec![1u8]; // little-endian
-        out.extend(4u32.to_le_bytes()); // MultiPoint
-        out.extend((points.len() as u32).to_le_bytes());
-        for point in points {
-            out.push(1);
-            out.extend(1u32.to_le_bytes()); // Point
-            let (x, y) = point.unwrap_or((f64::NAN, f64::NAN));
-            out.extend(x.to_le_bytes());
-            out.extend(y.to_le_bytes());
-        }
-        out
+    /// Two-band variant of [`raster_2x2`]: band 2 holds `[10, 20, 30, 40]`.
+    fn two_band_raster() -> RasterSpec {
+        raster_2x2().band_values(&[10u8, 20, 30, 40])
+    }
+
+    /// A `List<Float64>` scalar for comparing one list row via
+    /// `assert_scalar_result_equals`.
+    fn list_f64(values: &[Option<f64>]) -> ScalarValue {
+        let values: Vec<ScalarValue> = values.iter().map(|v| ScalarValue::Float64(*v)).collect();
+        ScalarValue::List(ScalarValue::new_list_nullable(&values, &DataType::Float64))
     }
 
     /// Extract one list row as a `Vec<Option<f64>>`.
@@ -515,36 +518,27 @@ mod tests {
     #[test]
     fn return_type_is_list_float64() {
         let return_type = RsValues { with_band: false }
-            .return_type(&[RASTER, SedonaType::Wkb(Edges::Planar, lnglat())])
+            .return_type(&[RASTER, geom_type()])
             .unwrap();
         assert_eq!(return_type, Some(SedonaType::Arrow(list_float64_type())));
     }
 
     #[test]
     fn multipoint_samples_each_point_in_order() {
-        let udf: ScalarUDF = rs_values_udf().into();
-        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
-        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
-
         // Pixel (0,0)=1, pixel (1,1)=4, and a point far outside -> NULL element.
-        let geoms = create_geom_array(
-            &[Some("MULTIPOINT (0.5 9.5, 1.5 8.5, 100 100)")],
-            &geom_type,
-        );
+        let tester = tester();
         let result = tester
-            .invoke_arrays(vec![Arc::new(raster_2x2().build()), geoms])
+            .invoke_scalar_scalar(raster_2x2(), "MULTIPOINT (0.5 9.5, 1.5 8.5, 100 100)")
             .unwrap();
-        assert_eq!(row(&result, 0), vec![Some(1.0), Some(4.0), None]);
+        tester.assert_scalar_result_equals(result, list_f64(&[Some(1.0), Some(4.0), None]));
     }
 
     #[test]
     fn single_point_yields_one_element_list() {
-        // A plain Point is accepted and produces a one-element list.
-        let udf: ScalarUDF = rs_values_udf().into();
-        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
-        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
-
-        let geoms = create_geom_array(&[Some("POINT (1.5 8.5)")], &geom_type);
+        // A plain Point is accepted and produces a one-element list (general,
+        // array-raster path).
+        let tester = tester();
+        let geoms = create_geom_array(&[Some("POINT (1.5 8.5)")], &geom_type());
         let result = tester
             .invoke_arrays(vec![Arc::new(raster_2x2().build()), geoms])
             .unwrap();
@@ -553,11 +547,8 @@ mod tests {
 
     #[test]
     fn empty_multipoint_yields_empty_list() {
-        let udf: ScalarUDF = rs_values_udf().into();
-        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
-        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
-
-        let geoms = create_geom_array(&[Some("MULTIPOINT EMPTY")], &geom_type);
+        let tester = tester();
+        let geoms = create_geom_array(&[Some("MULTIPOINT EMPTY")], &geom_type());
         let result = tester
             .invoke_arrays(vec![Arc::new(raster_2x2().build()), geoms])
             .unwrap();
@@ -571,28 +562,18 @@ mod tests {
 
     #[test]
     fn nodata_element_is_null() {
-        let udf: ScalarUDF = rs_values_udf().into();
-        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
-        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
-
         // Band [1, 2, 3, 4] with nodata=4: sampling pixel (1,1) reads nodata.
-        let raster = RasterSpec::d2(2, 2)
-            .band_values(&[1u8, 2, 3, 4])
-            .nodata(4u8)
-            .transform([0.0, 1.0, 0.0, 10.0, 0.0, -1.0])
-            .build();
-        let geoms = create_geom_array(&[Some("MULTIPOINT (0.5 9.5, 1.5 8.5)")], &geom_type);
-        let result = tester.invoke_arrays(vec![Arc::new(raster), geoms]).unwrap();
-        assert_eq!(row(&result, 0), vec![Some(1.0), None]);
+        let tester = tester();
+        let result = tester
+            .invoke_scalar_scalar(raster_2x2().nodata(4u8), "MULTIPOINT (0.5 9.5, 1.5 8.5)")
+            .unwrap();
+        tester.assert_scalar_result_equals(result, list_f64(&[Some(1.0), None]));
     }
 
     #[test]
     fn null_geometry_yields_null_list() {
-        let udf: ScalarUDF = rs_values_udf().into();
-        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
-        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
-
-        let geoms = create_geom_array(&[None], &geom_type);
+        let tester = tester();
+        let geoms = create_geom_array(&[None], &geom_type());
         let result = tester
             .invoke_arrays(vec![Arc::new(raster_2x2().build()), geoms])
             .unwrap();
@@ -602,19 +583,9 @@ mod tests {
 
     #[test]
     fn null_band_element_yields_null_list() {
-        let udf: ScalarUDF = rs_values_udf().into();
-        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
-        let tester = ScalarUdfTester::new(
-            udf,
-            vec![
-                RASTER,
-                geom_type.clone(),
-                SedonaType::Arrow(DataType::Int32),
-            ],
-        );
-
-        let geoms = create_geom_array(&[Some("MULTIPOINT (0.5 9.5)")], &geom_type);
-        let bands: arrow_array::ArrayRef = Arc::new(Int32Array::from(vec![None::<i32>]));
+        let tester = tester_with_band();
+        let geoms = create_geom_array(&[Some("MULTIPOINT (0.5 9.5)")], &geom_type());
+        let bands: ArrayRef = Arc::new(Int32Array::from(vec![None::<i32>]));
         let result = tester
             .invoke_arrays(vec![Arc::new(raster_2x2().build()), geoms, bands])
             .unwrap();
@@ -624,27 +595,12 @@ mod tests {
 
     #[test]
     fn second_band_is_addressable() {
-        let udf: ScalarUDF = rs_values_udf().into();
-        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
-        let tester = ScalarUdfTester::new(
-            udf,
-            vec![
-                RASTER,
-                geom_type.clone(),
-                SedonaType::Arrow(DataType::Int32),
-            ],
-        );
-
-        // Band 1 [1,2,3,4], band 2 [10,20,30,40]; sample band 2 at pixel (0,0).
-        let raster = RasterSpec::d2(2, 2)
-            .band_values(&[1u8, 2, 3, 4])
-            .band_values(&[10u8, 20, 30, 40])
-            .transform([0.0, 1.0, 0.0, 10.0, 0.0, -1.0])
-            .build();
-        let geoms = create_geom_array(&[Some("MULTIPOINT (0.5 9.5)")], &geom_type);
-        let bands: arrow_array::ArrayRef = Arc::new(Int32Array::from(vec![Some(2)]));
+        // Sample band 2 at pixel (0, 0) via a band column (general path).
+        let tester = tester_with_band();
+        let geoms = create_geom_array(&[Some("MULTIPOINT (0.5 9.5)")], &geom_type());
+        let bands: ArrayRef = Arc::new(Int32Array::from(vec![Some(2)]));
         let result = tester
-            .invoke_arrays(vec![Arc::new(raster), geoms, bands])
+            .invoke_arrays(vec![Arc::new(two_band_raster().build()), geoms, bands])
             .unwrap();
         assert_eq!(row(&result, 0), vec![Some(10.0)]);
     }
@@ -653,17 +609,10 @@ mod tests {
     fn default_band_requires_single_band_raster() {
         // With no band argument, a multiband raster is ambiguous and errors
         // rather than silently sampling band 1 (matches RS_SetBandNoDataValue).
-        let udf: ScalarUDF = rs_values_udf().into();
-        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
-        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
-        let raster = RasterSpec::d2(2, 2)
-            .band_values(&[1u8, 2, 3, 4])
-            .band_values(&[10u8, 20, 30, 40])
-            .transform([0.0, 1.0, 0.0, 10.0, 0.0, -1.0])
-            .build();
-        let geoms = create_geom_array(&[Some("MULTIPOINT (0.5 9.5)")], &geom_type);
-        let err = tester
-            .invoke_arrays(vec![Arc::new(raster), geoms])
+        // Array raster -> general path.
+        let geoms = create_geom_array(&[Some("MULTIPOINT (0.5 9.5)")], &geom_type());
+        let err = tester()
+            .invoke_arrays(vec![Arc::new(two_band_raster().build()), geoms])
             .unwrap_err()
             .to_string();
         assert!(
@@ -674,20 +623,12 @@ mod tests {
 
     #[test]
     fn non_point_geometry_errors() {
-        let udf: ScalarUDF = rs_values_udf().into();
-        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
-        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
-
-        let geoms = create_geom_array(&[Some("LINESTRING (0 0, 1 1)")], &geom_type);
-        let err = tester
-            .invoke_arrays(vec![
-                Arc::new(generate_test_rasters(1, None).unwrap()),
-                geoms,
-            ])
+        let err = tester()
+            .invoke_scalar_scalar(raster_2x2(), "LINESTRING (0 0, 1 1)")
             .unwrap_err()
             .to_string();
         assert!(
-            err.contains("expects a Point or MultiPoint"),
+            err.contains("expected a Point or MultiPoint"),
             "unexpected error: {err}"
         );
     }
@@ -696,10 +637,9 @@ mod tests {
     fn crs_mismatch_errors() {
         // Raster has a CRS (generate_test_rasters sets OGC:CRS84), points do not.
         let udf: ScalarUDF = rs_values_udf().into();
-        let geom_type = SedonaType::Wkb(Edges::Planar, None);
-        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
+        let tester = ScalarUdfTester::new(udf, vec![RASTER, WKB_GEOMETRY]);
         let rasters = generate_test_rasters(1, None).unwrap();
-        let geoms = create_geom_array(&[Some("MULTIPOINT (2.1 2.6)")], &geom_type);
+        let geoms = create_geom_array(&[Some("MULTIPOINT (2.1 2.6)")], &WKB_GEOMETRY);
         let err = tester
             .invoke_arrays(vec![Arc::new(rasters), geoms])
             .unwrap_err()
@@ -713,13 +653,12 @@ mod tests {
     #[test]
     fn non_2d_band_errors() {
         let udf: ScalarUDF = rs_values_udf().into();
-        let geom_type = SedonaType::Wkb(Edges::Planar, None);
-        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
+        let tester = ScalarUdfTester::new(udf, vec![RASTER, WKB_GEOMETRY]);
         let raster = RasterSpec::nd(&["time", "y", "x"], &[2, 2, 1])
             .band(BandDataType::UInt8)
             .crs(None)
             .build();
-        let geoms = create_geom_array(&[Some("MULTIPOINT (0 0)")], &geom_type);
+        let geoms = create_geom_array(&[Some("MULTIPOINT (0 0)")], &WKB_GEOMETRY);
         let err = tester
             .invoke_arrays(vec![Arc::new(raster), geoms])
             .unwrap_err()
@@ -731,14 +670,11 @@ mod tests {
     fn empty_sub_point_yields_null_element() {
         // A MultiPoint containing an EMPTY sub-point (`MULTIPOINT (0.5 9.5,
         // EMPTY, 1.5 8.5)`): the empty sub-point has no location to sample, so
-        // it contributes a NULL element while its neighbours sample normally.
-        let udf: ScalarUDF = rs_values_udf().into();
-        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
-        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
-
-        let wkb = multipoint_wkb(&[Some((0.5, 9.5)), None, Some((1.5, 8.5))]);
-        let geoms: arrow_array::ArrayRef =
-            Arc::new(arrow_array::BinaryArray::from(vec![Some(wkb.as_slice())]));
+        // it contributes a NULL element while its neighbours sample normally
+        // and in order (general, array-raster path).
+        let tester = tester();
+        let wkb = make_multipoint_wkb(&[Some((0.5, 9.5)), None, Some((1.5, 8.5))]);
+        let geoms: ArrayRef = Arc::new(BinaryArray::from(vec![Some(wkb.as_slice())]));
         let result = tester
             .invoke_arrays(vec![Arc::new(raster_2x2().build()), geoms])
             .unwrap();
@@ -750,26 +686,24 @@ mod tests {
         // A constant (scalar) raster takes the optimized hoisted path; verify
         // the per-element semantics match the general (array-raster) path:
         // in-bounds points sample, out-of-bounds and empty sub-points are NULL.
-        let udf: ScalarUDF = rs_values_udf().into();
-        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
-        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
+        let tester = tester();
 
         // MULTIPOINT (0.5 9.5, 1.5 8.5, 100 100, EMPTY), NULL, MULTIPOINT EMPTY
-        let full = multipoint_wkb(&[
+        let full = make_multipoint_wkb(&[
             Some((0.5, 9.5)),
             Some((1.5, 8.5)),
             Some((100.0, 100.0)),
             None,
         ]);
-        let empty = multipoint_wkb(&[]);
-        let geoms: arrow_array::ArrayRef = Arc::new(arrow_array::BinaryArray::from(vec![
+        let empty = make_multipoint_wkb(&[]);
+        let geoms: ArrayRef = Arc::new(BinaryArray::from(vec![
             Some(full.as_slice()),
             None,
             Some(empty.as_slice()),
         ]));
         let result = tester
             .invoke(vec![
-                ColumnarValue::Scalar(ScalarValue::Struct(Arc::new(raster_2x2().build()))),
+                ColumnarValue::Scalar(raster_2x2().scalar()),
                 ColumnarValue::Array(geoms),
             ])
             .unwrap();
@@ -789,64 +723,30 @@ mod tests {
     fn scalar_raster_constant_band_uses_fast_path() {
         // A scalar raster with a constant (scalar) band hoists that band's
         // buffer for the whole batch.
-        let udf: ScalarUDF = rs_values_udf().into();
-        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
-        let tester = ScalarUdfTester::new(
-            udf,
-            vec![
-                RASTER,
-                geom_type.clone(),
-                SedonaType::Arrow(DataType::Int32),
-            ],
-        );
-        let raster = RasterSpec::d2(2, 2)
-            .band_values(&[1u8, 2, 3, 4])
-            .band_values(&[10u8, 20, 30, 40])
-            .transform([0.0, 1.0, 0.0, 10.0, 0.0, -1.0])
-            .build();
-        let geoms = create_geom_array(&[Some("MULTIPOINT (0.5 9.5, 1.5 8.5)")], &geom_type);
+        let tester = tester_with_band();
         let result = tester
-            .invoke(vec![
-                ColumnarValue::Scalar(ScalarValue::Struct(Arc::new(raster))),
-                ColumnarValue::Array(geoms),
-                ColumnarValue::Scalar(ScalarValue::Int32(Some(2))),
-            ])
+            .invoke_scalar_scalar_scalar(two_band_raster(), "MULTIPOINT (0.5 9.5, 1.5 8.5)", 2)
             .unwrap();
-        let result = result.into_array(1).unwrap();
-        assert_eq!(row(&result, 0), vec![Some(10.0), Some(40.0)]);
+        tester.assert_scalar_result_equals(result, list_f64(&[Some(10.0), Some(40.0)]));
     }
 
     #[test]
     fn scalar_raster_band_column_resolves_per_row() {
         // A scalar raster with a band *column* still hoists affine/CRS/reproject
         // but resolves the band buffer per row; a NULL band element -> NULL row.
-        let udf: ScalarUDF = rs_values_udf().into();
-        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
-        let tester = ScalarUdfTester::new(
-            udf,
-            vec![
-                RASTER,
-                geom_type.clone(),
-                SedonaType::Arrow(DataType::Int32),
-            ],
-        );
-        let raster = RasterSpec::d2(2, 2)
-            .band_values(&[1u8, 2, 3, 4])
-            .band_values(&[10u8, 20, 30, 40])
-            .transform([0.0, 1.0, 0.0, 10.0, 0.0, -1.0])
-            .build();
+        let tester = tester_with_band();
         let geoms = create_geom_array(
             &[
                 Some("MULTIPOINT (0.5 9.5)"),
                 Some("MULTIPOINT (0.5 9.5)"),
                 Some("MULTIPOINT (0.5 9.5)"),
             ],
-            &geom_type,
+            &geom_type(),
         );
-        let bands: arrow_array::ArrayRef = Arc::new(Int32Array::from(vec![Some(1), Some(2), None]));
+        let bands: ArrayRef = Arc::new(Int32Array::from(vec![Some(1), Some(2), None]));
         let result = tester
             .invoke(vec![
-                ColumnarValue::Scalar(ScalarValue::Struct(Arc::new(raster))),
+                ColumnarValue::Scalar(two_band_raster().scalar()),
                 ColumnarValue::Array(geoms),
                 ColumnarValue::Array(bands),
             ])
@@ -861,46 +761,25 @@ mod tests {
     #[test]
     fn scalar_raster_null_scalar_band_is_all_null() {
         // A NULL scalar band makes every output NULL without touching the band.
-        let udf: ScalarUDF = rs_values_udf().into();
-        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
-        let tester = ScalarUdfTester::new(
-            udf,
-            vec![
-                RASTER,
-                geom_type.clone(),
-                SedonaType::Arrow(DataType::Int32),
-            ],
-        );
-        let geoms = create_geom_array(&[Some("MULTIPOINT (0.5 9.5)")], &geom_type);
+        let tester = tester_with_band();
         let result = tester
-            .invoke(vec![
-                ColumnarValue::Scalar(ScalarValue::Struct(Arc::new(raster_2x2().build()))),
-                ColumnarValue::Array(geoms),
-                ColumnarValue::Scalar(ScalarValue::Int32(None)),
-            ])
+            .invoke_scalar_scalar_scalar(
+                raster_2x2(),
+                "MULTIPOINT (0.5 9.5)",
+                ScalarValue::Int32(None),
+            )
             .unwrap();
-        let result = result.into_array(1).unwrap();
-        let list = result.as_any().downcast_ref::<ListArray>().unwrap();
-        assert!(list.is_null(0), "NULL scalar band should yield a NULL list");
+        assert!(
+            result.is_null(),
+            "NULL scalar band should yield a NULL list"
+        );
     }
 
     #[test]
     fn default_band_requires_single_band_raster_scalar_path() {
         // Same default-band ambiguity error on the scalar-raster fast path.
-        let udf: ScalarUDF = rs_values_udf().into();
-        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
-        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
-        let raster = RasterSpec::d2(2, 2)
-            .band_values(&[1u8, 2, 3, 4])
-            .band_values(&[10u8, 20, 30, 40])
-            .transform([0.0, 1.0, 0.0, 10.0, 0.0, -1.0])
-            .build();
-        let geoms = create_geom_array(&[Some("MULTIPOINT (0.5 9.5)")], &geom_type);
-        let err = tester
-            .invoke(vec![
-                ColumnarValue::Scalar(ScalarValue::Struct(Arc::new(raster))),
-                ColumnarValue::Array(geoms),
-            ])
+        let err = tester()
+            .invoke_scalar_scalar(two_band_raster(), "MULTIPOINT (0.5 9.5)")
             .unwrap_err()
             .to_string();
         assert!(
@@ -915,18 +794,11 @@ mod tests {
         // row has a geometry to sample: an all-NULL geometry column over a
         // multiband raster returns NULL rather than erroring — matching the
         // general path, which only resolves the band on rows with a geometry.
-        let udf: ScalarUDF = rs_values_udf().into();
-        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
-        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
-        let raster = RasterSpec::d2(2, 2)
-            .band_values(&[1u8, 2, 3, 4])
-            .band_values(&[10u8, 20, 30, 40])
-            .transform([0.0, 1.0, 0.0, 10.0, 0.0, -1.0])
-            .build();
-        let geoms = create_geom_array(&[None, None], &geom_type);
+        let tester = tester();
+        let geoms = create_geom_array(&[None, None], &geom_type());
         let result = tester
             .invoke(vec![
-                ColumnarValue::Scalar(ScalarValue::Struct(Arc::new(raster))),
+                ColumnarValue::Scalar(two_band_raster().scalar()),
                 ColumnarValue::Array(geoms),
             ])
             .unwrap();
@@ -938,11 +810,9 @@ mod tests {
     #[test]
     fn scalar_null_raster_is_all_null() {
         // A NULL scalar raster makes every row NULL.
-        let udf: ScalarUDF = rs_values_udf().into();
-        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
-        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
+        let tester = tester();
         let raster = generate_test_rasters(1, Some(0)).unwrap();
-        let geoms = create_geom_array(&[Some("MULTIPOINT (0.5 9.5)")], &geom_type);
+        let geoms = create_geom_array(&[Some("MULTIPOINT (0.5 9.5)")], &geom_type());
         let result = tester
             .invoke(vec![
                 ColumnarValue::Scalar(ScalarValue::Struct(Arc::new(raster))),

--- a/rust/sedona-raster-functions/src/rs_values.rs
+++ b/rust/sedona-raster-functions/src/rs_values.rs
@@ -1,0 +1,464 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! `RS_Values` — sample a raster's pixel value at each point of a MultiPoint.
+//!
+//! ```text
+//! RS_Values(raster, points)        -> List<Double>  -- band defaults to 1
+//! RS_Values(raster, points, band)  -> List<Double>
+//! ```
+//!
+//! The plural companion of [`RS_Value`](crate::rs_value): where `RS_Value` takes
+//! one Point and returns one Double, `RS_Values` takes a MultiPoint (a single
+//! Point is also accepted) and returns a `List<Double>` — one element per
+//! sub-point, in input order. Each element is `NULL` when its sub-point is empty,
+//! out of bounds, or reads the band's nodata; the whole list is `NULL` when the
+//! raster, geometry, or band is `NULL`. An empty MultiPoint yields an empty list.
+//!
+//! Sampling, CRS handling, and pixel decoding are shared with `RS_Value` via
+//! [`crate::sampling`]; this module only adds the per-sub-point iteration and the
+//! list-shaped output.
+//!
+//! Like `RS_Value`, the function is tagged [`NEEDS_PIXELS_METADATA_KEY`] so the
+//! planner materialises the raster InDb before a kernel runs, and only 2-D
+//! rasters are supported.
+
+use std::sync::Arc;
+
+use arrow_array::builder::{Float64Builder, ListBuilder};
+use arrow_schema::{DataType, Field};
+use datafusion_common::cast::as_int32_array;
+use datafusion_common::{exec_datafusion_err, exec_err, Result};
+use datafusion_expr::{ColumnarValue, Volatility};
+use geo_traits::{CoordTrait, GeometryTrait, GeometryType, MultiPointTrait, PointTrait};
+use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
+use sedona_proj::transform::with_global_proj_engine;
+use sedona_raster::affine_transformation::AffineMatrix;
+use sedona_raster::traits::{NdBuffer, RasterRef};
+use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
+use wkb::reader::read_wkb;
+
+use crate::crs_utils::resolve_crs;
+use crate::executor::RasterExecutor;
+use crate::rs_ensure_loaded::NEEDS_PIXELS_METADATA_KEY;
+use crate::sampling::{int32_array_arg, next_band, read_pixel, reproject_wkb, xy_to_pixel};
+
+/// The `List<Float64>` output type, matching what a default
+/// `ListBuilder<Float64Builder>` produces (field "item", nullable).
+fn list_float64_type() -> DataType {
+    DataType::List(Arc::new(Field::new("item", DataType::Float64, true)))
+}
+
+/// `RS_Values()` scalar UDF — sample pixel values at each point of a MultiPoint.
+pub fn rs_values_udf() -> SedonaScalarUDF {
+    SedonaScalarUDF::new(
+        "rs_values",
+        vec![
+            Arc::new(RsValues { with_band: false }), // RS_Values(raster, points)
+            Arc::new(RsValues { with_band: true }),  // RS_Values(raster, points, band)
+        ],
+        Volatility::Immutable,
+    )
+    // The kernels read pixel bytes, so the raster argument must be materialised
+    // InDb first; the planner injects RS_EnsureLoaded based on this flag.
+    .with_metadata(NEEDS_PIXELS_METADATA_KEY, "true")
+}
+
+/// Kernel for `RS_Values(raster, points[, band])`.
+#[derive(Debug)]
+struct RsValues {
+    with_band: bool,
+}
+
+impl SedonaScalarKernel for RsValues {
+    fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
+        let mut matchers = vec![
+            ArgMatcher::is_raster(),
+            ArgMatcher::is_geometry_or_geography(),
+        ];
+        if self.with_band {
+            matchers.push(ArgMatcher::is_integer());
+        }
+        let matcher = ArgMatcher::new(matchers, SedonaType::Arrow(list_float64_type()));
+        matcher.match_args(args)
+    }
+
+    fn invoke_batch(
+        &self,
+        arg_types: &[SedonaType],
+        args: &[ColumnarValue],
+    ) -> Result<ColumnarValue> {
+        let executor = RasterExecutor::new(arg_types, args);
+        let num_iterations = executor.num_iterations();
+        let mut list_builder = ListBuilder::new(Float64Builder::new());
+
+        // The optional band argument, materialised once as an Int32 array. Held
+        // as an `ArrayRef` so the typed view below borrows it instead of cloning
+        // the typed `Int32Array`.
+        let band_arr = if self.with_band {
+            Some(int32_array_arg(&args[2], num_iterations)?)
+        } else {
+            None
+        };
+        let band_array = band_arr.as_ref().map(|a| as_int32_array(a)).transpose()?;
+        let mut band_iter = band_array.map(|a| a.iter());
+
+        // Reprojecting the points into the raster CRS needs a PROJ engine.
+        with_global_proj_engine(|engine| {
+            executor.execute_raster_wkb_crs_void(|raster_opt, wkb_opt, geom_crs| {
+                let (raster, geom_wkb, band_num) =
+                    match (raster_opt, wkb_opt, next_band(&mut band_iter)) {
+                        (Some(raster), Some(geom_wkb), Some(band_num)) => {
+                            (raster, geom_wkb, band_num)
+                        }
+                        // A NULL raster, geometry, or band yields a NULL row.
+                        _ => {
+                            list_builder.append_null();
+                            return Ok(());
+                        }
+                    };
+
+                // Resolve the band buffer, nodata, and affine transform once for
+                // this row, then sample every sub-point against them.
+                let raster_crs = resolve_crs(raster.crs())?;
+                let band = raster
+                    .bands()
+                    .band(band_num)
+                    .map_err(|e| exec_datafusion_err!("RS_Values: {e}"))?;
+                if !band.is_spatial_2d() {
+                    return exec_err!(
+                        "RS_Values supports 2-D rasters only; band is not a 2-D (y, x) grid"
+                    );
+                }
+                let buffer = band
+                    .nd_buffer()
+                    .map_err(|e| exec_datafusion_err!("RS_Values: {e}"))?;
+                let nodata = band
+                    .nodata_as_f64()
+                    .map_err(|e| exec_datafusion_err!("RS_Values: {e}"))?;
+                let affine = AffineMatrix::from_metadata(&raster.metadata());
+
+                // Reproject the whole geometry into the raster CRS (a no-op that
+                // borrows the original bytes when the CRSes match or are absent).
+                let reprojected = reproject_wkb(geom_wkb, geom_crs, raster_crs.as_deref(), engine)?;
+                let effective = reprojected.as_deref().unwrap_or(geom_wkb);
+
+                sample_points_into_list(effective, &affine, &buffer, nodata, &mut list_builder)?;
+                list_builder.append(true);
+                Ok(())
+            })
+        })?;
+
+        executor.finish(Arc::new(list_builder.finish()))
+    }
+}
+
+/// Sample each sub-point of a Point/MultiPoint WKB into one list row.
+///
+/// The WKB is assumed to already be in the raster's CRS (reprojected by the
+/// caller). Each sub-point contributes one list element: its sampled value, or
+/// `NULL` when the sub-point is empty, non-finite, out of bounds, or nodata. A
+/// non-Point/MultiPoint geometry is an error.
+fn sample_points_into_list(
+    wkb: &[u8],
+    affine: &AffineMatrix,
+    buffer: &NdBuffer,
+    nodata: Option<f64>,
+    list_builder: &mut ListBuilder<Float64Builder>,
+) -> Result<()> {
+    let geom = read_wkb(wkb).map_err(|e| exec_datafusion_err!("RS_Values: {e}"))?;
+    match geom.as_type() {
+        GeometryType::Point(point) => {
+            let xy = point.coord().map(|c| (c.x(), c.y()));
+            append_sample(xy, affine, buffer, nodata, list_builder)?;
+        }
+        GeometryType::MultiPoint(multi_point) => {
+            for point in multi_point.points() {
+                let xy = point.coord().map(|c| (c.x(), c.y()));
+                append_sample(xy, affine, buffer, nodata, list_builder)?;
+            }
+        }
+        _ => return exec_err!("RS_Values expects a Point or MultiPoint geometry"),
+    }
+    Ok(())
+}
+
+/// Append one sampled value (or NULL) to the current list row for a sub-point's
+/// `(x, y)` in the raster CRS. `None` coordinates (an empty sub-point) and
+/// out-of-bounds/nodata pixels both append a NULL element.
+fn append_sample(
+    xy: Option<(f64, f64)>,
+    affine: &AffineMatrix,
+    buffer: &NdBuffer,
+    nodata: Option<f64>,
+    list_builder: &mut ListBuilder<Float64Builder>,
+) -> Result<()> {
+    let sample = match xy {
+        Some((x, y)) => match xy_to_pixel(affine, x, y)? {
+            Some((col, row)) => read_pixel(buffer, nodata, col, row)?,
+            None => None,
+        },
+        None => None,
+    };
+    match sample {
+        Some(value) => list_builder.values().append_value(value),
+        None => list_builder.values().append_null(),
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::{Array, Float64Array, Int32Array, ListArray};
+    use datafusion_expr::ScalarUDF;
+    use sedona_schema::crs::lnglat;
+    use sedona_schema::datatypes::{Edges, RASTER};
+    use sedona_schema::raster::BandDataType;
+    use sedona_testing::create::create_array as create_geom_array;
+    use sedona_testing::raster_spec::RasterSpec;
+    use sedona_testing::rasters::generate_test_rasters;
+    use sedona_testing::testers::ScalarUdfTester;
+
+    /// North-up 2x2 raster, origin (0, 10), 1x1 pixels, band values row-major
+    /// `[1, 2, 3, 4]` (row0 = [1, 2], row1 = [3, 4]). Pixel (0, 0) covers world
+    /// x∈[0,1), y∈[9,10) and holds 1; pixel (1, 1) holds 4.
+    fn raster_2x2() -> RasterSpec {
+        RasterSpec::d2(2, 2)
+            .band_values(&[1u8, 2, 3, 4])
+            .transform([0.0, 1.0, 0.0, 10.0, 0.0, -1.0])
+    }
+
+    /// Extract one list row as a `Vec<Option<f64>>`.
+    fn row(result: &dyn Array, i: usize) -> Vec<Option<f64>> {
+        let list = result.as_any().downcast_ref::<ListArray>().unwrap();
+        let values = list.value(i);
+        let values = values.as_any().downcast_ref::<Float64Array>().unwrap();
+        (0..values.len())
+            .map(|j| (!values.is_null(j)).then(|| values.value(j)))
+            .collect()
+    }
+
+    #[test]
+    fn udf_metadata() {
+        let udf: ScalarUDF = rs_values_udf().into();
+        assert_eq!(udf.name(), "rs_values");
+    }
+
+    #[test]
+    fn udf_marks_needs_pixels() {
+        assert_eq!(
+            rs_values_udf()
+                .metadata()
+                .get(NEEDS_PIXELS_METADATA_KEY)
+                .map(String::as_str),
+            Some("true")
+        );
+    }
+
+    #[test]
+    fn return_type_is_list_float64() {
+        let return_type = RsValues { with_band: false }
+            .return_type(&[RASTER, SedonaType::Wkb(Edges::Planar, lnglat())])
+            .unwrap();
+        assert_eq!(return_type, Some(SedonaType::Arrow(list_float64_type())));
+    }
+
+    #[test]
+    fn multipoint_samples_each_point_in_order() {
+        let udf: ScalarUDF = rs_values_udf().into();
+        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
+        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
+
+        // Pixel (0,0)=1, pixel (1,1)=4, and a point far outside -> NULL element.
+        let geoms = create_geom_array(
+            &[Some("MULTIPOINT (0.5 9.5, 1.5 8.5, 100 100)")],
+            &geom_type,
+        );
+        let result = tester
+            .invoke_arrays(vec![Arc::new(raster_2x2().build()), geoms])
+            .unwrap();
+        assert_eq!(row(&result, 0), vec![Some(1.0), Some(4.0), None]);
+    }
+
+    #[test]
+    fn single_point_yields_one_element_list() {
+        // A plain Point is accepted and produces a one-element list.
+        let udf: ScalarUDF = rs_values_udf().into();
+        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
+        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
+
+        let geoms = create_geom_array(&[Some("POINT (1.5 8.5)")], &geom_type);
+        let result = tester
+            .invoke_arrays(vec![Arc::new(raster_2x2().build()), geoms])
+            .unwrap();
+        assert_eq!(row(&result, 0), vec![Some(4.0)]);
+    }
+
+    #[test]
+    fn empty_multipoint_yields_empty_list() {
+        let udf: ScalarUDF = rs_values_udf().into();
+        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
+        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
+
+        let geoms = create_geom_array(&[Some("MULTIPOINT EMPTY")], &geom_type);
+        let result = tester
+            .invoke_arrays(vec![Arc::new(raster_2x2().build()), geoms])
+            .unwrap();
+        let list = result.as_any().downcast_ref::<ListArray>().unwrap();
+        assert!(
+            !list.is_null(0),
+            "empty MultiPoint is an empty list, not NULL"
+        );
+        assert_eq!(row(&result, 0), Vec::<Option<f64>>::new());
+    }
+
+    #[test]
+    fn nodata_element_is_null() {
+        let udf: ScalarUDF = rs_values_udf().into();
+        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
+        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
+
+        // Band [1, 2, 3, 4] with nodata=4: sampling pixel (1,1) reads nodata.
+        let raster = RasterSpec::d2(2, 2)
+            .band_values(&[1u8, 2, 3, 4])
+            .nodata(4u8)
+            .transform([0.0, 1.0, 0.0, 10.0, 0.0, -1.0])
+            .build();
+        let geoms = create_geom_array(&[Some("MULTIPOINT (0.5 9.5, 1.5 8.5)")], &geom_type);
+        let result = tester.invoke_arrays(vec![Arc::new(raster), geoms]).unwrap();
+        assert_eq!(row(&result, 0), vec![Some(1.0), None]);
+    }
+
+    #[test]
+    fn null_geometry_yields_null_list() {
+        let udf: ScalarUDF = rs_values_udf().into();
+        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
+        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
+
+        let geoms = create_geom_array(&[None], &geom_type);
+        let result = tester
+            .invoke_arrays(vec![Arc::new(raster_2x2().build()), geoms])
+            .unwrap();
+        let list = result.as_any().downcast_ref::<ListArray>().unwrap();
+        assert!(list.is_null(0));
+    }
+
+    #[test]
+    fn null_band_element_yields_null_list() {
+        let udf: ScalarUDF = rs_values_udf().into();
+        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
+        let tester = ScalarUdfTester::new(
+            udf,
+            vec![
+                RASTER,
+                geom_type.clone(),
+                SedonaType::Arrow(DataType::Int32),
+            ],
+        );
+
+        let geoms = create_geom_array(&[Some("MULTIPOINT (0.5 9.5)")], &geom_type);
+        let bands: arrow_array::ArrayRef = Arc::new(Int32Array::from(vec![None::<i32>]));
+        let result = tester
+            .invoke_arrays(vec![Arc::new(raster_2x2().build()), geoms, bands])
+            .unwrap();
+        let list = result.as_any().downcast_ref::<ListArray>().unwrap();
+        assert!(list.is_null(0));
+    }
+
+    #[test]
+    fn second_band_is_addressable() {
+        let udf: ScalarUDF = rs_values_udf().into();
+        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
+        let tester = ScalarUdfTester::new(
+            udf,
+            vec![
+                RASTER,
+                geom_type.clone(),
+                SedonaType::Arrow(DataType::Int32),
+            ],
+        );
+
+        // Band 1 [1,2,3,4], band 2 [10,20,30,40]; sample band 2 at pixel (0,0).
+        let raster = RasterSpec::d2(2, 2)
+            .band_values(&[1u8, 2, 3, 4])
+            .band_values(&[10u8, 20, 30, 40])
+            .transform([0.0, 1.0, 0.0, 10.0, 0.0, -1.0])
+            .build();
+        let geoms = create_geom_array(&[Some("MULTIPOINT (0.5 9.5)")], &geom_type);
+        let bands: arrow_array::ArrayRef = Arc::new(Int32Array::from(vec![Some(2)]));
+        let result = tester
+            .invoke_arrays(vec![Arc::new(raster), geoms, bands])
+            .unwrap();
+        assert_eq!(row(&result, 0), vec![Some(10.0)]);
+    }
+
+    #[test]
+    fn non_point_geometry_errors() {
+        let udf: ScalarUDF = rs_values_udf().into();
+        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
+        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
+
+        let geoms = create_geom_array(&[Some("LINESTRING (0 0, 1 1)")], &geom_type);
+        let err = tester
+            .invoke_arrays(vec![
+                Arc::new(generate_test_rasters(1, None).unwrap()),
+                geoms,
+            ])
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("expects a Point or MultiPoint"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn crs_mismatch_errors() {
+        // Raster has a CRS (generate_test_rasters sets OGC:CRS84), points do not.
+        let udf: ScalarUDF = rs_values_udf().into();
+        let geom_type = SedonaType::Wkb(Edges::Planar, None);
+        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
+        let rasters = generate_test_rasters(1, None).unwrap();
+        let geoms = create_geom_array(&[Some("MULTIPOINT (2.1 2.6)")], &geom_type);
+        let err = tester
+            .invoke_arrays(vec![Arc::new(rasters), geoms])
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("raster has a CRS but the point does not"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn non_2d_band_errors() {
+        let udf: ScalarUDF = rs_values_udf().into();
+        let geom_type = SedonaType::Wkb(Edges::Planar, None);
+        let tester = ScalarUdfTester::new(udf, vec![RASTER, geom_type.clone()]);
+        let raster = RasterSpec::nd(&["time", "y", "x"], &[2, 2, 1])
+            .band(BandDataType::UInt8)
+            .crs(None)
+            .build();
+        let geoms = create_geom_array(&[Some("MULTIPOINT (0 0)")], &geom_type);
+        let err = tester
+            .invoke_arrays(vec![Arc::new(raster), geoms])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("2-D"), "unexpected error: {err}");
+    }
+}

--- a/rust/sedona-raster-functions/src/sampling.rs
+++ b/rust/sedona-raster-functions/src/sampling.rs
@@ -90,7 +90,10 @@ pub(crate) fn default_band(func: &str, num_bands: usize) -> Result<usize> {
 /// defined in — so there is no neutral CRS to fall back to: a WGS84 pivot would
 /// silently sample the wrong pixel rather than compare geometries in a shared
 /// space.
+///
+/// `func` names the calling UDF for the error messages.
 pub(crate) fn reproject_wkb(
+    func: &str,
     wkb: &[u8],
     geom_crs: CrsRef<'_>,
     raster_crs: CrsRef<'_>,
@@ -105,8 +108,8 @@ pub(crate) fn reproject_wkb(
             }
         }
         (None, None) => Ok(None),
-        (Some(_), None) => exec_err!("point has a CRS but the raster does not"),
-        (None, Some(_)) => exec_err!("raster has a CRS but the point does not"),
+        (Some(_), None) => exec_err!("{func}: geometry has a CRS but the raster does not"),
+        (None, Some(_)) => exec_err!("{func}: raster has a CRS but the geometry does not"),
     }
 }
 
@@ -118,8 +121,10 @@ pub(crate) fn reproject_wkb(
 ///
 /// Errors when exactly one side carries a CRS. Hoisting this out of the per-row
 /// loop avoids a per-row `crs_equals`, whose `to_authority_code()` allocates a
-/// `String` every call (~15 ns/row, uniform across CRS types).
+/// `String` every call (~15 ns/row, uniform across CRS types). `func` names the
+/// calling UDF for the error messages.
 pub(crate) fn column_reproject_decision(
+    func: &str,
     geom_type: &SedonaType,
     raster_crs: CrsRef<'_>,
 ) -> Result<Option<bool>> {
@@ -131,8 +136,8 @@ pub(crate) fn column_reproject_decision(
     match (geom_crs, raster_crs) {
         (Some(p), Some(r)) => Ok(Some(!p.crs_equals(r))),
         (None, None) => Ok(Some(false)),
-        (Some(_), None) => exec_err!("point has a CRS but the raster does not"),
-        (None, Some(_)) => exec_err!("raster has a CRS but the point does not"),
+        (Some(_), None) => exec_err!("{func}: geometry has a CRS but the raster does not"),
+        (None, Some(_)) => exec_err!("{func}: raster has a CRS but the geometry does not"),
     }
 }
 
@@ -142,14 +147,20 @@ pub(crate) fn column_reproject_decision(
 /// A non-finite coordinate (e.g. `POINT(NaN 5)`) returns `None`: without this
 /// guard a NaN would survive `inv_transform` and the saturating `f64 -> i64`
 /// cast would turn it into 0 (in bounds), silently sampling pixel column 0
-/// rather than yielding NULL.
-pub(crate) fn xy_to_pixel(affine: &AffineMatrix, x: f64, y: f64) -> Result<Option<(i64, i64)>> {
+/// rather than yielding NULL. `func` names the calling UDF for the error
+/// message.
+pub(crate) fn xy_to_pixel(
+    func: &str,
+    affine: &AffineMatrix,
+    x: f64,
+    y: f64,
+) -> Result<Option<(i64, i64)>> {
     if !x.is_finite() || !y.is_finite() {
         return Ok(None);
     }
     let (raster_x, raster_y) = affine
         .inv_transform(x, y)
-        .map_err(|e| exec_datafusion_err!("raster sampling: {e}"))?;
+        .map_err(|e| exec_datafusion_err!("{func}: {e}"))?;
     // Floor (not truncate toward zero) so a point just outside the top/left edge
     // maps to a negative index and is rejected as out of bounds, rather than
     // truncating to 0 and sampling an edge pixel. The `f64 -> i64` cast saturates
@@ -164,8 +175,10 @@ pub(crate) fn xy_to_pixel(affine: &AffineMatrix, x: f64, y: f64) -> Result<Optio
 /// points from one buffer without re-resolving per point.
 ///
 /// Reads exactly one pixel by computing its byte offset from the band's strides
-/// — zero-copy and O(1), no whole-band materialisation.
+/// — zero-copy and O(1), no whole-band materialisation. `func` names the
+/// calling UDF for the error messages.
 pub(crate) fn read_pixel(
+    func: &str,
     buffer: &NdBuffer,
     nodata: Option<f64>,
     col: i64,
@@ -186,24 +199,25 @@ pub(crate) fn read_pixel(
         .zip(col.checked_mul(buffer.strides[1]))
         .and_then(|(r, c)| r.checked_add(c))
         .and_then(|rc| rc.checked_add(buffer.offset as i64))
-        .ok_or_else(|| exec_datafusion_err!("raster sampling: pixel byte offset overflow"))?;
+        .ok_or_else(|| exec_datafusion_err!("{func}: pixel byte offset overflow"))?;
     let end_offset = byte_offset
         .checked_add(size)
-        .ok_or_else(|| exec_datafusion_err!("raster sampling: pixel byte offset overflow"))?;
+        .ok_or_else(|| exec_datafusion_err!("{func}: pixel byte offset overflow"))?;
     let start = usize::try_from(byte_offset)
-        .map_err(|_| exec_datafusion_err!("raster sampling: negative pixel byte offset"))?;
+        .map_err(|_| exec_datafusion_err!("{func}: negative pixel byte offset"))?;
     let end = usize::try_from(end_offset)
-        .map_err(|_| exec_datafusion_err!("raster sampling: pixel byte offset overflow"))?;
-    let bytes = buffer.buffer.get(start..end).ok_or_else(|| {
-        exec_datafusion_err!("raster sampling: pixel is out of the band's buffer bounds")
-    })?;
+        .map_err(|_| exec_datafusion_err!("{func}: pixel byte offset overflow"))?;
+    let bytes = buffer
+        .buffer
+        .get(start..end)
+        .ok_or_else(|| exec_datafusion_err!("{func}: pixel is out of the band's buffer bounds"))?;
 
     // Decode the pixel to f64. The lossless converter errors (rather than
     // silently rounding) on Int64/UInt64 values beyond f64's exact-integer
     // range (2^53) — the value functions return a Double, so such a pixel can't
     // be represented faithfully; failing loudly is preferred over a wrong value.
     let value = nodata_bytes_to_f64_lossless(bytes, &buffer.data_type)
-        .map_err(|e| exec_datafusion_err!("raster sampling: {e}"))?;
+        .map_err(|e| exec_datafusion_err!("{func}: {e}"))?;
 
     if let Some(nodata) = nodata {
         if value == nodata || (value.is_nan() && nodata.is_nan()) {

--- a/rust/sedona-raster-functions/src/sampling.rs
+++ b/rust/sedona-raster-functions/src/sampling.rs
@@ -1,0 +1,199 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Point-sampling primitives shared by the raster value functions
+//! (`RS_Value`, `RS_Values`).
+//!
+//! These helpers turn a geometry coordinate into a pixel read against a band's
+//! [`NdBuffer`](sedona_raster::traits::NdBuffer): reprojecting into the raster's
+//! CRS, mapping a world coordinate to a `(col, row)` index, and decoding the one
+//! pixel there. They are geometry-shape agnostic — `RS_Value` drives them with a
+//! single Point, `RS_Values` with each sub-point of a MultiPoint — so the pixel
+//! math and CRS handling live in exactly one place.
+
+use arrow_array::ArrayRef;
+use arrow_schema::DataType;
+use datafusion_common::{exec_datafusion_err, exec_err, Result};
+use datafusion_expr::ColumnarValue;
+use sedona_raster::affine_transformation::AffineMatrix;
+use sedona_raster::traits::{nodata_bytes_to_f64_lossless, NdBuffer};
+use sedona_schema::crs::CrsRef;
+use sedona_schema::datatypes::SedonaType;
+
+use crate::crs_utils::crs_transform_wkb;
+
+/// Materialise an integer argument as an owned `Int32` [`ArrayRef`] for the
+/// batch. Callers keep the returned `ArrayRef` alive and borrow a typed
+/// `&Int32Array` view from it (via `as_int32_array`) rather than cloning the
+/// typed array.
+pub(crate) fn int32_array_arg(arg: &ColumnarValue, num_iterations: usize) -> Result<ArrayRef> {
+    arg.clone()
+        .cast_to(&DataType::Int32, None)?
+        .into_array(num_iterations)
+}
+
+/// Advance the optional band-number iterator one row, yielding the 1-based band
+/// to sample. A missing band argument defaults to band 1; a NULL band element
+/// returns `None`, which the caller propagates to a NULL result. Band 0 and
+/// negative values map to 0 so [`Bands::band`](sedona_raster::traits::Bands::band)
+/// rejects them as not 1-based rather than being silently coerced.
+pub(crate) fn next_band(
+    band_iter: &mut Option<arrow_array::iterator::ArrayIter<&arrow_array::Int32Array>>,
+) -> Option<usize> {
+    match band_iter.as_mut() {
+        None => Some(1),
+        Some(iter) => iter.next().flatten().map(|b| b.max(0) as usize),
+    }
+}
+
+/// Reproject `wkb` from its CRS into the raster CRS, returning the transformed
+/// WKB only when a reprojection actually happened (so the caller can sample the
+/// original bytes otherwise — no allocation in the common case).
+///
+/// Errors if exactly one of the geometry / raster carries a CRS: sampling across
+/// a known and an unknown CRS would silently mislocate the geometry.
+///
+/// Unlike the spatial predicates (`RS_Intersects` et al.), which fall back to a
+/// WGS84 pivot when a direct transform between two CRSes fails, a failed
+/// transform here is propagated as an error. Sampling has to land the geometry
+/// in the raster's own CRS — that is the only space its affine/pixel grid is
+/// defined in — so there is no neutral CRS to fall back to: a WGS84 pivot would
+/// silently sample the wrong pixel rather than compare geometries in a shared
+/// space.
+pub(crate) fn reproject_wkb(
+    wkb: &[u8],
+    geom_crs: CrsRef<'_>,
+    raster_crs: CrsRef<'_>,
+    engine: &dyn sedona_geometry::transform::CrsEngine,
+) -> Result<Option<Vec<u8>>> {
+    match (geom_crs, raster_crs) {
+        (Some(geom_crs), Some(raster_crs)) => {
+            if geom_crs.crs_equals(raster_crs) {
+                Ok(None)
+            } else {
+                Ok(Some(crs_transform_wkb(wkb, geom_crs, raster_crs, engine)?))
+            }
+        }
+        (None, None) => Ok(None),
+        (Some(_), None) => exec_err!("point has a CRS but the raster does not"),
+        (None, Some(_)) => exec_err!("raster has a CRS but the point does not"),
+    }
+}
+
+/// For a **column-level** geometry CRS, decide once whether sampling needs a
+/// reprojection into the raster CRS:
+/// - `Some(true)`  — CRSes differ, reproject each geometry;
+/// - `Some(false)` — CRSes match (or both absent), sample original coordinates;
+/// - `None`        — the geometry CRS is carried per row, so decide per row.
+///
+/// Errors when exactly one side carries a CRS. Hoisting this out of the per-row
+/// loop avoids a per-row `crs_equals`, whose `to_authority_code()` allocates a
+/// `String` every call (~15 ns/row, uniform across CRS types).
+pub(crate) fn column_reproject_decision(
+    geom_type: &SedonaType,
+    raster_crs: CrsRef<'_>,
+) -> Result<Option<bool>> {
+    let geom_crs = match geom_type {
+        SedonaType::Wkb(_, c) | SedonaType::WkbView(_, c) => c.as_deref(),
+        // A per-item CRS varies by row; the caller decides per row.
+        _ => return Ok(None),
+    };
+    match (geom_crs, raster_crs) {
+        (Some(p), Some(r)) => Ok(Some(!p.crs_equals(r))),
+        (None, None) => Ok(Some(false)),
+        (Some(_), None) => exec_err!("point has a CRS but the raster does not"),
+        (None, Some(_)) => exec_err!("raster has a CRS but the point does not"),
+    }
+}
+
+/// Map a coordinate in the raster's CRS to a 0-based `(col, row)` pixel index,
+/// or `None` when the coordinate has no location to sample.
+///
+/// A non-finite coordinate (e.g. `POINT(NaN 5)`) returns `None`: without this
+/// guard a NaN would survive `inv_transform` and the saturating `f64 -> i64`
+/// cast would turn it into 0 (in bounds), silently sampling pixel column 0
+/// rather than yielding NULL.
+pub(crate) fn xy_to_pixel(affine: &AffineMatrix, x: f64, y: f64) -> Result<Option<(i64, i64)>> {
+    if !x.is_finite() || !y.is_finite() {
+        return Ok(None);
+    }
+    let (raster_x, raster_y) = affine
+        .inv_transform(x, y)
+        .map_err(|e| exec_datafusion_err!("raster sampling: {e}"))?;
+    // Floor (not truncate toward zero) so a point just outside the top/left edge
+    // maps to a negative index and is rejected as out of bounds, rather than
+    // truncating to 0 and sampling an edge pixel. The `f64 -> i64` cast saturates
+    // (never panics); the bounds check in `read_pixel` rejects an out-of-range
+    // index as NULL.
+    Ok(Some((raster_x.floor() as i64, raster_y.floor() as i64)))
+}
+
+/// Read pixel `(col, row)` from an already-resolved band buffer and nodata
+/// value. Returns `None` for an out-of-bounds pixel or one that equals nodata.
+/// Resolving the band once and calling this per point lets a caller sample many
+/// points from one buffer without re-resolving per point.
+///
+/// Reads exactly one pixel by computing its byte offset from the band's strides
+/// — zero-copy and O(1), no whole-band materialisation.
+pub(crate) fn read_pixel(
+    buffer: &NdBuffer,
+    nodata: Option<f64>,
+    col: i64,
+    row: i64,
+) -> Result<Option<f64>> {
+    let (height, width) = (buffer.shape[0], buffer.shape[1]);
+    if row < 0 || row >= height || col < 0 || col >= width {
+        return Ok(None);
+    }
+
+    // Byte offset of the (row, col) pixel via the band's own strides, so the
+    // read stays correct for any layout the producer hands us. Checked
+    // arithmetic throughout: `row`/`col` are already in bounds, but a corrupt
+    // stride or offset must surface as an error, never an i64 overflow panic.
+    let size = buffer.data_type.byte_size() as i64;
+    let byte_offset = row
+        .checked_mul(buffer.strides[0])
+        .zip(col.checked_mul(buffer.strides[1]))
+        .and_then(|(r, c)| r.checked_add(c))
+        .and_then(|rc| rc.checked_add(buffer.offset as i64))
+        .ok_or_else(|| exec_datafusion_err!("raster sampling: pixel byte offset overflow"))?;
+    let end_offset = byte_offset
+        .checked_add(size)
+        .ok_or_else(|| exec_datafusion_err!("raster sampling: pixel byte offset overflow"))?;
+    let start = usize::try_from(byte_offset)
+        .map_err(|_| exec_datafusion_err!("raster sampling: negative pixel byte offset"))?;
+    let end = usize::try_from(end_offset)
+        .map_err(|_| exec_datafusion_err!("raster sampling: pixel byte offset overflow"))?;
+    let bytes = buffer.buffer.get(start..end).ok_or_else(|| {
+        exec_datafusion_err!("raster sampling: pixel is out of the band's buffer bounds")
+    })?;
+
+    // Decode the pixel to f64. The lossless converter errors (rather than
+    // silently rounding) on Int64/UInt64 values beyond f64's exact-integer
+    // range (2^53) — the value functions return a Double, so such a pixel can't
+    // be represented faithfully; failing loudly is preferred over a wrong value.
+    let value = nodata_bytes_to_f64_lossless(bytes, &buffer.data_type)
+        .map_err(|e| exec_datafusion_err!("raster sampling: {e}"))?;
+
+    if let Some(nodata) = nodata {
+        if value == nodata || (value.is_nan() && nodata.is_nan()) {
+            return Ok(None);
+        }
+    }
+
+    Ok(Some(value))
+}

--- a/rust/sedona-raster-functions/src/sampling.rs
+++ b/rust/sedona-raster-functions/src/sampling.rs
@@ -25,16 +25,19 @@
 //! single Point, `RS_Values` with each sub-point of a MultiPoint — so the pixel
 //! math and CRS handling live in exactly one place.
 
+use std::rc::Rc;
+
 use arrow_array::ArrayRef;
 use arrow_schema::DataType;
-use datafusion_common::{exec_datafusion_err, exec_err, Result};
+use datafusion_common::{exec_datafusion_err, exec_err, DataFusionError, Result};
 use datafusion_expr::ColumnarValue;
+use sedona_geometry::error::SedonaGeometryError;
+use sedona_geometry::transform::{visit_point_coords, CrsEngine, CrsTransform};
 use sedona_raster::affine_transformation::AffineMatrix;
 use sedona_raster::traits::{nodata_bytes_to_f64_lossless, NdBuffer};
 use sedona_schema::crs::CrsRef;
 use sedona_schema::datatypes::SedonaType;
-
-use crate::crs_utils::crs_transform_wkb;
+use wkb::reader::read_wkb;
 
 /// Materialise an integer argument as an owned `Int32` [`ArrayRef`] for the
 /// batch. Callers keep the returned `ArrayRef` alive and borrow a typed
@@ -76,12 +79,12 @@ pub(crate) fn default_band(func: &str, num_bands: usize) -> Result<usize> {
     }
 }
 
-/// Reproject `wkb` from its CRS into the raster CRS, returning the transformed
-/// WKB only when a reprojection actually happened (so the caller can sample the
-/// original bytes otherwise — no allocation in the common case).
+/// Resolve the coordinate transform that lands a geometry in the raster's
+/// CRS, or `None` when the coordinates can be sampled as-is (equal CRSes, or
+/// both absent).
 ///
-/// Errors if exactly one of the geometry / raster carries a CRS: sampling across
-/// a known and an unknown CRS would silently mislocate the geometry.
+/// Errors if exactly one of the geometry / raster carries a CRS: sampling
+/// across a known and an unknown CRS would silently mislocate the geometry.
 ///
 /// Unlike the spatial predicates (`RS_Intersects` et al.), which fall back to a
 /// WGS84 pivot when a direct transform between two CRSes fails, a failed
@@ -92,19 +95,26 @@ pub(crate) fn default_band(func: &str, num_bands: usize) -> Result<usize> {
 /// space.
 ///
 /// `func` names the calling UDF for the error messages.
-pub(crate) fn reproject_wkb(
+pub(crate) fn point_crs_transform(
     func: &str,
-    wkb: &[u8],
     geom_crs: CrsRef<'_>,
     raster_crs: CrsRef<'_>,
-    engine: &dyn sedona_geometry::transform::CrsEngine,
-) -> Result<Option<Vec<u8>>> {
+    engine: &dyn CrsEngine,
+) -> Result<Option<Rc<dyn CrsTransform>>> {
     match (geom_crs, raster_crs) {
         (Some(geom_crs), Some(raster_crs)) => {
             if geom_crs.crs_equals(raster_crs) {
                 Ok(None)
             } else {
-                Ok(Some(crs_transform_wkb(wkb, geom_crs, raster_crs, engine)?))
+                engine
+                    .get_transform_crs_to_crs(
+                        &geom_crs.to_crs_string(),
+                        &raster_crs.to_crs_string(),
+                        None,
+                        "",
+                    )
+                    .map(Some)
+                    .map_err(|e| exec_datafusion_err!("{func}: CRS transform error: {e}"))
             }
         }
         (None, None) => Ok(None),
@@ -113,32 +123,56 @@ pub(crate) fn reproject_wkb(
     }
 }
 
-/// For a **column-level** geometry CRS, decide once whether sampling needs a
-/// reprojection into the raster CRS:
-/// - `Some(true)`  — CRSes differ, reproject each geometry;
-/// - `Some(false)` — CRSes match (or both absent), sample original coordinates;
-/// - `None`        — the geometry CRS is carried per row, so decide per row.
+/// For a **column-level** geometry CRS, resolve the raster-CRS transform once
+/// for the whole batch:
+/// - `Some(None)`     — CRSes match (or both absent), sample original coordinates;
+/// - `Some(Some(t))`  — CRSes differ, apply `t` to every geometry;
+/// - `None`           — the geometry CRS is carried per row, so resolve per row.
 ///
 /// Errors when exactly one side carries a CRS. Hoisting this out of the per-row
-/// loop avoids a per-row `crs_equals`, whose `to_authority_code()` allocates a
-/// `String` every call (~15 ns/row, uniform across CRS types). `func` names the
-/// calling UDF for the error messages.
-pub(crate) fn column_reproject_decision(
+/// loop avoids both a per-row `crs_equals` (whose `to_authority_code()`
+/// allocates a `String` every call) and a per-row transform lookup. `func`
+/// names the calling UDF for the error messages.
+#[allow(clippy::type_complexity)]
+pub(crate) fn column_point_crs_transform(
     func: &str,
     geom_type: &SedonaType,
     raster_crs: CrsRef<'_>,
-) -> Result<Option<bool>> {
+    engine: &dyn CrsEngine,
+) -> Result<Option<Option<Rc<dyn CrsTransform>>>> {
     let geom_crs = match geom_type {
         SedonaType::Wkb(_, c) | SedonaType::WkbView(_, c) => c.as_deref(),
-        // A per-item CRS varies by row; the caller decides per row.
+        // A per-item CRS varies by row; the caller resolves per row.
         _ => return Ok(None),
     };
-    match (geom_crs, raster_crs) {
-        (Some(p), Some(r)) => Ok(Some(!p.crs_equals(r))),
-        (None, None) => Ok(Some(false)),
-        (Some(_), None) => exec_err!("{func}: geometry has a CRS but the raster does not"),
-        (None, Some(_)) => exec_err!("{func}: raster has a CRS but the geometry does not"),
-    }
+    point_crs_transform(func, geom_crs, raster_crs, engine).map(Some)
+}
+
+/// Visit each point of a Point/MultiPoint WKB as `Some((x, y))` in the
+/// raster's CRS (`None` for an empty sub-point), applying `trans` to each
+/// coordinate when given.
+///
+/// A thin [`visit_point_coords`] adapter that parses the WKB and threads
+/// DataFusion errors out of the geometry-crate callback (via
+/// `SedonaGeometryError::External`), so callers sample in one pass with no
+/// transformed-WKB materialisation or coordinate scratch buffer.
+pub(crate) fn visit_points(
+    func: &str,
+    wkb: &[u8],
+    trans: Option<&dyn CrsTransform>,
+    mut visit: impl FnMut(Option<(f64, f64)>) -> Result<()>,
+) -> Result<()> {
+    let geom = read_wkb(wkb).map_err(|e| exec_datafusion_err!("{func}: {e}"))?;
+    visit_point_coords(&geom, trans, |xy| {
+        visit(xy).map_err(|e| SedonaGeometryError::External(Box::new(e)))
+    })
+    .map_err(|e| match e {
+        SedonaGeometryError::External(inner) => match inner.downcast::<DataFusionError>() {
+            Ok(df) => *df,
+            Err(other) => exec_datafusion_err!("{func}: {other}"),
+        },
+        other => exec_datafusion_err!("{func}: {other}"),
+    })
 }
 
 /// Map a coordinate in the raster's CRS to a 0-based `(col, row)` pixel index,

--- a/rust/sedona-raster-functions/src/sampling.rs
+++ b/rust/sedona-raster-functions/src/sampling.rs
@@ -60,6 +60,22 @@ pub(crate) fn next_band(
     }
 }
 
+/// Resolve the 1-based band to sample when no band argument was given: band 1
+/// for a single-band raster, otherwise an error. Sampling an unspecified band of
+/// a multiband raster is ambiguous, so the caller must name the band rather than
+/// silently getting band 1 (matches `RS_SetBandNoDataValue`'s 2-argument form).
+/// `func` names the calling UDF for the error message.
+pub(crate) fn default_band(func: &str, num_bands: usize) -> Result<usize> {
+    if num_bands == 1 {
+        Ok(1)
+    } else {
+        exec_err!(
+            "{func}: raster has {num_bands} bands; specify which band to sample (the \
+             2-argument form is only allowed for a single-band raster)"
+        )
+    }
+}
+
 /// Reproject `wkb` from its CRS into the raster CRS, returning the transformed
 /// WKB only when a reprojection actually happened (so the caller can sample the
 /// original bytes otherwise — no allocation in the common case).

--- a/rust/sedona-testing/src/benchmark_util.rs
+++ b/rust/sedona-testing/src/benchmark_util.rs
@@ -20,7 +20,7 @@ use arrow_array::{ArrayRef, Float64Array, Int64Array};
 use arrow_schema::DataType;
 
 use datafusion_common::{exec_datafusion_err, Result, ScalarValue};
-use datafusion_expr::{AggregateUDF, ScalarUDF};
+use datafusion_expr::{AggregateUDF, ColumnarValue, ScalarUDF};
 use geo_types::Rect;
 use rand::{distr::Uniform, rngs::StdRng, Rng, RngExt, SeedableRng};
 
@@ -171,6 +171,8 @@ pub enum BenchmarkArgs {
     ArrayArray(BenchmarkArgSpec, BenchmarkArgSpec),
     /// Invoke a function with an array and two scalar inputs
     ArrayScalarScalar(BenchmarkArgSpec, BenchmarkArgSpec, BenchmarkArgSpec),
+    /// Invoke a ternary function with a scalar, an array, and a scalar input
+    ScalarArrayScalar(BenchmarkArgSpec, BenchmarkArgSpec, BenchmarkArgSpec),
     /// Invoke a ternary function with two arrays and a scalar
     ArrayArrayScalar(BenchmarkArgSpec, BenchmarkArgSpec, BenchmarkArgSpec),
     /// Invoke a ternary function with three arrays
@@ -206,7 +208,8 @@ impl BenchmarkArgs {
             | BenchmarkArgs::ArrayArrayArrayArray(_, _, _, _) => self.specs(),
             BenchmarkArgs::ScalarArray(_, col)
             | BenchmarkArgs::ArrayScalar(col, _)
-            | BenchmarkArgs::ArrayScalarScalar(col, _, _) => {
+            | BenchmarkArgs::ArrayScalarScalar(col, _, _)
+            | BenchmarkArgs::ScalarArrayScalar(_, col, _) => {
                 vec![col.clone()]
             }
         };
@@ -216,7 +219,8 @@ impl BenchmarkArgs {
             | BenchmarkArgs::ArrayArrayScalar(_, _, col) => {
                 vec![col.clone()]
             }
-            BenchmarkArgs::ArrayScalarScalar(_, col0, col1) => {
+            BenchmarkArgs::ArrayScalarScalar(_, col0, col1)
+            | BenchmarkArgs::ScalarArrayScalar(col0, _, col1) => {
                 vec![col0.clone(), col1.clone()]
             }
             _ => vec![],
@@ -251,6 +255,7 @@ impl BenchmarkArgs {
                 vec![col0.clone(), col1.clone()]
             }
             BenchmarkArgs::ArrayScalarScalar(col0, col1, col2)
+            | BenchmarkArgs::ScalarArrayScalar(col0, col1, col2)
             | BenchmarkArgs::ArrayArrayScalar(col0, col1, col2)
             | BenchmarkArgs::ArrayArrayArray(col0, col1, col2) => {
                 vec![col0.clone(), col1.clone(), col2.clone()]
@@ -566,6 +571,17 @@ impl BenchmarkData {
                         scalar0.clone(),
                         scalar1.clone(),
                     )?;
+                }
+            }
+            BenchmarkArgs::ScalarArrayScalar(_, _, _) => {
+                let scalar0 = &self.scalars[0];
+                let scalar1 = &self.scalars[1];
+                for i in 0..self.num_batches {
+                    tester.invoke(vec![
+                        ColumnarValue::Scalar(scalar0.clone()),
+                        ColumnarValue::Array(self.arrays[0][i].clone()),
+                        ColumnarValue::Scalar(scalar1.clone()),
+                    ])?;
                 }
             }
             BenchmarkArgs::ArrayArrayScalar(_, _, _) => {

--- a/rust/sedona-testing/src/create.rs
+++ b/rust/sedona-testing/src/create.rs
@@ -144,6 +144,27 @@ where
         .collect()
 }
 
+/// Build MultiPoint WKB from `Option<(x, y)>` sub-points, where `None` is an
+/// EMPTY sub-point (encoded as a point with NaN ordinates).
+///
+/// Exists because [`make_wkb`]'s WKT parser cannot express an EMPTY sub-point
+/// inside a MultiPoint (see `fixtures::MULTIPOINT_WITH_EMPTY_CHILD_WKB` for the
+/// single-child constant); this builds the same encoding for arbitrary point
+/// lists.
+pub fn make_multipoint_wkb(points: &[Option<(f64, f64)>]) -> Vec<u8> {
+    let mut out = vec![1u8]; // little-endian
+    out.extend(4u32.to_le_bytes()); // MultiPoint
+    out.extend((points.len() as u32).to_le_bytes());
+    for point in points {
+        out.push(1);
+        out.extend(1u32.to_le_bytes()); // Point
+        let (x, y) = point.unwrap_or((f64::NAN, f64::NAN));
+        out.extend(x.to_le_bytes());
+        out.extend(y.to_le_bytes());
+    }
+    out
+}
+
 /// Create a WKB from a WKT string.
 pub fn make_wkb(wkt_value: &str) -> Vec<u8> {
     let geom = Wkt::<f64>::from_str(wkt_value).unwrap();

--- a/rust/sedona-testing/src/raster_spec.rs
+++ b/rust/sedona-testing/src/raster_spec.rs
@@ -227,6 +227,23 @@ impl RasterSpec {
         self
     }
 
+    /// Set a north-up (zero-skew) geotransform from the raster's world-space
+    /// bounding box: the pixel grid spans `[xmin, xmax] x [ymin, ymax]`
+    /// exactly, so pixel (0, 0) is the top-left cell under `ymax`.
+    ///
+    /// A bbox is usually much easier to picture in a test than raw
+    /// geotransform coefficients.
+    pub fn bbox(self, xmin: f64, ymin: f64, xmax: f64, ymax: f64) -> Self {
+        assert!(
+            xmax > xmin && ymax > ymin,
+            "bbox requires xmin < xmax and ymin < ymax, got [{xmin}, {ymin}, {xmax}, {ymax}]"
+        );
+        let (width, height) = (self.spatial_shape[0] as f64, self.spatial_shape[1] as f64);
+        let scale_x = (xmax - xmin) / width;
+        let scale_y = -(ymax - ymin) / height;
+        self.transform([xmin, scale_x, 0.0, ymax, 0.0, scale_y])
+    }
+
     /// Add a band with the spec's default layout and sequential pixel values
     /// (0, 1, 2, … in `data_type`).
     pub fn band(self, data_type: BandDataType) -> Self {


### PR DESCRIPTION
`RS_Values(raster, points [, band]) -> List<Double>` — the plural of `RS_Value`, sampling one pixel per point.

The points are carried as a **MultiPoint** (a bare Point is also accepted), diverging from Sedona's `RS_Values(raster, Array<Geometry>)`: `SedonaType` has no `List<geometry>` representation, so the array-of-geometry signature would need new type-system plumbing. This keeps the first cut self-contained; the canonical signature can follow.

Sampling, CRS handling, and pixel decoding are shared with `RS_Value` via a new `sampling` module rather than duplicated.

> [!IMPORTANT]
> **Behavior change to `RS_Value`:** the 2-argument form `RS_Value(raster, point)` used to silently sample band 1 on a multiband raster; it now raises `raster has N bands; specify which band to sample`. This diverges from Sedona Spark and PostGIS `ST_Value` (which default to band 1 unconditionally) in favor of the convention set by `RS_SetBandNoDataValue`'s 2-argument form: omitting the band is only unambiguous on a single-band raster. Queries hitting the new error should pass the band explicitly, e.g. `RS_Value(raster, point, 1)`.
