### PR TITLE
test(rust/sedona-raster-gdal): make RS_Polygonize float assertion GDAL-version tolerant

### DIFF
--- a/rust/sedona-raster-gdal/src/rs_polygonize.rs
+++ b/rust/sedona-raster-gdal/src/rs_polygonize.rs
@@ -472,7 +472,18 @@ mod tests {
             .map(|i| values2.value(i))
             .collect::<Vec<_>>();
         sorted_vals2.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        assert_eq!(sorted_vals2, vec![0.0, 0.0, 1.5, 2.7f32 as f64]);
+        // Compare with a tolerance rather than exact equality: the raster's
+        // float value can come back at f32 or f64 precision depending on the
+        // GDAL version (e.g. 2.7 vs the f32-widened 2.700000047683716), so an
+        // exact `assert_eq!` is brittle across GDAL versions.
+        let expected2 = [0.0, 0.0, 1.5, 2.7];
+        assert_eq!(sorted_vals2.len(), expected2.len());
+        for (got, want) in sorted_vals2.iter().zip(expected2.iter()) {
+            assert!(
+                (got - want).abs() < 1e-6,
+                "expected ~{want}, got {got} (all: {sorted_vals2:?})"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
RS_Polygonize's float-value assertion used an exact `assert_eq!` against an f32-widened literal, which fails on GDAL 3.13 (returns exact f64 `2.7`) even though it passed on older GDAL. Compare the polygon values with a small tolerance so the test is robust across GDAL versions.
