### PR TITLE
chore(ci): Trust gemfury/tap for nightly wheel upload

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -212,6 +212,7 @@ jobs:
       - name: Install gemfury client
         run: |
           brew tap gemfury/tap
+          brew trust gemfury/tap
           brew install fury-cli
           fury --version
 

--- a/.github/workflows/wheels-expr.yml
+++ b/.github/workflows/wheels-expr.yml
@@ -103,6 +103,7 @@ jobs:
       - name: Install gemfury client
         run: |
           brew tap gemfury/tap
+          brew trust gemfury/tap
           brew install fury-cli
           fury --version
 

--- a/.github/workflows/wheels-zarr.yml
+++ b/.github/workflows/wheels-zarr.yml
@@ -194,6 +194,7 @@ jobs:
       - name: Install gemfury client
         run: |
           brew tap gemfury/tap
+          brew trust gemfury/tap
           brew install fury-cli
           fury --version
 


### PR DESCRIPTION
In CI we see

```
2026-07-06T05:24:41.0193660Z Cloning into '/opt/homebrew/Library/Taps/gemfury/homebrew-tap'...
2026-07-06T05:24:41.9775680Z Tapped 2 formulae (15 files, 34.3KB).
2026-07-06T05:24:43.5060660Z ##[error]Refusing to load formula gemfury/tap/fury-cli from untrusted tap gemfury/tap.
Run `brew trust --formula gemfury/tap/fury-cli` or `brew trust gemfury/tap` to trust it.
```

which is causing the wheel upload jobs to fail.

This PR adds the requisite trust so our nightlies continue to be uploaded.