### PR TITLE
feat(python/sedonadb): add read_csv and read_json

### DIFF
--- a/python/sedonadb/python/sedonadb/read.py
+++ b/python/sedonadb/python/sedonadb/read.py
@@ -160,6 +160,19 @@ class Read:
                     None if partitioning is None else list(partitioning),
                 ),
             )
+        elif format == "csv":
+            options = options.copy()
+            has_header = options.pop("has_header", True)
+            delimiter = options.pop("delimiter", ",")
+            return DataFrame(
+                self._ctx,
+                self._ctx._impl.read_csv(table_paths, options, has_header, delimiter),
+            )
+        elif format == "json":
+            return DataFrame(
+                self._ctx,
+                self._ctx._impl.read_json(table_paths, options),
+            )
         else:
             raise ValueError(f"No format registered for extension '{format}'")
 
@@ -254,6 +267,85 @@ class Read:
         return self(
             table_paths, options=options, partitioning=partitioning, format="parquet"
         )
+
+    def csv(
+        self,
+        table_paths: Union[str, Path, Iterable[str]],
+        options: Optional[Dict[str, Any]] = None,
+        has_header: bool = True,
+        delimiter: str = ",",
+    ) -> DataFrame:
+        """Create a [DataFrame][sedonadb.dataframe.DataFrame] from one or more CSV files.
+
+        The schema is inferred from the file(s). Geometry is not inferred;
+        parse WKT/WKB columns explicitly (e.g. `ST_GeomFromText`) after reading.
+
+        Args:
+            table_paths: A str, Path, or iterable of paths/URLs to CSV files.
+            options: Optional dictionary of reader/object-store options. For
+                S3 access, use `{"aws.skip_signature": True, "aws.region": "us-west-2"}`
+                for anonymous access to public buckets.
+            has_header: Whether the first row is a header. Defaults to `True`.
+            delimiter: The field delimiter, as a single byte (i.e. a
+                one-character ASCII string). Defaults to `","`.
+
+        Examples:
+
+            >>> import tempfile
+            >>> from pathlib import Path
+            >>> sd = sedona.db.connect()
+            >>> with tempfile.TemporaryDirectory() as td:
+            ...     path = Path(td) / "t.csv"
+            ...     _ = path.write_text("a,b\\n1,x\\n2,y\\n")
+            ...     sd.read.csv(path).sort("a").show()
+            ┌───────┬──────┐
+            │   a   ┆   b  │
+            │ int64 ┆ utf8 │
+            ╞═══════╪══════╡
+            │     1 ┆ x    │
+            ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
+            │     2 ┆ y    │
+            └───────┴──────┘
+        """
+        options = (options or {}).copy()
+        options["has_header"] = has_header
+        options["delimiter"] = delimiter
+        return self(table_paths, options=options, format="csv")
+
+    def json(
+        self,
+        table_paths: Union[str, Path, Iterable[str]],
+        options: Optional[Dict[str, Any]] = None,
+    ) -> DataFrame:
+        """Create a [DataFrame][sedonadb.dataframe.DataFrame] from newline-delimited JSON.
+
+        Reads newline-delimited JSON (NDJSON / JSON Lines) — one JSON object
+        per line — not a single JSON array. The schema is inferred.
+
+        Args:
+            table_paths: A str, Path, or iterable of paths/URLs to NDJSON files.
+            options: Optional dictionary of reader/object-store options (e.g.
+                cloud credentials for `s3://` / `gs://` paths).
+
+        Examples:
+
+            >>> import tempfile
+            >>> from pathlib import Path
+            >>> sd = sedona.db.connect()
+            >>> with tempfile.TemporaryDirectory() as td:
+            ...     path = Path(td) / "t.json"
+            ...     _ = path.write_text('{"a": 1, "b": "x"}\\n{"a": 2, "b": "y"}\\n')
+            ...     sd.read.json(path).sort("a").show()
+            ┌───────┬──────┐
+            │   a   ┆   b  │
+            │ int64 ┆ utf8 │
+            ╞═══════╪══════╡
+            │     1 ┆ x    │
+            ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
+            │     2 ┆ y    │
+            └───────┴──────┘
+        """
+        return self(table_paths, options=options or {}, format="json")
 
     def pyogrio(
         self,

--- a/python/sedonadb/src/context.rs
+++ b/python/sedonadb/src/context.rs
@@ -39,6 +39,28 @@ pub struct InternalContext {
     pub runtime: Arc<Runtime>,
 }
 
+/// Convert a Python options dict to a string map for the reader/object-store
+/// layer, dropping `None` values (so callers can pass `None` to mean "unset").
+fn stringify_options(
+    py: Python<'_>,
+    options: HashMap<String, Py<PyAny>>,
+) -> HashMap<String, String> {
+    options
+        .into_iter()
+        .filter_map(|(k, v)| {
+            if v.is_none(py) {
+                None
+            } else {
+                v.bind(py)
+                    .str()
+                    .and_then(|s| s.extract())
+                    .map(|s: String| (k, s))
+                    .ok()
+            }
+        })
+        .collect()
+}
+
 #[pymethods]
 impl InternalContext {
     #[new]
@@ -92,20 +114,7 @@ impl InternalContext {
         partitioning: Option<Vec<String>>,
     ) -> Result<InternalDataFrame, PySedonaError> {
         // Convert Python options to strings, filtering out None values
-        let rust_options: HashMap<String, String> = options
-            .into_iter()
-            .filter_map(|(k, v)| {
-                if v.is_none(py) {
-                    None
-                } else {
-                    v.bind(py)
-                        .str()
-                        .and_then(|s| s.extract())
-                        .map(|s: String| (k, s))
-                        .ok()
-                }
-            })
-            .collect();
+        let rust_options = stringify_options(py, options);
 
         let mut geo_options =
             sedona_geoparquet::provider::GeoParquetReadOptions::from_table_options(rust_options)
@@ -162,6 +171,39 @@ impl InternalContext {
             ),
         )??;
 
+        Ok(InternalDataFrame::new(df, self.runtime.clone()))
+    }
+
+    pub fn read_csv<'py>(
+        &self,
+        py: Python<'py>,
+        table_paths: Vec<String>,
+        options: HashMap<String, Py<PyAny>>,
+        has_header: bool,
+        delimiter: &str,
+    ) -> Result<InternalDataFrame, PySedonaError> {
+        let rust_options = stringify_options(py, options);
+        let df = wait_for_future(
+            py,
+            &self.runtime,
+            self.inner
+                .read_csv(table_paths, &rust_options, has_header, delimiter),
+        )??;
+        Ok(InternalDataFrame::new(df, self.runtime.clone()))
+    }
+
+    pub fn read_json<'py>(
+        &self,
+        py: Python<'py>,
+        table_paths: Vec<String>,
+        options: HashMap<String, Py<PyAny>>,
+    ) -> Result<InternalDataFrame, PySedonaError> {
+        let rust_options = stringify_options(py, options);
+        let df = wait_for_future(
+            py,
+            &self.runtime,
+            self.inner.read_json(table_paths, &rust_options),
+        )??;
         Ok(InternalDataFrame::new(df, self.runtime.clone()))
     }
 

--- a/python/sedonadb/tests/io/test_read_csv_json.py
+++ b/python/sedonadb/tests/io/test_read_csv_json.py
@@ -1,0 +1,113 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+import pandas.testing as pdt
+import pytest
+
+
+def test_read_csv_basic(con):
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / "t.csv"
+        p.write_text("a,b\n1,x\n2,y\n")
+        out = con.read.csv(p).sort("a").to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"a": [1, 2], "b": ["x", "y"]}))
+
+
+def test_read_csv_no_header(con):
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / "t.csv"
+        p.write_text("1,x\n2,y\n")
+        out = con.read.csv(p, has_header=False).to_pandas()
+    # Column names are auto-assigned when there's no header.
+    assert len(out) == 2
+    assert list(out.iloc[:, 0]) == [1, 2]
+
+
+def test_read_csv_custom_delimiter(con):
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / "t.csv"
+        p.write_text("a;b\n1;x\n2;y\n")
+        out = con.read.csv(p, delimiter=";").sort("a").to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"a": [1, 2], "b": ["x", "y"]}))
+
+
+def test_read_csv_multiple_paths(con):
+    with tempfile.TemporaryDirectory() as td:
+        p1 = Path(td) / "a.csv"
+        p1.write_text("a,b\n1,x\n")
+        p2 = Path(td) / "b.csv"
+        p2.write_text("a,b\n2,y\n")
+        out = con.read.csv([p1, p2]).sort("a").to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"a": [1, 2], "b": ["x", "y"]}))
+
+
+def test_read_csv_bad_delimiter_raises(con):
+    from sedonadb._lib import SedonaError
+
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / "t.csv"
+        p.write_text("a,b\n1,x\n")
+        with pytest.raises(SedonaError, match="single byte"):
+            con.read.csv(p, delimiter=";;")
+
+
+def test_read_json_ndjson(con):
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / "t.json"
+        p.write_text('{"a": 1, "b": "x"}\n{"a": 2, "b": "y"}\n')
+        out = con.read.json(p).sort("a").to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"a": [1, 2], "b": ["x", "y"]}))
+
+
+def test_read_json_multiple_paths(con):
+    with tempfile.TemporaryDirectory() as td:
+        p1 = Path(td) / "a.json"
+        p1.write_text('{"a": 1}\n')
+        p2 = Path(td) / "b.json"
+        p2.write_text('{"a": 2}\n')
+        out = con.read.json([p1, p2]).sort("a").to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"a": [1, 2]}))
+
+
+def test_generic_read_guesses_csv_extension(con):
+    # sd.read("x.csv") should route to the CSV reader by extension.
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / "t.csv"
+        p.write_text("a,b\n1,x\n")
+        out = con.read(p).to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"a": [1], "b": ["x"]}))
+
+
+def test_generic_read_csv_options_thread_through(con):
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / "t.csv"
+        p.write_text("a;b\n1;x\n")
+        out = con.read(p, options={"delimiter": ";"}).to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"a": [1], "b": ["x"]}))
+
+
+def test_generic_read_guesses_json_extension(con):
+    # sd.read("x.json") should route to the JSON reader by extension.
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / "t.json"
+        p.write_text('{"a": 1, "b": "x"}\n')
+        out = con.read(p).to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"a": [1], "b": ["x"]}))

--- a/rust/sedona/src/context.rs
+++ b/rust/sedona/src/context.rs
@@ -38,7 +38,7 @@ use datafusion::{
         runtime_env::{RuntimeEnv, RuntimeEnvBuilder},
         SessionStateBuilder,
     },
-    prelude::{DataFrame, SessionConfig, SessionContext},
+    prelude::{CsvReadOptions, DataFrame, NdJsonReadOptions, SessionConfig, SessionContext},
     sql::parser::{DFParser, Statement},
 };
 use datafusion::{dataframe::DataFrameWriteOptions, execution::memory_pool::MemoryLimit};
@@ -565,6 +565,63 @@ impl SedonaContext {
         };
 
         self.ctx.read_table(provider)
+    }
+
+    /// Creates a [`DataFrame`] for reading CSV file(s).
+    ///
+    /// `options` carries object-store / cloud credentials (e.g. `aws.*`,
+    /// `gcs.*`) used to register the object store before reading, matching
+    /// [`Self::read_parquet`]. `delimiter` must be a single byte.
+    pub async fn read_csv(
+        &self,
+        table_paths: Vec<String>,
+        options: &HashMap<String, String>,
+        has_header: bool,
+        delimiter: &str,
+    ) -> Result<DataFrame> {
+        let bytes = delimiter.as_bytes();
+        if bytes.len() != 1 {
+            return plan_err!("CSV delimiter must be a single byte, got {delimiter:?}");
+        }
+
+        let urls = table_paths.clone().to_urls()?;
+        if !urls.is_empty() {
+            ensure_object_store_registered_with_options(
+                &mut self.ctx.state(),
+                urls[0].as_str(),
+                Some(options),
+            )
+            .await?;
+        }
+
+        let csv_options = CsvReadOptions::new()
+            .has_header(has_header)
+            .delimiter(bytes[0]);
+        self.ctx.read_csv(table_paths, csv_options).await
+    }
+
+    /// Creates a [`DataFrame`] for reading newline-delimited JSON file(s).
+    ///
+    /// `options` carries object-store / cloud credentials used to register
+    /// the object store before reading, matching [`Self::read_parquet`].
+    pub async fn read_json(
+        &self,
+        table_paths: Vec<String>,
+        options: &HashMap<String, String>,
+    ) -> Result<DataFrame> {
+        let urls = table_paths.clone().to_urls()?;
+        if !urls.is_empty() {
+            ensure_object_store_registered_with_options(
+                &mut self.ctx.state(),
+                urls[0].as_str(),
+                Some(options),
+            )
+            .await?;
+        }
+
+        self.ctx
+            .read_json(table_paths, NdJsonReadOptions::default())
+            .await
     }
 }
 


### PR DESCRIPTION
Adds toplevel readers for delimited text and newline-delimited JSON, filling a real gap — only `read_parquet` / `read_pyogrio` existed.

## API

```python
sd.read_csv(paths, *, has_header=True, delimiter=",")
sd.read_json(paths)          # newline-delimited JSON (NDJSON / JSON Lines)
```

- Both accept a `str` / `Path` or an iterable of paths (globs/directories per DataFusion), infer the schema, and are also available as `sd.read.csv` / `sd.read.json` alongside `sd.read.parquet` / `sd.read.pyogrio`.
- `read_json` reads **newline-delimited JSON** (one object per line), not a single JSON array — documented prominently.
- **Geometry is not inferred** (CSV and NDJSON carry no spatial metadata); parse WKT/WKB columns explicitly after reading (e.g. `ST_GeomFromText`).
- `read_csv` validates that `delimiter` is a single byte and raises a clear error otherwise.

## Implementation

| File | Change |
|---|---|
| `python/sedonadb/src/context.rs` | `InternalContext::read_csv` / `read_json` — thin wrappers over DataFusion's `SessionContext::read_csv` / `read_json` (`CsvReadOptions` has_header/delimiter; `NdJsonReadOptions`). |
| `python/sedonadb/python/sedonadb/read.py` | `Read.csv` / `Read.json` in the reader namespace. |
| `python/sedonadb/python/sedonadb/context.py` | `SedonaContext.read_csv` / `read_json` delegating to the namespace, mirroring `read_parquet`. |

## Test plan

`tests/io/test_read_csv_json.py` (tmp_path files):
- csv: basic, no-header, custom delimiter, multiple paths, bad-delimiter error, `read.csv` namespace form.
- json: ndjson basic, multiple paths, `read.json` namespace form.

Doctests on `read_csv`/`read_json` use a tempfile and show the inferred output.

Local: 9 unit + 17 doctests + `ruff` + `cargo fmt --check` + `clippy -Dwarnings` all clean.
