### PR TITLE
feat(c/sedona-geos): Add ST_HausdorffDistance

### DIFF
--- a/c/sedona-geos/src/lib.rs
+++ b/c/sedona-geos/src/lib.rs
@@ -32,6 +32,7 @@ mod st_convexhull;
 mod st_delaunaytriangles;
 mod st_dwithin;
 mod st_exteriorring;
+mod st_hausdorffdistance;
 mod st_isring;
 mod st_issimple;
 mod st_isvalid;

--- a/c/sedona-geos/src/register.rs
+++ b/c/sedona-geos/src/register.rs
@@ -60,6 +60,8 @@ pub fn scalar_kernels() -> Vec<(&'static str, Vec<ScalarKernelRef>)> {
         "st_distance" => crate::distance::st_distance_impl,
         "st_dwithin" => crate::st_dwithin::st_dwithin_impl,
         "st_equals" => crate::binary_predicates::st_equals_impl,
+        "st_hausdorffdistance" => crate::st_hausdorffdistance::st_hausdorff_distance_impl,
+        "st_hausdorffdistance" => crate::st_hausdorffdistance::st_hausdorff_distance_densify_impl,
         "st_exteriorring" => crate::st_exteriorring::st_exterior_ring_impl,
         "st_intersection" => crate::overlay::st_intersection_impl,
         "st_intersects" => crate::binary_predicates::st_intersects_impl,

--- a/c/sedona-geos/src/st_hausdorffdistance.rs
+++ b/c/sedona-geos/src/st_hausdorffdistance.rs
@@ -1,0 +1,354 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+use std::sync::Arc;
+
+use arrow_array::builder::Float64Builder;
+use arrow_schema::DataType;
+use datafusion_common::{cast::as_float64_array, error::Result, DataFusionError};
+use datafusion_expr::ColumnarValue;
+use geos::Geom;
+use sedona_expr::{
+    item_crs::ItemCrsKernel,
+    scalar_udf::{ScalarKernelRef, SedonaScalarKernel},
+};
+use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
+
+use crate::executor::GeosExecutor;
+
+/// ST_HausdorffDistance(geometry, geometry) implementation using the geos crate
+pub fn st_hausdorff_distance_impl() -> ScalarKernelRef {
+    Arc::new(STHausdorffDistance {})
+}
+
+/// ST_HausdorffDistance(geometry, geometry, densifyFrac) implementation using the geos crate
+pub fn st_hausdorff_distance_densify_impl() -> Vec<ScalarKernelRef> {
+    ItemCrsKernel::wrap_impl(STHausdorffDistanceDensify {})
+}
+
+#[derive(Debug)]
+struct STHausdorffDistance {}
+
+impl SedonaScalarKernel for STHausdorffDistance {
+    fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
+        let matcher = ArgMatcher::new(
+            vec![ArgMatcher::is_geometry(), ArgMatcher::is_geometry()],
+            SedonaType::Arrow(DataType::Float64),
+        );
+
+        matcher.match_args(args)
+    }
+
+    fn invoke_batch(
+        &self,
+        arg_types: &[SedonaType],
+        args: &[ColumnarValue],
+    ) -> Result<ColumnarValue> {
+        let executor = GeosExecutor::new(arg_types, args);
+        let mut builder = Float64Builder::with_capacity(executor.num_iterations());
+        executor.execute_wkb_wkb_void(|lhs, rhs| {
+            match (lhs, rhs) {
+                (Some(lhs), Some(rhs)) => {
+                    if let Some(distance) = invoke_scalar(lhs, rhs)? {
+                        builder.append_value(distance);
+                    } else {
+                        builder.append_null();
+                    }
+                }
+                _ => builder.append_null(),
+            }
+
+            Ok(())
+        })?;
+
+        executor.finish(Arc::new(builder.finish()))
+    }
+}
+
+fn invoke_scalar(lhs: &geos::Geometry, rhs: &geos::Geometry) -> Result<Option<f64>> {
+    // Return NULL for empty geometries (PostGIS compatibility)
+    if lhs.is_empty().unwrap_or(false) || rhs.is_empty().unwrap_or(false) {
+        return Ok(None);
+    }
+    let distance = lhs.hausdorff_distance(rhs).map_err(|e| {
+        DataFusionError::Execution(format!("Failed to calculate hausdorff distance: {e}"))
+    })?;
+    Ok(Some(distance))
+}
+
+#[derive(Debug)]
+struct STHausdorffDistanceDensify {}
+
+impl SedonaScalarKernel for STHausdorffDistanceDensify {
+    fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
+        let matcher = ArgMatcher::new(
+            vec![
+                ArgMatcher::is_geometry(),
+                ArgMatcher::is_geometry(),
+                ArgMatcher::is_numeric(),
+            ],
+            SedonaType::Arrow(DataType::Float64),
+        );
+
+        matcher.match_args(args)
+    }
+
+    fn invoke_batch(
+        &self,
+        arg_types: &[SedonaType],
+        args: &[ColumnarValue],
+    ) -> Result<ColumnarValue> {
+        let arg2 = args[2].cast_to(&DataType::Float64, None)?;
+        let executor = GeosExecutor::new(arg_types, args);
+        let arg2_array = arg2.to_array(executor.num_iterations())?;
+        let arg2_f64_array = as_float64_array(&arg2_array)?;
+        let mut arg2_iter = arg2_f64_array.iter();
+        let mut builder = Float64Builder::with_capacity(executor.num_iterations());
+        executor.execute_wkb_wkb_void(|lhs, rhs| {
+            match (lhs, rhs, arg2_iter.next().unwrap()) {
+                (Some(lhs), Some(rhs), Some(densify_frac)) => {
+                    if let Some(distance) = invoke_scalar_densify(lhs, rhs, densify_frac)? {
+                        builder.append_value(distance);
+                    } else {
+                        builder.append_null();
+                    }
+                }
+                _ => builder.append_null(),
+            };
+            Ok(())
+        })?;
+        executor.finish(Arc::new(builder.finish()))
+    }
+}
+
+fn invoke_scalar_densify(
+    lhs: &geos::Geometry,
+    rhs: &geos::Geometry,
+    densify_frac: f64,
+) -> Result<Option<f64>> {
+    // Return NULL for empty geometries (PostGIS compatibility)
+    if lhs.is_empty().unwrap_or(false) || rhs.is_empty().unwrap_or(false) {
+        return Ok(None);
+    }
+    let distance = lhs
+        .hausdorff_distance_densify(rhs, densify_frac)
+        .map_err(|e| {
+            DataFusionError::Execution(format!("Failed to calculate hausdorff distance: {e}"))
+        })?;
+    Ok(Some(distance))
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow_array::{create_array as arrow_array, ArrayRef};
+    use datafusion_common::ScalarValue;
+    use rstest::rstest;
+    use sedona_expr::scalar_udf::SedonaScalarUDF;
+    use sedona_schema::datatypes::{WKB_GEOMETRY, WKB_GEOMETRY_ITEM_CRS, WKB_VIEW_GEOMETRY};
+    use sedona_testing::compare::assert_array_equal;
+    use sedona_testing::create::create_array;
+    use sedona_testing::testers::ScalarUdfTester;
+
+    use super::*;
+
+    #[rstest]
+    fn udf(#[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType) {
+        let udf = SedonaScalarUDF::from_impl("st_hausdorffdistance", st_hausdorff_distance_impl());
+        let tester = ScalarUdfTester::new(udf.into(), vec![sedona_type.clone(), sedona_type.clone()]);
+        tester.assert_return_type(DataType::Float64);
+
+        // Point to point - Hausdorff distance equals Euclidean distance
+        let result = tester
+            .invoke_scalar_scalar("POINT (0 0)", "POINT (3 4)")
+            .unwrap();
+        tester.assert_scalar_result_equals(result, 5.0);
+
+        // NULL handling
+        let result = tester
+            .invoke_scalar_scalar(ScalarValue::Null, ScalarValue::Null)
+            .unwrap();
+        assert!(result.is_null());
+
+        let result = tester
+            .invoke_scalar_scalar("POINT (0 0)", ScalarValue::Null)
+            .unwrap();
+        assert!(result.is_null());
+
+        let result = tester
+            .invoke_scalar_scalar(ScalarValue::Null, "POINT (0 0)")
+            .unwrap();
+        assert!(result.is_null());
+
+        // EMPTY geometries return NULL (PostGIS compatibility)
+        let result = tester
+            .invoke_scalar_scalar("POINT EMPTY", "POINT (0 0)")
+            .unwrap();
+        assert!(result.is_null());
+
+        let result = tester
+            .invoke_scalar_scalar("POINT EMPTY", "POINT EMPTY")
+            .unwrap();
+        assert!(result.is_null());
+
+        // LineString to LineString
+        let result = tester
+            .invoke_scalar_scalar("LINESTRING (0 0, 2 0)", "LINESTRING (0 1, 1 1, 2 1)")
+            .unwrap();
+        tester.assert_scalar_result_equals(result, 1.0);
+
+        // Polygon to Polygon
+        let result = tester
+            .invoke_scalar_scalar(
+                "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))",
+                "POLYGON ((2 0, 3 0, 3 1, 2 1, 2 0))",
+            )
+            .unwrap();
+        tester.assert_scalar_result_equals(result, 2.0);
+
+        // Array batch test with multiple geometry types
+        let arg1 = create_array(
+            &[
+                Some("POINT (0 0)"),
+                Some("LINESTRING (0 0, 1 0)"),
+                Some("POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))"),
+                Some("MULTIPOINT ((0 0), (1 0))"),
+                Some("MULTILINESTRING ((0 0, 1 0), (0 1, 1 1))"),
+                Some("MULTIPOLYGON (((0 0, 1 0, 1 1, 0 1, 0 0)))"),
+                Some("GEOMETRYCOLLECTION (POINT (0 0))"),
+                None,
+            ],
+            &sedona_type,
+        );
+        let arg2 = create_array(
+            &[
+                Some("POINT (3 4)"),
+                Some("LINESTRING (0 1, 1 1)"),
+                Some("POLYGON ((2 0, 3 0, 3 1, 2 1, 2 0))"),
+                Some("MULTIPOINT ((3 4), (4 4))"),
+                Some("MULTILINESTRING ((0 2, 1 2))"),
+                Some("MULTIPOLYGON (((2 0, 3 0, 3 1, 2 1, 2 0)))"),
+                Some("GEOMETRYCOLLECTION (POINT (3 4))"),
+                Some("POINT (0 0)"),
+            ],
+            &sedona_type,
+        );
+        let expected: ArrayRef = arrow_array!(Float64, [
+            Some(5.0),  // Point to Point
+            Some(1.0),  // LineString to LineString
+            Some(2.0),  // Polygon to Polygon
+            Some(5.0),  // MultiPoint to MultiPoint
+            Some(2.0),  // MultiLineString to MultiLineString
+            Some(2.0),  // MultiPolygon to MultiPolygon
+            Some(5.0),  // GeometryCollection to GeometryCollection
+            None        // NULL
+        ]);
+        assert_array_equal(
+            &tester.invoke_arrays(vec![arg1, arg2]).unwrap(),
+            &expected,
+        );
+    }
+
+    #[rstest]
+    fn udf_densify(
+        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY, WKB_GEOMETRY_ITEM_CRS.clone())]
+        sedona_type: SedonaType,
+    ) {
+        let udf = SedonaScalarUDF::from_impl(
+            "st_hausdorffdistance",
+            st_hausdorff_distance_densify_impl(),
+        );
+        let tester = ScalarUdfTester::new(
+            udf.into(),
+            vec![
+                sedona_type.clone(),
+                sedona_type.clone(),
+                SedonaType::Arrow(DataType::Float64),
+            ],
+        );
+        tester.assert_return_type(DataType::Float64);
+
+        // With densify fraction
+        let result = tester
+            .invoke_scalar_scalar_scalar("LINESTRING (0 0, 100 0)", "LINESTRING (0 1, 0 1)", 0.5)
+            .unwrap();
+        // Without densification this would be 1.0, with densification it should be sqrt(100^2 + 1^2) ≈ 100.005
+        let result_f64: f64 = result.try_into().unwrap();
+        assert!(result_f64 > 1.0);
+
+        // NULL handling
+        let result = tester
+            .invoke_scalar_scalar_scalar(ScalarValue::Null, ScalarValue::Null, ScalarValue::Null)
+            .unwrap();
+        assert!(result.is_null());
+
+        // Array batch test
+        let arg1 = create_array(
+            &[
+                Some("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))"),
+                Some("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))"),
+                None,
+                Some("POINT EMPTY"),
+            ],
+            &sedona_type,
+        );
+        let arg2 = create_array(
+            &[
+                Some("POINT (0.5 0.5)"),
+                Some("POINT (5 5)"),
+                Some("POINT (0 0)"),
+                Some("POINT EMPTY"),
+            ],
+            &sedona_type,
+        );
+        let densify_frac = arrow_array!(Float64, [Some(0.5), Some(0.5), Some(0.5), Some(0.5)]);
+
+        let result = tester.invoke_arrays(vec![arg1, arg2, densify_frac]).unwrap();
+        // Just verify it runs without error and returns correct nulls
+        assert_eq!(result.len(), 4);
+    }
+
+    #[test]
+    fn udf_densify_invalid_frac() {
+        let udf = SedonaScalarUDF::from_impl(
+            "st_hausdorffdistance",
+            st_hausdorff_distance_densify_impl(),
+        );
+        let tester = ScalarUdfTester::new(
+            udf.into(),
+            vec![
+                WKB_GEOMETRY,
+                WKB_GEOMETRY,
+                SedonaType::Arrow(DataType::Float64),
+            ],
+        );
+
+        // densifyFrac less than 0 should error
+        let result = tester.invoke_scalar_scalar_scalar(
+            "LINESTRING (0 0, 100 0)",
+            "LINESTRING (0 1, 100 1)",
+            -0.1,
+        );
+        assert!(result.is_err());
+
+        // densifyFrac greater than 1 should error
+        let result = tester.invoke_scalar_scalar_scalar(
+            "LINESTRING (0 0, 100 0)",
+            "LINESTRING (0 1, 100 1)",
+            1.5,
+        );
+        assert!(result.is_err());
+    }
+}

--- a/c/sedona-geos/src/st_hausdorffdistance.rs
+++ b/c/sedona-geos/src/st_hausdorffdistance.rs
@@ -167,7 +167,8 @@ mod tests {
     #[rstest]
     fn udf(#[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType) {
         let udf = SedonaScalarUDF::from_impl("st_hausdorffdistance", st_hausdorff_distance_impl());
-        let tester = ScalarUdfTester::new(udf.into(), vec![sedona_type.clone(), sedona_type.clone()]);
+        let tester =
+            ScalarUdfTester::new(udf.into(), vec![sedona_type.clone(), sedona_type.clone()]);
         tester.assert_return_type(DataType::Float64);
 
         // Point to point - Hausdorff distance equals Euclidean distance
@@ -245,20 +246,20 @@ mod tests {
             ],
             &sedona_type,
         );
-        let expected: ArrayRef = arrow_array!(Float64, [
-            Some(5.0),  // Point to Point
-            Some(1.0),  // LineString to LineString
-            Some(2.0),  // Polygon to Polygon
-            Some(5.0),  // MultiPoint to MultiPoint
-            Some(2.0),  // MultiLineString to MultiLineString
-            Some(2.0),  // MultiPolygon to MultiPolygon
-            Some(5.0),  // GeometryCollection to GeometryCollection
-            None        // NULL
-        ]);
-        assert_array_equal(
-            &tester.invoke_arrays(vec![arg1, arg2]).unwrap(),
-            &expected,
+        let expected: ArrayRef = arrow_array!(
+            Float64,
+            [
+                Some(5.0), // Point to Point
+                Some(1.0), // LineString to LineString
+                Some(2.0), // Polygon to Polygon
+                Some(5.0), // MultiPoint to MultiPoint
+                Some(2.0), // MultiLineString to MultiLineString
+                Some(2.0), // MultiPolygon to MultiPolygon
+                Some(5.0), // GeometryCollection to GeometryCollection
+                None       // NULL
+            ]
         );
+        assert_array_equal(&tester.invoke_arrays(vec![arg1, arg2]).unwrap(), &expected);
     }
 
     #[rstest]
@@ -315,7 +316,9 @@ mod tests {
         );
         let densify_frac = arrow_array!(Float64, [Some(0.5), Some(0.5), Some(0.5), Some(0.5)]);
 
-        let result = tester.invoke_arrays(vec![arg1, arg2, densify_frac]).unwrap();
+        let result = tester
+            .invoke_arrays(vec![arg1, arg2, densify_frac])
+            .unwrap();
         // Just verify it runs without error and returns correct nulls
         assert_eq!(result.len(), 4);
     }

--- a/c/sedona-geos/src/st_hausdorffdistance.rs
+++ b/c/sedona-geos/src/st_hausdorffdistance.rs
@@ -18,9 +18,12 @@ use std::sync::Arc;
 
 use arrow_array::builder::Float64Builder;
 use arrow_schema::DataType;
-use datafusion_common::{cast::as_float64_array, error::Result, DataFusionError};
+use datafusion_common::{
+    cast::as_float64_array, error::Result, exec_datafusion_err, DataFusionError,
+};
 use datafusion_expr::ColumnarValue;
 use geos::Geom;
+use sedona_common::sedona_internal_datafusion_err;
 use sedona_expr::{
     item_crs::ItemCrsKernel,
     scalar_udf::{ScalarKernelRef, SedonaScalarKernel},
@@ -30,8 +33,8 @@ use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
 use crate::executor::GeosExecutor;
 
 /// ST_HausdorffDistance(geometry, geometry) implementation using the geos crate
-pub fn st_hausdorff_distance_impl() -> ScalarKernelRef {
-    Arc::new(STHausdorffDistance {})
+pub fn st_hausdorff_distance_impl() -> Vec<ScalarKernelRef> {
+    ItemCrsKernel::wrap_impl(STHausdorffDistance {})
 }
 
 /// ST_HausdorffDistance(geometry, geometry, densifyFrac) implementation using the geos crate
@@ -79,13 +82,19 @@ impl SedonaScalarKernel for STHausdorffDistance {
 }
 
 fn invoke_scalar(lhs: &geos::Geometry, rhs: &geos::Geometry) -> Result<Option<f64>> {
-    // Return NULL for empty geometries (PostGIS compatibility)
-    if lhs.is_empty().unwrap_or(false) || rhs.is_empty().unwrap_or(false) {
+    // Return NULL for empty geometries
+    if lhs
+        .is_empty()
+        .map_err(|e| sedona_internal_datafusion_err!("is_empty() call failed: {e}"))?
+        || rhs
+            .is_empty()
+            .map_err(|e| sedona_internal_datafusion_err!("is_empty() call failed: {e}"))?
+    {
         return Ok(None);
     }
-    let distance = lhs.hausdorff_distance(rhs).map_err(|e| {
-        DataFusionError::Execution(format!("Failed to calculate hausdorff distance: {e}"))
-    })?;
+    let distance = lhs
+        .hausdorff_distance(rhs)
+        .map_err(|e| exec_datafusion_err!("Failed to calculate hausdorff distance: {e}"))?;
     Ok(Some(distance))
 }
 
@@ -140,9 +149,16 @@ fn invoke_scalar_densify(
     densify_frac: f64,
 ) -> Result<Option<f64>> {
     // Return NULL for empty geometries (PostGIS compatibility)
-    if lhs.is_empty().unwrap_or(false) || rhs.is_empty().unwrap_or(false) {
+    if lhs
+        .is_empty()
+        .map_err(|e| sedona_internal_datafusion_err!("is_empty() call failed: {e}"))?
+        || rhs
+            .is_empty()
+            .map_err(|e| sedona_internal_datafusion_err!("is_empty() call failed: {e}"))?
+    {
         return Ok(None);
     }
+
     let distance = lhs
         .hausdorff_distance_densify(rhs, densify_frac)
         .map_err(|e| {
@@ -153,7 +169,8 @@ fn invoke_scalar_densify(
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::{create_array as arrow_array, ArrayRef};
+    use arrow_array::{create_array as arrow_array, Array, ArrayRef};
+    use datafusion_common::cast::as_float64_array;
     use datafusion_common::ScalarValue;
     use rstest::rstest;
     use sedona_expr::scalar_udf::SedonaScalarUDF;
@@ -281,13 +298,20 @@ mod tests {
         );
         tester.assert_return_type(DataType::Float64);
 
-        // With densify fraction
+        // With densify fraction - this example shows different results for different fractions
+        // The densify fraction of 0.5 adds interpolated points, improving the accuracy
         let result = tester
-            .invoke_scalar_scalar_scalar("LINESTRING (0 0, 100 0)", "LINESTRING (0 1, 0 1)", 0.5)
+            .invoke_scalar_scalar_scalar(
+                "LINESTRING (130 0, 0 0, 0 150)",
+                "LINESTRING (10 10, 10 150, 130 10)",
+                0.5,
+            )
             .unwrap();
-        // Without densification this would be 1.0, with densification it should be sqrt(100^2 + 1^2) ≈ 100.005
         let result_f64: f64 = result.try_into().unwrap();
-        assert!(result_f64 > 1.0);
+        assert!(
+            (result_f64 - 70.0).abs() < 0.01,
+            "Expected ~70.0, got {result_f64}"
+        );
 
         // NULL handling
         let result = tester
@@ -295,11 +319,12 @@ mod tests {
             .unwrap();
         assert!(result.is_null());
 
-        // Array batch test
+        // Array batch test - varying densify fractions show different results
         let arg1 = create_array(
             &[
-                Some("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))"),
-                Some("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))"),
+                Some("LINESTRING (130 0, 0 0, 0 150)"),
+                Some("LINESTRING (130 0, 0 0, 0 150)"),
+                Some("LINESTRING (130 0, 0 0, 0 150)"),
                 None,
                 Some("POINT EMPTY"),
             ],
@@ -307,20 +332,43 @@ mod tests {
         );
         let arg2 = create_array(
             &[
-                Some("POINT (0.5 0.5)"),
-                Some("POINT (5 5)"),
-                Some("POINT (0 0)"),
+                Some("LINESTRING (10 10, 10 150, 130 10)"),
+                Some("LINESTRING (10 10, 10 150, 130 10)"),
+                Some("LINESTRING (10 10, 10 150, 130 10)"),
+                Some("LINESTRING (0 0, 1 1)"),
                 Some("POINT EMPTY"),
             ],
             &sedona_type,
         );
-        let densify_frac = arrow_array!(Float64, [Some(0.5), Some(0.5), Some(0.5), Some(0.5)]);
+        // Different densify fractions: smaller fractions create more segments, improving accuracy
+        let densify_frac = arrow_array!(
+            Float64,
+            [Some(0.5), Some(0.25), Some(0.1), Some(0.5), Some(0.5)]
+        );
 
         let result = tester
             .invoke_arrays(vec![arg1, arg2, densify_frac])
             .unwrap();
-        // Just verify it runs without error and returns correct nulls
-        assert_eq!(result.len(), 4);
+        assert_eq!(result.len(), 5);
+        // First three results should all be close to ~70.0 (the continuous Hausdorff distance)
+        let result_array = as_float64_array(&result).unwrap();
+        assert!(
+            (result_array.value(0) - 70.0).abs() < 0.01,
+            "Expected ~70.0, got {}",
+            result_array.value(0)
+        );
+        assert!(
+            (result_array.value(1) - 70.0).abs() < 0.01,
+            "Expected ~70.0, got {}",
+            result_array.value(1)
+        );
+        assert!(
+            (result_array.value(2) - 70.0).abs() < 0.01,
+            "Expected ~70.0, got {}",
+            result_array.value(2)
+        );
+        assert!(result_array.is_null(3)); // NULL input
+        assert!(result_array.is_null(4)); // EMPTY geometry
     }
 
     #[test]

--- a/docs/reference/sql/st_hausdorffdistance.qmd
+++ b/docs/reference/sql/st_hausdorffdistance.qmd
@@ -1,0 +1,68 @@
+---
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+title: ST_HausdorffDistance
+description: Returns the Hausdorff distance between two geometries.
+kernels:
+  - returns: double
+    args: [geometry, geometry]
+  - returns: double
+    args:
+    - geometry
+    - geometry
+    - name: densifyFrac
+      type: double
+      description: >
+        A fraction by which to densify each segment of the geometries before computing
+        the distance. A value of 0.25 will densify the segment by adding vertices every
+        1/4 of the segment length. Densification can give a more accurate result for
+        geometries with long segments or complex shapes.
+---
+
+## Description
+
+Returns the Hausdorff distance between its inputs. The Hausdorff distance is a measure of the similarity between two geometric shapes. This implementation returns the greatest of all distances from a point in one geometry to the closest point in the other geometry.
+
+Returns `NULL` if either geometry is `NULL`. Returns 0 if either geometry is empty.
+
+## Examples
+
+Basic Hausdorff distance between two points:
+
+```sql
+SELECT ST_HausdorffDistance(ST_Point(0, 0), ST_Point(3, 4));
+```
+
+Hausdorff distance between two linestrings:
+
+```sql
+SELECT ST_HausdorffDistance(
+    ST_GeomFromText('LINESTRING (0 0, 2 0)'),
+    ST_GeomFromText('LINESTRING (0 1, 2 1)')
+);
+```
+
+Using densification for more accurate results as needed:
+
+```sql
+SELECT ST_HausdorffDistance(
+    ST_GeomFromText('LINESTRING (130 0, 0 0, 0 150)'),
+    ST_GeomFromText('LINESTRING (10 10, 10 150, 130 10)'),
+    0.5
+);
+```

--- a/docs/reference/sql/st_hausdorffdistance.qmd
+++ b/docs/reference/sql/st_hausdorffdistance.qmd
@@ -36,7 +36,7 @@ kernels:
 
 ## Description
 
-Returns the Hausdorff distance between its inputs. The Hausdorff distance is a measure of the similarity between two geometric shapes. This implementation returns the greatest of all distances from a point in one geometry to the closest point in the other geometry.
+The Hausdorff distance is a measure of the similarity between two geometric shapes. This implementation returns the greatest of all distances from a point in one geometry to the closest point in the other geometry.
 
 Returns `NULL` if either geometry is `NULL`. Returns 0 if either geometry is empty.
 

--- a/python/sedonadb/src/reader.rs
+++ b/python/sedonadb/src/reader.rs
@@ -45,16 +45,13 @@ impl Iterator for PySedonaStreamReader {
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             match wait_for_future_from_rust(&self.runtime, self.stream.try_next()) {
-                Ok(Ok(maybe_batch)) => match maybe_batch {
-                    Some(batch) => {
-                        if batch.num_rows() == 0 {
-                            continue;
-                        }
-
-                        return Some(Ok(batch));
+                Ok(Ok(maybe_batch)) => {
+                    let batch = maybe_batch?;
+                    if batch.num_rows() == 0 {
+                        continue;
                     }
-                    None => return None,
-                },
+                    return Some(Ok(batch));
+                }
                 Ok(Err(df_err)) => return Some(Err(ArrowError::ExternalError(Box::new(df_err)))),
                 Err(py_err) => return Some(Err(ArrowError::ExternalError(Box::new(py_err)))),
             }

--- a/python/sedonadb/tests/functions/test_distance.py
+++ b/python/sedonadb/tests/functions/test_distance.py
@@ -45,3 +45,105 @@ def test_st_distance(eng, geom1, geom2, expected):
         expected,
         numeric_epsilon=1e-8,
     )
+
+
+@pytest.mark.parametrize("eng", [SedonaDB, PostGIS])
+@pytest.mark.parametrize(
+    ("geom1", "geom2", "expected"),
+    [
+        # NULL handling
+        (None, None, None),
+        ("POINT (0 0)", None, None),
+        (None, "POINT (0 0)", None),
+        # EMPTY geometries return NULL
+        ("POINT EMPTY", "POINT EMPTY", None),
+        ("POINT EMPTY", "POINT (0 0)", None),
+        ("POINT (0 0)", "POINT EMPTY", None),
+        ("LINESTRING EMPTY", "LINESTRING (0 0, 1 1)", None),
+        ("POLYGON EMPTY", "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))", None),
+        # Point to Point
+        ("POINT (0 0)", "POINT (0 0)", 0),
+        ("POINT (0 0)", "POINT (3 4)", 5.0),
+        # Point to LineString
+        ("POINT (0 0)", "LINESTRING (1 0, 2 0)", 2.0),
+        # Point to Polygon
+        ("POINT (0 0)", "POLYGON ((1 0, 2 0, 2 1, 1 1, 1 0))", 2.23606797749979),
+        # LineString to LineString
+        ("LINESTRING (0 0, 2 0)", "LINESTRING (0 1, 1 1, 2 1)", 1.0),
+        ("LINESTRING (0 0, 100 0, 10 100, 10 100)", "LINESTRING (0 100, 0 10, 80 10)", 22.360679774997898),
+        # LineString to Polygon
+        (
+            "LINESTRING (0 0, 1 0)",
+            "POLYGON ((2 0, 3 0, 3 1, 2 1, 2 0))",
+            2.23606797749979,
+        ),
+        # Polygon to Polygon
+        (
+            "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))",
+            "POLYGON ((2 0, 3 0, 3 1, 2 1, 2 0))",
+            2.0,
+        ),
+        (
+            "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))",
+            "POLYGON ((5 5, 6 5, 6 6, 5 6, 5 5))",
+            7.0710678118654755,
+        ),
+        # MultiPoint
+        ("MULTIPOINT ((0 0), (1 0))", "MULTIPOINT ((3 4), (4 4))", 5.0),
+        # MultiLineString
+        (
+            "MULTILINESTRING ((0 0, 1 0), (0 1, 1 1))",
+            "MULTILINESTRING ((0 2, 1 2))",
+            2.0,
+        ),
+        # MultiPolygon
+        (
+            "MULTIPOLYGON (((0 0, 1 0, 1 1, 0 1, 0 0)))",
+            "MULTIPOLYGON (((2 0, 3 0, 3 1, 2 1, 2 0)))",
+            2.0,
+        ),
+        # GeometryCollection
+        (
+            "GEOMETRYCOLLECTION (POINT (0 0))",
+            "GEOMETRYCOLLECTION (POINT (3 4))",
+            5.0,
+        ),
+    ],
+)
+def test_st_hausdorffdistance(eng, geom1, geom2, expected):
+    eng = eng.create_or_skip()
+    eng.assert_query_result(
+        f"SELECT ST_HausdorffDistance({geom_or_null(geom1)}, {geom_or_null(geom2)})",
+        expected,
+        numeric_epsilon=1e-8,
+    )
+
+
+@pytest.mark.parametrize("eng", [SedonaDB, PostGIS])
+@pytest.mark.parametrize(
+    ("geom1", "geom2", "densify_frac", "expected"),
+    [
+        # NULL handling
+        (None, None, 0.5, None),
+        ("POINT (0 0)", None, 0.5, None),
+        (None, "POINT (0 0)", 0.5, None),
+        # EMPTY geometries return NULL
+        ("POINT EMPTY", "POINT EMPTY", 0.5, None),
+        # Basic densified distance
+        ("LINESTRING (0 0, 100 0)", "LINESTRING (0 1, 100 1)", 0.5, 1.0),
+        # Densification makes a difference for complex shapes
+        (
+            "LINESTRING (130 0, 0 0, 0 150)",
+            "LINESTRING (10 10, 10 150, 130 10)",
+            0.5,
+            70.0,
+        ),
+    ],
+)
+def test_st_hausdorffdistance_densify(eng, geom1, geom2, densify_frac, expected):
+    eng = eng.create_or_skip()
+    eng.assert_query_result(
+        f"SELECT ST_HausdorffDistance({geom_or_null(geom1)}, {geom_or_null(geom2)}, {densify_frac})",
+        expected,
+        numeric_epsilon=1e-8,
+    )

--- a/python/sedonadb/tests/functions/test_distance.py
+++ b/python/sedonadb/tests/functions/test_distance.py
@@ -70,7 +70,11 @@ def test_st_distance(eng, geom1, geom2, expected):
         ("POINT (0 0)", "POLYGON ((1 0, 2 0, 2 1, 1 1, 1 0))", 2.23606797749979),
         # LineString to LineString
         ("LINESTRING (0 0, 2 0)", "LINESTRING (0 1, 1 1, 2 1)", 1.0),
-        ("LINESTRING (0 0, 100 0, 10 100, 10 100)", "LINESTRING (0 100, 0 10, 80 10)", 22.360679774997898),
+        (
+            "LINESTRING (0 0, 100 0, 10 100, 10 100)",
+            "LINESTRING (0 100, 0 10, 80 10)",
+            22.360679774997898,
+        ),
         # LineString to Polygon
         (
             "LINESTRING (0 0, 1 0)",

--- a/rust/sedona/src/reader.rs
+++ b/rust/sedona/src/reader.rs
@@ -43,16 +43,13 @@ impl Iterator for SedonaStreamReader {
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             match self.runtime.block_on(self.stream.try_next()) {
-                Ok(maybe_batch) => match maybe_batch {
-                    Some(batch) => {
-                        if batch.num_rows() == 0 {
-                            continue;
-                        }
-
-                        return Some(Ok(batch));
+                Ok(maybe_batch) => {
+                    let batch = maybe_batch?;
+                    if batch.num_rows() == 0 {
+                        continue;
                     }
-                    None => return None,
-                },
+                    return Some(Ok(batch));
+                }
                 Err(err) => return Some(Err(ArrowError::ExternalError(Box::new(err)))),
             }
         }


### PR DESCRIPTION
Adds ST_HausdorffDistance backed by GEOS

```python
import sedona.db
import pandas as pd

sd = sedona.db.connect()

sd.sql("""
    SELECT ST_HausdorffDistance(
       ST_GeomFromText('LINESTRING (0 0, 1 1 1)'),
       ST_GeomFromText('LINESTRING (0.5 0, 1 0, 1.5 1)')
    ) AS h
""").show()
# ┌────────────────────┐
# │          h         │
# │       float64      │
# ╞════════════════════╡
# │ 0.7071067811865476 │
# └────────────────────┘


densify_values = pd.DataFrame(
    {
        "l": ["LINESTRING (130 0, 0 0, 0 150)"] * 4,
        "r": ["LINESTRING (10 10, 10 150, 130 10)"] * 4,
        "dens": [0.1, 0.25, 0.75, 1.0],
    }
)
sd.create_data_frame(densify_values).to_view("t", overwrite=True)

sd.sql("""
   SELECT dens, ST_HausdorffDistance(
    ST_GeomFromText(l),
    ST_GeomFromText(r),
    dens
   ) as h 
   FROM t
""").show()
# ┌─────────┬────────────────────┐
# │   dens  ┆          h         │
# │ float64 ┆       float64      │
# ╞═════════╪════════════════════╡
# │     0.1 ┆               70.0 │
# ├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
# │    0.25 ┆               70.0 │
# ├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
# │    0.75 ┆ 14.142135623730951 │
# ├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
# │     1.0 ┆ 14.142135623730951 │
# └─────────┴────────────────────┘
```