### PR TITLE
fix(rust/sedona-functions): Fix scalar iteration with num_iterations > 1

### DIFF
--- a/c/sedona-geos/src/st_area.rs
+++ b/c/sedona-geos/src/st_area.rs
@@ -57,7 +57,7 @@ impl SedonaScalarKernel for STArea {
         executor.execute_wkb_void(|maybe_wkb| {
             match maybe_wkb {
                 Some(wkb) => {
-                    builder.append_value(invoke_scalar(&wkb)?);
+                    builder.append_value(invoke_scalar(wkb)?);
                 }
                 _ => builder.append_null(),
             }

--- a/c/sedona-geos/src/st_boundary.rs
+++ b/c/sedona-geos/src/st_boundary.rs
@@ -70,7 +70,7 @@ impl SedonaScalarKernel for STBoundary {
         executor.execute_wkb_void(|maybe_wkb| {
             match maybe_wkb {
                 Some(wkb) => {
-                    invoke_scalar(&wkb, &mut builder)?;
+                    invoke_scalar(wkb, &mut builder)?;
                     builder.append_value([]);
                 }
                 _ => builder.append_null(),

--- a/c/sedona-geos/src/st_buffer.rs
+++ b/c/sedona-geos/src/st_buffer.rs
@@ -132,7 +132,7 @@ fn invoke_batch_impl(arg_types: &[SedonaType], args: &[ColumnarValue]) -> Result
                 if (is_left && distance < 0.0) || (is_right && distance > 0.0) {
                     distance = -distance;
                 }
-                invoke_scalar(&wkb, distance, &params, &mut builder)?;
+                invoke_scalar(wkb, distance, &params, &mut builder)?;
                 builder.append_value([]);
             }
             _ => builder.append_null(),

--- a/c/sedona-geos/src/st_buildarea.rs
+++ b/c/sedona-geos/src/st_buildarea.rs
@@ -64,7 +64,7 @@ impl SedonaScalarKernel for STBuildArea {
         executor.execute_wkb_void(|maybe_geom| {
             match maybe_geom {
                 Some(geom) => {
-                    if invoke_scalar(&geom, &mut builder)? {
+                    if invoke_scalar(geom, &mut builder)? {
                         builder.append_value([]);
                     } else {
                         builder.append_null();

--- a/c/sedona-geos/src/st_centroid.rs
+++ b/c/sedona-geos/src/st_centroid.rs
@@ -61,7 +61,7 @@ impl SedonaScalarKernel for STCentroid {
         executor.execute_wkb_void(|maybe_wkb| {
             match maybe_wkb {
                 Some(wkb) => {
-                    invoke_scalar(&wkb, &mut builder)?;
+                    invoke_scalar(wkb, &mut builder)?;
                     builder.append_value([]);
                 }
                 _ => builder.append_null(),

--- a/c/sedona-geos/src/st_concavehull.rs
+++ b/c/sedona-geos/src/st_concavehull.rs
@@ -121,7 +121,7 @@ fn invoke_batch_impl(arg_types: &[SedonaType], args: &[ColumnarValue]) -> Result
             allow_holes_iter.next().unwrap(),
         ) {
             (Some(wkb), Some(pct_convex), Some(allow_holes)) => {
-                invoke_scalar(&wkb, pct_convex, allow_holes, &mut builder)?;
+                invoke_scalar(wkb, pct_convex, allow_holes, &mut builder)?;
                 builder.append_value([]);
             }
             _ => builder.append_null(),

--- a/c/sedona-geos/src/st_convexhull.rs
+++ b/c/sedona-geos/src/st_convexhull.rs
@@ -61,7 +61,7 @@ impl SedonaScalarKernel for STConvexHull {
         executor.execute_wkb_void(|maybe_wkb| {
             match maybe_wkb {
                 Some(wkb) => {
-                    invoke_scalar(&wkb, &mut builder)?;
+                    invoke_scalar(wkb, &mut builder)?;
                     builder.append_value([]);
                 }
                 _ => builder.append_null(),

--- a/c/sedona-geos/src/st_delaunaytriangles.rs
+++ b/c/sedona-geos/src/st_delaunaytriangles.rs
@@ -78,7 +78,7 @@ impl SedonaScalarKernel for STDelaunayTriangles {
         executor.execute_wkb_void(|maybe_geom| {
             match maybe_geom {
                 Some(geom) => {
-                    invoke_scalar(&geom, 0.0, false, &mut builder)?;
+                    invoke_scalar(geom, 0.0, false, &mut builder)?;
                     builder.append_value([]);
                 }
                 None => builder.append_null(),
@@ -125,7 +125,7 @@ impl SedonaScalarKernel for STDelaunayTrianglesWithTolerance {
         executor.execute_wkb_void(|maybe_geom| {
             match (maybe_geom, tol_iter.next().unwrap()) {
                 (Some(geom), Some(tol)) => {
-                    invoke_scalar(&geom, tol, false, &mut builder)?;
+                    invoke_scalar(geom, tol, false, &mut builder)?;
                     builder.append_value([]);
                 }
                 _ => builder.append_null(),
@@ -197,7 +197,7 @@ impl SedonaScalarKernel for STDelaunayTrianglesWithFlags {
                             ))
                         }
                     };
-                    invoke_scalar(&geom, tol, only_edges, &mut builder)?;
+                    invoke_scalar(geom, tol, only_edges, &mut builder)?;
                     builder.append_value([]);
                 }
                 _ => builder.append_null(),

--- a/c/sedona-geos/src/st_exteriorring.rs
+++ b/c/sedona-geos/src/st_exteriorring.rs
@@ -71,7 +71,7 @@ impl SedonaScalarKernel for STExteriorRing {
         executor.execute_wkb_void(|maybe_geom| {
             match maybe_geom {
                 Some(geom) => {
-                    if invoke_scalar(&geom, &mut builder)? {
+                    if invoke_scalar(geom, &mut builder)? {
                         builder.append_value([]);
                     } else {
                         builder.append_null();

--- a/c/sedona-geos/src/st_isring.rs
+++ b/c/sedona-geos/src/st_isring.rs
@@ -59,7 +59,7 @@ impl SedonaScalarKernel for STIsRing {
         executor.execute_wkb_void(|maybe_wkb| {
             match maybe_wkb {
                 Some(wkb) => {
-                    builder.append_value(invoke_scalar(&wkb)?);
+                    builder.append_value(invoke_scalar(wkb)?);
                 }
                 _ => builder.append_null(),
             }

--- a/c/sedona-geos/src/st_issimple.rs
+++ b/c/sedona-geos/src/st_issimple.rs
@@ -58,7 +58,7 @@ impl SedonaScalarKernel for STIsSimple {
         executor.execute_wkb_void(|maybe_wkb| {
             match maybe_wkb {
                 Some(wkb) => {
-                    builder.append_value(invoke_scalar(&wkb)?);
+                    builder.append_value(invoke_scalar(wkb)?);
                 }
                 _ => builder.append_null(),
             }

--- a/c/sedona-geos/src/st_isvalid.rs
+++ b/c/sedona-geos/src/st_isvalid.rs
@@ -57,7 +57,7 @@ impl SedonaScalarKernel for STIsValid {
         executor.execute_wkb_void(|maybe_wkb| {
             match maybe_wkb {
                 Some(wkb) => {
-                    builder.append_value(invoke_scalar(&wkb)?);
+                    builder.append_value(invoke_scalar(wkb)?);
                 }
                 _ => builder.append_null(),
             }

--- a/c/sedona-geos/src/st_isvalidreason.rs
+++ b/c/sedona-geos/src/st_isvalidreason.rs
@@ -61,7 +61,7 @@ impl SedonaScalarKernel for STIsValidReason {
         executor.execute_wkb_void(|maybe_wkb| {
             match maybe_wkb {
                 Some(wkb) => {
-                    builder.append_value(invoke_scalar(&wkb)?);
+                    builder.append_value(invoke_scalar(wkb)?);
                 }
                 _ => builder.append_null(),
             }

--- a/c/sedona-geos/src/st_length.rs
+++ b/c/sedona-geos/src/st_length.rs
@@ -60,7 +60,7 @@ impl SedonaScalarKernel for STLength {
         executor.execute_wkb_void(|maybe_wkb| {
             match maybe_wkb {
                 Some(wkb) => {
-                    builder.append_value(invoke_scalar(&wkb).map_err(|e| {
+                    builder.append_value(invoke_scalar(wkb).map_err(|e| {
                         DataFusionError::Execution(format!("Failed to calculate length: {e}"))
                     })?);
                 }

--- a/c/sedona-geos/src/st_line_merge.rs
+++ b/c/sedona-geos/src/st_line_merge.rs
@@ -89,7 +89,7 @@ impl SedonaScalarKernel for STLineMerge {
         executor.execute_wkb_void(|maybe_wkb| {
             match maybe_wkb {
                 Some(wkb) => {
-                    invoke_scalar(&wkb, &mut builder, directed)?;
+                    invoke_scalar(wkb, &mut builder, directed)?;
                     builder.append_value([]);
                 }
                 None => builder.append_null(),

--- a/c/sedona-geos/src/st_makevalid.rs
+++ b/c/sedona-geos/src/st_makevalid.rs
@@ -63,7 +63,7 @@ impl SedonaScalarKernel for STMakeValid {
         executor.execute_wkb_void(|maybe_wkb| {
             match maybe_wkb {
                 Some(wkb) => {
-                    invoke_scalar(&wkb, &mut builder)?;
+                    invoke_scalar(wkb, &mut builder)?;
                     builder.append_value([]);
                 }
                 _ => builder.append_null(),

--- a/c/sedona-geos/src/st_minimumclearance.rs
+++ b/c/sedona-geos/src/st_minimumclearance.rs
@@ -58,7 +58,7 @@ impl SedonaScalarKernel for STMinimumClearance {
         executor.execute_wkb_void(|maybe_wkb| {
             match maybe_wkb {
                 Some(wkb) => {
-                    builder.append_value(invoke_scalar(&wkb)?);
+                    builder.append_value(invoke_scalar(wkb)?);
                 }
                 _ => builder.append_null(),
             }

--- a/c/sedona-geos/src/st_minimumclearance_line.rs
+++ b/c/sedona-geos/src/st_minimumclearance_line.rs
@@ -63,7 +63,7 @@ impl SedonaScalarKernel for STMinimumClearanceLine {
         executor.execute_wkb_void(|maybe_wkb| {
             match maybe_wkb {
                 Some(wkb) => {
-                    invoke_scalar(&wkb, &mut builder)?;
+                    invoke_scalar(wkb, &mut builder)?;
                     builder.append_value([]);
                 }
                 _ => builder.append_null(),

--- a/c/sedona-geos/src/st_normalize.rs
+++ b/c/sedona-geos/src/st_normalize.rs
@@ -67,7 +67,7 @@ impl SedonaScalarKernel for STNormalize {
         executor.execute_wkb_void(|maybe_wkb| {
             match maybe_wkb {
                 Some(wkb) => {
-                    invoke_scalar(&wkb, &mut builder)?;
+                    invoke_scalar(wkb, &mut builder)?;
                     builder.append_value([]);
                 }
                 _ => builder.append_null(),

--- a/c/sedona-geos/src/st_nrings.rs
+++ b/c/sedona-geos/src/st_nrings.rs
@@ -56,7 +56,7 @@ impl SedonaScalarKernel for STNRings {
             match maybe_geom {
                 None => builder.append_null(),
                 Some(geom) => {
-                    let val = invoke_scalar(&geom)?;
+                    let val = invoke_scalar(geom)?;
                     builder.append_value(val);
                 }
             }

--- a/c/sedona-geos/src/st_numinteriorrings.rs
+++ b/c/sedona-geos/src/st_numinteriorrings.rs
@@ -57,7 +57,7 @@ impl SedonaScalarKernel for STNumInteriorRings {
             match maybe_geom {
                 None => builder.append_null(),
                 Some(geom) => {
-                    let res = invoke_scalar(&geom)?;
+                    let res = invoke_scalar(geom)?;
                     match res {
                         Some(n) => builder.append_value(n),
                         None => builder.append_null(),

--- a/c/sedona-geos/src/st_perimeter.rs
+++ b/c/sedona-geos/src/st_perimeter.rs
@@ -59,7 +59,7 @@ impl SedonaScalarKernel for STPerimeter {
         executor.execute_wkb_void(|maybe_wkb| {
             match maybe_wkb {
                 Some(wkb) => {
-                    builder.append_value(invoke_scalar(&wkb).map_err(|e| {
+                    builder.append_value(invoke_scalar(wkb).map_err(|e| {
                         DataFusionError::Execution(format!("Failed to calculate perimeter: {e}"))
                     })?);
                 }

--- a/c/sedona-geos/src/st_pointonsurface.rs
+++ b/c/sedona-geos/src/st_pointonsurface.rs
@@ -64,7 +64,7 @@ impl SedonaScalarKernel for STPointOnSurface {
         executor.execute_wkb_void(|maybe_geom| {
             match maybe_geom {
                 Some(geom) => {
-                    invoke_scalar(&geom, &mut builder)?;
+                    invoke_scalar(geom, &mut builder)?;
                     builder.append_value([]);
                 }
                 _ => builder.append_null(),

--- a/c/sedona-geos/src/st_polygonize.rs
+++ b/c/sedona-geos/src/st_polygonize.rs
@@ -61,7 +61,7 @@ impl SedonaScalarKernel for STPolygonize {
         executor.execute_wkb_void(|maybe_wkb| {
             match maybe_wkb {
                 Some(wkb) => {
-                    invoke_scalar(&wkb, &mut builder)?;
+                    invoke_scalar(wkb, &mut builder)?;
                     builder.append_value([]);
                 }
                 _ => builder.append_null(),

--- a/c/sedona-geos/src/st_reduce_precision.rs
+++ b/c/sedona-geos/src/st_reduce_precision.rs
@@ -73,7 +73,7 @@ impl SedonaScalarKernel for STReducePrecision {
         executor.execute_wkb_void(|wkb| {
             match (wkb, grid_size_iter.next().unwrap()) {
                 (Some(wkb), Some(grid_size)) => {
-                    invoke_scalar(&wkb, grid_size, &mut builder)?;
+                    invoke_scalar(wkb, grid_size, &mut builder)?;
                     builder.append_value([]);
                 }
                 _ => builder.append_null(),

--- a/c/sedona-geos/src/st_simplify.rs
+++ b/c/sedona-geos/src/st_simplify.rs
@@ -74,7 +74,7 @@ impl SedonaScalarKernel for STSimplify {
         executor.execute_wkb_void(|wkb| {
             match (wkb, tolerance_iter.next().unwrap()) {
                 (Some(wkb), Some(tolerance)) => {
-                    invoke_scalar(&wkb, tolerance, &mut builder)?;
+                    invoke_scalar(wkb, tolerance, &mut builder)?;
                     builder.append_value([]);
                 }
                 _ => builder.append_null(),

--- a/c/sedona-geos/src/st_simplifypreservetopology.rs
+++ b/c/sedona-geos/src/st_simplifypreservetopology.rs
@@ -76,7 +76,7 @@ impl SedonaScalarKernel for STSimplifyPreserveTopology {
         executor.execute_wkb_void(|wkb| {
             match (wkb, tolerance_iter.next().unwrap()) {
                 (Some(wkb), Some(tolerance)) => {
-                    invoke_scalar(&wkb, tolerance, &mut builder)?;
+                    invoke_scalar(wkb, tolerance, &mut builder)?;
                     builder.append_value([]);
                 }
                 _ => builder.append_null(),

--- a/c/sedona-geos/src/st_unaryunion.rs
+++ b/c/sedona-geos/src/st_unaryunion.rs
@@ -59,7 +59,7 @@ impl SedonaScalarKernel for STUnaryUnion {
         executor.execute_wkb_void(|maybe_wkb| {
             match maybe_wkb {
                 Some(wkb) => {
-                    invoke_scalar(&wkb, &mut builder)?;
+                    invoke_scalar(wkb, &mut builder)?;
                     builder.append_value([]);
                 }
                 _ => builder.append_null(),

--- a/c/sedona-proj/src/st_transform.rs
+++ b/c/sedona-proj/src/st_transform.rs
@@ -177,7 +177,7 @@ impl SedonaScalarKernel for STTransform {
                     executor.execute_wkb_void(|maybe_wkb| {
                         match maybe_wkb {
                             Some(wkb) => {
-                                invoke_scalar(&wkb, crs_transform.as_ref(), &mut builder)?;
+                                invoke_scalar(wkb, crs_transform.as_ref(), &mut builder)?;
                                 builder.append_value([]);
                             }
                             None => builder.append_null(),
@@ -226,7 +226,7 @@ impl SedonaScalarKernel for STTransform {
                         }
 
                         if maybe_from_crs == maybe_to_crs {
-                            invoke_noop(&wkb, &mut builder)?;
+                            invoke_noop(wkb, &mut builder)?;
                             builder.append_value([]);
                             return Ok(());
                         }
@@ -242,7 +242,7 @@ impl SedonaScalarKernel for STTransform {
                             )
                         };
 
-                        invoke_scalar(&wkb, crs_transform.as_ref(), &mut builder)?;
+                        invoke_scalar(wkb, crs_transform.as_ref(), &mut builder)?;
                         builder.append_value([]);
                     }
                     _ => {

--- a/rust/sedona-functions/src/executor.rs
+++ b/rust/sedona-functions/src/executor.rs
@@ -103,7 +103,7 @@ impl<'a, 'b, Factory0: GeometryFactory, Factory1: GeometryFactory>
     /// a [Wkb] scalar. For [SedonaType::Wkb] and [SedonaType::WkbView] arrays, this
     /// is the conversion that would normally happen. For other future supported geometry
     /// array types, this may incur a cast of item-wise conversion overhead.
-    pub fn execute_wkb_void<F: FnMut(Option<Factory0::Geom<'b>>) -> Result<()>>(
+    pub fn execute_wkb_void<F: FnMut(Option<&Factory0::Geom<'b>>) -> Result<()>>(
         &self,
         mut func: F,
     ) -> Result<()> {
@@ -114,7 +114,7 @@ impl<'a, 'b, Factory0: GeometryFactory, Factory1: GeometryFactory>
             }
             ColumnarValue::Scalar(scalar_value) => {
                 let wkb0 = scalar_value.scalar_from_factory(&self.factory0)?;
-                func(wkb0)
+                func(wkb0.as_ref())
             }
         }
     }
@@ -146,7 +146,7 @@ impl<'a, 'b, Factory0: GeometryFactory, Factory1: GeometryFactory>
                     &self.factory0,
                     &self.arg_types[0],
                     self.num_iterations(),
-                    |wkb0| func(wkb0.as_ref(), wkb1.as_ref()),
+                    |wkb0| func(wkb0, wkb1.as_ref()),
                 )
             }
             (ColumnarValue::Scalar(scalar_value), ColumnarValue::Array(array)) => {
@@ -155,7 +155,7 @@ impl<'a, 'b, Factory0: GeometryFactory, Factory1: GeometryFactory>
                     &self.factory1,
                     &self.arg_types[1],
                     self.num_iterations(),
-                    |wkb1| func(wkb0.as_ref(), wkb1.as_ref()),
+                    |wkb1| func(wkb0.as_ref(), wkb1),
                 )
             }
             (ColumnarValue::Scalar(scalar_value0), ColumnarValue::Scalar(scalar_value1)) => {
@@ -285,7 +285,7 @@ pub trait IterGeo {
     fn iter_with_factory<
         'a,
         Factory: GeometryFactory,
-        F: FnMut(Option<Factory::Geom<'a>>) -> Result<()>,
+        F: FnMut(Option<&Factory::Geom<'a>>) -> Result<()>,
     >(
         &'a self,
         factory: &Factory,
@@ -299,7 +299,7 @@ pub trait IterGeo {
             |maybe_bytes| match maybe_bytes {
                 Some(wkb_bytes) => {
                     let geom = factory.try_from_wkb(wkb_bytes)?;
-                    func(Some(geom))
+                    func(Some(&geom))
                 }
                 None => func(None),
             },
@@ -311,7 +311,7 @@ pub trait IterGeo {
     /// The function will always be called num_iteration types to support
     /// efficient iteration over scalar containers (e.g., so that implementations
     /// can parse the Wkb once and reuse the object).
-    fn iter_as_wkb<'a, F: FnMut(Option<Wkb<'a>>) -> Result<()>>(
+    fn iter_as_wkb<'a, F: FnMut(Option<&Wkb<'a>>) -> Result<()>>(
         &'a self,
         sedona_type: &SedonaType,
         num_iterations: usize,
@@ -552,7 +552,7 @@ mod tests {
         let mut i = 0;
         wkb_array_ref
             .iter_as_wkb(&WKB_GEOMETRY, 3, |maybe_geom| {
-                write_to_test_output(&mut wkt_out, i, maybe_geom.as_ref()).unwrap();
+                write_to_test_output(&mut wkt_out, i, maybe_geom).unwrap();
                 i += 1;
                 Ok(())
             })
@@ -578,7 +578,7 @@ mod tests {
         let mut i = 0;
         wkb_view_array_ref
             .iter_as_wkb(&WKB_VIEW_GEOMETRY, 3, |maybe_geom| {
-                write_to_test_output(&mut wkt_out, i, maybe_geom.as_ref()).unwrap();
+                write_to_test_output(&mut wkt_out, i, maybe_geom).unwrap();
                 i += 1;
                 Ok(())
             })

--- a/rust/sedona-functions/src/executor.rs
+++ b/rust/sedona-functions/src/executor.rs
@@ -114,7 +114,10 @@ impl<'a, 'b, Factory0: GeometryFactory, Factory1: GeometryFactory>
             }
             ColumnarValue::Scalar(scalar_value) => {
                 let wkb0 = scalar_value.scalar_from_factory(&self.factory0)?;
-                func(wkb0.as_ref())
+                for _ in 0..self.num_iterations {
+                    func(wkb0.as_ref())?;
+                }
+                Ok(())
             }
         }
     }
@@ -161,7 +164,10 @@ impl<'a, 'b, Factory0: GeometryFactory, Factory1: GeometryFactory>
             (ColumnarValue::Scalar(scalar_value0), ColumnarValue::Scalar(scalar_value1)) => {
                 let wkb0 = scalar_value0.scalar_from_factory(&self.factory0)?;
                 let wkb1 = scalar_value1.scalar_from_factory(&self.factory1)?;
-                func(wkb0.as_ref(), wkb1.as_ref())
+                for _ in 0..self.num_iterations {
+                    func(wkb0.as_ref(), wkb1.as_ref())?;
+                }
+                Ok(())
             }
         }
     }
@@ -797,5 +803,67 @@ mod tests {
             .scalar_from_factory(&factory)
             .unwrap_err();
         assert!(err.message().contains("Can't iterate over"));
+    }
+
+    #[test]
+    fn execute_wkb_void_scalar_with_num_iterations() {
+        let wkb_scalar = ColumnarValue::Scalar(ScalarValue::Binary(Some(POINT.to_vec())));
+        // A non-geometry array that drives num_iterations
+        let float_array: ArrayRef = create_array!(Float64, [1.0, 2.0, 3.0]);
+        let float_value = ColumnarValue::Array(float_array);
+
+        let arg_types = [WKB_GEOMETRY, SedonaType::Arrow(DataType::Float64)];
+        let args = [wkb_scalar, float_value];
+        let executor = WkbExecutor::new(&arg_types, &args);
+
+        assert_eq!(executor.num_iterations(), 3);
+
+        let mut count = 0;
+        executor
+            .execute_wkb_void(|maybe_geom| {
+                assert!(maybe_geom.is_some());
+                count += 1;
+                Ok(())
+            })
+            .unwrap();
+
+        assert_eq!(
+            count, 3,
+            "Scalar geometry should iterate num_iterations times"
+        );
+    }
+
+    #[test]
+    fn execute_wkb_wkb_void_scalars_with_num_iterations() {
+        let wkb_scalar0 = ColumnarValue::Scalar(ScalarValue::Binary(Some(POINT.to_vec())));
+        let wkb_scalar1 = ColumnarValue::Scalar(ScalarValue::Binary(Some(POINT.to_vec())));
+        // A non-geometry array that drives num_iterations
+        let float_array: ArrayRef = create_array!(Float64, [0.1, 0.25, 0.5, 1.0]);
+        let float_value = ColumnarValue::Array(float_array);
+
+        let arg_types = [
+            WKB_GEOMETRY,
+            WKB_GEOMETRY,
+            SedonaType::Arrow(DataType::Float64),
+        ];
+        let args = [wkb_scalar0, wkb_scalar1, float_value];
+        let executor = WkbExecutor::new(&arg_types, &args);
+
+        assert_eq!(executor.num_iterations(), 4);
+
+        let mut count = 0;
+        executor
+            .execute_wkb_wkb_void(|maybe_geom0, maybe_geom1| {
+                assert!(maybe_geom0.is_some());
+                assert!(maybe_geom1.is_some());
+                count += 1;
+                Ok(())
+            })
+            .unwrap();
+
+        assert_eq!(
+            count, 4,
+            "Two scalar geometries should iterate num_iterations times"
+        );
     }
 }

--- a/rust/sedona-functions/src/st_affine.rs
+++ b/rust/sedona-functions/src/st_affine.rs
@@ -117,7 +117,7 @@ impl SedonaScalarKernel for STAffine {
             let maybe_mat = affine_iter.next().unwrap();
             match (maybe_wkb, maybe_mat) {
                 (Some(wkb), Some(mat)) => {
-                    transform(&wkb, &mat, &mut builder)
+                    transform(wkb, &mat, &mut builder)
                         .map_err(|e| DataFusionError::Execution(e.to_string()))?;
                     builder.append_value([]);
                 }

--- a/rust/sedona-functions/src/st_asewkb.rs
+++ b/rust/sedona-functions/src/st_asewkb.rs
@@ -82,7 +82,7 @@ impl SedonaScalarKernel for STAsEWKB {
         executor.execute_wkb_void(|maybe_wkb| {
             match maybe_wkb {
                 Some(wkb) => {
-                    write_ewkb_geometry(&mut builder, &wkb, maybe_srid)
+                    write_ewkb_geometry(&mut builder, wkb, maybe_srid)
                         .map_err(|e| exec_datafusion_err!("EWKB writer error {e}"))?;
                     builder.append_value([]);
                 }
@@ -156,7 +156,7 @@ impl SedonaScalarKernel for STAsEWKBItemCrs {
             let maybe_srid = srid_iter.next().unwrap()?;
             match maybe_wkb {
                 Some(wkb) => {
-                    write_ewkb_geometry(&mut builder, &wkb, maybe_srid)
+                    write_ewkb_geometry(&mut builder, wkb, maybe_srid)
                         .map_err(|e| exec_datafusion_err!("EWKB writer error {e}"))?;
                     builder.append_value([]);
                 }

--- a/rust/sedona-functions/src/st_dimension.rs
+++ b/rust/sedona-functions/src/st_dimension.rs
@@ -62,7 +62,7 @@ impl SedonaScalarKernel for STDimension {
         executor.execute_wkb_void(|maybe_item| {
             match maybe_item {
                 Some(item) => {
-                    builder.append_value(invoke_scalar(&item)?);
+                    builder.append_value(invoke_scalar(item)?);
                 }
                 None => builder.append_null(),
             }

--- a/rust/sedona-functions/src/st_dump.rs
+++ b/rust/sedona-functions/src/st_dump.rs
@@ -233,7 +233,7 @@ impl SedonaScalarKernel for STDump {
         let mut builder = STDumpBuilder::new(executor.num_iterations(), return_type.clone());
         executor.execute_wkb_void(|maybe_wkb| {
             if let Some(wkb) = maybe_wkb {
-                builder.append(&wkb)?;
+                builder.append(wkb)?;
             } else {
                 builder.append_null();
             }

--- a/rust/sedona-functions/src/st_flipcoordinates.rs
+++ b/rust/sedona-functions/src/st_flipcoordinates.rs
@@ -81,7 +81,7 @@ impl SedonaScalarKernel for STFlipCoordinates {
         executor.execute_wkb_void(|maybe_item| {
             match maybe_item {
                 Some(item) => {
-                    invoke_scalar(&item, &mut transform, &mut builder)?;
+                    invoke_scalar(item, &mut transform, &mut builder)?;
                     builder.append_value([]);
                 }
                 None => builder.append_null(),

--- a/rust/sedona-functions/src/st_geometryn.rs
+++ b/rust/sedona-functions/src/st_geometryn.rs
@@ -88,7 +88,7 @@ impl SedonaScalarKernel for STGeometryN {
         executor.execute_wkb_void(|maybe_wkb| {
             match (maybe_wkb, index_iter.next().unwrap()) {
                 (Some(wkb), Some(index)) => {
-                    if invoke_scalar(&wkb, (index - 1) as usize, &mut builder)? {
+                    if invoke_scalar(wkb, (index - 1) as usize, &mut builder)? {
                         builder.append_value([]);
                     } else {
                         // Unsupported Geometry Type, Invalid index encountered

--- a/rust/sedona-functions/src/st_interiorringn.rs
+++ b/rust/sedona-functions/src/st_interiorringn.rs
@@ -89,7 +89,7 @@ impl SedonaScalarKernel for STInteriorRingN {
         executor.execute_wkb_void(|maybe_wkb| {
             match (maybe_wkb, index_iter.next().unwrap()) {
                 (Some(wkb), Some(index)) => {
-                    if invoke_scalar(&wkb, (index - 1) as usize, &mut builder)? {
+                    if invoke_scalar(wkb, (index - 1) as usize, &mut builder)? {
                         builder.append_value([]);
                     } else {
                         // Unsupported Geometry Type, Invalid index encountered

--- a/rust/sedona-functions/src/st_isclosed.rs
+++ b/rust/sedona-functions/src/st_isclosed.rs
@@ -67,7 +67,7 @@ impl SedonaScalarKernel for STIsClosed {
         executor.execute_wkb_void(|maybe_item| {
             match maybe_item {
                 Some(item) => {
-                    builder.append_value(invoke_scalar(&item)?);
+                    builder.append_value(invoke_scalar(item)?);
                 }
                 None => builder.append_null(),
             }

--- a/rust/sedona-functions/src/st_isempty.rs
+++ b/rust/sedona-functions/src/st_isempty.rs
@@ -61,7 +61,7 @@ impl SedonaScalarKernel for STIsEmpty {
         executor.execute_wkb_void(|maybe_item| {
             match maybe_item {
                 Some(item) => {
-                    builder.append_value(invoke_scalar(&item)?);
+                    builder.append_value(invoke_scalar(item)?);
                 }
                 None => builder.append_null(),
             }

--- a/rust/sedona-functions/src/st_points.rs
+++ b/rust/sedona-functions/src/st_points.rs
@@ -84,13 +84,13 @@ impl SedonaScalarKernel for STPoints {
         executor.execute_wkb_void(|maybe_wkb| {
             if let Some(wkb) = maybe_wkb {
                 // We need to know the number of points before actually writing the points.
-                let n_points = count_wkb_points_recursively(&wkb);
+                let n_points = count_wkb_points_recursively(wkb);
 
                 if write_wkb_multipoint_header(&mut builder, wkb.dim(), n_points).is_err() {
                     return sedona_internal_err!("Failed to write WKB point header");
                 };
 
-                if write_wkb_points_recursively(&mut builder, &wkb).is_err() {
+                if write_wkb_points_recursively(&mut builder, wkb).is_err() {
                     return sedona_internal_err!("Failed to write WKB point header");
                 };
 
@@ -141,7 +141,7 @@ impl SedonaScalarKernel for STNPoints {
 
         executor.execute_wkb_void(|maybe_wkb| {
             if let Some(wkb) = maybe_wkb {
-                builder.append_value(count_wkb_points_recursively(&wkb) as u64);
+                builder.append_value(count_wkb_points_recursively(wkb) as u64);
             } else {
                 builder.append_null();
             }

--- a/rust/sedona-functions/src/st_reverse.rs
+++ b/rust/sedona-functions/src/st_reverse.rs
@@ -88,7 +88,7 @@ impl SedonaScalarKernel for STReverse {
         executor.execute_wkb_void(|maybe_wkb| {
             match maybe_wkb {
                 Some(wkb) => {
-                    invoke_scalar(&wkb, &mut builder)
+                    invoke_scalar(wkb, &mut builder)
                         .map_err(|e| exec_datafusion_err!("ST_Reverse error: {e}"))?;
                     builder.append_value([]);
                 }

--- a/rust/sedona-functions/src/st_rotate.rs
+++ b/rust/sedona-functions/src/st_rotate.rs
@@ -109,7 +109,7 @@ impl SedonaScalarKernel for STRotate {
             let maybe_mat = affine_iter.next().unwrap();
             match (maybe_wkb, maybe_mat) {
                 (Some(wkb), Some(mat)) => {
-                    transform(&wkb, &mat, &mut builder)
+                    transform(wkb, &mat, &mut builder)
                         .map_err(|e| DataFusionError::Execution(e.to_string()))?;
                     builder.append_value([]);
                 }

--- a/rust/sedona-functions/src/st_scale.rs
+++ b/rust/sedona-functions/src/st_scale.rs
@@ -104,7 +104,7 @@ impl SedonaScalarKernel for STScale {
             let maybe_mat = affine_iter.next().unwrap();
             match (maybe_wkb, maybe_mat) {
                 (Some(wkb), Some(mat)) => {
-                    transform(&wkb, &mat, &mut builder)
+                    transform(wkb, &mat, &mut builder)
                         .map_err(|e| DataFusionError::Execution(e.to_string()))?;
                     builder.append_value([]);
                 }

--- a/rust/sedona-functions/src/st_segmentize.rs
+++ b/rust/sedona-functions/src/st_segmentize.rs
@@ -106,7 +106,7 @@ impl SedonaScalarKernel for STSegmentize {
                         return exec_err!("max_segment_length must be finite and >= 0");
                     }
 
-                    segmentize_wkb(&wkb, max_len, &mut coords_scratch, &mut builder)
+                    segmentize_wkb(wkb, max_len, &mut coords_scratch, &mut builder)
                         .map_err(|e| exec_datafusion_err!("Segmentize error: {e}"))?;
                     builder.append_value([]);
                 }

--- a/rust/sedona-functions/src/st_start_point.rs
+++ b/rust/sedona-functions/src/st_start_point.rs
@@ -102,7 +102,7 @@ impl SedonaScalarKernel for STStartOrEndPoint {
 
         executor.execute_wkb_void(|maybe_wkb| {
             if let Some(wkb) = maybe_wkb {
-                if let Some(coord) = extract_start_or_end_coord(&wkb, self.from_start) {
+                if let Some(coord) = extract_start_or_end_coord(wkb, self.from_start) {
                     if write_wkb_point_from_coord(&mut builder, coord).is_err() {
                         return sedona_internal_err!("Failed to write WKB point header");
                     };

--- a/rust/sedona-functions/src/st_xyzm.rs
+++ b/rust/sedona-functions/src/st_xyzm.rs
@@ -141,7 +141,7 @@ impl SedonaScalarKernel for STXyzm {
         executor.execute_wkb_void(|maybe_item| {
             match maybe_item {
                 Some(item) => {
-                    builder.append_option(invoke_scalar(&item, dim_index)?);
+                    builder.append_option(invoke_scalar(item, dim_index)?);
                 }
                 None => builder.append_null(),
             }

--- a/rust/sedona-functions/src/st_xyzm_minmax.rs
+++ b/rust/sedona-functions/src/st_xyzm_minmax.rs
@@ -149,7 +149,7 @@ impl SedonaScalarKernel for STXyzmMinMax {
         executor.execute_wkb_void(|maybe_item| {
             match maybe_item {
                 Some(item) => {
-                    builder.append_option(invoke_scalar(&item, self.dim, self.is_max)?);
+                    builder.append_option(invoke_scalar(item, self.dim, self.is_max)?);
                 }
                 None => builder.append_null(),
             }

--- a/rust/sedona-geo/src/st_area.rs
+++ b/rust/sedona-geo/src/st_area.rs
@@ -57,7 +57,7 @@ impl SedonaScalarKernel for STArea {
         executor.execute_wkb_void(|maybe_wkb| {
             match maybe_wkb {
                 Some(wkb) => {
-                    builder.append_value(invoke_scalar(&wkb)?);
+                    builder.append_value(invoke_scalar(wkb)?);
                 }
                 _ => builder.append_null(),
             }

--- a/rust/sedona-geo/src/st_asgeojson.rs
+++ b/rust/sedona-geo/src/st_asgeojson.rs
@@ -67,7 +67,7 @@ impl SedonaScalarKernel for STAsGeoJSON {
         executor.execute_wkb_void(|maybe_wkb| {
             match maybe_wkb {
                 Some(wkb) => {
-                    let json_str = geom_to_geojson(&wkb)?;
+                    let json_str = geom_to_geojson(wkb)?;
                     builder.append_value(&json_str);
                 }
                 None => builder.append_null(),

--- a/rust/sedona-geo/src/st_buffer.rs
+++ b/rust/sedona-geo/src/st_buffer.rs
@@ -80,7 +80,7 @@ impl SedonaScalarKernel for STBuffer {
         executor.execute_wkb_void(|maybe_wkb| {
             match (maybe_wkb, distance_iter.next().unwrap()) {
                 (Some(wkb), Some(distance)) => {
-                    invoke_scalar(&wkb, BufferStyle::new(distance), &mut builder)?;
+                    invoke_scalar(wkb, BufferStyle::new(distance), &mut builder)?;
                     builder.append_value([]);
                 }
                 _ => builder.append_null(),

--- a/rust/sedona-geo/src/st_centroid.rs
+++ b/rust/sedona-geo/src/st_centroid.rs
@@ -64,7 +64,7 @@ impl SedonaScalarKernel for STCentroid {
         executor.execute_wkb_void(|maybe_wkb| {
             match maybe_wkb {
                 Some(wkb) => {
-                    let centroid_wkb = invoke_scalar(&wkb)?;
+                    let centroid_wkb = invoke_scalar(wkb)?;
                     builder.append_value(&centroid_wkb);
                 }
                 _ => builder.append_null(),

--- a/rust/sedona-geo/src/st_concavehull.rs
+++ b/rust/sedona-geo/src/st_concavehull.rs
@@ -84,7 +84,7 @@ fn invoke_batch_impl(arg_types: &[SedonaType], args: &[ColumnarValue]) -> Result
     executor.execute_wkb_void(|maybe_wkb| {
         match (maybe_wkb, pct_convex_iter.next().unwrap()) {
             (Some(wkb), Some(pct_convex)) => {
-                invoke_scalar(&wkb, pct_convex, &mut builder)?;
+                invoke_scalar(wkb, pct_convex, &mut builder)?;
                 builder.append_value([]);
             }
             _ => builder.append_null(),

--- a/rust/sedona-geo/src/st_intersection_agg.rs
+++ b/rust/sedona-geo/src/st_intersection_agg.rs
@@ -155,7 +155,7 @@ impl IntersectionAccumulator {
     fn execute_update(&mut self, executor: WkbExecutor) -> Result<()> {
         executor.execute_wkb_void(|maybe_item| {
             if let Some(item) = maybe_item {
-                self.update_intersection(&item)?;
+                self.update_intersection(item)?;
             }
             Ok(())
         })?;

--- a/rust/sedona-geo/src/st_length.rs
+++ b/rust/sedona-geo/src/st_length.rs
@@ -58,7 +58,7 @@ impl SedonaScalarKernel for STLength {
         executor.execute_wkb_void(|maybe_wkb| {
             match maybe_wkb {
                 Some(wkb) => {
-                    builder.append_value(invoke_scalar(&wkb)?);
+                    builder.append_value(invoke_scalar(wkb)?);
                 }
                 _ => builder.append_null(),
             }

--- a/rust/sedona-geo/src/st_line_interpolate_point.rs
+++ b/rust/sedona-geo/src/st_line_interpolate_point.rs
@@ -73,7 +73,7 @@ impl SedonaScalarKernel for STLineInterpolatePoint {
             let maybe_ratio = arg1_iter.next().unwrap();
             match (maybe_geom, maybe_ratio) {
                 (Some(geom), Some(ratio)) => {
-                    let (x, y) = invoke_scalar(&geom, ratio)?;
+                    let (x, y) = invoke_scalar(geom, ratio)?;
                     write_wkb_point(&mut builder, (x, y))
                         .map_err(|e| DataFusionError::External(Box::new(e)))?;
                     builder.append_value([]);

--- a/rust/sedona-geo/src/st_perimeter.rs
+++ b/rust/sedona-geo/src/st_perimeter.rs
@@ -58,7 +58,7 @@ impl SedonaScalarKernel for STPerimeter {
         executor.execute_wkb_void(|maybe_wkb| {
             match maybe_wkb {
                 Some(wkb) => {
-                    builder.append_value(invoke_scalar(&wkb)?);
+                    builder.append_value(invoke_scalar(wkb)?);
                 }
                 _ => builder.append_null(),
             }

--- a/rust/sedona-geo/src/st_union_agg.rs
+++ b/rust/sedona-geo/src/st_union_agg.rs
@@ -149,7 +149,7 @@ impl UnionAccumulator {
     fn execute_update(&mut self, executor: WkbExecutor) -> Result<()> {
         executor.execute_wkb_void(|maybe_item| {
             if let Some(item) = maybe_item {
-                self.update_union(&item)?;
+                self.update_union(item)?;
             }
             Ok(())
         })?;

--- a/rust/sedona-geo/src/to_geo.rs
+++ b/rust/sedona-geo/src/to_geo.rs
@@ -183,7 +183,7 @@ mod tests {
         let executor = GeoTypesExecutor::new(&[WKB_GEOMETRY], &args);
         executor
             .execute_wkb_void(|geo| {
-                actual_items.push(geo);
+                actual_items.push(geo.cloned());
                 Ok(())
             })
             .unwrap();

--- a/rust/sedona-geometry/src/bounds.rs
+++ b/rust/sedona-geometry/src/bounds.rs
@@ -159,7 +159,7 @@ impl WkbBounder2D for WkbGeometryBounder {
     fn update_wkb_bytes(&mut self, wkb_value: &[u8]) -> Result<(), SedonaGeometryError> {
         let wkb = wkb::reader::read_wkb(wkb_value)
             .map_err(|e| SedonaGeometryError::External(Box::new(e)))?;
-        geo_traits_update_xy_bounds(wkb, &mut self.x, &mut self.y)?;
+        geo_traits_update_xy_bounds(&wkb, &mut self.x, &mut self.y)?;
         Ok(())
     }
 
@@ -211,7 +211,7 @@ pub fn geo_traits_bounds_xy(
 ) -> Result<BoundingBox, SedonaGeometryError> {
     let mut x = Interval::empty();
     let mut y = Interval::empty();
-    geo_traits_update_xy_bounds(geom, &mut x, &mut y)?;
+    geo_traits_update_xy_bounds(&geom, &mut x, &mut y)?;
     Ok(BoundingBox::xy(x, y))
 }
 
@@ -238,7 +238,7 @@ pub fn geo_traits_bounds_m(
 /// Useful for updating bounds in-place when accumulating
 /// bounds for statistics or function implementations.
 pub fn geo_traits_update_xy_bounds(
-    geom: impl GeometryTrait<T = f64>,
+    geom: &impl GeometryTrait<T = f64>,
     x: &mut Interval,
     y: &mut Interval,
 ) -> Result<(), SedonaGeometryError> {
@@ -272,22 +272,22 @@ pub fn geo_traits_update_xy_bounds(
         }
         GeometryType::MultiPoint(multi_pt) => {
             for pt in multi_pt.points() {
-                geo_traits_update_xy_bounds(pt, x, y)?;
+                geo_traits_update_xy_bounds(&pt, x, y)?;
             }
         }
         GeometryType::MultiLineString(multi_ls) => {
             for ls in multi_ls.line_strings() {
-                geo_traits_update_xy_bounds(ls, x, y)?;
+                geo_traits_update_xy_bounds(&ls, x, y)?;
             }
         }
         GeometryType::MultiPolygon(multi_pl) => {
             for pl in multi_pl.polygons() {
-                geo_traits_update_xy_bounds(pl, x, y)?;
+                geo_traits_update_xy_bounds(&pl, x, y)?;
             }
         }
         GeometryType::GeometryCollection(collection) => {
             for geom in collection.geometries() {
-                geo_traits_update_xy_bounds(geom, x, y)?;
+                geo_traits_update_xy_bounds(&geom, x, y)?;
             }
         }
         _ => {

--- a/rust/sedona-geoparquet/src/writer.rs
+++ b/rust/sedona-geoparquet/src/writer.rs
@@ -503,7 +503,7 @@ impl SedonaScalarKernel for GeoParquetBbox {
             match maybe_item {
                 Some(item) => {
                     nulls.append(true);
-                    append_float_bbox(&item, &mut builders)?;
+                    append_float_bbox(item, &mut builders)?;
                 }
                 None => {
                     // If we have a null, we set the outer validity bitmap to null
@@ -550,7 +550,7 @@ fn bbox_fields() -> Fields {
 // a set of builders, ensuring the float bounds always include the double
 // bounds.
 fn append_float_bbox(
-    wkb: impl GeometryTrait<T = f64>,
+    wkb: &impl GeometryTrait<T = f64>,
     builders: &mut [Float32Builder],
 ) -> Result<()> {
     let mut x = Interval::empty();

--- a/rust/sedona-spatial-join/src/operand_evaluator.rs
+++ b/rust/sedona-spatial-join/src/operand_evaluator.rs
@@ -199,11 +199,9 @@ impl EvaluatedGeometryArray {
                 // `wkbs` are both owned by the `EvaluatedGeometryArray`, so they have the same lifetime. We'll never
                 // have a situation where the `EvaluatedGeometryArray` is dropped while the `wkbs` are still in use
                 // (guaranteed by the scope of the `wkbs` field and lifetime signature of the `wkbs` method).
-                wkbs.push(unsafe {
-                    transmute::<Option<wkb::reader::Wkb<'_>>, Option<wkb::reader::Wkb<'_>>>(Some(
-                        wkb,
-                    ))
-                });
+                wkbs.push(Some(unsafe {
+                    transmute::<Wkb<'_>, Wkb<'static>>(wkb)
+                }));
             } else {
                 rect_vec.push(Bounds2D::empty());
                 wkbs.push(None);
@@ -237,11 +235,9 @@ impl EvaluatedGeometryArray {
             if let Some(wkb_bytes) = wkb_opt {
                 let wkb = wkb::reader::read_wkb(wkb_bytes)
                     .map_err(|e| exec_datafusion_err!("WKB parse failed: {e}"))?;
-                wkbs.push(unsafe {
-                    transmute::<Option<wkb::reader::Wkb<'_>>, Option<wkb::reader::Wkb<'_>>>(Some(
-                        wkb,
-                    ))
-                });
+                wkbs.push(Some(unsafe {
+                    transmute::<Wkb<'_>, Wkb<'static>>(wkb)
+                }));
             } else {
                 wkbs.push(None);
             }

--- a/rust/sedona-spatial-join/src/operand_evaluator.rs
+++ b/rust/sedona-spatial-join/src/operand_evaluator.rs
@@ -20,7 +20,9 @@ use std::{mem::transmute, sync::Arc};
 use arrow::compute::{concat as arrow_concat, interleave as arrow_interleave};
 use arrow_array::{Array, ArrayRef, Float64Array, RecordBatch};
 use arrow_schema::DataType;
-use datafusion_common::{utils::proxy::VecAllocExt, JoinSide, Result, ScalarValue};
+use datafusion_common::{
+    exec_datafusion_err, utils::proxy::VecAllocExt, JoinSide, Result, ScalarValue,
+};
 use datafusion_expr::ColumnarValue;
 use datafusion_physical_expr::PhysicalExpr;
 use sedona_functions::executor::IterGeo;
@@ -183,22 +185,30 @@ impl EvaluatedGeometryArray {
         let mut wkbs = Vec::with_capacity(num_rows);
         let mut x = Interval::empty();
         let mut y = Interval::empty();
-        geometry_array.iter_as_wkb(sedona_type, num_rows, |wkb_opt| {
-            if let Some(wkb) = &wkb_opt {
+        geometry_array.iter_as_wkb_bytes(sedona_type, num_rows, |wkb_opt| {
+            if let Some(wkb_bytes) = &wkb_opt {
+                let wkb = wkb::reader::read_wkb(wkb_bytes)
+                    .map_err(|e| exec_datafusion_err!("WKB parse failed: {e}"))?;
                 x = Interval::empty();
                 y = Interval::empty();
-                geo_traits_update_xy_bounds(wkb, &mut x, &mut y)
+                geo_traits_update_xy_bounds(&wkb, &mut x, &mut y)
                     .map_err(|e| sedona_internal_datafusion_err!("{e}"))?;
                 rect_vec.push(Bounds2D::new(x, y));
+
+                // Safety: The wkbs must reference buffers inside the `geometry_array`. Since the `geometry_array` and
+                // `wkbs` are both owned by the `EvaluatedGeometryArray`, so they have the same lifetime. We'll never
+                // have a situation where the `EvaluatedGeometryArray` is dropped while the `wkbs` are still in use
+                // (guaranteed by the scope of the `wkbs` field and lifetime signature of the `wkbs` method).
+                wkbs.push(unsafe {
+                    transmute::<Option<wkb::reader::Wkb<'_>>, Option<wkb::reader::Wkb<'_>>>(Some(
+                        wkb,
+                    ))
+                });
             } else {
-                rect_vec.push(Bounds2D::empty())
+                rect_vec.push(Bounds2D::empty());
+                wkbs.push(None);
             }
 
-            // Safety: The wkbs must reference buffers inside the `geometry_array`. Since the `geometry_array` and
-            // `wkbs` are both owned by the `EvaluatedGeometryArray`, so they have the same lifetime. We'll never
-            // have a situation where the `EvaluatedGeometryArray` is dropped while the `wkbs` are still in use
-            // (guaranteed by the scope of the `wkbs` field and lifetime signature of the `wkbs` method).
-            wkbs.push(wkb_opt.map(|wkb| unsafe { transmute(wkb) }));
             Ok(())
         })?;
 
@@ -223,8 +233,18 @@ impl EvaluatedGeometryArray {
         // (guaranteed by the scope of the `wkbs` field and lifetime signature of the `wkbs` method).
         let num_rows = geometry_array.len();
         let mut wkbs = Vec::with_capacity(num_rows);
-        geometry_array.iter_as_wkb(sedona_type, num_rows, |wkb_opt| {
-            wkbs.push(wkb_opt.map(|wkb| unsafe { transmute(wkb) }));
+        geometry_array.iter_as_wkb_bytes(sedona_type, num_rows, |wkb_opt| {
+            if let Some(wkb_bytes) = wkb_opt {
+                let wkb = wkb::reader::read_wkb(wkb_bytes)
+                    .map_err(|e| exec_datafusion_err!("WKB parse failed: {e}"))?;
+                wkbs.push(unsafe {
+                    transmute::<Option<wkb::reader::Wkb<'_>>, Option<wkb::reader::Wkb<'_>>>(Some(
+                        wkb,
+                    ))
+                });
+            } else {
+                wkbs.push(None);
+            }
             Ok(())
         })?;
 

--- a/rust/sedona-spatial-join/src/operand_evaluator.rs
+++ b/rust/sedona-spatial-join/src/operand_evaluator.rs
@@ -199,9 +199,7 @@ impl EvaluatedGeometryArray {
                 // `wkbs` are both owned by the `EvaluatedGeometryArray`, so they have the same lifetime. We'll never
                 // have a situation where the `EvaluatedGeometryArray` is dropped while the `wkbs` are still in use
                 // (guaranteed by the scope of the `wkbs` field and lifetime signature of the `wkbs` method).
-                wkbs.push(Some(unsafe {
-                    transmute::<Wkb<'_>, Wkb<'static>>(wkb)
-                }));
+                wkbs.push(Some(unsafe { transmute::<Wkb<'_>, Wkb<'static>>(wkb) }));
             } else {
                 rect_vec.push(Bounds2D::empty());
                 wkbs.push(None);
@@ -235,9 +233,7 @@ impl EvaluatedGeometryArray {
             if let Some(wkb_bytes) = wkb_opt {
                 let wkb = wkb::reader::read_wkb(wkb_bytes)
                     .map_err(|e| exec_datafusion_err!("WKB parse failed: {e}"))?;
-                wkbs.push(Some(unsafe {
-                    transmute::<Wkb<'_>, Wkb<'static>>(wkb)
-                }));
+                wkbs.push(Some(unsafe { transmute::<Wkb<'_>, Wkb<'static>>(wkb) }));
             } else {
                 wkbs.push(None);
             }

--- a/rust/sedona-spatial-join/tests/spatial_join_integration.rs
+++ b/rust/sedona-spatial-join/tests/spatial_join_integration.rs
@@ -1264,7 +1264,7 @@ fn extract_geoms_and_ids(partitions: &[Vec<RecordBatch>]) -> Vec<(i32, geo::Geom
                 .execute_wkb_void(|maybe_geom| {
                     if let Some(id_opt) = id_iter.next() {
                         if let (Some(id), Some(geom)) = (id_opt, maybe_geom) {
-                            result.push((id, geom))
+                            result.push((id, geom.clone()))
                         }
                     }
                     Ok(())


### PR DESCRIPTION
This PR fixes scalar function calls with scalar geometry values but non-scalar "other" arguments, like ST_Buffer(scalar_geom, col_dist) or ST_DWithin(scalar_geom, scalar_geom, col_dist). These calls are less common so this was never caught.

The PR notably updates the executor so that it iterates over references and not values. The only place that had exploited this was the spatial join, where it was relatively easy to just add in the call to `read_wkb()` required to avoid the copy.

Most of the files here are a one line change updating reference usage.

Fixes #1038