### PR TITLE
fix(c/sedona-tg): handle collection point containment boundaries

### DIFF
--- a/c/sedona-tg/src/tg.rs
+++ b/c/sedona-tg/src/tg.rs
@@ -311,9 +311,55 @@ mod test {
             "POLYGON ((1 1, 1 2, 2 1, 1 1))",
             false,
         );
+        test_predicate::<Contains>("GEOMETRYCOLLECTION (POINT (0 0))", "POINT (0 0)", true);
+        test_predicate::<Contains>(
+            "GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (0 0, 0 1))",
+            "POINT (0 0)",
+            false,
+        );
+        test_predicate::<Contains>(
+            "GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (0 0, 0 1))",
+            "POINT (0 0.5)",
+            true,
+        );
+        test_predicate::<Contains>(
+            "GEOMETRYCOLLECTION (POINT (-1 -1), LINESTRING (0 0, 0 1))",
+            "POINT (-1 -1)",
+            true,
+        );
+        test_predicate::<Contains>(
+            "GEOMETRYCOLLECTION (POINT (0 0), POLYGON ((0 0, 0 1, 1 0, 0 0)))",
+            "POINT (0 0)",
+            false,
+        );
+        test_predicate::<Contains>(
+            "GEOMETRYCOLLECTION (POINT (0 0), POLYGON ((0 0, 0 1, 1 0, 0 0)))",
+            "POINT (0.25 0.25)",
+            true,
+        );
+        test_predicate::<Contains>(
+            "MULTILINESTRING ((0 0, 0 1), (0 0, 1 0))",
+            "POINT (0 0)",
+            true,
+        );
+        test_predicate::<Contains>(
+            "GEOMETRYCOLLECTION (LINESTRING (0 0, 0 1), POLYGON ((0 0, 0 1, 1 0, 0 0)))",
+            "LINESTRING (0 0, 0 1)",
+            false,
+        );
+        test_predicate::<Contains>(
+            "GEOMETRYCOLLECTION (LINESTRING (0 0, 0 1), POLYGON ((0 0, 0 1, 1 0, 0 0)))",
+            "LINESTRING (0 0, 0.25 0.25)",
+            true,
+        );
 
         test_predicate::<Within>("POINT (1 1)", "POLYGON ((0 0, 5 0, 0 5, 0 0))", true);
         test_predicate::<Within>("POINT (-1 -1)", "POLYGON ((0 0, 5 0, 0 5, 0 0))", false);
+        test_predicate::<Within>(
+            "POINT (0 0)",
+            "GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (0 0, 0 1))",
+            false,
+        );
 
         test_predicate::<Covers>("POLYGON ((0 0, 5 0, 0 5, 0 0))", "POINT (1 1)", true);
         test_predicate::<Covers>("POLYGON ((0 0, 5 0, 0 5, 0 0))", "POINT (-1 -1)", false);
@@ -322,9 +368,19 @@ mod test {
             "POLYGON ((1 1, 1 2, 2 1, 1 1))",
             false,
         );
+        test_predicate::<Covers>(
+            "GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (0 0, 0 1))",
+            "POINT (0 0)",
+            true,
+        );
 
         test_predicate::<CoveredBy>("POINT (1 1)", "POLYGON ((0 0, 5 0, 0 5, 0 0))", true);
         test_predicate::<CoveredBy>("POINT (-1 -1)", "POLYGON ((0 0, 5 0, 0 5, 0 0))", false);
+        test_predicate::<CoveredBy>(
+            "POINT (0 0)",
+            "GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (0 0, 0 1))",
+            true,
+        );
 
         test_predicate::<Touches>("POLYGON ((0 0, 5 0, 0 5, 0 0))", "POINT (0 0)", true);
         test_predicate::<Touches>("POLYGON ((0 0, 5 0, 0 5, 0 0))", "POINT (1 1)", false);

--- a/c/sedona-tg/src/tg/tg.c
+++ b/c/sedona-tg/src/tg/tg.c
@@ -6195,37 +6195,295 @@ static bool point_contains_base_geom(struct tg_point point,
     return false;
 }
 
-struct geom_contains_iter_ctx {
+struct geom_contains_point_ctx {
+    struct tg_point point;
+    bool point_hit;
+    bool line_interior_hit;
+    int line_boundary_hits;
+    bool poly_interior_hit;
+    bool poly_boundary_hit;
+};
+
+static bool geom_as_point(const struct tg_geom *geom, struct tg_point *point) {
+    if (!geom) {
+        return false;
+    }
+    switch (geom->head.base) {
+    case BASE_GEOM:
+        if (geom->head.type == TG_POINT) {
+            *point = geom->point;
+            return true;
+        }
+        return false;
+    case BASE_POINT:
+        *point = ((struct boxed_point*)geom)->point;
+        return true;
+    default:
+        return false;
+    }
+}
+
+static bool geom_contains_point_iter(const struct tg_geom *geom, void *udata) {
+    struct geom_contains_point_ctx *ctx = udata;
+    if (tg_geom_is_empty(geom)) {
+        return true;
+    }
+
+    switch (geom->head.base) {
+    case BASE_GEOM:
+        switch (geom->head.type) {
+        case TG_POINT:
+            if (tg_point_contains_point(geom->point, ctx->point)) {
+                ctx->point_hit = true;
+            }
+            break;
+        case TG_LINESTRING:
+            if (tg_line_contains_point(geom->line, ctx->point)) {
+                ctx->line_interior_hit = true;
+            } else if (tg_line_touches_point(geom->line, ctx->point)) {
+                ctx->line_boundary_hits++;
+            }
+            break;
+        case TG_POLYGON:
+            if (tg_poly_contains_point(geom->poly, ctx->point)) {
+                ctx->poly_interior_hit = true;
+            } else if (tg_poly_touches_point(geom->poly, ctx->point)) {
+                ctx->poly_boundary_hit = true;
+            }
+            break;
+        case TG_MULTIPOINT:
+        case TG_MULTILINESTRING:
+        case TG_MULTIPOLYGON:
+        case TG_GEOMETRYCOLLECTION:
+            tg_geom_foreach(geom, geom_contains_point_iter, ctx);
+            break;
+        }
+        break;
+    case BASE_POINT:
+        if (tg_point_contains_point(((struct boxed_point*)geom)->point,
+            ctx->point))
+        {
+            ctx->point_hit = true;
+        }
+        break;
+    case BASE_LINE:
+        if (tg_line_contains_point((struct tg_line*)geom, ctx->point)) {
+            ctx->line_interior_hit = true;
+        } else if (tg_line_touches_point((struct tg_line*)geom, ctx->point)) {
+            ctx->line_boundary_hits++;
+        }
+        break;
+    case BASE_RING:
+    case BASE_POLY:
+        if (tg_poly_contains_point((struct tg_poly*)geom, ctx->point)) {
+            ctx->poly_interior_hit = true;
+        } else if (tg_poly_touches_point((struct tg_poly*)geom, ctx->point)) {
+            ctx->poly_boundary_hit = true;
+        }
+        break;
+    }
+    return true;
+}
+
+static bool geom_collection_contains_point(const struct tg_geom *geom,
+    struct tg_point point)
+{
+    struct geom_contains_point_ctx ctx = { .point = point };
+    tg_geom_foreach(geom, geom_contains_point_iter, &ctx);
+
+    if (ctx.poly_interior_hit) {
+        return true;
+    }
+    if (ctx.poly_boundary_hit) {
+        return false;
+    }
+    if (ctx.line_boundary_hits % 2 == 1) {
+        return false;
+    }
+    if (ctx.line_interior_hit || ctx.line_boundary_hits > 0) {
+        return true;
+    }
+    return ctx.point_hit;
+}
+
+struct geom_contains_line_ctx {
+    const struct tg_line *line;
+    bool poly_interior_hit;
+    bool poly_boundary_cover;
+    bool line_interior_hit;
+};
+
+static void geom_contains_line_check_poly(struct geom_contains_line_ctx *ctx,
+    const struct tg_poly *poly)
+{
+    if (tg_poly_intersects_line(poly, ctx->line)) {
+        if (!tg_poly_touches_line(poly, ctx->line)) {
+            ctx->poly_interior_hit = true;
+        } else if (tg_poly_covers_line(poly, ctx->line)) {
+            ctx->poly_boundary_cover = true;
+        }
+    }
+}
+
+static bool geom_contains_line_iter(const struct tg_geom *geom, void *udata) {
+    struct geom_contains_line_ctx *ctx = udata;
+    if (tg_geom_is_empty(geom)) {
+        return true;
+    }
+
+    switch (geom->head.base) {
+    case BASE_GEOM:
+        switch (geom->head.type) {
+        case TG_LINESTRING:
+            if (tg_line_contains_line(geom->line, ctx->line)) {
+                ctx->line_interior_hit = true;
+            }
+            break;
+        case TG_POLYGON:
+            geom_contains_line_check_poly(ctx, geom->poly);
+            break;
+        case TG_POINT:
+        case TG_MULTIPOINT:
+        case TG_MULTILINESTRING:
+        case TG_MULTIPOLYGON:
+        case TG_GEOMETRYCOLLECTION:
+            break;
+        }
+        break;
+    case BASE_LINE:
+        if (tg_line_contains_line((struct tg_line*)geom, ctx->line)) {
+            ctx->line_interior_hit = true;
+        }
+        break;
+    case BASE_RING:
+    case BASE_POLY:
+        geom_contains_line_check_poly(ctx, (struct tg_poly*)geom);
+        break;
+    case BASE_POINT:
+        break;
+    }
+
+    return !ctx->poly_interior_hit;
+}
+
+static bool geom_collection_contains_line(const struct tg_geom *geom,
+    const struct tg_line *line)
+{
+    struct geom_contains_line_ctx ctx = { .line = line };
+    tg_geom_foreach(geom, geom_contains_line_iter, &ctx);
+    return ctx.poly_interior_hit ||
+        (!ctx.poly_boundary_cover && ctx.line_interior_hit);
+}
+
+struct geom_contains_poly_ctx {
+    const struct tg_poly *poly;
+    bool poly_interior_hit;
+};
+
+static bool geom_contains_poly_iter(const struct tg_geom *geom, void *udata) {
+    struct geom_contains_poly_ctx *ctx = udata;
+    if (tg_geom_is_empty(geom)) {
+        return true;
+    }
+
+    switch (geom->head.base) {
+    case BASE_GEOM:
+        if (geom->head.type == TG_POLYGON &&
+            tg_poly_intersects_poly(geom->poly, ctx->poly) &&
+            !tg_poly_touches_poly(geom->poly, ctx->poly))
+        {
+            ctx->poly_interior_hit = true;
+            return false;
+        }
+        break;
+    case BASE_RING:
+    case BASE_POLY:
+        if (tg_poly_intersects_poly((struct tg_poly*)geom, ctx->poly) &&
+            !tg_poly_touches_poly((struct tg_poly*)geom, ctx->poly))
+        {
+            ctx->poly_interior_hit = true;
+            return false;
+        }
+        break;
+    case BASE_POINT:
+    case BASE_LINE:
+        break;
+    }
+
+    return true;
+}
+
+static bool geom_collection_contains_poly(const struct tg_geom *geom,
+    const struct tg_poly *poly)
+{
+    struct geom_contains_poly_ctx ctx = { .poly = poly };
+    tg_geom_foreach(geom, geom_contains_poly_iter, &ctx);
+    return ctx.poly_interior_hit;
+}
+
+static bool geom_collection_component_interior_intersects(
+    const struct tg_geom *geom, const struct tg_geom *other)
+{
+    struct tg_point point;
+    if (geom_as_point(other, &point)) {
+        return geom_collection_contains_point(geom, point);
+    }
+
+    switch (other->head.base) {
+    case BASE_GEOM:
+        switch (other->head.type) {
+        case TG_LINESTRING:
+            return geom_collection_contains_line(geom, other->line);
+        case TG_POLYGON:
+            return geom_collection_contains_poly(geom, other->poly);
+        case TG_POINT:
+        case TG_MULTIPOINT:
+        case TG_MULTILINESTRING:
+        case TG_MULTIPOLYGON:
+        case TG_GEOMETRYCOLLECTION:
+            return false;
+        }
+        break;
+    case BASE_LINE:
+        return geom_collection_contains_line(geom, (struct tg_line*)other);
+    case BASE_RING:
+    case BASE_POLY:
+        return geom_collection_contains_poly(geom, (struct tg_poly*)other);
+    case BASE_POINT:
+        break;
+    }
+
+    return false;
+}
+
+struct geom_contains_interior_ctx {
     const struct tg_geom *geom;
     bool result;
 };
 
-
-static bool geom_contains_iter0(const struct tg_geom *geom, void *udata) {
-    struct geom_contains_iter_ctx *ctx = udata;
-    if (tg_geom_contains(geom, ctx->geom)) {
-        // found a child object that contains geom, end inner loop
+static bool geom_contains_interior_iter(const struct tg_geom *geom,
+    void *udata)
+{
+    struct geom_contains_interior_ctx *ctx = udata;
+    if (!tg_geom_is_empty(geom) &&
+        geom_collection_component_interior_intersects(ctx->geom, geom))
+    {
         ctx->result = true;
         return false;
     }
     return true;
 }
 
-static bool geom_contains_iter(const struct tg_geom *geom, void *udata) {
-    struct geom_contains_iter_ctx *ctx = udata;
-    // skip empty geometries
-    if (!tg_geom_is_empty(geom)) {
-        struct geom_contains_iter_ctx ctx0 = { .geom = geom };
-        tg_geom_foreach(ctx->geom, geom_contains_iter0, &ctx0);
-        if (!ctx0.result) {
-            // unmark and quit the loop
-            ctx->result = false;
-            return false;
-        }
-        // mark that at least one geom is contained
-        ctx->result = true;
+static bool geom_collection_contains_geom(const struct tg_geom *geom,
+    const struct tg_geom *other)
+{
+    if (!tg_geom_covers(geom, other)) {
+        return false;
     }
-    return true;
+
+    struct geom_contains_interior_ctx ctx = { .geom = geom };
+    tg_geom_foreach(other, geom_contains_interior_iter, &ctx);
+    return ctx.result;
 }
 
 static bool base_geom_contains_geom(const struct tg_geom *geom,
@@ -6242,12 +6500,8 @@ static bool base_geom_contains_geom(const struct tg_geom *geom,
         case TG_MULTIPOINT:
         case TG_MULTILINESTRING:
         case TG_MULTIPOLYGON:
-        case TG_GEOMETRYCOLLECTION: {
-            // all children of 'other' must be fully within 'geom'
-            struct geom_contains_iter_ctx ctx = { .geom = geom };
-            tg_geom_foreach(other, geom_contains_iter, &ctx);
-            return ctx.result;
-        }
+        case TG_GEOMETRYCOLLECTION:
+            return geom_collection_contains_geom(geom, other);
         }
     }
     return false;

--- a/python/sedonadb/tests/functions/test_predicates.py
+++ b/python/sedonadb/tests/functions/test_predicates.py
@@ -45,6 +45,48 @@ from sedonadb.testing import geom_or_null, PostGIS, SedonaDB, val_or_null
             "GEOMETRYCOLLECTION (POINT (0 0), POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)), LINESTRING (0 0, 1 1))",
             False,
         ),
+        (
+            "GEOMETRYCOLLECTION (POINT (0 0))",
+            "POINT (0 0)",
+            True,
+        ),
+        (
+            "GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (0 0, 0 1))",
+            "POINT (0 0)",
+            False,
+        ),
+        # True because the point is no longer on the boundary
+        (
+            "GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (0 0, 0 1))",
+            "POINT (0 0.5)",
+            True,
+        ),
+        # True because the point is no longer on the boundary
+        (
+            "GEOMETRYCOLLECTION (POINT (-1 -1), LINESTRING (0 0, 0 1))",
+            "POINT (-1 -1)",
+            True,
+        ),
+        (
+            "GEOMETRYCOLLECTION (POINT (0 0), POLYGON ((0 0, 0 1, 1 0, 0 0)))",
+            "POINT (0 0)",
+            False,
+        ),
+        (
+            "GEOMETRYCOLLECTION (POINT (0 0), POLYGON ((0 0, 0 1, 1 0, 0 0)))",
+            "POINT (0.25 0.25)",
+            True,
+        ),
+        (
+            "GEOMETRYCOLLECTION (LINESTRING (0 0, 0 1), POLYGON ((0 0, 0 1, 1 0, 0 0)))",
+            "LINESTRING (0 0, 0 1)",
+            False,
+        ),
+        (
+            "GEOMETRYCOLLECTION (LINESTRING (0 0, 0 1), POLYGON ((0 0, 0 1, 1 0, 0 0)))",
+            "LINESTRING (0 0, 0.25 0.25)",
+            True,
+        ),
     ],
 )
 def test_st_contains(eng, geom1, geom2, expected):
@@ -322,32 +364,9 @@ def test_st_touches(eng, geom1, geom2, expected):
             "MULTIPOLYGON (((0 0, 1 0, 1 1, 0 1, 0 0)), ((0 0, 1 0, 1 1, 0 1, 0 0)))",
             True,
         ),
-        # Identical geometries are not considered within each other
-        ("POINT (0 0)", "POINT (0 0)", True),
-        (
-            "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))",
-            "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))",
-            True,
-        ),
-        ("LINESTRING (0 0, 1 1)", "LINESTRING (0 0, 1 1)", True),
-    ],
-)
-def test_st_within(eng, geom1, geom2, expected):
-    eng = eng.create_or_skip()
-    eng.assert_query_result(
-        f"SELECT ST_Within({geom_or_null(geom1)}, {geom_or_null(geom2)})",
-        expected,
-    )
-
-
-@pytest.mark.xfail(reason="https://github.com/tidwall/tg/issues/20")
-@pytest.mark.parametrize("eng", [SedonaDB, PostGIS])
-@pytest.mark.parametrize(
-    ("geom1", "geom2", "expected"),
-    [
-        # These cases demonstrates the weirdness of ST_Contains:
-        # Both POINT(0 0) and GEOMETRYCOLLECTION (POINT (0 0)) contains POINT (0 0),
-        # but GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (0 0, 1 1)) does not contain POINT (0 0).
+        # These cases demonstrate the weirdness of ST_Contains:
+        # Both POINT(0 0) and GEOMETRYCOLLECTION (POINT (0 0)) contain POINT (0 0),
+        # but GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (0 0, 1 1)) does not.
         # See https://lin-ear-th-inking.blogspot.com/2007/06/subtleties-of-ogc-covers-spatial.html
         (
             "POINT (0 0)",
@@ -359,9 +378,17 @@ def test_st_within(eng, geom1, geom2, expected):
             "GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (0 0, 1 1), POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)))",
             False,
         ),
+        # Identical geometries are considered within each other
+        ("POINT (0 0)", "POINT (0 0)", True),
+        (
+            "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))",
+            "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))",
+            True,
+        ),
+        ("LINESTRING (0 0, 1 1)", "LINESTRING (0 0, 1 1)", True),
     ],
 )
-def test_st_within_skipped(eng, geom1, geom2, expected):
+def test_st_within(eng, geom1, geom2, expected):
     eng = eng.create_or_skip()
     eng.assert_query_result(
         f"SELECT ST_Within({geom_or_null(geom1)}, {geom_or_null(geom2)})",


### PR DESCRIPTION
Collection containment in tg treated a target geometry as contained if any flattened child contained it. This made `ST_Contains(GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (0 0, 0 1)), POINT (0 0))` return true via the point child even though GEOS/PostGIS classify that point on the collection boundary.

Require collection contains to satisfy `covers` first, then find an interior intersection against flattened point, line, or polygon targets. This preserves covers/coveredby behavior while making contains/within respect point components shadowed by higher-dimensional boundaries and line targets covered by polygon boundaries.

Fixes #1035.

Tests: `cargo test -p sedona-tg`; `cargo test -p sedona-tg predicates -- --nocapture`; `cargo fmt --check --package sedona-tg`; `git diff --check`.