### PR TITLE
feat(python/sedonadb): add DataFrame.unnest

### DIFF
--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -504,6 +504,65 @@ class DataFrame:
 
         return DataFrame(self._ctx, self._impl.drop_columns(list(cols)))
 
+    def unnest(self, *columns: str) -> "DataFrame":
+        """Expand list/array column(s) so each element becomes its own row.
+
+        This is the relational form of `pandas`/`GeoPandas` `explode()`: for
+        each input row, a list-typed column is expanded to one output row per
+        element, with the other columns repeated. When several columns are
+        given, they are unnested in parallel (position by position).
+
+        A common spatial use is flattening a multi-geometry: `ST_Dump(geom)`
+        returns a list of parts, and `unnest()` turns each part into its own
+        row.
+
+        Args:
+            *columns: One or more list/array column names to expand. At least
+                one is required.
+
+        Examples:
+
+            >>> sd = sedona.db.connect()
+            >>> df = sd.sql("SELECT 'a' AS label, [10, 20, 30] AS vals")
+            >>> df.unnest("vals").show()
+            ┌───────┬───────┐
+            │ label ┆  vals │
+            │  utf8 ┆ int64 │
+            ╞═══════╪═══════╡
+            │ a     ┆    10 │
+            ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+            │ a     ┆    20 │
+            ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+            │ a     ┆    30 │
+            └───────┴───────┘
+
+            Explode a multi-geometry into one row per part: dump the parts with
+            `ST_Dump`, `unnest` the resulting list, then read the geometry out
+            of the `{path, geom}` struct each element carries.
+
+            >>> multi = sd.sql("SELECT ST_GeomFromText('MULTIPOINT (0 0, 1 1)') AS geometry")
+            >>> dumped = multi.select(multi["geometry"].geo.dump().alias("dump")).unnest("dump")
+            >>> dumped.select(dumped["dump"]["geom"].alias("geometry")).show()
+            ┌────────────┐
+            │  geometry  │
+            │  geometry  │
+            ╞════════════╡
+            │ POINT(0 0) │
+            ├╌╌╌╌╌╌╌╌╌╌╌╌┤
+            │ POINT(1 1) │
+            └────────────┘
+        """
+        if not columns:
+            raise ValueError("unnest() requires at least one column name")
+
+        for c in columns:
+            if not isinstance(c, str):
+                raise TypeError(
+                    f"unnest() expects str arguments, got {type(c).__name__}"
+                )
+
+        return DataFrame(self._ctx, self._impl.unnest(list(columns)))
+
     def agg(self, *exprs: Expr, **named_exprs: Expr) -> "DataFrame":
         """Aggregate the entire DataFrame to a single row.
 

--- a/python/sedonadb/src/dataframe.rs
+++ b/python/sedonadb/src/dataframe.rs
@@ -232,6 +232,17 @@ impl InternalDataFrame {
         Ok(InternalDataFrame::new(inner, self.runtime.clone()))
     }
 
+    fn unnest(&self, columns: Vec<String>) -> Result<InternalDataFrame, PySedonaError> {
+        if columns.is_empty() {
+            return Err(PySedonaError::SedonaPython(
+                "unnest() requires at least one column name".to_string(),
+            ));
+        }
+        let borrowed: Vec<&str> = columns.iter().map(String::as_str).collect();
+        let inner = self.inner.clone().unnest_columns(&borrowed)?;
+        Ok(InternalDataFrame::new(inner, self.runtime.clone()))
+    }
+
     /// Aggregate the rows of the DataFrame, optionally partitioned by
     /// `group_exprs`. Both inputs are `Vec<PyExpr>` so the same Rust
     /// method serves global aggregation (`group_exprs` empty, called

--- a/python/sedonadb/tests/expr/test_dataframe_unnest.py
+++ b/python/sedonadb/tests/expr/test_dataframe_unnest.py
@@ -1,0 +1,79 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pandas as pd
+import pandas.testing as pdt
+import pytest
+
+from sedonadb._lib import SedonaError
+from sedonadb.dataframe import DataFrame
+
+
+def test_unnest_expands_list_to_rows(con):
+    # Each list element becomes its own row; other columns are repeated.
+    df = con.sql("SELECT 'a' AS label, [10, 20, 30] AS vals")
+    out = df.unnest("vals").sort("vals").to_pandas()
+    pdt.assert_frame_equal(
+        out,
+        pd.DataFrame({"label": ["a", "a", "a"], "vals": [10, 20, 30]}),
+    )
+
+
+def test_unnest_multiple_columns_parallel(con):
+    # Multiple columns are expanded position-by-position, not cross-product.
+    df = con.sql("SELECT [1, 2] AS a, [10, 20] AS b")
+    out = df.unnest("a", "b").sort("a").to_pandas()
+    pdt.assert_frame_equal(out, pd.DataFrame({"a": [1, 2], "b": [10, 20]}))
+
+
+def test_unnest_st_dump_multigeometry(con):
+    # The spatial explode pattern: ST_Dump yields a list of parts, unnest
+    # turns each part into its own row.
+    df = con.sql(
+        "SELECT ST_Dump(ST_GeomFromText('MULTIPOINT(0 0, 1 1, 2 2)')) AS parts"
+    )
+    assert df.unnest("parts").count() == 3
+
+
+def test_unnest_returns_lazy_dataframe(con):
+    df = con.sql("SELECT [1, 2] AS vals")
+    assert isinstance(df.unnest("vals"), DataFrame)
+
+
+def test_unnest_no_args_raises(con):
+    df = con.sql("SELECT [1, 2] AS vals")
+    with pytest.raises(ValueError, match="at least one column"):
+        df.unnest()
+
+
+def test_unnest_non_str_raises(con):
+    df = con.sql("SELECT [1, 2] AS vals")
+    with pytest.raises(TypeError, match="expects str"):
+        df.unnest(123)
+
+
+def test_unnest_unknown_column_raises(con):
+    df = con.sql("SELECT [1, 2] AS vals")
+    with pytest.raises(SedonaError, match="No field named"):
+        df.unnest("nope")
+
+
+def test_unnest_geometry_column_raises(con):
+    # A raw geometry (Binary) column can't be unnested directly; ST_Dump first.
+    df = con.sql("SELECT ST_Point(0.0, 0.0) AS geom")
+    with pytest.raises(SedonaError, match="unnest"):
+        df.unnest("geom")


### PR DESCRIPTION
Adds `DataFrame.unnest(*columns)`, which expands list/array column(s) so each element becomes its own row — the relational form of pandas/GeoPandas `explode()`.

```python
df.unnest("vals")       # [10, 20, 30] -> 3 rows, other columns repeated
df.unnest("a", "b")     # multiple columns unnested in parallel (position-by-position)
df.unnest("parts")      # ST_Dump(geom) -> one row per part (spatial explode)
```

## Design

- Thin wrapper over DataFusion's `DataFrame::unnest_columns`; mirrors the existing `drop_columns` binding.
- **Engine-neutral naming** (`unnest`, matching Ibis / DuckDB SQL `UNNEST`) rather than the pandas-flavored `explode`, consistent with the relational DataFrame surface.
- Clear errors: no arguments -> `ValueError`; non-str argument -> `TypeError`; unknown column -> `SedonaError` ("No field named …"); a raw geometry (Binary) column -> `SedonaError` (unnest a multi-geometry via `ST_Dump` first).

## Tests

New `tests/expr/test_dataframe_unnest.py` (8 tests): list-to-rows expansion, parallel multi-column unnest, the `ST_Dump` + `unnest` multi-geometry explode, laziness, and the four error paths. Plus a doctest on the method.