### PR TITLE
ci(python-wheels): diagnose test hangs, serialize pyogrio open/close

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -46,6 +46,7 @@ env:
 jobs:
   windows-x86_64:
     runs-on: windows-2022
+    timeout-minutes: 150
 
     steps:
       - uses: actions/checkout@v7
@@ -75,7 +76,7 @@ jobs:
           CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
           CIBW_BUILD: "*-win_amd64"
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas
-          CIBW_TEST_COMMAND: pytest {package}/tests -vv
+          CIBW_TEST_COMMAND: pytest {package}/tests -vv -o faulthandler_timeout=600
 
       - uses: actions/upload-artifact@v7
         with:
@@ -84,6 +85,7 @@ jobs:
 
   macOS-arm64:
     runs-on: macOS-latest
+    timeout-minutes: 150
 
     steps:
       - uses: actions/checkout@v7
@@ -110,7 +112,7 @@ jobs:
         env:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas duckdb
-          CIBW_TEST_COMMAND: pytest {package}/tests -vv
+          CIBW_TEST_COMMAND: pytest {package}/tests -vv -o faulthandler_timeout=600
 
       - uses: actions/upload-artifact@v7
         with:
@@ -119,6 +121,7 @@ jobs:
 
   macOS-amd64:
     runs-on: macos-15-intel
+    timeout-minutes: 150
 
     steps:
       - uses: actions/checkout@v7
@@ -145,7 +148,7 @@ jobs:
         env:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas duckdb
-          CIBW_TEST_COMMAND: pytest {package}/tests -vv
+          CIBW_TEST_COMMAND: pytest {package}/tests -vv -o faulthandler_timeout=600
           SEDONADB_MACOS_ARCH: x86_64
 
       - uses: actions/upload-artifact@v7
@@ -156,6 +159,7 @@ jobs:
   wheels-linux:
     name: ${{ matrix.config.label }}
     runs-on: ${{ matrix.config.os }}
+    timeout-minutes: 150
     strategy:
       matrix:
         config:
@@ -177,7 +181,7 @@ jobs:
         env:
           CIBW_SKIP: "*musllinux*"
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas duckdb
-          CIBW_TEST_COMMAND: pytest {package}/tests -vv
+          CIBW_TEST_COMMAND: pytest {package}/tests -vv -o faulthandler_timeout=600
 
       - uses: actions/upload-artifact@v7
         with:

--- a/python/sedonadb/python/sedonadb/datasource.py
+++ b/python/sedonadb/python/sedonadb/datasource.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import sys
+import threading
 from typing import Any, Mapping
 
 from sedonadb._lib import PyExternalFormat, PyProjectedRecordBatchReader
@@ -202,13 +203,26 @@ class PyogrioReaderShelter:
     is no longer required).
     """
 
+    # Serializes dataset open/close. pyogrio releases the GIL around the
+    # GDAL open, so a multi-file scan otherwise opens datasets from several
+    # threads at once, which can crash the process (SIGABRT) depending on
+    # the GDAL build and driver. Reentrant because a garbage-collected
+    # shelter's __del__ may run on a thread that is already holding the
+    # lock in __init__.
+    _open_close_lock = threading.RLock()
+
     def __init__(self, inner, output_names=None):
         self._inner = inner
         self._output_names = output_names
-        self._meta, self._reader = self._inner.__enter__()
+        self._entered = False
+        with PyogrioReaderShelter._open_close_lock:
+            self._meta, self._reader = self._inner.__enter__()
+            self._entered = True
 
     def __del__(self):
-        self._inner.__exit__(None, None, None)
+        if self._entered:
+            with PyogrioReaderShelter._open_close_lock:
+                self._inner.__exit__(None, None, None)
 
     def __arrow_c_stream__(self, requested_schema=None):
         if self._output_names is None:


### PR DESCRIPTION
For #1048; also addresses the pyogrio crash tracked in #924.

## Root cause

The wheel-test hang and the #924 SIGABRT are the same bug: a race between concurrent pyogrio dataset opens/closes. `pyogrio.raw.open_arrow` releases the GIL around the GDAL open, so a multi-file scan opens datasets from several DataFusion worker threads at once, while `PyogrioReaderShelter.__del__` closes datasets from whichever thread garbage collection happens to run on. Depending on platform and timing this crashes or deadlocks the process.

Main's wheel runs caught it twice this weekend, and pytest's built-in faulthandler captured the crash site on the abort ([run](https://github.com/apache/sedona-db/actions/runs/29274039339), linux-x86_64, **cp39** — so this is not specific to CPython 3.14 or arm64 as #1048 first guessed; the arm64 hangs are the same race manifesting differently):

```
Fatal Python error: Aborted

Thread 0x00007f855be77700 (most recent call first):
  File ".../contextlib.py", line 119 in __enter__
  File ".../sedonadb/datasource.py", line 208 in __init__     # PyogrioReaderShelter: pyogrio open_arrow.__enter__
  File ".../sedonadb/datasource.py", line 189 in open_reader  # on a worker thread, during test_read_ogr_multi_file
```

In the same run, macOS-arm64 hung until GitHub's 6-hour job kill; the [next main run](https://github.com/apache/sedona-db/actions/runs/29356925862) wedged both macOS-arm64 and linux-x86_64 for 4+ hours until superseded.

## Changes

- `datasource.py`: a module-level reentrant lock serializes pyogrio dataset open/close. Reentrant because a garbage-collected shelter's `__del__` can run on a thread already holding the lock in `__init__`; the `_entered` flag keeps `__del__` from closing a context that never opened. Only open/close are serialized — reads still run concurrently.
- `python-wheels.yml`: `-o faulthandler_timeout=600` on every `CIBW_TEST_COMMAND`, so any future test stuck for 10 minutes dumps all thread stacks to the CI log instead of wedging silently, and `timeout-minutes: 150` on the wheel jobs so a wedged run fails in 2.5 hours instead of occupying a runner for 6.

The full wheel matrix on this PR [passed in 2h08m](https://github.com/apache/sedona-db/actions/runs/29358220457) while the two uninstrumented main runs above aborted/hung.

The lock is the tactical fix; the durable one is reading OGR through a Rust `ArrowArrayStream` (`OGR_L_GetArrowStream` in c/sedona-gdal) so no Python runs on worker threads at all — tracked in #924.
