### PR TITLE
test(python/sedonadb): guard rasterio behind importorskip in raster tests

### DIFF
--- a/python/sedonadb/tests/functions/test_raster_functions.py
+++ b/python/sedonadb/tests/functions/test_raster_functions.py
@@ -18,9 +18,6 @@
 import numpy as np
 import pandas as pd
 import pytest
-from rasterio.features import rasterize
-from rasterio.io import MemoryFile
-from rasterio.transform import Affine
 from shapely import wkt
 
 from sedonadb.testing import SedonaDB
@@ -154,6 +151,10 @@ def test_rs_value_matches_rasterio(con):
     positions per pixel (toward the corners, kept inside the pixel to avoid floor
     ambiguity at exact boundaries) and a batch of random interior points.
     """
+
+    pytest.importorskip("rasterio")
+    from rasterio.io import MemoryFile
+    from rasterio.transform import Affine
 
     rng = np.random.default_rng(42)
     height, width = 7, 5
@@ -360,6 +361,10 @@ def _rs_as_raster_sql(
 def test_rs_as_raster_matches_rasterio(
     con, sedona_testing, all_touched, use_geometry_extent
 ):
+    pytest.importorskip("rasterio")
+    from rasterio.features import rasterize
+    from rasterio.transform import Affine
+
     path = sedona_testing / "data/raster/test4.tiff"
     transform = (0.0, 1.0, 0.0, 10.0, 0.0, -1.0)
 
@@ -395,6 +400,10 @@ def test_rs_as_raster_matches_rasterio(
 
 
 def test_rs_as_raster_all_touched_changes_pixels(con, sedona_testing):
+    pytest.importorskip("rasterio")
+    from rasterio.features import rasterize
+    from rasterio.transform import Affine
+
     path = sedona_testing / "data/raster/test4.tiff"
     transform = (0.0, 1.0, 0.0, 10.0, 0.0, -1.0)
     geom = "POLYGON((1.9 8.9, 1.9 6.1, 3.1 6.1, 3.1 8.9, 1.9 8.9))"

--- a/python/sedonadb/tests/functions/test_rs_clip.py
+++ b/python/sedonadb/tests/functions/test_rs_clip.py
@@ -31,7 +31,6 @@ import numpy as np
 import pyarrow as pa
 import pytest
 import shapely
-from rasterio.transform import Affine
 
 from sedonadb.expr import lit
 from sedonadb.raster_testing import (
@@ -42,6 +41,8 @@ from sedonadb.raster_testing import (
     random_raster_data,
     write_geotiff,
 )
+
+pytest.importorskip("rasterio")
 
 
 # GDAL-order geotransform: origin (100, 500), 2-wide by 3-tall north-up pixels.
@@ -230,6 +231,8 @@ def test_rs_clip_skewed_rasters_match_rasterio(
     and the output geotransform shifts the origin by the full affine (both
     skew terms). The geometry is defined in pixel space and mapped through
     the transform under test so it overlaps the grid whatever the rotation."""
+    from rasterio.transform import Affine
+
     tiff = tmp_path / "clip_skewed.tif"
     write_geotiff(
         tiff,

--- a/python/sedonadb/tests/functions/test_rs_clip.py
+++ b/python/sedonadb/tests/functions/test_rs_clip.py
@@ -42,8 +42,6 @@ from sedonadb.raster_testing import (
     write_geotiff,
 )
 
-pytest.importorskip("rasterio")
-
 
 # GDAL-order geotransform: origin (100, 500), 2-wide by 3-tall north-up pixels.
 # With a 7x6 raster the extent is x in [100, 114], y in [482, 500]; pixel
@@ -286,6 +284,7 @@ def test_rs_clip_signature_defaults(con, tmp_path):
     """Each shorter signature behaves as the full 7-arg form with the defaults
     filled in: all_touched = false, no_data_value = the band's own, crop = true,
     lenient = true."""
+    pytest.importorskip("sedonadb_expr")
     tiff = tmp_path / "clip_sigs.tif"
     write_geotiff(
         tiff,
@@ -376,6 +375,7 @@ def test_rs_clip_strict_and_argument_errors(con, tmp_path):
     """Error pathways: strict (lenient = false) empty-mask messages depend on
     all_touched; a non-representable nodata and an out-of-range band error
     regardless of leniency."""
+    pytest.importorskip("sedonadb_expr")
     tiff = tmp_path / "clip_errors.tif"
     write_geotiff(
         tiff,


### PR DESCRIPTION
The wheel-build smoke tests install only the sedonadb wheel plus a small fixed set of test deps — rasterio isn't among them, and it has no cp39 wheel for linux aarch64 at all — so a module-level rasterio import breaks test collection there. Restoring the `importorskip` guards lets the rasterio cross-check tests skip cleanly in that environment while still running in the full test lane, where rasterio and an aligned GDAL are present.