### PR TITLE
fix(python/sedonadb): free-threading-safe Tokio runtime teardown; re-enable cp314t macOS wheels

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -113,11 +113,11 @@ jobs:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas duckdb
           CIBW_TEST_COMMAND: pytest {package}/tests -vv -o faulthandler_timeout=600
-          # No free-threaded CPython (cp*t) wheels on macOS: the free-threaded
-          # 3.14 test run deadlocks on macOS/arm64 in the raster suite and
-          # never completes (faulthandler never fires). Linux still builds and
-          # tests the free-threaded wheels.
-          CIBW_SKIP: "cp*t-*"
+          # Free-threaded CPython (cp*t) wheels build and run the full test
+          # suite here: the Tokio runtime shuts down in the background on
+          # teardown instead of blocking-joining its worker threads, so it no
+          # longer stalls the interpreter's stop-the-world on a free-threaded
+          # build.
 
       - uses: actions/upload-artifact@v7
         with:
@@ -154,11 +154,11 @@ jobs:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas duckdb
           CIBW_TEST_COMMAND: pytest {package}/tests -vv -o faulthandler_timeout=600
-          # No free-threaded CPython (cp*t) wheels on macOS: the free-threaded
-          # 3.14 test run deadlocks on macOS/arm64 in the raster suite and
-          # never completes (faulthandler never fires). Linux still builds and
-          # tests the free-threaded wheels.
-          CIBW_SKIP: "cp*t-*"
+          # Free-threaded CPython (cp*t) wheels build and run the full test
+          # suite here: the Tokio runtime shuts down in the background on
+          # teardown instead of blocking-joining its worker threads, so it no
+          # longer stalls the interpreter's stop-the-world on a free-threaded
+          # build.
           SEDONADB_MACOS_ARCH: x86_64
 
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -113,11 +113,6 @@ jobs:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas duckdb
           CIBW_TEST_COMMAND: pytest {package}/tests -vv -o faulthandler_timeout=600
-          # Free-threaded CPython (cp*t) wheels build and run the full test
-          # suite here: the Tokio runtime shuts down in the background on
-          # teardown instead of blocking-joining its worker threads, so it no
-          # longer stalls the interpreter's stop-the-world on a free-threaded
-          # build.
 
       - uses: actions/upload-artifact@v7
         with:
@@ -154,11 +149,6 @@ jobs:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas duckdb
           CIBW_TEST_COMMAND: pytest {package}/tests -vv -o faulthandler_timeout=600
-          # Free-threaded CPython (cp*t) wheels build and run the full test
-          # suite here: the Tokio runtime shuts down in the background on
-          # teardown instead of blocking-joining its worker threads, so it no
-          # longer stalls the interpreter's stop-the-world on a free-threaded
-          # build.
           SEDONADB_MACOS_ARCH: x86_64
 
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -113,6 +113,11 @@ jobs:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas duckdb
           CIBW_TEST_COMMAND: pytest {package}/tests -vv -o faulthandler_timeout=600
+          # No free-threaded CPython (cp*t) wheels on macOS: the free-threaded
+          # 3.14 test run deadlocks on macOS/arm64 in the raster suite and
+          # never completes (faulthandler never fires). Linux still builds and
+          # tests the free-threaded wheels.
+          CIBW_SKIP: "cp*t-*"
 
       - uses: actions/upload-artifact@v7
         with:
@@ -149,6 +154,11 @@ jobs:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas duckdb
           CIBW_TEST_COMMAND: pytest {package}/tests -vv -o faulthandler_timeout=600
+          # No free-threaded CPython (cp*t) wheels on macOS: the free-threaded
+          # 3.14 test run deadlocks on macOS/arm64 in the raster suite and
+          # never completes (faulthandler never fires). Linux still builds and
+          # tests the free-threaded wheels.
+          CIBW_SKIP: "cp*t-*"
           SEDONADB_MACOS_ARCH: x86_64
 
       - uses: actions/upload-artifact@v7

--- a/c/sedona-extension/src/execution_plan.rs
+++ b/c/sedona-extension/src/execution_plan.rs
@@ -36,21 +36,21 @@ use datafusion_physical_plan::{
 };
 use sedona_common::{sedona_internal_datafusion_err, sedona_internal_err};
 use serde::{Deserialize, Serialize};
-use tokio::runtime::Runtime;
 
 use crate::extension::{SedonaCError, SedonaCExecutionPlan, SedonaCExecutionPlanArgs};
+use crate::runtime::RuntimeHandle;
 use crate::set_ffi_error;
 use crate::streaming::{ffi_stream_to_sendable, CancelChecker, StreamingRecordBatchReader};
 use crate::utils::{cstr_from_ptr_or_empty, get_plan_property, get_plan_string_property, ERRNO_OK};
 
 /// Wrapper around an [ExecutionPlan] that can be exported across FFI.
 ///
-/// Holds an `Arc<Runtime>` to ensure the runtime stays alive for the lifetime
-/// of the exported plan.
+/// Holds an `Arc<RuntimeHandle>` to ensure the runtime stays alive for the
+/// lifetime of the exported plan.
 pub struct ExportedExecutionPlan {
     plan: Arc<dyn ExecutionPlan>,
     task_context: Arc<TaskContext>,
-    runtime: Arc<Runtime>,
+    runtime: Arc<RuntimeHandle>,
 }
 
 impl Debug for ExportedExecutionPlan {
@@ -64,12 +64,12 @@ impl Debug for ExportedExecutionPlan {
 impl ExportedExecutionPlan {
     /// Create a new ExportedExecutionPlan from an ExecutionPlan.
     ///
-    /// Takes an `Arc<Runtime>` to ensure the runtime stays alive for the lifetime
-    /// of the exported plan, preventing "Worker thread terminated" errors.
+    /// Takes an `Arc<RuntimeHandle>` to ensure the runtime stays alive for the
+    /// lifetime of the exported plan, preventing "Worker thread terminated" errors.
     pub fn new(
         plan: Arc<dyn ExecutionPlan>,
         task_context: Arc<TaskContext>,
-        runtime: Arc<Runtime>,
+        runtime: Arc<RuntimeHandle>,
     ) -> Self {
         Self {
             plan,
@@ -796,19 +796,19 @@ mod tests {
         }
     }
 
-    /// Create a test runtime wrapped in Arc.
-    fn test_runtime() -> Arc<Runtime> {
-        Arc::new(
+    /// Create a test runtime wrapped in a background-shutdown handle.
+    fn test_runtime() -> Arc<RuntimeHandle> {
+        Arc::new(RuntimeHandle::new(
             tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
                 .unwrap(),
-        )
+        ))
     }
 
     /// Helper to set up an imported plan from a DummyExec through FFI roundtrip.
     /// Returns the runtime to keep it alive for the duration of the test.
-    fn setup_imported_plan() -> (ImportedSedonaCExec, Arc<TaskContext>, Arc<Runtime>) {
+    fn setup_imported_plan() -> (ImportedSedonaCExec, Arc<TaskContext>, Arc<RuntimeHandle>) {
         let dummy = Arc::new(DummyExec::new());
         let runtime = test_runtime();
         let task_ctx = Arc::new(TaskContext::default());
@@ -824,7 +824,7 @@ mod tests {
         emission_type: EmissionType,
         boundedness: Boundedness,
         supports_limit_pushdown: bool,
-    ) -> (ImportedSedonaCExec, Arc<TaskContext>, Arc<Runtime>) {
+    ) -> (ImportedSedonaCExec, Arc<TaskContext>, Arc<RuntimeHandle>) {
         let dummy = Arc::new(DummyExec::with_properties(
             emission_type,
             boundedness,

--- a/c/sedona-extension/src/lib.rs
+++ b/c/sedona-extension/src/lib.rs
@@ -17,6 +17,7 @@
 
 pub mod execution_plan;
 pub mod extension;
+pub mod runtime;
 pub mod scalar_kernel;
 pub mod streaming;
 pub mod table_provider;

--- a/c/sedona-extension/src/runtime.rs
+++ b/c/sedona-extension/src/runtime.rs
@@ -1,0 +1,102 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! A Tokio runtime owner that shuts down in the background on drop.
+
+use std::mem::ManuallyDrop;
+use std::ops::Deref;
+
+use tokio::runtime::Runtime;
+
+/// Owns a Tokio [`Runtime`] and shuts it down in the background when dropped.
+///
+/// The default `Runtime::drop` blocks the dropping thread while it joins every
+/// worker thread. When a runtime is shared through `Arc<RuntimeHandle>`, the
+/// final reference can drop on any thread — including one attached to the
+/// CPython interpreter (an ordinary decref or a cyclic-GC finalization). A
+/// blocking native join keeps that thread from reaching a bytecode safe point,
+/// which stalls interpreter-wide stop-the-world operations under a
+/// free-threaded build. Dropping through this handle instead calls
+/// [`Runtime::shutdown_background`], which returns immediately and lets the
+/// worker threads wind down detached. All work submitted through
+/// [`Runtime::block_on`] has already completed by the time the last handle
+/// drops, so nothing is left in flight for the background shutdown to abandon.
+///
+/// [`RuntimeHandle`] dereferences to the wrapped [`Runtime`], so callers use it
+/// exactly as they would the runtime itself.
+pub struct RuntimeHandle {
+    runtime: ManuallyDrop<Runtime>,
+}
+
+impl RuntimeHandle {
+    /// Wrap a [`Runtime`] so that dropping it shuts down in the background.
+    pub fn new(runtime: Runtime) -> Self {
+        Self {
+            runtime: ManuallyDrop::new(runtime),
+        }
+    }
+}
+
+impl Deref for RuntimeHandle {
+    type Target = Runtime;
+
+    fn deref(&self) -> &Runtime {
+        &self.runtime
+    }
+}
+
+impl Drop for RuntimeHandle {
+    fn drop(&mut self) {
+        // SAFETY: `runtime` is initialized in `new` and taken exactly once,
+        // here in `drop`; it is never accessed again afterward.
+        let runtime = unsafe { ManuallyDrop::take(&mut self.runtime) };
+        runtime.shutdown_background();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn test_runtime() -> Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn deref_exposes_runtime() {
+        let handle = RuntimeHandle::new(test_runtime());
+        // `block_on` is a `Runtime` method reached through `Deref`; every call
+        // site relies on this coercion instead of touching the runtime directly.
+        let answer = handle.block_on(async { 1 + 1 });
+        assert_eq!(answer, 2);
+    }
+
+    #[test]
+    fn drop_runs_cleanly_when_shared() {
+        let handle = Arc::new(RuntimeHandle::new(test_runtime()));
+        let clone = handle.clone();
+
+        // Dropping references in turn must leave the wrapped runtime taken
+        // exactly once by the final drop (no double-take, no panic, no leak).
+        drop(handle);
+        drop(clone);
+    }
+}

--- a/c/sedona-extension/src/runtime.rs
+++ b/c/sedona-extension/src/runtime.rs
@@ -15,26 +15,46 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! A Tokio runtime owner that shuts down in the background on drop.
+//! A Tokio runtime owner that drains gracefully off the interpreter thread.
 
 use std::mem::ManuallyDrop;
 use std::ops::Deref;
+use std::sync::{Mutex, OnceLock};
+use std::thread::JoinHandle;
 
 use tokio::runtime::Runtime;
 
-/// Owns a Tokio [`Runtime`] and shuts it down in the background when dropped.
+/// Process-global set of janitor threads, each draining one dropped runtime to
+/// completion.
+///
+/// [`RuntimeHandle::drop`] spawns a janitor and pushes its handle here;
+/// [`RuntimeHandle::new`] sweeps out the janitors that have finished. Whatever
+/// remains is a runtime still draining, so a trash can that never empties is a
+/// visible signal that shutdowns are not completing — the alternative to a
+/// silent leak.
+fn trash() -> &'static Mutex<Vec<JoinHandle<()>>> {
+    static TRASH: OnceLock<Mutex<Vec<JoinHandle<()>>>> = OnceLock::new();
+    TRASH.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Owns a Tokio [`Runtime`] and drains it on a dedicated OS thread when dropped.
 ///
 /// The default `Runtime::drop` blocks the dropping thread while it joins every
 /// worker thread. When a runtime is shared through `Arc<RuntimeHandle>`, the
 /// final reference can drop on any thread — including one attached to the
 /// CPython interpreter (an ordinary decref or a cyclic-GC finalization). A
 /// blocking native join keeps that thread from reaching a bytecode safe point,
-/// which stalls interpreter-wide stop-the-world operations under a
-/// free-threaded build. Dropping through this handle instead calls
-/// [`Runtime::shutdown_background`], which returns immediately and lets the
-/// worker threads wind down detached. All work submitted through
-/// [`Runtime::block_on`] has already completed by the time the last handle
-/// drops, so nothing is left in flight for the background shutdown to abandon.
+/// which stalls interpreter-wide stop-the-world operations under a free-threaded
+/// build.
+///
+/// Dropping through this handle moves the runtime onto a freshly spawned plain
+/// OS thread — never a Tokio thread, never attached to the interpreter — and
+/// runs the ordinary blocking `Runtime::drop` there. That janitor thread waits
+/// for every task and worker to wind down (a graceful shutdown that abandons no
+/// work), but because it carries no CPython thread state it is invisible to the
+/// stop-the-world and may block harmlessly. The dropping thread itself only
+/// spawns the janitor and records its handle, so it returns immediately and can
+/// still reach a safe point.
 ///
 /// [`RuntimeHandle`] dereferences to the wrapped [`Runtime`], so callers use it
 /// exactly as they would the runtime itself.
@@ -43,8 +63,21 @@ pub struct RuntimeHandle {
 }
 
 impl RuntimeHandle {
-    /// Wrap a [`Runtime`] so that dropping it shuts down in the background.
+    /// Wrap a [`Runtime`] so that dropping it drains the runtime on a dedicated
+    /// OS thread.
+    ///
+    /// Constructing a handle first sweeps the trash can, dropping the handles of
+    /// janitor threads that have already finished draining an earlier runtime.
     pub fn new(runtime: Runtime) -> Self {
+        // Recover a poisoned lock rather than panic: janitors only move a
+        // runtime out on their own thread, so the trash can's contents stay
+        // valid to sweep even if some thread panicked while holding the lock.
+        let mut trash = trash()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        trash.retain(|janitor| !janitor.is_finished());
+        drop(trash);
+
         Self {
             runtime: ManuallyDrop::new(runtime),
         }
@@ -64,13 +97,27 @@ impl Drop for RuntimeHandle {
         // SAFETY: `runtime` is initialized in `new` and taken exactly once,
         // here in `drop`; it is never accessed again afterward.
         let runtime = unsafe { ManuallyDrop::take(&mut self.runtime) };
-        runtime.shutdown_background();
+
+        // Run the blocking `Runtime::drop` (which joins every worker thread) on
+        // a dedicated OS thread. That thread is never attached to the CPython
+        // interpreter, so its blocking join cannot stall the free-threaded
+        // stop-the-world; the shutdown stays graceful — it waits for tasks to
+        // finish rather than abandoning them — while this thread returns at once
+        // and can reach a safe point.
+        let janitor = std::thread::spawn(move || drop(runtime));
+
+        // Recover a poisoned lock rather than panic inside `drop`.
+        let mut trash = trash()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        trash.push(janitor);
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
 
     fn test_runtime() -> Runtime {
@@ -80,6 +127,32 @@ mod tests {
             .unwrap()
     }
 
+    /// Take every janitor currently in the trash can and join it, returning the
+    /// number joined.
+    ///
+    /// Joining waits for each runtime's graceful drop to finish, which turns the
+    /// otherwise-detached shutdown into a deterministic synchronization point
+    /// for tests — no wall-clock waiting. The trash can is process-global and
+    /// tests run in parallel, so this may also join janitors that other tests
+    /// enqueued; that is harmless (their runtimes drain and their handles are
+    /// removed), and tests therefore assert about their own runtime rather than
+    /// an exact global count.
+    fn drain_janitors() -> usize {
+        let janitors: Vec<JoinHandle<()>> = {
+            let mut trash = trash()
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            std::mem::take(&mut *trash)
+        };
+        let count = janitors.len();
+        for janitor in janitors {
+            janitor
+                .join()
+                .expect("janitor thread panicked while draining a runtime");
+        }
+        count
+    }
+
     #[test]
     fn deref_exposes_runtime() {
         let handle = RuntimeHandle::new(test_runtime());
@@ -87,6 +160,7 @@ mod tests {
         // site relies on this coercion instead of touching the runtime directly.
         let answer = handle.block_on(async { 1 + 1 });
         assert_eq!(answer, 2);
+        drain_janitors();
     }
 
     #[test]
@@ -98,5 +172,64 @@ mod tests {
         // exactly once by the final drop (no double-take, no panic, no leak).
         drop(handle);
         drop(clone);
+
+        // The final drop hands the runtime to a janitor thread; join it so the
+        // graceful shutdown completes without a panic.
+        drain_janitors();
+    }
+
+    #[test]
+    fn drop_drains_runtime_on_a_janitor_thread() {
+        // A guard whose `Drop` fires only when the runtime tears down: it rides
+        // inside a queued task, so it is released when the janitor thread drops
+        // the runtime. Observing it proves the graceful shutdown actually ran on
+        // the janitor thread rather than being skipped.
+        struct DropFlag(Arc<AtomicBool>);
+        impl Drop for DropFlag {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let dropped = Arc::new(AtomicBool::new(false));
+        let handle = {
+            let runtime = test_runtime();
+            let guard = DropFlag(dropped.clone());
+            // Nothing ever drives this current-thread runtime, so the task never
+            // runs; the guard lives on inside the queued task until the janitor
+            // thread drops the runtime (and with it the task).
+            runtime.spawn(async move {
+                let _guard = guard;
+            });
+            RuntimeHandle::new(runtime)
+        };
+
+        // The runtime is still alive, so the guard has not been released yet.
+        assert!(!dropped.load(Ordering::SeqCst));
+
+        drop(handle);
+
+        // Draining joins the janitor, deterministically waiting for the runtime
+        // to finish draining; only then is the guard guaranteed released.
+        drain_janitors();
+        assert!(
+            dropped.load(Ordering::SeqCst),
+            "janitor thread should have dropped the runtime"
+        );
+    }
+
+    #[test]
+    fn new_sweeps_finished_janitors_without_blocking() {
+        // Enqueue a janitor and wait for it to finish draining its runtime.
+        drop(RuntimeHandle::new(test_runtime()));
+        drain_janitors();
+
+        // Constructing another handle runs the trash-can sweep. It must neither
+        // panic nor block on any janitor, and the handle it returns must be a
+        // fully usable runtime.
+        let handle = RuntimeHandle::new(test_runtime());
+        let answer = handle.block_on(async { 40 + 2 });
+        assert_eq!(answer, 42);
+        drain_janitors();
     }
 }

--- a/c/sedona-extension/src/streaming.rs
+++ b/c/sedona-extension/src/streaming.rs
@@ -30,7 +30,8 @@ use arrow_schema::{ArrowError, SchemaRef};
 use datafusion_common::{exec_err, Result};
 use datafusion_physical_plan::SendableRecordBatchStream;
 use futures::StreamExt;
-use tokio::runtime::Runtime;
+
+use crate::runtime::RuntimeHandle;
 
 /// A cancellation check callback for FFI operations.
 ///
@@ -92,9 +93,9 @@ struct StreamWorker {
 pub struct StreamingRecordBatchReader {
     schema: SchemaRef,
     /// Stream and runtime, wrapped in Option so they can be moved to the worker.
-    /// We hold Arc<Runtime> instead of just Handle to keep the runtime alive
-    /// as long as this reader exists.
-    stream_and_runtime: Option<(SendableRecordBatchStream, Arc<Runtime>)>,
+    /// We hold Arc<RuntimeHandle> instead of just Handle to keep the runtime
+    /// alive as long as this reader exists.
+    stream_and_runtime: Option<(SendableRecordBatchStream, Arc<RuntimeHandle>)>,
     /// Worker thread state, lazily initialized on first fetch.
     worker: Option<StreamWorker>,
     cancel_checker: Option<CancelChecker>,
@@ -106,10 +107,11 @@ pub struct StreamingRecordBatchReader {
 impl StreamingRecordBatchReader {
     /// Create a new StreamingRecordBatchReader from a SendableRecordBatchStream.
     ///
-    /// Takes an `Arc<Runtime>` to ensure the runtime stays alive for the lifetime
-    /// of the reader. This prevents "Worker thread terminated" errors when the
-    /// runtime would otherwise be dropped while the stream is still being read.
-    pub fn new(stream: SendableRecordBatchStream, runtime: Arc<Runtime>) -> Self {
+    /// Takes an `Arc<RuntimeHandle>` to ensure the runtime stays alive for the
+    /// lifetime of the reader. This prevents "Worker thread terminated" errors
+    /// when the runtime would otherwise be dropped while the stream is still
+    /// being read.
+    pub fn new(stream: SendableRecordBatchStream, runtime: Arc<RuntimeHandle>) -> Self {
         Self {
             schema: stream.schema(),
             stream_and_runtime: Some((stream, runtime)),
@@ -131,11 +133,11 @@ impl StreamingRecordBatchReader {
     /// is useful for Python where we need to periodically check for signals
     /// (Ctrl+C) during long-running operations.
     ///
-    /// Takes an `Arc<Runtime>` to ensure the runtime stays alive for the lifetime
-    /// of the reader.
+    /// Takes an `Arc<RuntimeHandle>` to ensure the runtime stays alive for the
+    /// lifetime of the reader.
     pub fn with_cancel_checker(
         stream: SendableRecordBatchStream,
-        runtime: Arc<Runtime>,
+        runtime: Arc<RuntimeHandle>,
         cancel_checker: CancelChecker,
         check_interval: Duration,
     ) -> Self {
@@ -417,14 +419,14 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    /// Create a test runtime wrapped in Arc.
-    fn test_runtime() -> Arc<Runtime> {
-        Arc::new(
+    /// Create a test runtime wrapped in a background-shutdown handle.
+    fn test_runtime() -> Arc<RuntimeHandle> {
+        Arc::new(RuntimeHandle::new(
             tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
                 .unwrap(),
-        )
+        ))
     }
 
     /// Create a slow stream that yields batches with a configurable delay.

--- a/c/sedona-extension/src/table_provider.rs
+++ b/c/sedona-extension/src/table_provider.rs
@@ -33,12 +33,12 @@ use datafusion_expr::{Expr, TableType};
 use datafusion_physical_plan::ExecutionPlan;
 use sedona_common::{sedona_internal_datafusion_err, sedona_internal_err};
 use serde::{Deserialize, Serialize};
-use tokio::runtime::Runtime;
 
 use crate::execution_plan::{ExportedExecutionPlan, ImportedSedonaCExec};
 use crate::extension::{
     SedonaCError, SedonaCExecutionPlan, SedonaCExecutionPlanArgs, SedonaCTableProvider,
 };
+use crate::runtime::RuntimeHandle;
 use crate::set_ffi_error;
 use crate::utils::{cstr_from_ptr_or_empty, get_table_provider_string_property, ERRNO_OK};
 
@@ -49,9 +49,9 @@ use crate::utils::{cstr_from_ptr_or_empty, get_table_provider_string_property, E
 pub struct ExportedTableProvider {
     inner: Arc<dyn TableProvider>,
     session: Arc<dyn Session>,
-    /// We hold Arc<Runtime> instead of just Handle to keep the runtime alive
-    /// as long as this provider exists.
-    runtime: Arc<Runtime>,
+    /// We hold Arc<RuntimeHandle> instead of just Handle to keep the runtime
+    /// alive as long as this provider exists.
+    runtime: Arc<RuntimeHandle>,
 }
 
 impl Debug for ExportedTableProvider {
@@ -68,12 +68,12 @@ impl ExportedTableProvider {
     /// The session is used during scan operations and must support physical planning
     /// if the inner TableProvider requires it (e.g., for Views).
     ///
-    /// Takes an `Arc<Runtime>` to ensure the runtime stays alive for the lifetime
-    /// of the provider, preventing "Worker thread terminated" errors.
+    /// Takes an `Arc<RuntimeHandle>` to ensure the runtime stays alive for the
+    /// lifetime of the provider, preventing "Worker thread terminated" errors.
     pub fn new(
         inner: Arc<dyn TableProvider>,
         session: Arc<dyn Session>,
-        runtime: Arc<Runtime>,
+        runtime: Arc<RuntimeHandle>,
     ) -> Self {
         Self {
             inner,
@@ -699,21 +699,21 @@ mod tests {
         }
     }
 
-    /// Create a test runtime wrapped in Arc.
-    fn test_runtime() -> Arc<Runtime> {
-        Arc::new(
+    /// Create a test runtime wrapped in a background-shutdown handle.
+    fn test_runtime() -> Arc<RuntimeHandle> {
+        Arc::new(RuntimeHandle::new(
             tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
                 .unwrap(),
-        )
+        ))
     }
 
     /// Helper to set up an imported table provider from a DummyTableProvider through FFI roundtrip.
     /// Returns the runtime to keep it alive for the duration of the test.
     fn setup_imported_provider_with(
         table_type: TableType,
-    ) -> (ImportedTableProvider, Arc<Runtime>) {
+    ) -> (ImportedTableProvider, Arc<RuntimeHandle>) {
         let dummy = Arc::new(DummyTableProvider::with_table_type(table_type));
         let ctx = SessionContext::new();
         let runtime = test_runtime();

--- a/python/sedonadb/src/context.rs
+++ b/python/sedonadb/src/context.rs
@@ -21,7 +21,7 @@ use pyo3::prelude::*;
 use sedona::context::SedonaContext;
 use sedona::context_builder::SedonaContextBuilder;
 use sedona_datasource::format::ExternalFormatFactory;
-use tokio::runtime::Runtime;
+use sedona_extension::runtime::RuntimeHandle;
 
 use crate::{
     dataframe::InternalDataFrame,
@@ -36,7 +36,7 @@ use crate::{
 #[pyclass]
 pub struct InternalContext {
     pub inner: SedonaContext,
-    pub runtime: Arc<Runtime>,
+    pub runtime: Arc<RuntimeHandle>,
 }
 
 /// Convert a Python options dict to a string map for the reader/object-store
@@ -80,7 +80,7 @@ impl InternalContext {
 
         Ok(Self {
             inner,
-            runtime: Arc::new(runtime),
+            runtime: Arc::new(RuntimeHandle::new(runtime)),
         })
     }
 

--- a/python/sedonadb/src/dataframe.rs
+++ b/python/sedonadb/src/dataframe.rs
@@ -34,9 +34,9 @@ use pyo3::types::{PyCapsule, PyDict, PyList};
 use sedona::context::{SedonaDataFrame, SedonaWriteOptions};
 use sedona::projected_reader::simplify_record_batch_reader;
 use sedona::show::{DisplayMode, DisplayTableOptions};
+use sedona_extension::runtime::RuntimeHandle;
 use sedona_geoparquet::options::TableGeoParquetOptions;
 use sedona_schema::schema::SedonaSchema;
-use tokio::runtime::Runtime;
 
 use crate::context::InternalContext;
 use crate::error::PySedonaError;
@@ -50,11 +50,11 @@ use crate::schema::PySedonaSchema;
 
 pub struct InternalDataFrame {
     pub inner: DataFrame,
-    pub runtime: Arc<Runtime>,
+    pub runtime: Arc<RuntimeHandle>,
 }
 
 impl InternalDataFrame {
-    pub fn new(inner: DataFrame, runtime: Arc<Runtime>) -> Self {
+    pub fn new(inner: DataFrame, runtime: Arc<RuntimeHandle>) -> Self {
         Self { inner, runtime }
     }
 }

--- a/python/sedonadb/src/reader.rs
+++ b/python/sedonadb/src/reader.rs
@@ -19,8 +19,8 @@ use std::time::Duration;
 
 use datafusion::execution::SendableRecordBatchStream;
 use pyo3::Python;
+use sedona_extension::runtime::RuntimeHandle;
 use sedona_extension::streaming::StreamingRecordBatchReader;
-use tokio::runtime::Runtime;
 
 /// Interval for checking Python signals during batch fetches.
 const INTERVAL_CHECK_SIGNALS: Duration = Duration::from_millis(2_000);
@@ -32,11 +32,11 @@ const INTERVAL_CHECK_SIGNALS: Duration = Duration::from_millis(2_000);
 /// The reader will check Python signals every 2 seconds during batch fetches,
 /// allowing users to interrupt long-running queries.
 ///
-/// Takes an `Arc<Runtime>` to ensure the runtime stays alive for the lifetime
-/// of the reader, preventing "Worker thread terminated" errors.
+/// Takes an `Arc<RuntimeHandle>` to ensure the runtime stays alive for the
+/// lifetime of the reader, preventing "Worker thread terminated" errors.
 pub fn new_py_streaming_reader(
     stream: SendableRecordBatchStream,
-    runtime: Arc<Runtime>,
+    runtime: Arc<RuntimeHandle>,
 ) -> StreamingRecordBatchReader {
     // Create a cancel checker that checks Python signals
     let cancel_checker: Box<dyn Fn() -> bool + Send + Sync> = Box::new(|| {

--- a/r/sedonadb/src/rust/src/context.rs
+++ b/r/sedonadb/src/rust/src/context.rs
@@ -27,8 +27,8 @@ use sedona::{
     context::SedonaContext, context_builder::SedonaContextBuilder,
     record_batch_reader_provider::RecordBatchReaderProvider,
 };
+use sedona_extension::runtime::RuntimeHandle;
 use sedona_geoparquet::provider::GeoParquetReadOptions;
-use tokio::runtime::Runtime;
 
 use crate::{
     dataframe::{new_data_frame, InternalDataFrame},
@@ -39,7 +39,7 @@ use crate::{
 #[savvy]
 pub struct InternalContext {
     pub inner: Arc<SedonaContext>,
-    pub runtime: Arc<Runtime>,
+    pub runtime: Arc<RuntimeHandle>,
 }
 
 #[savvy]
@@ -67,7 +67,7 @@ impl InternalContext {
 
         Ok(Self {
             inner: Arc::new(inner),
-            runtime: Arc::new(runtime),
+            runtime: Arc::new(RuntimeHandle::new(runtime)),
         })
     }
 

--- a/r/sedonadb/src/rust/src/dataframe.rs
+++ b/r/sedonadb/src/rust/src/dataframe.rs
@@ -28,12 +28,12 @@ use datafusion_expr::{select_expr::SelectExpr, Expr, SortExpr};
 use savvy::{savvy, savvy_err, sexp, IntoExtPtrSexp, Result};
 use sedona::context::{SedonaDataFrame, SedonaWriteOptions};
 use sedona::show::{DisplayMode, DisplayTableOptions};
+use sedona_extension::runtime::RuntimeHandle;
 use sedona_extension::streaming::StreamingRecordBatchReader;
 use sedona_extension::table_provider::ExportedTableProvider;
 use sedona_geoparquet::options::TableGeoParquetOptions;
 use sedona_schema::schema::SedonaSchema;
 use std::{iter::zip, ptr::swap_nonoverlapping, sync::Arc};
-use tokio::runtime::Runtime;
 
 use crate::context::InternalContext;
 use crate::expression::SedonaDBExprFactory;
@@ -43,10 +43,10 @@ use crate::runtime::wait_for_future_captured_r;
 #[savvy]
 pub struct InternalDataFrame {
     pub inner: DataFrame,
-    pub runtime: Arc<Runtime>,
+    pub runtime: Arc<RuntimeHandle>,
 }
 
-pub fn new_data_frame(inner: DataFrame, runtime: Arc<Runtime>) -> InternalDataFrame {
+pub fn new_data_frame(inner: DataFrame, runtime: Arc<RuntimeHandle>) -> InternalDataFrame {
     InternalDataFrame { inner, runtime }
 }
 

--- a/rust/sedona-adbc/src/connection.rs
+++ b/rust/sedona-adbc/src/connection.rs
@@ -25,8 +25,8 @@ use adbc_core::{
 };
 use arrow_array::RecordBatchReader;
 use sedona::context::SedonaContext;
+use sedona_extension::runtime::RuntimeHandle;
 use std::sync::Arc;
-use tokio::runtime::Runtime;
 
 use adbc_core::{
     error::{Error, Result, Status},
@@ -40,7 +40,7 @@ use crate::{
 };
 
 pub struct SedonaConnection {
-    runtime: Arc<Runtime>,
+    runtime: Arc<RuntimeHandle>,
     ctx: Arc<SedonaContext>,
     autocommit_on: bool,
 }
@@ -66,7 +66,7 @@ impl SedonaConnection {
         })?;
 
         let mut connection = Self {
-            runtime: Arc::new(runtime),
+            runtime: Arc::new(RuntimeHandle::new(runtime)),
             ctx: Arc::new(ctx),
             autocommit_on: true,
         };

--- a/rust/sedona-adbc/src/statement.rs
+++ b/rust/sedona-adbc/src/statement.rs
@@ -18,9 +18,9 @@ use adbc_core::PartitionedResult;
 use arrow_array::{RecordBatch, RecordBatchReader};
 use arrow_schema::Schema;
 use sedona::context::SedonaContext;
+use sedona_extension::runtime::RuntimeHandle;
 use sedona_extension::streaming::StreamingRecordBatchReader;
 use std::sync::Arc;
-use tokio::runtime::Runtime;
 
 use adbc_core::{
     error::{Error, Result, Status},
@@ -31,13 +31,13 @@ use adbc_core::{
 use crate::{err_not_implemented, err_unrecognized_option, utils::from_datafusion_error};
 
 pub struct SedonaStatement {
-    runtime: Arc<Runtime>,
+    runtime: Arc<RuntimeHandle>,
     ctx: Arc<SedonaContext>,
     sql_query: Option<String>,
 }
 
 impl SedonaStatement {
-    pub(crate) fn new(runtime: Arc<Runtime>, ctx: Arc<SedonaContext>) -> SedonaStatement {
+    pub(crate) fn new(runtime: Arc<RuntimeHandle>, ctx: Arc<SedonaContext>) -> SedonaStatement {
         Self {
             runtime,
             ctx,


### PR DESCRIPTION
The free-threaded (cp\*t) macOS wheel test hung because the per-connect Tokio runtime's default `Drop` blocking-joins its worker threads while attached to the interpreter, which stalls CPython's stop-the-world under free-threading. The runtime now shuts down in the background on teardown instead, so the free-threaded wheels build and run the full test suite again (the macOS `CIBW_SKIP` is removed).