### PR TITLE
feat: add RS_ReprojectMatch

### DIFF
--- a/c/sedona-gdal/src/dyn_load.rs
+++ b/c/sedona-gdal/src/dyn_load.rs
@@ -126,6 +126,7 @@ fn load_all_symbols(lib: &Library, api: &mut SedonaGdalApi) -> Result<(), GdalIn
     load_fn!(lib, api, OSRSetAxisMappingStrategy);
     load_fn!(lib, api, OSRDestroySpatialReference);
     load_fn!(lib, api, OSRExportToPROJJSON);
+    load_fn!(lib, api, OSRExportToWkt);
     load_fn!(lib, api, OSRClone);
     load_fn!(lib, api, OSRRelease);
 
@@ -162,6 +163,13 @@ fn load_all_symbols(lib: &Library, api: &mut SedonaGdalApi) -> Result<(), GdalIn
     // --- VRT ---
     load_fn!(lib, api, VRTCreate);
     load_fn!(lib, api, VRTAddSimpleSource);
+
+    // --- Warp / Reproject ---
+    load_fn!(lib, api, GDALReprojectImage);
+    load_fn!(lib, api, GDALCreateGenImgProjTransformer);
+    load_fn!(lib, api, GDALDestroyGenImgProjTransformer);
+    load_fn!(lib, api, GDALSuggestedWarpOutput);
+    load_fn!(lib, api, GDALGenImgProjTransform);
 
     // --- Rasterize / Polygonize ---
     load_fn!(lib, api, GDALRasterizeGeometries);

--- a/c/sedona-gdal/src/gdal.rs
+++ b/c/sedona-gdal/src/gdal.rs
@@ -133,9 +133,17 @@ impl Gdal {
     // -- Warp / Reproject ----------------------------------------------------
 
     /// Reproject/warp `src` into the pre-created `dst` dataset.
-    /// See also [`warp::reproject_image`].
-    pub fn reproject_image(&self, src: &Dataset, dst: &Dataset, alg: ResampleAlg) -> Result<()> {
-        warp::reproject_image(self.api, src, dst, alg)
+    ///
+    /// `warp_memory_limit_bytes` is GDAL's working-memory cache size for the
+    /// warp; pass `0.0` for GDAL's default. See also [`warp::reproject_image`].
+    pub fn reproject_image(
+        &self,
+        src: &Dataset,
+        dst: &Dataset,
+        alg: ResampleAlg,
+        warp_memory_limit_bytes: f64,
+    ) -> Result<()> {
+        warp::reproject_image(self.api, src, dst, alg, warp_memory_limit_bytes)
     }
 
     /// Compute the output geotransform and pixel dimensions a reprojection of

--- a/c/sedona-gdal/src/gdal.rs
+++ b/c/sedona-gdal/src/gdal.rs
@@ -28,6 +28,7 @@ use crate::driver::{Driver, DriverManager};
 use crate::errors::Result;
 use crate::gdal_api::GdalApi;
 use crate::gdal_dyn_bindgen::{GDALOpenFlags, OGRFieldType};
+use crate::geo_transform::GeoTransform;
 use crate::mem::create_mem_dataset;
 use crate::raster::polygonize::{fpolygonize, polygonize, PolygonizeOptions};
 use crate::raster::rasterband::RasterBand;
@@ -35,12 +36,14 @@ use crate::raster::rasterize::{rasterize, RasterizeOptions};
 use crate::raster::rasterize_affine::rasterize_affine;
 use crate::raster::types::DatasetOptions;
 use crate::raster::types::GdalDataType;
+use crate::raster::types::ResampleAlg;
 use crate::spatial_ref::SpatialRef;
 use crate::vector::feature::FieldDefn;
 use crate::vector::geometry::Geometry;
 use crate::vector::layer::Layer;
 use crate::vrt::VrtDataset;
 use crate::vsi;
+use crate::warp;
 
 /// High-level convenience wrapper around [`GdalApi`].
 ///
@@ -119,6 +122,31 @@ impl Gdal {
     /// See also [`SpatialRef::from_wkt`].
     pub fn spatial_ref_from_wkt(&self, wkt: &str) -> Result<SpatialRef> {
         SpatialRef::from_wkt(self.api, wkt)
+    }
+
+    /// Create a spatial reference from any user-input form (`EPSG:xxxx`, WKT,
+    /// PROJJSON, ...). See also [`SpatialRef::from_definition`].
+    pub fn spatial_ref_from_definition(&self, definition: &str) -> Result<SpatialRef> {
+        SpatialRef::from_definition(self.api, definition)
+    }
+
+    // -- Warp / Reproject ----------------------------------------------------
+
+    /// Reproject/warp `src` into the pre-created `dst` dataset.
+    /// See also [`warp::reproject_image`].
+    pub fn reproject_image(&self, src: &Dataset, dst: &Dataset, alg: ResampleAlg) -> Result<()> {
+        warp::reproject_image(self.api, src, dst, alg)
+    }
+
+    /// Compute the output geotransform and pixel dimensions a reprojection of
+    /// `src` into `dst_srs` should use (GDAL's `GDALSuggestedWarpOutput`).
+    pub fn suggested_warp_output(
+        &self,
+        src: &Dataset,
+        dst_srs: &SpatialRef,
+    ) -> Result<(GeoTransform, usize, usize)> {
+        let transformer = warp::GenImgProjTransformer::new(self.api, src, dst_srs)?;
+        warp::suggested_warp_output(self.api, src, &transformer)
     }
 
     // -- VRT -----------------------------------------------------------------

--- a/c/sedona-gdal/src/gdal_api.rs
+++ b/c/sedona-gdal/src/gdal_api.rs
@@ -22,7 +22,7 @@ use libloading::Library;
 
 use crate::dyn_load;
 use crate::errors::{GdalError, GdalInitLibraryError};
-use crate::gdal_dyn_bindgen::SedonaGdalApi;
+use crate::gdal_dyn_bindgen::{GDALTransformerFunc, SedonaGdalApi};
 
 /// Invoke a function pointer from the `SedonaGdalApi` struct.
 ///
@@ -94,6 +94,14 @@ impl GdalApi {
                 .to_string_lossy()
                 .into_owned()
         }
+    }
+
+    /// Return the `GDALGenImgProjTransform` callback, passed as the transformer
+    /// to `GDALSuggestedWarpOutput`. Errors if the symbol did not resolve.
+    pub(crate) fn gen_img_proj_transform_fn(&self) -> Result<GDALTransformerFunc, GdalError> {
+        self.inner.GDALGenImgProjTransform.ok_or_else(|| {
+            GdalError::BadArgument("GDALGenImgProjTransform symbol is not available".to_string())
+        })
     }
 
     /// Check the last CPL error and return a `GdalError::CplError`, it always returns an error struct

--- a/c/sedona-gdal/src/gdal_dyn_bindgen.rs
+++ b/c/sedona-gdal/src/gdal_dyn_bindgen.rs
@@ -31,6 +31,10 @@ pub type GDALRWFlag = c_int;
 pub type OGRwkbByteOrder = c_int;
 pub type GDALOpenFlags = c_uint;
 pub type GDALRIOResampleAlg = c_int;
+/// Warp resampling algorithm (`GDALResampleAlg`), distinct from the RasterIO
+/// `GDALRIOResampleAlg` above: it is an unsigned enum and its `GRA_*` values
+/// diverge from `GRIORA_*` beyond the shared 0..=6 range (warp has no Gauss).
+pub type GDALResampleAlg = c_uint;
 
 // --- Opaque handle types ---
 
@@ -202,6 +206,17 @@ pub const GRIORA_Lanczos: GDALRIOResampleAlg = 4;
 pub const GRIORA_Average: GDALRIOResampleAlg = 5;
 pub const GRIORA_Mode: GDALRIOResampleAlg = 6;
 pub const GRIORA_Gauss: GDALRIOResampleAlg = 7;
+
+// --- GDALResampleAlg (warp) constants ---
+// Warp's algorithm enum. Values 0..=6 coincide with the RasterIO GRIORA_*
+// above, but this is a separate unsigned enum used by the warp API.
+pub const GRA_NearestNeighbour: GDALResampleAlg = 0;
+pub const GRA_Bilinear: GDALResampleAlg = 1;
+pub const GRA_Cubic: GDALResampleAlg = 2;
+pub const GRA_CubicSpline: GDALResampleAlg = 3;
+pub const GRA_Lanczos: GDALResampleAlg = 4;
+pub const GRA_Average: GDALResampleAlg = 5;
+pub const GRA_Mode: GDALResampleAlg = 6;
 
 // --- GDAL open flags constants ---
 
@@ -391,6 +406,9 @@ pub(crate) struct SedonaGdalApi {
             papszOptions: *const *const c_char,
         ) -> OGRErr,
     >,
+    pub OSRExportToWkt: Option<
+        unsafe extern "C" fn(hSRS: OGRSpatialReferenceH, ppszWkt: *mut *mut c_char) -> OGRErr,
+    >,
     pub OSRClone: Option<unsafe extern "C" fn(hSRS: OGRSpatialReferenceH) -> OGRSpatialReferenceH>,
     pub OSRRelease: Option<unsafe extern "C" fn(hSRS: OGRSpatialReferenceH)>,
 
@@ -487,6 +505,48 @@ pub(crate) struct SedonaGdalApi {
             dfNoDataValue: c_double,
         ) -> CPLErr,
     >,
+
+    // --- Warp / Reproject ---
+    // `psOptions` is a `GDALWarpOptions*`; we only ever pass NULL (the datasets
+    // carry their own SRS/nodata), so it is typed as an opaque pointer rather
+    // than binding the large `GDALWarpOptions` struct.
+    pub GDALReprojectImage: Option<
+        unsafe extern "C" fn(
+            hSrcDS: GDALDatasetH,
+            pszSrcWKT: *const c_char,
+            hDstDS: GDALDatasetH,
+            pszDstWKT: *const c_char,
+            eResampleAlg: GDALResampleAlg,
+            dfWarpMemoryLimit: c_double,
+            dfMaxError: c_double,
+            pfnProgress: GDALProgressFunc,
+            pProgressArg: *mut c_void,
+            psWarpOptions: *mut c_void,
+        ) -> CPLErr,
+    >,
+    pub GDALCreateGenImgProjTransformer: Option<
+        unsafe extern "C" fn(
+            hSrcDS: GDALDatasetH,
+            pszSrcWKT: *const c_char,
+            hDstDS: GDALDatasetH,
+            pszDstWKT: *const c_char,
+            bGCPUseOK: c_int,
+            dfGCPErrorThreshold: c_double,
+            nOrder: c_int,
+        ) -> *mut c_void,
+    >,
+    pub GDALDestroyGenImgProjTransformer: Option<unsafe extern "C" fn(pTransformArg: *mut c_void)>,
+    pub GDALSuggestedWarpOutput: Option<
+        unsafe extern "C" fn(
+            hSrcDS: GDALDatasetH,
+            pfnTransformer: GDALTransformerFunc,
+            pTransformArg: *mut c_void,
+            padfGeoTransformOut: *mut c_double,
+            pnPixels: *mut c_int,
+            pnLines: *mut c_int,
+        ) -> CPLErr,
+    >,
+    pub GDALGenImgProjTransform: Option<GDALTransformerFunc>,
 
     // --- Rasterize / Polygonize ---
     pub GDALRasterizeGeometries: Option<

--- a/c/sedona-gdal/src/lib.rs
+++ b/c/sedona-gdal/src/lib.rs
@@ -39,3 +39,4 @@ pub mod spatial_ref;
 pub mod vector;
 pub mod vrt;
 pub mod vsi;
+pub mod warp;

--- a/c/sedona-gdal/src/raster/types.rs
+++ b/c/sedona-gdal/src/raster/types.rs
@@ -20,7 +20,8 @@
 //! Original code is licensed under MIT.
 
 use crate::gdal_dyn_bindgen::{
-    self, GDALDataType, GDALOpenFlags, GDALRIOResampleAlg, GDAL_OF_READONLY, GDAL_OF_VERBOSE_ERROR,
+    self, GDALDataType, GDALOpenFlags, GDALRIOResampleAlg, GDALResampleAlg, GDAL_OF_READONLY,
+    GDAL_OF_VERBOSE_ERROR,
 };
 
 /// A Rust-friendly enum mirroring the georust/gdal `GdalDataType` names.
@@ -193,6 +194,23 @@ impl ResampleAlg {
             ResampleAlg::Average => gdal_dyn_bindgen::GRIORA_Average,
             ResampleAlg::Mode => gdal_dyn_bindgen::GRIORA_Mode,
             ResampleAlg::Gauss => gdal_dyn_bindgen::GRIORA_Gauss,
+        }
+    }
+
+    /// Convert to the warp `GDALResampleAlg` value used by `GDALReprojectImage`.
+    ///
+    /// Returns `None` for algorithms the warp API has no equivalent for (Gauss),
+    /// so callers surface a clear error rather than silently mis-mapping.
+    pub fn to_gdal_warp(self) -> Option<GDALResampleAlg> {
+        match self {
+            ResampleAlg::NearestNeighbour => Some(gdal_dyn_bindgen::GRA_NearestNeighbour),
+            ResampleAlg::Bilinear => Some(gdal_dyn_bindgen::GRA_Bilinear),
+            ResampleAlg::Cubic => Some(gdal_dyn_bindgen::GRA_Cubic),
+            ResampleAlg::CubicSpline => Some(gdal_dyn_bindgen::GRA_CubicSpline),
+            ResampleAlg::Lanczos => Some(gdal_dyn_bindgen::GRA_Lanczos),
+            ResampleAlg::Average => Some(gdal_dyn_bindgen::GRA_Average),
+            ResampleAlg::Mode => Some(gdal_dyn_bindgen::GRA_Mode),
+            ResampleAlg::Gauss => None,
         }
     }
 

--- a/c/sedona-gdal/src/spatial_ref.rs
+++ b/c/sedona-gdal/src/spatial_ref.rs
@@ -154,6 +154,33 @@ impl SpatialRef {
         unsafe { call_gdal_api!(self.api, OSRSetAxisMappingStrategy, self.c_srs, strategy) };
     }
 
+    /// Export to WKT string.
+    ///
+    /// Used to hand GDAL's warp transformer a concrete target CRS definition
+    /// (`GDALCreateGenImgProjTransformer` takes WKT), independent of whatever
+    /// user-input form (`EPSG:xxxx`, PROJJSON, WKT) the CRS came in as.
+    pub fn to_wkt(&self) -> Result<String> {
+        unsafe {
+            let mut ptr: *mut std::os::raw::c_char = ptr::null_mut();
+            let rv = call_gdal_api!(self.api, OSRExportToWkt, self.c_srs, &mut ptr);
+            if rv != OGRERR_NONE {
+                if !ptr.is_null() {
+                    call_gdal_api!(self.api, VSIFree, ptr as *mut std::ffi::c_void);
+                }
+                return Err(GdalError::OgrError {
+                    err: rv,
+                    method_name: "OSRExportToWkt",
+                });
+            }
+            if ptr.is_null() {
+                return Err(self.api.last_null_pointer_err("OSRExportToWkt"));
+            }
+            let result = CStr::from_ptr(ptr).to_string_lossy().into_owned();
+            call_gdal_api!(self.api, VSIFree, ptr as *mut std::ffi::c_void);
+            Ok(result)
+        }
+    }
+
     /// Export to PROJJSON string.
     pub fn to_projjson(&self) -> Result<String> {
         unsafe {

--- a/c/sedona-gdal/src/warp.rs
+++ b/c/sedona-gdal/src/warp.rs
@@ -45,11 +45,15 @@ use crate::spatial_ref::SpatialRef;
 /// left **untouched**: `GDALReprojectImage` with no warp options writes only
 /// covered pixels. Callers that grow the extent must therefore pre-fill `dst`'s
 /// band buffers with the desired background/nodata value before warping.
+///
+/// `warp_memory_limit_bytes` is GDAL's working-memory cache size for the warp
+/// (its `dfWarpMemoryLimit`); pass `0.0` to use GDAL's own default.
 pub fn reproject_image(
     api: &'static GdalApi,
     src: &Dataset,
     dst: &Dataset,
     alg: ResampleAlg,
+    warp_memory_limit_bytes: f64,
 ) -> Result<()> {
     let gra = alg.to_gdal_warp().ok_or_else(|| {
         GdalError::BadArgument(format!(
@@ -66,7 +70,7 @@ pub fn reproject_image(
             dst.c_dataset(),
             null(), // dst WKT: NULL means "use the destination dataset's own SRS"
             gra,
-            0.0,        // warp memory limit (0 = GDAL default)
+            warp_memory_limit_bytes, // warp memory limit (0.0 = GDAL default)
             0.0,        // max error in pixels (0 = exact transformer, no approximation)
             None,       // progress callback
             null_mut(), // progress arg
@@ -194,7 +198,7 @@ mod tests {
                 .unwrap();
             dst.set_projection("EPSG:4326").unwrap();
 
-            gdal.reproject_image(&src, &dst, ResampleAlg::NearestNeighbour)
+            gdal.reproject_image(&src, &dst, ResampleAlg::NearestNeighbour, 0.0)
                 .unwrap();
 
             let out = dst

--- a/c/sedona-gdal/src/warp.rs
+++ b/c/sedona-gdal/src/warp.rs
@@ -1,0 +1,241 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! GDAL warp / reproject API wrappers.
+//!
+//! Sits alongside the RasterIO resampling in [`crate::raster::rasterband`]: this
+//! is the (re)gridding path that can move the output origin off the source grid,
+//! grow the output extent beyond the source footprint, and change the CRS —
+//! things RasterIO's read-into-a-buffer cannot do.
+
+use std::ffi::CString;
+use std::os::raw::c_void;
+use std::ptr::{null, null_mut};
+
+use crate::dataset::Dataset;
+use crate::errors::{GdalError, Result};
+use crate::gdal_api::{call_gdal_api, GdalApi};
+use crate::gdal_dyn_bindgen::{CE_Failure, CE_None};
+use crate::geo_transform::GeoTransform;
+use crate::raster::types::ResampleAlg;
+use crate::spatial_ref::SpatialRef;
+
+/// Reproject/warp `src` into the already-created `dst` dataset.
+///
+/// Both datasets carry their own spatial reference (set via `set_projection` /
+/// `set_spatial_ref`), so the warp reprojects from the source SRS to the
+/// destination SRS, resampling with `alg`. The output grid — origin, pixel size,
+/// dimensions — is whatever `dst` was created with.
+///
+/// Destination cells that the (reprojected) source footprint does not cover are
+/// left **untouched**: `GDALReprojectImage` with no warp options writes only
+/// covered pixels. Callers that grow the extent must therefore pre-fill `dst`'s
+/// band buffers with the desired background/nodata value before warping.
+pub fn reproject_image(
+    api: &'static GdalApi,
+    src: &Dataset,
+    dst: &Dataset,
+    alg: ResampleAlg,
+) -> Result<()> {
+    let gra = alg.to_gdal_warp().ok_or_else(|| {
+        GdalError::BadArgument(format!(
+            "resample algorithm {alg:?} is not supported by the warp API"
+        ))
+    })?;
+
+    let rv = unsafe {
+        call_gdal_api!(
+            api,
+            GDALReprojectImage,
+            src.c_dataset(),
+            null(), // src WKT: NULL means "use the source dataset's own SRS"
+            dst.c_dataset(),
+            null(), // dst WKT: NULL means "use the destination dataset's own SRS"
+            gra,
+            0.0,        // warp memory limit (0 = GDAL default)
+            0.0,        // max error in pixels (0 = exact transformer, no approximation)
+            None,       // progress callback
+            null_mut(), // progress arg
+            null_mut()  // GDALWarpOptions* (NULL = defaults)
+        )
+    };
+    if rv != CE_None {
+        return Err(api.last_cpl_err(CE_Failure as u32));
+    }
+    Ok(())
+}
+
+/// A GDAL image-to-image reprojection transformer.
+///
+/// Owns the argument returned by `GDALCreateGenImgProjTransformer` and destroys
+/// it on drop. Its sole use here is feeding [`suggested_warp_output`], which asks
+/// GDAL what output grid a reprojection into the target CRS should use.
+pub struct GenImgProjTransformer {
+    api: &'static GdalApi,
+    handle: *mut c_void,
+}
+
+// SAFETY: `GenImgProjTransformer` uniquely owns its transformer handle and only
+// moves that ownership across threads; the handle is destroyed exactly once on
+// drop and this wrapper offers no shared concurrent access, so `Send` is sound.
+unsafe impl Send for GenImgProjTransformer {}
+
+impl Drop for GenImgProjTransformer {
+    fn drop(&mut self) {
+        if !self.handle.is_null() {
+            unsafe { call_gdal_api!(self.api, GDALDestroyGenImgProjTransformer, self.handle) };
+        }
+    }
+}
+
+impl GenImgProjTransformer {
+    /// Create a transformer mapping `src` (using its own SRS) into `dst_srs`.
+    pub fn new(api: &'static GdalApi, src: &Dataset, dst_srs: &SpatialRef) -> Result<Self> {
+        let dst_wkt = dst_srs.to_wkt()?;
+        let c_dst_wkt = CString::new(dst_wkt)?;
+        let handle = unsafe {
+            call_gdal_api!(
+                api,
+                GDALCreateGenImgProjTransformer,
+                src.c_dataset(),
+                null(),             // src WKT: use the source dataset's own SRS
+                null_mut(),         // dst dataset: none (target given as WKT below)
+                c_dst_wkt.as_ptr(), // dst WKT
+                0,                  // bGCPUseOK
+                0.0,                // dfGCPErrorThreshold
+                0                   // nOrder
+            )
+        };
+        if handle.is_null() {
+            return Err(api.last_null_pointer_err("GDALCreateGenImgProjTransformer"));
+        }
+        Ok(Self { api, handle })
+    }
+}
+
+/// Compute the output geotransform and pixel dimensions a reprojection of `src`
+/// through `transformer` should use (GDAL's `GDALSuggestedWarpOutput`).
+///
+/// The returned geotransform is north-up (no skew) in the target CRS; this is
+/// the same computation `rasterio.warp.calculate_default_transform` performs.
+pub fn suggested_warp_output(
+    api: &'static GdalApi,
+    src: &Dataset,
+    transformer: &GenImgProjTransformer,
+) -> Result<(GeoTransform, usize, usize)> {
+    let pfn = api.gen_img_proj_transform_fn()?;
+
+    let mut gt: GeoTransform = [0.0; 6];
+    let mut n_pixels: i32 = 0;
+    let mut n_lines: i32 = 0;
+    let rv = unsafe {
+        call_gdal_api!(
+            api,
+            GDALSuggestedWarpOutput,
+            src.c_dataset(),
+            pfn,
+            transformer.handle,
+            gt.as_mut_ptr(),
+            &mut n_pixels,
+            &mut n_lines
+        )
+    };
+    if rv != CE_None {
+        return Err(api.last_cpl_err(CE_Failure as u32));
+    }
+    if n_pixels <= 0 || n_lines <= 0 {
+        return Err(GdalError::BadArgument(format!(
+            "GDALSuggestedWarpOutput returned non-positive size {n_pixels}x{n_lines}"
+        )));
+    }
+    Ok((gt, n_pixels as usize, n_lines as usize))
+}
+
+#[cfg(all(test, feature = "gdal-sys"))]
+mod tests {
+    use crate::global::with_global_gdal;
+    use crate::raster::types::{Buffer, GdalDataType, ResampleAlg};
+
+    #[test]
+    fn reproject_same_crs_upsamples_into_dst_grid() {
+        with_global_gdal(|gdal| {
+            // 2x1 source, values [10, 20], extent x[0,4] y[0,2], EPSG:4326.
+            let src = gdal
+                .create_mem_dataset(2, 1, 1, GdalDataType::UInt8)
+                .unwrap();
+            src.set_geo_transform(&[0.0, 2.0, 0.0, 2.0, 0.0, -2.0])
+                .unwrap();
+            src.set_projection("EPSG:4326").unwrap();
+            let mut buf = Buffer::new((2, 1), vec![10u8, 20]);
+            src.rasterband(1)
+                .unwrap()
+                .write((0, 0), (2, 1), &mut buf)
+                .unwrap();
+
+            // 4x2 destination on the same extent (extent-preserving upsample).
+            let dst = gdal
+                .create_mem_dataset(4, 2, 1, GdalDataType::UInt8)
+                .unwrap();
+            dst.set_geo_transform(&[0.0, 1.0, 0.0, 2.0, 0.0, -1.0])
+                .unwrap();
+            dst.set_projection("EPSG:4326").unwrap();
+
+            gdal.reproject_image(&src, &dst, ResampleAlg::NearestNeighbour)
+                .unwrap();
+
+            let out = dst
+                .rasterband(1)
+                .unwrap()
+                .read_as::<u8>((0, 0), (4, 2), (4, 2), None)
+                .unwrap();
+            // Nearest 2x integer upsample replicates each source pixel 2x2.
+            assert_eq!(out.data(), [10, 10, 20, 20, 10, 10, 20, 20]);
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn suggested_warp_output_reprojects_extent() {
+        with_global_gdal(|gdal| {
+            // A small EPSG:4326 raster; suggest the output grid for EPSG:3857.
+            let src = gdal
+                .create_mem_dataset(8, 8, 1, GdalDataType::UInt8)
+                .unwrap();
+            src.set_geo_transform(&[10.0, 0.5, 0.0, 50.0, 0.0, -0.5])
+                .unwrap();
+            src.set_projection("EPSG:4326").unwrap();
+
+            let dst_srs = gdal.spatial_ref_from_definition("EPSG:3857").unwrap();
+            let (gt, px, ln) = gdal.suggested_warp_output(&src, &dst_srs).unwrap();
+
+            assert!(px > 0 && ln > 0);
+            // Web Mercator origin x for 10 deg lon is ~1.11e6 m; the suggested
+            // grid is north-up (no skew) and its pixel size is positive/negative.
+            assert!(
+                gt[2] == 0.0 && gt[4] == 0.0,
+                "suggested transform is north-up"
+            );
+            assert!(gt[1] > 0.0 && gt[5] < 0.0, "positive x res, negative y res");
+            assert!(
+                gt[0] > 1.0e6 && gt[0] < 1.2e6,
+                "3857 origin x near 1.11e6, got {}",
+                gt[0]
+            );
+        })
+        .unwrap();
+    }
+}

--- a/docs/reference/sql/rs_reprojectmatch.qmd
+++ b/docs/reference/sql/rs_reprojectmatch.qmd
@@ -1,0 +1,83 @@
+---
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+title: RS_ReprojectMatch
+description: >
+  Reprojects a raster onto a reference raster's CRS, grid, and extent.
+kernels:
+  - returns: raster
+    args:
+    - name: raster
+      type: raster
+    - name: reference
+      type: raster
+  - returns: raster
+    args:
+    - name: raster
+      type: raster
+    - name: reference
+      type: raster
+    - name: algorithm
+      type: string
+      description: >
+        Resampling algorithm (case-insensitive): `NearestNeighbor` (the
+        default), `Bilinear`, `Cubic` (alias `Bicubic`), `CubicSpline`,
+        `Lanczos`, `Average`, or `Mode`.
+---
+
+::: callout-warning
+**Experimental.** This function is experimental; its behavior may change without
+notice.
+:::
+
+## Description
+
+`RS_ReprojectMatch` reprojects `raster` onto the grid of `reference`: the output
+always has the **same** CRS, extent, resolution, and dimensions as `reference`,
+in the spirit of `rioxarray`'s `reproject_match`. The reference contributes only
+its grid — its pixel values are never read.
+
+The input's band count and order, per-band data type, and nodata are preserved.
+Pixel values are recomputed by GDAL's warp using the chosen `algorithm` (nearest
+neighbour by default). Cells of the reference grid that the reprojected input
+does not cover are filled with the input band's nodata value (or zero when a
+band has none).
+
+Both rasters must agree on whether they carry a CRS: reprojecting between an
+unknown CRS and a real one is undefined, so it is an error for exactly one side
+to have a CRS. When neither has one, the operation is a same-space regrid onto
+the reference grid.
+
+::: callout-note
+This reads the entire input raster into memory.
+:::
+
+## Examples
+
+Reprojecting the example raster onto its own grid is an identity, so the output
+keeps the example's width (64):
+
+```sql
+SELECT RS_Width(RS_ReprojectMatch(RS_Example(), RS_Example()));
+```
+
+The same, choosing bilinear resampling explicitly:
+
+```sql
+SELECT RS_Height(RS_ReprojectMatch(RS_Example(), RS_Example(), 'Bilinear'));
+```

--- a/docs/reference/sql/rs_reprojectmatch.qmd
+++ b/docs/reference/sql/rs_reprojectmatch.qmd
@@ -63,12 +63,11 @@ unknown CRS and a real one is undefined, so it is an error for exactly one side
 to have a CRS. When neither has one, the operation is a same-space regrid onto
 the reference grid.
 
-`Int64` and `UInt64` input rasters are supported for **nearest-neighbor**
-resampling (a pure value copy, so 64-bit integers survive exactly) when the
-band's nodata is absent or has magnitude ≤ 2^53. Other resampling algorithms
-work in a floating type, and the warp carries nodata as a double, so a
-non-nearest algorithm or a nodata above 2^53 would lose precision and raises an
-error; cast to another type first.
+`Int64` and `UInt64` input rasters are **not supported**: GDAL's warp routes
+64-bit integer pixels through a floating working type (a double for
+nearest/interpolation, a 32-bit float for mode on GDAL < 3.13), so no resampling
+method can represent them exactly. Cast to a supported type (for example `Int32`
+or `Float64`) first.
 
 ::: callout-note
 This reads the entire input raster into memory.

--- a/docs/reference/sql/rs_reprojectmatch.qmd
+++ b/docs/reference/sql/rs_reprojectmatch.qmd
@@ -63,8 +63,12 @@ unknown CRS and a real one is undefined, so it is an error for exactly one side
 to have a CRS. When neither has one, the operation is a same-space regrid onto
 the reference grid.
 
-`Int64` and `UInt64` input rasters are not supported (the warp cannot represent
-their nodata exactly) and raise an error; cast to another type first.
+`Int64` and `UInt64` input rasters are supported for **nearest-neighbor**
+resampling (a pure value copy, so 64-bit integers survive exactly) when the
+band's nodata is absent or has magnitude ≤ 2^53. Other resampling algorithms
+work in a floating type, and the warp carries nodata as a double, so a
+non-nearest algorithm or a nodata above 2^53 would lose precision and raises an
+error; cast to another type first.
 
 ::: callout-note
 This reads the entire input raster into memory.

--- a/docs/reference/sql/rs_reprojectmatch.qmd
+++ b/docs/reference/sql/rs_reprojectmatch.qmd
@@ -63,6 +63,9 @@ unknown CRS and a real one is undefined, so it is an error for exactly one side
 to have a CRS. When neither has one, the operation is a same-space regrid onto
 the reference grid.
 
+`Int64` and `UInt64` input rasters are not supported (the warp cannot represent
+their nodata exactly) and raise an error; cast to another type first.
+
 ::: callout-note
 This reads the entire input raster into memory.
 :::

--- a/python/sedonadb/python/sedonadb/raster_testing.py
+++ b/python/sedonadb/python/sedonadb/raster_testing.py
@@ -275,6 +275,23 @@ class RasterEngine:
         """
         self._not_implemented("resample")
 
+    def reproject_match(
+        self,
+        path,
+        reference_path,
+        *,
+        algorithm: str = "NearestNeighbor",
+    ) -> Optional[DecodedRaster]:
+        """Reproject the GeoTIFF at `path` onto the reference GeoTIFF's grid.
+
+        The output takes the reference's CRS, transform, and dimensions exactly;
+        only the input's (warped) pixels and band structure survive. Cells the
+        reprojected input does not cover fill with the input band's nodata (or
+        zero when a band has none). The result is a `DecodedRaster` (pixels,
+        geotransform, nodata).
+        """
+        self._not_implemented("reproject_match")
+
     def zonal_stats(
         self,
         path,
@@ -496,6 +513,24 @@ class SedonaDB(RasterEngine):
                 df.nodata,
                 df.extent,
             )
+        ).to_arrow_table()["r"]
+        return decode_raster(result[0])
+
+    def reproject_match(self, path, reference_path, *, algorithm="NearestNeighbor"):
+        # Both rasters travel as table columns (not literals) so the kernel runs
+        # its real array path.
+        df = self._one_row_df(
+            {
+                "in_path": (str(path), pa.utf8()),
+                "ref_path": (str(reference_path), pa.utf8()),
+                "algorithm": (algorithm, pa.utf8()),
+            }
+        )
+        result = df.select(
+            r=df.in_path.funcs.rs_frompath().funcs.rs_reprojectmatch(
+                df.ref_path.funcs.rs_frompath(),
+                df.algorithm,
+            ),
         ).to_arrow_table()["r"]
         return decode_raster(result[0])
 
@@ -1034,6 +1069,50 @@ class Rasterio(RasterEngine):
             )
             return DecodedRaster(
                 destination, tuple(dst_transform.to_gdal()), list(src.nodatavals)
+            )
+
+    def reproject_match(self, path, reference_path, *, algorithm="NearestNeighbor"):
+        """Reference for `RS_ReprojectMatch`: warp the input onto the reference grid.
+
+        The reference contributes only its CRS/transform/dimensions; the input's
+        pixels are warped onto that grid with the same GDAL `reproject` (nearest
+        is integer selection, so it matches exactly). Cells outside the
+        reprojected input footprint fill with the destination pre-fill (the input
+        band nodata, or zero when it has none). Source nodata is deliberately not
+        masked — RS_ReprojectMatch's warp passes source values through — so this
+        does not pass `src_nodata` either.
+        """
+        import rasterio
+        from rasterio.enums import Resampling
+        from rasterio.warp import reproject
+
+        # Only the algorithms the parity tests exercise are mapped; an unknown
+        # name raises rather than silently falling back to nearest.
+        resampling = {
+            "nearestneighbor": Resampling.nearest,
+            "nearestneighbour": Resampling.nearest,
+            "bilinear": Resampling.bilinear,
+            "cubic": Resampling.cubic,
+            "average": Resampling.average,
+        }.get(algorithm.lower())
+        if resampling is None:
+            raise ValueError(f"unsupported resampling algorithm {algorithm!r}")
+
+        with rasterio.open(str(path)) as src, rasterio.open(str(reference_path)) as ref:
+            src_data = src.read()
+            dst = np.zeros((src.count, ref.height, ref.width), dtype=src_data.dtype)
+            reproject(
+                source=src_data,
+                destination=dst,
+                src_transform=src.transform,
+                src_crs=src.crs,
+                dst_transform=ref.transform,
+                dst_crs=ref.crs,
+                dst_nodata=src.nodata,
+                resampling=resampling,
+            )
+            return DecodedRaster(
+                dst, tuple(ref.transform.to_gdal()), [src.nodata] * src.count
             )
 
     def zonal_stats(

--- a/python/sedonadb/python/sedonadb/raster_testing.py
+++ b/python/sedonadb/python/sedonadb/raster_testing.py
@@ -1287,6 +1287,37 @@ def write_geotiff(
         dst.write(data)
 
 
+def write_random_geotiff(
+    path, dtype, *, bands, height, width, gdal_transform, crs=None, nodata=None
+) -> None:
+    """Write a GeoTIFF of random `dtype` pixels on the given grid.
+
+    Combines `random_raster_data` (dtype extremes planted in opposite corners)
+    with `write_geotiff` — the input-raster fixture shape shared by raster warp
+    parity tests. `gdal_transform`, `crs`, and `nodata` are as `write_geotiff`.
+    """
+    data = random_raster_data(dtype, bands=bands, height=height, width=width)
+    write_geotiff(path, data, gdal_transform=gdal_transform, nodata=nodata, crs=crs)
+
+
+def write_grid_geotiff(path, *, gdal_transform, width, height, crs=None) -> None:
+    """Write a zeroed single-band GeoTIFF whose only role is to define a grid.
+
+    Its pixels are never read — only its extent, resolution, and CRS matter,
+    e.g. as the reference grid for `RS_ReprojectMatch`.
+    """
+    data = np.zeros((1, height, width), dtype="uint8")
+    write_geotiff(path, data, gdal_transform=gdal_transform, crs=crs)
+
+
+def assert_transform_and_nodata(got: DecodedRaster, expected: DecodedRaster) -> None:
+    """Assert two decoded rasters share a geotransform (to 1e-12) and per-band
+    nodata. A lighter check than `assert_decoded_equal` for tests that compare
+    pixels separately — e.g. with a resampling tolerance."""
+    assert got.gdal_transform == approx_geotransform(expected.gdal_transform)
+    assert got.nodata == expected.nodata
+
+
 def dtype_min(dtype):
     """The minimum representable value of a numpy dtype — SedonaDB's default
     nodata sentinel when neither an explicit value nor a band nodata exists."""

--- a/python/sedonadb/tests/functions/test_rs_reprojectmatch.py
+++ b/python/sedonadb/tests/functions/test_rs_reprojectmatch.py
@@ -205,10 +205,86 @@ def test_reproject_match_cross_crs_matches_rasterio(con, tmp_path):
 
 
 @pytest.mark.parametrize("dtype", ["int64", "uint64"])
-def test_reproject_match_int64_uint64_rejected(con, tmp_path, dtype):
-    """Int64/UInt64 rasters are rejected up front: GDAL's warp can't represent
-    their nodata exactly in the double the warp path uses, so RS_ReprojectMatch
-    errors (regardless of nodata) rather than silently mis-warping."""
+def test_reproject_match_int64_uint64_nearest_matches_rasterio(con, tmp_path, dtype):
+    """Int64/UInt64 rasters warp under nearest-neighbour resampling — a pure
+    value copy, so pixels (including the dtype extremes planted past f64's 2^53
+    precision) survive exactly. A 2x nearest upsample onto a finer reference
+    grid is bit-exact against rasterio and preserves the dtype and (absent)
+    nodata."""
+    reference = Rasterio.create_or_skip()
+    sedona = SedonaDB(con)
+
+    in_transform = (100.0, 2.0, 0.0, 500.0, 0.0, -2.0)
+    tiff = tmp_path / "in.tif"
+    write_random_geotiff(
+        tiff,
+        dtype,
+        bands=1,
+        height=3,
+        width=4,
+        gdal_transform=in_transform,
+        crs="EPSG:4326",
+    )
+    ref_transform = (100.0, 1.0, 0.0, 500.0, 0.0, -1.0)
+    ref = tmp_path / "ref.tif"
+    write_grid_geotiff(
+        ref, gdal_transform=ref_transform, width=8, height=6, crs="EPSG:4326"
+    )
+
+    got = sedona.reproject_match(tiff, ref)
+    expected = reference.reproject_match(tiff, ref)
+
+    assert got.pixels.dtype == np.dtype(dtype)
+    np.testing.assert_array_equal(got.pixels, expected.pixels)
+    assert got.pixels.shape == (1, 6, 8)
+    assert_transform_and_nodata(got, expected)
+
+
+def test_reproject_match_int64_representable_nodata_uncovered(con, tmp_path):
+    """A representable (≤ 2^53) Int64 nodata rides the warp's double exactly:
+    covered nearest pixels match rasterio and the uncovered overhang fills with
+    the nodata."""
+    reference = Rasterio.create_or_skip()
+    sedona = SedonaDB(con)
+
+    in_transform = (0.0, 2.0, 0.0, 6.0, 0.0, -2.0)  # 3x3 -> extent x[0,6] y[0,6]
+    tiff = tmp_path / "in.tif"
+    write_geotiff(
+        tiff,
+        np.array([[[10, 20, 30], [40, 50, 60], [70, 80, 90]]], dtype="int64"),
+        gdal_transform=in_transform,
+        nodata=0,
+        crs="EPSG:4326",
+    )
+    # Reference overhangs on the right and bottom (5x5 at the input resolution).
+    ref_transform = (0.0, 2.0, 0.0, 6.0, 0.0, -2.0)
+    ref = tmp_path / "ref.tif"
+    write_grid_geotiff(
+        ref, gdal_transform=ref_transform, width=5, height=5, crs="EPSG:4326"
+    )
+
+    got = sedona.reproject_match(tiff, ref)
+    expected = reference.reproject_match(tiff, ref)
+
+    assert got.pixels.dtype == np.dtype("int64")
+    assert got.pixels.shape == (1, 5, 5)
+    np.testing.assert_array_equal(got.pixels, expected.pixels)
+    assert_transform_and_nodata(got, expected)
+    # The overhang (cols/rows 3..4) fills with the input nodata (0) in both.
+    assert (got.pixels[0, :, 3:] == 0).all()
+    assert (got.pixels[0, 3:, :] == 0).all()
+
+
+@pytest.mark.parametrize("dtype", ["int64", "uint64"])
+def test_reproject_match_int64_uint64_nonnearest_rejected(con, tmp_path, dtype):
+    """Non-nearest resampling of an Int64/UInt64 raster would resample in a
+    floating working type and lose precision, so it errors up front.
+
+    The other lossy case — a 64-bit nodata past f64's 2^53 precision — cannot be
+    exercised here: rasterio stores nodata as a double at write time, so a
+    fixture GeoTIFF can never carry a non-f64-exact 64-bit nodata. That
+    rejection is covered by the Rust unit tests, which control the raw nodata
+    bytes directly."""
     pytest.importorskip("rasterio")  # write_geotiff needs rasterio
     sedona = SedonaDB(con)
 
@@ -228,8 +304,8 @@ def test_reproject_match_int64_uint64_rejected(con, tmp_path, dtype):
         crs="EPSG:4326",
     )
 
-    with pytest.raises(Exception, match="Int64/UInt64"):
-        sedona.reproject_match(tiff, ref)
+    with pytest.raises(Exception, match="requires nearest-neighbor resampling"):
+        sedona.reproject_match(tiff, ref, algorithm="Bilinear")
 
 
 def test_reproject_match_null_raster_is_null(con, tmp_path):

--- a/python/sedonadb/tests/functions/test_rs_reprojectmatch.py
+++ b/python/sedonadb/tests/functions/test_rs_reprojectmatch.py
@@ -205,86 +205,10 @@ def test_reproject_match_cross_crs_matches_rasterio(con, tmp_path):
 
 
 @pytest.mark.parametrize("dtype", ["int64", "uint64"])
-def test_reproject_match_int64_uint64_nearest_matches_rasterio(con, tmp_path, dtype):
-    """Int64/UInt64 rasters warp under nearest-neighbour resampling — a pure
-    value copy, so pixels (including the dtype extremes planted past f64's 2^53
-    precision) survive exactly. A 2x nearest upsample onto a finer reference
-    grid is bit-exact against rasterio and preserves the dtype and (absent)
-    nodata."""
-    reference = Rasterio.create_or_skip()
-    sedona = SedonaDB(con)
-
-    in_transform = (100.0, 2.0, 0.0, 500.0, 0.0, -2.0)
-    tiff = tmp_path / "in.tif"
-    write_random_geotiff(
-        tiff,
-        dtype,
-        bands=1,
-        height=3,
-        width=4,
-        gdal_transform=in_transform,
-        crs="EPSG:4326",
-    )
-    ref_transform = (100.0, 1.0, 0.0, 500.0, 0.0, -1.0)
-    ref = tmp_path / "ref.tif"
-    write_grid_geotiff(
-        ref, gdal_transform=ref_transform, width=8, height=6, crs="EPSG:4326"
-    )
-
-    got = sedona.reproject_match(tiff, ref)
-    expected = reference.reproject_match(tiff, ref)
-
-    assert got.pixels.dtype == np.dtype(dtype)
-    np.testing.assert_array_equal(got.pixels, expected.pixels)
-    assert got.pixels.shape == (1, 6, 8)
-    assert_transform_and_nodata(got, expected)
-
-
-def test_reproject_match_int64_representable_nodata_uncovered(con, tmp_path):
-    """A representable (≤ 2^53) Int64 nodata rides the warp's double exactly:
-    covered nearest pixels match rasterio and the uncovered overhang fills with
-    the nodata."""
-    reference = Rasterio.create_or_skip()
-    sedona = SedonaDB(con)
-
-    in_transform = (0.0, 2.0, 0.0, 6.0, 0.0, -2.0)  # 3x3 -> extent x[0,6] y[0,6]
-    tiff = tmp_path / "in.tif"
-    write_geotiff(
-        tiff,
-        np.array([[[10, 20, 30], [40, 50, 60], [70, 80, 90]]], dtype="int64"),
-        gdal_transform=in_transform,
-        nodata=0,
-        crs="EPSG:4326",
-    )
-    # Reference overhangs on the right and bottom (5x5 at the input resolution).
-    ref_transform = (0.0, 2.0, 0.0, 6.0, 0.0, -2.0)
-    ref = tmp_path / "ref.tif"
-    write_grid_geotiff(
-        ref, gdal_transform=ref_transform, width=5, height=5, crs="EPSG:4326"
-    )
-
-    got = sedona.reproject_match(tiff, ref)
-    expected = reference.reproject_match(tiff, ref)
-
-    assert got.pixels.dtype == np.dtype("int64")
-    assert got.pixels.shape == (1, 5, 5)
-    np.testing.assert_array_equal(got.pixels, expected.pixels)
-    assert_transform_and_nodata(got, expected)
-    # The overhang (cols/rows 3..4) fills with the input nodata (0) in both.
-    assert (got.pixels[0, :, 3:] == 0).all()
-    assert (got.pixels[0, 3:, :] == 0).all()
-
-
-@pytest.mark.parametrize("dtype", ["int64", "uint64"])
-def test_reproject_match_int64_uint64_nonnearest_rejected(con, tmp_path, dtype):
-    """Non-nearest resampling of an Int64/UInt64 raster would resample in a
-    floating working type and lose precision, so it errors up front.
-
-    The other lossy case — a 64-bit nodata past f64's 2^53 precision — cannot be
-    exercised here: rasterio stores nodata as a double at write time, so a
-    fixture GeoTIFF can never carry a non-f64-exact 64-bit nodata. That
-    rejection is covered by the Rust unit tests, which control the raw nodata
-    bytes directly."""
+def test_reproject_match_int64_uint64_rejected(con, tmp_path, dtype):
+    """GDAL's warp routes 64-bit integers through a floating working type, so no
+    resampling method preserves them exactly. Int64/UInt64 rasters are rejected
+    up front regardless of algorithm — nearest and bilinear both error."""
     pytest.importorskip("rasterio")  # write_geotiff needs rasterio
     sedona = SedonaDB(con)
 
@@ -304,8 +228,9 @@ def test_reproject_match_int64_uint64_nonnearest_rejected(con, tmp_path, dtype):
         crs="EPSG:4326",
     )
 
-    with pytest.raises(Exception, match="requires nearest-neighbor resampling"):
-        sedona.reproject_match(tiff, ref, algorithm="Bilinear")
+    for algorithm in ["NearestNeighbor", "Bilinear"]:
+        with pytest.raises(Exception, match="does not support Int64/UInt64 rasters"):
+            sedona.reproject_match(tiff, ref, algorithm=algorithm)
 
 
 def test_reproject_match_null_raster_is_null(con, tmp_path):

--- a/python/sedonadb/tests/functions/test_rs_reprojectmatch.py
+++ b/python/sedonadb/tests/functions/test_rs_reprojectmatch.py
@@ -31,7 +31,9 @@ both raster engines from `sedonadb.raster_testing`:
 - Cells the reprojected input does not cover fill with the input band nodata.
 
 Both rasters travel as table columns (not literals) so the kernel runs its real
-array path.
+array path. The engines (`SedonaDB` under test, `Rasterio` reference) and the
+raster writers are constructed inline in each test rather than through pytest
+fixtures, so each test reads self-contained.
 """
 
 import numpy as np
@@ -41,85 +43,41 @@ import pytest
 from sedonadb.raster_testing import (
     Rasterio,
     SedonaDB,
+    assert_transform_and_nodata,
     decode_raster,
-    random_raster_data,
     write_geotiff,
+    write_grid_geotiff,
+    write_random_geotiff,
 )
 
 DTYPES = ["uint8", "uint16", "int16", "int32", "float32", "float64"]
 
 
-@pytest.fixture()
-def sedona(con):
-    return SedonaDB(con)
-
-
-@pytest.fixture()
-def reference():
-    return Rasterio.create_or_skip()
-
-
-def _write(
-    tmp_path,
-    dtype,
-    *,
-    bands,
-    height,
-    width,
-    nodata=None,
-    transform,
-    crs,
-    name,
-):
-    path = tmp_path / f"reprojectmatch_{name}_{dtype}_{width}x{height}.tif"
-    data = random_raster_data(dtype, bands=bands, height=height, width=width)
-    write_geotiff(path, data, gdal_transform=transform, nodata=nodata, crs=crs)
-    return path
-
-
-def _write_grid(tmp_path, *, transform, width, height, crs, name):
-    """Write a zeroed reference raster whose only role is to define a grid."""
-    data = np.zeros((1, height, width), dtype="uint8")
-    path = tmp_path / f"reprojectmatch_{name}_{width}x{height}.tif"
-    write_geotiff(path, data, gdal_transform=transform, crs=crs)
-    return path
-
-
-def _assert_transform_and_nodata(got, expected):
-    assert got.gdal_transform == pytest.approx(
-        expected.gdal_transform, rel=1e-12, abs=1e-12
-    )
-    assert got.nodata == expected.nodata
-
-
 @pytest.mark.parametrize("dtype", DTYPES)
-def test_reproject_match_same_crs_upsample_matches_rasterio(
-    sedona, reference, tmp_path, dtype
-):
+def test_reproject_match_same_crs_upsample_matches_rasterio(con, tmp_path, dtype):
     """A 2x integer nearest upsample onto a finer reference grid replicates each
     source pixel into a 2x2 block — unambiguous, so bit-exact against rasterio.
     The output takes the reference's transform and dimensions."""
+    reference = Rasterio.create_or_skip()
+    sedona = SedonaDB(con)
+
     # Input: 4x3 pixels of 2x2, extent x[100,108] y[494,500], EPSG:4326.
     in_transform = (100.0, 2.0, 0.0, 500.0, 0.0, -2.0)
-    tiff = _write(
-        tmp_path,
+    tiff = tmp_path / "in.tif"
+    write_random_geotiff(
+        tiff,
         dtype,
         bands=2,
         height=3,
         width=4,
-        transform=in_transform,
+        gdal_transform=in_transform,
         crs="EPSG:4326",
-        name="in",
     )
     # Reference: same extent at 1x1 pixels (8x6), same CRS.
     ref_transform = (100.0, 1.0, 0.0, 500.0, 0.0, -1.0)
-    ref = _write_grid(
-        tmp_path,
-        transform=ref_transform,
-        width=8,
-        height=6,
-        crs="EPSG:4326",
-        name="ref",
+    ref = tmp_path / "ref.tif"
+    write_grid_geotiff(
+        ref, gdal_transform=ref_transform, width=8, height=6, crs="EPSG:4326"
     )
 
     got = sedona.reproject_match(tiff, ref)
@@ -127,35 +85,34 @@ def test_reproject_match_same_crs_upsample_matches_rasterio(
 
     np.testing.assert_array_equal(got.pixels, expected.pixels)
     assert got.pixels.shape == (2, 6, 8)
-    _assert_transform_and_nodata(got, expected)
+    assert_transform_and_nodata(got, expected)
 
 
-def test_reproject_match_uncovered_cells_are_nodata(sedona, reference, tmp_path):
+def test_reproject_match_uncovered_cells_are_nodata(con, tmp_path):
     """The reference grid extends past the input footprint; the uncovered border
     fills with the input band nodata. Both engines warp with GDAL, so the
     nearest pixels and the nodata fill match exactly."""
+    reference = Rasterio.create_or_skip()
+    sedona = SedonaDB(con)
+
     in_transform = (0.0, 2.0, 0.0, 6.0, 0.0, -2.0)  # 3x3 -> extent x[0,6] y[0,6]
-    tiff = _write(
-        tmp_path,
+    tiff = tmp_path / "in.tif"
+    write_random_geotiff(
+        tiff,
         "uint8",
         bands=1,
         height=3,
         width=3,
         nodata=200.0,
-        transform=in_transform,
+        gdal_transform=in_transform,
         crs="EPSG:4326",
-        name="in",
     )
     # Reference spans x[0,10] y[-4,6] at 2x2 -> a 5x5 grid overhanging on the
     # right and bottom.
     ref_transform = (0.0, 2.0, 0.0, 6.0, 0.0, -2.0)
-    ref = _write_grid(
-        tmp_path,
-        transform=ref_transform,
-        width=5,
-        height=5,
-        crs="EPSG:4326",
-        name="ref",
+    ref = tmp_path / "ref.tif"
+    write_grid_geotiff(
+        ref, gdal_transform=ref_transform, width=5, height=5, crs="EPSG:4326"
     )
 
     got = sedona.reproject_match(tiff, ref)
@@ -163,34 +120,33 @@ def test_reproject_match_uncovered_cells_are_nodata(sedona, reference, tmp_path)
 
     assert got.pixels.shape == (1, 5, 5)
     np.testing.assert_array_equal(got.pixels, expected.pixels)
-    _assert_transform_and_nodata(got, expected)
+    assert_transform_and_nodata(got, expected)
     # The overhang (cols/rows 3..4) is nodata in both engines.
     assert (got.pixels[0, :, 3:] == 200).all()
     assert (got.pixels[0, 3:, :] == 200).all()
 
 
-def test_reproject_match_bilinear_matches_rasterio(sedona, reference, tmp_path):
+def test_reproject_match_bilinear_matches_rasterio(con, tmp_path):
     """Bilinear blends neighbours, so it is compared to rasterio with a small
     tolerance. A float band avoids integer truncation of the interpolation."""
+    reference = Rasterio.create_or_skip()
+    sedona = SedonaDB(con)
+
     in_transform = (100.0, 1.0, 0.0, 508.0, 0.0, -1.0)
-    tiff = _write(
-        tmp_path,
+    tiff = tmp_path / "in.tif"
+    write_random_geotiff(
+        tiff,
         "float64",
         bands=1,
         height=8,
         width=8,
-        transform=in_transform,
+        gdal_transform=in_transform,
         crs="EPSG:4326",
-        name="in",
     )
     ref_transform = (100.0, 2.0, 0.0, 508.0, 0.0, -2.0)
-    ref = _write_grid(
-        tmp_path,
-        transform=ref_transform,
-        width=4,
-        height=4,
-        crs="EPSG:4326",
-        name="ref",
+    ref = tmp_path / "ref.tif"
+    write_grid_geotiff(
+        ref, gdal_transform=ref_transform, width=4, height=4, crs="EPSG:4326"
     )
 
     got = sedona.reproject_match(tiff, ref, algorithm="Bilinear")
@@ -198,30 +154,33 @@ def test_reproject_match_bilinear_matches_rasterio(sedona, reference, tmp_path):
 
     np.testing.assert_allclose(got.pixels, expected.pixels, rtol=1e-6, atol=1e-6)
     assert got.pixels.shape == (1, 4, 4)
-    _assert_transform_and_nodata(got, expected)
+    assert_transform_and_nodata(got, expected)
 
 
-def test_reproject_match_cross_crs_matches_rasterio(sedona, reference, tmp_path):
+def test_reproject_match_cross_crs_matches_rasterio(con, tmp_path):
     """Reproject a mid-latitude EPSG:4326 raster onto an EPSG:3857 reference
     grid. The reference grid is GDAL's suggested output (via rasterio's
     `calculate_default_transform`); both engines wrap the same GDAL warp, so the
     nearest-neighbour pixels match exactly."""
+    reference = Rasterio.create_or_skip()
+    sedona = SedonaDB(con)
+
     import rasterio
     from rasterio.crs import CRS
     from rasterio.warp import calculate_default_transform
 
     # 4x4 at 0.5 deg pixels near (10 E, 44 N).
     in_transform = (10.0, 0.5, 0.0, 44.0, 0.0, -0.5)
-    tiff = _write(
-        tmp_path,
+    tiff = tmp_path / "in.tif"
+    write_random_geotiff(
+        tiff,
         "uint8",
         bands=1,
         height=4,
         width=4,
         nodata=200.0,
-        transform=in_transform,
+        gdal_transform=in_transform,
         crs="EPSG:4326",
-        name="in",
     )
 
     with rasterio.open(str(tiff)) as src:
@@ -229,31 +188,59 @@ def test_reproject_match_cross_crs_matches_rasterio(sedona, reference, tmp_path)
         dst_transform, dst_w, dst_h = calculate_default_transform(
             src.crs, dst_crs, src.width, src.height, *src.bounds
         )
-    ref = _write_grid(
-        tmp_path,
-        transform=dst_transform.to_gdal(),
+    ref = tmp_path / "ref3857.tif"
+    write_grid_geotiff(
+        ref,
+        gdal_transform=dst_transform.to_gdal(),
         width=dst_w,
         height=dst_h,
         crs="EPSG:3857",
-        name="ref3857",
     )
 
     got = sedona.reproject_match(tiff, ref)
     expected = reference.reproject_match(tiff, ref)
 
     np.testing.assert_array_equal(got.pixels, expected.pixels)
-    _assert_transform_and_nodata(got, expected)
+    assert_transform_and_nodata(got, expected)
+
+
+@pytest.mark.parametrize("dtype", ["int64", "uint64"])
+def test_reproject_match_int64_uint64_rejected(con, tmp_path, dtype):
+    """Int64/UInt64 rasters are rejected up front: GDAL's warp can't represent
+    their nodata exactly in the double the warp path uses, so RS_ReprojectMatch
+    errors (regardless of nodata) rather than silently mis-warping."""
+    pytest.importorskip("rasterio")  # write_geotiff needs rasterio
+    sedona = SedonaDB(con)
+
+    tiff = tmp_path / "in.tif"
+    write_geotiff(
+        tiff,
+        np.array([[[1, 2], [3, 4]]], dtype=dtype),
+        gdal_transform=(0.0, 2.0, 0.0, 4.0, 0.0, -2.0),
+        crs="EPSG:4326",
+    )
+    ref = tmp_path / "ref.tif"
+    write_grid_geotiff(
+        ref,
+        gdal_transform=(0.0, 1.0, 0.0, 4.0, 0.0, -1.0),
+        width=4,
+        height=4,
+        crs="EPSG:4326",
+    )
+
+    with pytest.raises(Exception, match="Int64/UInt64"):
+        sedona.reproject_match(tiff, ref)
 
 
 def test_reproject_match_null_raster_is_null(con, tmp_path):
     """A NULL input raster yields a NULL result rather than erroring."""
-    ref = _write_grid(
-        tmp_path,
-        transform=(0.0, 1.0, 0.0, 4.0, 0.0, -1.0),
+    ref = tmp_path / "refnull.tif"
+    write_grid_geotiff(
+        ref,
+        gdal_transform=(0.0, 1.0, 0.0, 4.0, 0.0, -1.0),
         width=4,
         height=4,
         crs="EPSG:4326",
-        name="refnull",
     )
     table = pa.table(
         {
@@ -273,24 +260,24 @@ def test_reproject_match_null_raster_is_null(con, tmp_path):
 def test_reproject_match_sql_smoke(con, tmp_path):
     """One SQL-text invocation keeps the parser path covered (everything else
     routes through the expression API)."""
-    pytest.importorskip("rasterio")  # write_geotiff needs rasterio
-    tiff = _write(
-        tmp_path,
+    pytest.importorskip("rasterio")  # write_random_geotiff needs rasterio
+    tiff = tmp_path / "smoke_in.tif"
+    write_random_geotiff(
+        tiff,
         "uint8",
         bands=1,
         height=2,
         width=2,
-        transform=(0.0, 2.0, 0.0, 4.0, 0.0, -2.0),
+        gdal_transform=(0.0, 2.0, 0.0, 4.0, 0.0, -2.0),
         crs="EPSG:4326",
-        name="smoke_in",
     )
-    ref = _write_grid(
-        tmp_path,
-        transform=(0.0, 1.0, 0.0, 4.0, 0.0, -1.0),
+    ref = tmp_path / "smoke_ref.tif"
+    write_grid_geotiff(
+        ref,
+        gdal_transform=(0.0, 1.0, 0.0, 4.0, 0.0, -1.0),
         width=4,
         height=4,
         crs="EPSG:4326",
-        name="smoke_ref",
     )
     tab = con.sql(
         "SELECT RS_Width(RS_ReprojectMatch(RS_FromPath($1), RS_FromPath($2))) AS w",

--- a/python/sedonadb/tests/functions/test_rs_reprojectmatch.py
+++ b/python/sedonadb/tests/functions/test_rs_reprojectmatch.py
@@ -1,0 +1,299 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""RS_ReprojectMatch cross-checked against a rasterio reference implementation.
+
+Each test writes an input raster and a reference raster (numpy array + GDAL
+geotransform + CRS) and reprojects the input onto the reference's grid through
+both raster engines from `sedonadb.raster_testing`:
+
+- **Same-CRS regrid** onto a finer/coarser reference shares GDAL's warp with
+  rasterio's `reproject`. Nearest-neighbour is integer selection, so pixels are
+  compared exactly; bilinear accumulates over neighbours so it uses a small
+  tolerance (rasterio may bundle a different GDAL build).
+- **Cross-CRS** (EPSG:4326 -> EPSG:3857) reprojects onto the reference grid;
+  both engines wrap the same GDAL warp, so nearest-neighbour pixels match
+  exactly.
+- Cells the reprojected input does not cover fill with the input band nodata.
+
+Both rasters travel as table columns (not literals) so the kernel runs its real
+array path.
+"""
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from sedonadb.raster_testing import (
+    Rasterio,
+    SedonaDB,
+    decode_raster,
+    random_raster_data,
+    write_geotiff,
+)
+
+DTYPES = ["uint8", "uint16", "int16", "int32", "float32", "float64"]
+
+
+@pytest.fixture()
+def sedona(con):
+    return SedonaDB(con)
+
+
+@pytest.fixture()
+def reference():
+    return Rasterio.create_or_skip()
+
+
+def _write(
+    tmp_path,
+    dtype,
+    *,
+    bands,
+    height,
+    width,
+    nodata=None,
+    transform,
+    crs,
+    name,
+):
+    path = tmp_path / f"reprojectmatch_{name}_{dtype}_{width}x{height}.tif"
+    data = random_raster_data(dtype, bands=bands, height=height, width=width)
+    write_geotiff(path, data, gdal_transform=transform, nodata=nodata, crs=crs)
+    return path
+
+
+def _write_grid(tmp_path, *, transform, width, height, crs, name):
+    """Write a zeroed reference raster whose only role is to define a grid."""
+    data = np.zeros((1, height, width), dtype="uint8")
+    path = tmp_path / f"reprojectmatch_{name}_{width}x{height}.tif"
+    write_geotiff(path, data, gdal_transform=transform, crs=crs)
+    return path
+
+
+def _assert_transform_and_nodata(got, expected):
+    assert got.gdal_transform == pytest.approx(
+        expected.gdal_transform, rel=1e-12, abs=1e-12
+    )
+    assert got.nodata == expected.nodata
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_reproject_match_same_crs_upsample_matches_rasterio(
+    sedona, reference, tmp_path, dtype
+):
+    """A 2x integer nearest upsample onto a finer reference grid replicates each
+    source pixel into a 2x2 block — unambiguous, so bit-exact against rasterio.
+    The output takes the reference's transform and dimensions."""
+    # Input: 4x3 pixels of 2x2, extent x[100,108] y[494,500], EPSG:4326.
+    in_transform = (100.0, 2.0, 0.0, 500.0, 0.0, -2.0)
+    tiff = _write(
+        tmp_path,
+        dtype,
+        bands=2,
+        height=3,
+        width=4,
+        transform=in_transform,
+        crs="EPSG:4326",
+        name="in",
+    )
+    # Reference: same extent at 1x1 pixels (8x6), same CRS.
+    ref_transform = (100.0, 1.0, 0.0, 500.0, 0.0, -1.0)
+    ref = _write_grid(
+        tmp_path,
+        transform=ref_transform,
+        width=8,
+        height=6,
+        crs="EPSG:4326",
+        name="ref",
+    )
+
+    got = sedona.reproject_match(tiff, ref)
+    expected = reference.reproject_match(tiff, ref)
+
+    np.testing.assert_array_equal(got.pixels, expected.pixels)
+    assert got.pixels.shape == (2, 6, 8)
+    _assert_transform_and_nodata(got, expected)
+
+
+def test_reproject_match_uncovered_cells_are_nodata(sedona, reference, tmp_path):
+    """The reference grid extends past the input footprint; the uncovered border
+    fills with the input band nodata. Both engines warp with GDAL, so the
+    nearest pixels and the nodata fill match exactly."""
+    in_transform = (0.0, 2.0, 0.0, 6.0, 0.0, -2.0)  # 3x3 -> extent x[0,6] y[0,6]
+    tiff = _write(
+        tmp_path,
+        "uint8",
+        bands=1,
+        height=3,
+        width=3,
+        nodata=200.0,
+        transform=in_transform,
+        crs="EPSG:4326",
+        name="in",
+    )
+    # Reference spans x[0,10] y[-4,6] at 2x2 -> a 5x5 grid overhanging on the
+    # right and bottom.
+    ref_transform = (0.0, 2.0, 0.0, 6.0, 0.0, -2.0)
+    ref = _write_grid(
+        tmp_path,
+        transform=ref_transform,
+        width=5,
+        height=5,
+        crs="EPSG:4326",
+        name="ref",
+    )
+
+    got = sedona.reproject_match(tiff, ref)
+    expected = reference.reproject_match(tiff, ref)
+
+    assert got.pixels.shape == (1, 5, 5)
+    np.testing.assert_array_equal(got.pixels, expected.pixels)
+    _assert_transform_and_nodata(got, expected)
+    # The overhang (cols/rows 3..4) is nodata in both engines.
+    assert (got.pixels[0, :, 3:] == 200).all()
+    assert (got.pixels[0, 3:, :] == 200).all()
+
+
+def test_reproject_match_bilinear_matches_rasterio(sedona, reference, tmp_path):
+    """Bilinear blends neighbours, so it is compared to rasterio with a small
+    tolerance. A float band avoids integer truncation of the interpolation."""
+    in_transform = (100.0, 1.0, 0.0, 508.0, 0.0, -1.0)
+    tiff = _write(
+        tmp_path,
+        "float64",
+        bands=1,
+        height=8,
+        width=8,
+        transform=in_transform,
+        crs="EPSG:4326",
+        name="in",
+    )
+    ref_transform = (100.0, 2.0, 0.0, 508.0, 0.0, -2.0)
+    ref = _write_grid(
+        tmp_path,
+        transform=ref_transform,
+        width=4,
+        height=4,
+        crs="EPSG:4326",
+        name="ref",
+    )
+
+    got = sedona.reproject_match(tiff, ref, algorithm="Bilinear")
+    expected = reference.reproject_match(tiff, ref, algorithm="Bilinear")
+
+    np.testing.assert_allclose(got.pixels, expected.pixels, rtol=1e-6, atol=1e-6)
+    assert got.pixels.shape == (1, 4, 4)
+    _assert_transform_and_nodata(got, expected)
+
+
+def test_reproject_match_cross_crs_matches_rasterio(sedona, reference, tmp_path):
+    """Reproject a mid-latitude EPSG:4326 raster onto an EPSG:3857 reference
+    grid. The reference grid is GDAL's suggested output (via rasterio's
+    `calculate_default_transform`); both engines wrap the same GDAL warp, so the
+    nearest-neighbour pixels match exactly."""
+    import rasterio
+    from rasterio.crs import CRS
+    from rasterio.warp import calculate_default_transform
+
+    # 4x4 at 0.5 deg pixels near (10 E, 44 N).
+    in_transform = (10.0, 0.5, 0.0, 44.0, 0.0, -0.5)
+    tiff = _write(
+        tmp_path,
+        "uint8",
+        bands=1,
+        height=4,
+        width=4,
+        nodata=200.0,
+        transform=in_transform,
+        crs="EPSG:4326",
+        name="in",
+    )
+
+    with rasterio.open(str(tiff)) as src:
+        dst_crs = CRS.from_epsg(3857)
+        dst_transform, dst_w, dst_h = calculate_default_transform(
+            src.crs, dst_crs, src.width, src.height, *src.bounds
+        )
+    ref = _write_grid(
+        tmp_path,
+        transform=dst_transform.to_gdal(),
+        width=dst_w,
+        height=dst_h,
+        crs="EPSG:3857",
+        name="ref3857",
+    )
+
+    got = sedona.reproject_match(tiff, ref)
+    expected = reference.reproject_match(tiff, ref)
+
+    np.testing.assert_array_equal(got.pixels, expected.pixels)
+    _assert_transform_and_nodata(got, expected)
+
+
+def test_reproject_match_null_raster_is_null(con, tmp_path):
+    """A NULL input raster yields a NULL result rather than erroring."""
+    ref = _write_grid(
+        tmp_path,
+        transform=(0.0, 1.0, 0.0, 4.0, 0.0, -1.0),
+        width=4,
+        height=4,
+        crs="EPSG:4326",
+        name="refnull",
+    )
+    table = pa.table(
+        {
+            "path": pa.array([None], type=pa.utf8()),
+            "ref": pa.array([str(ref)], type=pa.utf8()),
+        }
+    )
+    df = con.create_data_frame(table)
+    result = df.select(
+        r=df.path.funcs.rs_frompath().funcs.rs_reprojectmatch(
+            df.ref.funcs.rs_frompath()
+        )
+    ).to_arrow_table()["r"]
+    assert decode_raster(result[0]) is None
+
+
+def test_reproject_match_sql_smoke(con, tmp_path):
+    """One SQL-text invocation keeps the parser path covered (everything else
+    routes through the expression API)."""
+    pytest.importorskip("rasterio")  # write_geotiff needs rasterio
+    tiff = _write(
+        tmp_path,
+        "uint8",
+        bands=1,
+        height=2,
+        width=2,
+        transform=(0.0, 2.0, 0.0, 4.0, 0.0, -2.0),
+        crs="EPSG:4326",
+        name="smoke_in",
+    )
+    ref = _write_grid(
+        tmp_path,
+        transform=(0.0, 1.0, 0.0, 4.0, 0.0, -1.0),
+        width=4,
+        height=4,
+        crs="EPSG:4326",
+        name="smoke_ref",
+    )
+    tab = con.sql(
+        "SELECT RS_Width(RS_ReprojectMatch(RS_FromPath($1), RS_FromPath($2))) AS w",
+        params=(str(tiff), str(ref)),
+    ).to_arrow_table()
+    assert tab["w"][0].as_py() == 4

--- a/rust/sedona-common/src/option.rs
+++ b/rust/sedona-common/src/option.rs
@@ -58,6 +58,13 @@ config_namespace! {
         /// This can be helpful for diagnosing issues with GDAL dataset handling,
         /// but may produce verbose output. Set to true to enable CPL_DEBUG output from GDAL.
         pub cpl_debug: bool, default = false
+
+        /// Memory limit, in megabytes, for GDAL warp operations (used by
+        /// RS_ReprojectMatch). GDAL caches working data up to this size while
+        /// warping; a larger limit can reduce the number of passes over a large
+        /// raster at the cost of memory. Megabytes match `gdalwarp -wm`. Leave
+        /// unset to use GDAL's own default.
+        pub warp_memory_limit_mb: Option<usize>, default = None
     }
 }
 

--- a/rust/sedona-raster-gdal/src/lib.rs
+++ b/rust/sedona-raster-gdal/src/lib.rs
@@ -39,6 +39,7 @@ mod rs_clip;
 mod rs_frompath;
 mod rs_metadata;
 mod rs_polygonize;
+mod rs_reproject_match;
 mod source_uri;
 mod utils;
 
@@ -54,6 +55,7 @@ pub use rs_clip::rs_clip_udf;
 pub use rs_frompath::rs_frompath_udf;
 pub use rs_metadata::rs_metadata_udf;
 pub use rs_polygonize::rs_polygonize_udf;
+pub use rs_reproject_match::rs_reproject_match_udf;
 pub use utils::{
     append_as_indb_raster, append_as_outdb_raster, append_nd_from_dataset, dataset_to_indb_raster,
     gdal_dataset_to_nd_raster,

--- a/rust/sedona-raster-gdal/src/register.rs
+++ b/rust/sedona-raster-gdal/src/register.rs
@@ -26,5 +26,6 @@ pub fn default_function_set() -> FunctionSet {
     function_set.insert_scalar_udf(crate::rs_frompath::rs_frompath_udf());
     function_set.insert_scalar_udf(crate::rs_metadata::rs_metadata_udf());
     function_set.insert_scalar_udf(crate::rs_polygonize::rs_polygonize_udf());
+    function_set.insert_scalar_udf(crate::rs_reproject_match::rs_reproject_match_udf());
     function_set
 }

--- a/rust/sedona-raster-gdal/src/rs_reproject_match.rs
+++ b/rust/sedona-raster-gdal/src/rs_reproject_match.rs
@@ -26,18 +26,24 @@
 //!
 //! The reference raster contributes only its grid — transform, dimensions, and
 //! CRS — never its pixels.
+//!
+//! Int64/UInt64 input rasters are rejected up front: GDAL's warp kernels don't
+//! handle 64-bit integer pixels well, and such a band's nodata can't round-trip
+//! through the `f64` the warp path uses (`bytes_to_f64` rejects it). Rejecting
+//! keeps the behavior identical with or without nodata; cast to a supported
+//! type first.
 
 use std::sync::Arc;
 
 use arrow_array::ArrayRef;
 use arrow_schema::DataType;
-use datafusion_common::cast::as_string_array;
+use datafusion_common::cast::as_string_view_array;
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::error::Result;
 use datafusion_common::{exec_err, ScalarValue};
 use datafusion_expr::{ColumnarValue, Volatility};
 
-use sedona_common::sedona_internal_err;
+use sedona_common::{sedona_internal_err, SedonaOptions};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_gdal::geo_transform::GeoTransform;
 use sedona_gdal::raster::types::ResampleAlg;
@@ -50,6 +56,7 @@ use sedona_raster_functions::rs_ensure_loaded::{
 use sedona_raster_functions::RasterExecutor;
 use sedona_schema::datatypes::{SedonaType, RASTER};
 use sedona_schema::matchers::ArgMatcher;
+use sedona_schema::raster::BandDataType;
 
 use crate::gdal_common::{raster_ref_to_gdal_mem, with_gdal, GdalBandLayout};
 use crate::gdal_dataset_provider::configure_thread_local_options;
@@ -124,18 +131,20 @@ impl SedonaScalarKernel for RsReprojectMatch {
         let num_iterations = RasterExecutor::num_iterations_over(args);
 
         // Algorithm string at index 2 (when arg_count == 3); otherwise the
-        // Spark default `NearestNeighbor`. Expand to an array so a per-row
-        // column and a scalar are handled identically.
+        // Spark default `NearestNeighbor`. Expand to a `Utf8View` array so a
+        // per-row column and a scalar are handled identically (the view avoids
+        // re-buffering the string in the scalar-to-array case).
+        let warp_memory_limit_bytes = warp_memory_limit_bytes_from_config(config_options);
         let algorithm_array = if self.arg_count >= 3 {
             args[2]
                 .clone()
-                .cast_to(&DataType::Utf8, None)?
+                .cast_to(&DataType::Utf8View, None)?
                 .into_array(num_iterations)?
         } else {
-            ScalarValue::Utf8(Some("NearestNeighbor".to_string()))
+            ScalarValue::Utf8View(Some("NearestNeighbor".to_string()))
                 .to_array_of_size(num_iterations)?
         };
-        let algorithm_array = as_string_array(&algorithm_array)?.clone();
+        let algorithm_array = as_string_view_array(&algorithm_array)?.clone();
         let mut algorithm_iter = algorithm_array.iter();
 
         let mut builder = RasterBuilder::new(num_iterations);
@@ -161,7 +170,14 @@ impl SedonaScalarKernel for RsReprojectMatch {
                 };
 
                 let alg = parse_algorithm(algorithm)?;
-                reproject_match(gdal, raster, reference, alg, &mut builder)?;
+                reproject_match(
+                    gdal,
+                    raster,
+                    reference,
+                    alg,
+                    warp_memory_limit_bytes,
+                    &mut builder,
+                )?;
                 Ok(())
             })?;
 
@@ -169,6 +185,16 @@ impl SedonaScalarKernel for RsReprojectMatch {
             RasterExecutor::finish_over(args, out)
         })
     }
+}
+
+/// The GDAL warp memory limit in bytes from `sedona.gdal.warp_memory_limit_mb`,
+/// or `0.0` (GDAL's own default) when unset. Megabytes match `gdalwarp -wm`.
+fn warp_memory_limit_bytes_from_config(config_options: Option<&ConfigOptions>) -> f64 {
+    config_options
+        .and_then(|c| c.extensions.get::<SedonaOptions>())
+        .and_then(|opts| opts.gdal.warp_memory_limit_mb)
+        .map(|mb| mb as f64 * 1_000_000.0)
+        .unwrap_or(0.0)
 }
 
 /// Reproject `raster` onto `reference`'s grid, appending the result to `builder`.
@@ -180,6 +206,7 @@ fn reproject_match(
     raster: &RasterRefImpl<'_>,
     reference: &RasterRefImpl<'_>,
     alg: ResampleAlg,
+    warp_memory_limit_bytes: f64,
     builder: &mut RasterBuilder,
 ) -> Result<()> {
     let src_width = raster.width()?;
@@ -228,6 +255,21 @@ fn reproject_match(
     transform.copy_from_slice(ref_transform);
 
     let band_count = raster.bands().len();
+
+    // GDAL's warp kernels don't handle 64-bit integer pixels well, and an
+    // Int64/UInt64 nodata can't round-trip through the f64 the warp path uses
+    // (`bytes_to_f64` rejects it). Reject these dtypes up front so the behavior
+    // is the same with or without nodata rather than mis-warping silently.
+    for i in 0..band_count {
+        if let Some(BandDataType::Int64 | BandDataType::UInt64) = raster.band_data_type(i) {
+            return exec_err!(
+                "RS_ReprojectMatch does not support Int64/UInt64 rasters (their nodata \
+                 cannot be represented exactly in the double the warp requires); cast to \
+                 a supported type first"
+            );
+        }
+    }
+
     let band_indices: Vec<usize> = (1..=band_count).collect();
     let layout = GdalBandLayout::from_raster(raster, &band_indices)?;
     // SAFETY: the returned dataset references `raster`'s band bytes zero-copy;
@@ -241,6 +283,7 @@ fn reproject_match(
         height: ref_height as usize,
         crs: reference.crs(),
         alg,
+        warp_memory_limit_bytes,
     };
     append_warped_nd_from_dataset(gdal, &src_dataset, &layout, builder, &warp_grid)
 }
@@ -534,5 +577,33 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("unknown algorithm"), "got: {err}");
+    }
+
+    #[test]
+    fn int64_and_uint64_rasters_are_rejected() {
+        // GDAL's warp path can't represent an Int64/UInt64 nodata exactly, so
+        // these dtypes are rejected up front (regardless of nodata) rather than
+        // silently mis-warped. Both 64-bit integer dtypes error the same way.
+        let reference = RasterSpec::d2(2, 2)
+            .band_values(&[0u8; 4])
+            .bbox(0.0, 0.0, 2.0, 2.0)
+            .crs(Some("EPSG:4326"));
+
+        let int64_source = RasterSpec::d2(2, 2)
+            .band_values(&[1i64, 2, 3, 4])
+            .bbox(0.0, 0.0, 2.0, 2.0)
+            .crs(Some("EPSG:4326"));
+        let uint64_source = RasterSpec::d2(2, 2)
+            .band_values(&[1u64, 2, 3, 4])
+            .bbox(0.0, 0.0, 2.0, 2.0)
+            .crs(Some("EPSG:4326"));
+
+        for source in [int64_source, uint64_source] {
+            let err = tester()
+                .invoke_scalar_scalar_scalar(&source, &reference, "NearestNeighbor")
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("Int64/UInt64"), "got: {err}");
+        }
     }
 }

--- a/rust/sedona-raster-gdal/src/rs_reproject_match.rs
+++ b/rust/sedona-raster-gdal/src/rs_reproject_match.rs
@@ -27,14 +27,10 @@
 //! The reference raster contributes only its grid — transform, dimensions, and
 //! CRS — never its pixels.
 //!
-//! Int64/UInt64 input rasters are supported only where GDAL warps them
-//! exactly. Nearest-neighbor resampling is a pure value copy (no arithmetic),
-//! so it preserves 64-bit integer pixels bit for bit; the other algorithms
-//! resample in a floating working type and lose precision above 2^53. The warp
-//! also carries nodata as a `double`, so a 64-bit nodata must be absent or
-//! round-trip exactly through `f64` (magnitude ≤ 2^53). Non-nearest resampling
-//! or a nodata that isn't f64-exact is rejected up front; cast to a supported
-//! type first.
+//! Int64/UInt64 input rasters are not supported: GDAL's warp routes 64-bit
+//! integer pixels through a floating working type (a `double` for
+//! nearest/interpolation, a 32-bit `float` for mode on GDAL < 3.13), which
+//! cannot represent them exactly. Cast to a supported type first.
 
 use std::sync::Arc;
 
@@ -259,28 +255,18 @@ fn reproject_match(
 
     let band_count = raster.bands().len();
 
-    // GDAL warps Int64/UInt64 pixels exactly only under nearest-neighbor
-    // resampling — a pure value copy with no arithmetic, so it preserves 64-bit
-    // integers, whereas bilinear/cubic and the rest resample in a floating
-    // working type and lose precision above 2^53. The warp also carries nodata
-    // as a double, so a 64-bit nodata must be absent or round-trip exactly
-    // through f64. Allow the exact cases; reject only the lossy ones.
+    // GDAL's warp routes 64-bit integer pixels through a floating working type
+    // (a double for nearest/interpolation, a 32-bit float for mode on GDAL <
+    // 3.13), so no resampling method preserves Int64/UInt64 exactly. Reject
+    // these dtypes up front rather than mis-warping silently.
     for i in 0..band_count {
-        let Some(dtype) = raster.band_data_type(i) else {
-            continue;
-        };
-        if !matches!(dtype, BandDataType::Int64 | BandDataType::UInt64) {
-            continue;
-        }
-        if alg != ResampleAlg::NearestNeighbour {
+        if let Some(BandDataType::Int64 | BandDataType::UInt64) = raster.band_data_type(i) {
             return exec_err!(
-                "RS_ReprojectMatch requires nearest-neighbor resampling for Int64/UInt64 \
-                 rasters (other methods resample in a floating working type and lose \
-                 precision); pass the nearest-neighbor algorithm or cast to a supported type."
+                "RS_ReprojectMatch does not support Int64/UInt64 rasters: GDAL's warp routes \
+                 64-bit integer pixels through a floating working type (a double for \
+                 nearest/interpolation, a 32-bit float for mode on GDAL < 3.13), which cannot \
+                 represent them exactly. Cast to a supported type (e.g. Int32/Float64) first."
             );
-        }
-        if let Some(nodata) = raster.band_nodata(i) {
-            reject_lossy_int64_nodata(nodata, dtype)?;
         }
     }
 
@@ -300,47 +286,6 @@ fn reproject_match(
         warp_memory_limit_bytes,
     };
     append_warped_nd_from_dataset(gdal, &src_dataset, &layout, builder, &warp_grid)
-}
-
-/// Reject an Int64/UInt64 band whose nodata cannot round-trip through `f64`.
-///
-/// The warp carries nodata as a `double` (the destination pre-fill and GDAL's
-/// warp options both), so a 64-bit nodata whose magnitude exceeds 2^53 cannot
-/// be represented exactly. `nodata` is the band's little-endian nodata bytes;
-/// `dtype` must be `Int64` or `UInt64` (other types are validated elsewhere).
-fn reject_lossy_int64_nodata(nodata: &[u8], dtype: BandDataType) -> Result<()> {
-    let bytes: [u8; 8] = match nodata.try_into() {
-        Ok(bytes) => bytes,
-        Err(_) => {
-            return sedona_internal_err!(
-                "RS_ReprojectMatch: {dtype:?} nodata must be 8 bytes, got {}",
-                nodata.len()
-            );
-        }
-    };
-    // Compare the f64 round-trip in a wider integer so the float-to-int cast
-    // can't saturate: `u64::MAX as f64` rounds up to 2^64 and `2^64 as u64`
-    // would clamp back to `u64::MAX` (and `i64::MAX as f64` likewise to 2^63),
-    // faking a round-trip — but 2^64 / 2^63 land exactly in u128 / i128.
-    let (value, exact) = match dtype {
-        BandDataType::Int64 => {
-            let v = i64::from_le_bytes(bytes);
-            (v.to_string(), (v as f64) as i128 == v as i128)
-        }
-        BandDataType::UInt64 => {
-            let v = u64::from_le_bytes(bytes);
-            (v.to_string(), (v as f64) as u128 == v as u128)
-        }
-        _ => return Ok(()),
-    };
-    if !exact {
-        return exec_err!(
-            "RS_ReprojectMatch cannot reproject an Int64/UInt64 raster whose nodata value \
-             {value} is not exactly representable as a 64-bit float (the warp carries nodata \
-             as a double); use a nodata magnitude ≤ 2^53 or a different type."
-        );
-    }
-    Ok(())
 }
 
 /// Map an algorithm name (case-insensitive) to a GDAL [`ResampleAlg`]. An empty
@@ -635,125 +580,10 @@ mod tests {
     }
 
     #[test]
-    fn int64_uint64_nearest_no_nodata_is_exact() {
-        // Nearest resampling is a pure value copy, so 64-bit integers survive
-        // exactly — even magnitudes past f64's 2^53 precision (i64::MAX/MIN,
-        // u64::MAX). A 2x nearest upsample replicates each source pixel into a
-        // 2x2 block, so the whole output is bit-exact.
-        let reference = RasterSpec::d2(4, 4)
-            .band_values(&[0u8; 16])
-            .bbox(0.0, 0.0, 4.0, 4.0)
-            .crs(Some("EPSG:4326"));
-
-        let int64_source = RasterSpec::d2(2, 2)
-            .band_values(&[i64::MAX, i64::MIN, 3, 4])
-            .bbox(0.0, 0.0, 4.0, 4.0)
-            .crs(Some("EPSG:4326"));
-        let int64_expected = RasterSpec::d2(4, 4)
-            .band_values(&[
-                i64::MAX,
-                i64::MAX,
-                i64::MIN,
-                i64::MIN, //
-                i64::MAX,
-                i64::MAX,
-                i64::MIN,
-                i64::MIN, //
-                3,
-                3,
-                4,
-                4, //
-                3,
-                3,
-                4,
-                4, //
-            ])
-            .bbox(0.0, 0.0, 4.0, 4.0)
-            .crs(Some("EPSG:4326"));
-        assert_raster_scalar_equals(
-            &reproject(&int64_source, &reference, "NearestNeighbor"),
-            &int64_expected,
-        );
-
-        let uint64_source = RasterSpec::d2(2, 2)
-            .band_values(&[u64::MAX, 2, 3, 4])
-            .bbox(0.0, 0.0, 4.0, 4.0)
-            .crs(Some("EPSG:4326"));
-        let uint64_expected = RasterSpec::d2(4, 4)
-            .band_values(&[
-                u64::MAX,
-                u64::MAX,
-                2,
-                2, //
-                u64::MAX,
-                u64::MAX,
-                2,
-                2, //
-                3,
-                3,
-                4,
-                4, //
-                3,
-                3,
-                4,
-                4, //
-            ])
-            .bbox(0.0, 0.0, 4.0, 4.0)
-            .crs(Some("EPSG:4326"));
-        assert_raster_scalar_equals(
-            &reproject(&uint64_source, &reference, "NearestNeighbor"),
-            &uint64_expected,
-        );
-    }
-
-    #[test]
-    fn int64_uint64_nearest_representable_nodata_fills_uncovered() {
-        // With an f64-exact nodata (0 for int64; 2^53, the largest exact
-        // magnitude, for uint64) the allowed nearest path copies covered cells
-        // exactly and fills the uncovered overhang with the input nodata. The
-        // reference spans x[0,4] at the input's resolution; the input covers
-        // x[0,2], so the right half is uncovered.
-        const P53: u64 = 1 << 53; // 9_007_199_254_740_992, exactly f64-representable
-        let reference = RasterSpec::d2(4, 1)
-            .band_values(&[0u8; 4])
-            .bbox(0.0, 0.0, 4.0, 1.0)
-            .crs(Some("EPSG:4326"));
-
-        let int64_source = RasterSpec::d2(2, 1)
-            .band_values(&[10i64, 20])
-            .nodata(0i64)
-            .bbox(0.0, 0.0, 2.0, 1.0)
-            .crs(Some("EPSG:4326"));
-        let int64_expected = RasterSpec::d2(4, 1)
-            .band_values(&[10i64, 20, 0, 0])
-            .nodata(0i64)
-            .bbox(0.0, 0.0, 4.0, 1.0)
-            .crs(Some("EPSG:4326"));
-        assert_raster_scalar_equals(
-            &reproject(&int64_source, &reference, "NearestNeighbor"),
-            &int64_expected,
-        );
-
-        let uint64_source = RasterSpec::d2(2, 1)
-            .band_values(&[10u64, 20])
-            .nodata(P53)
-            .bbox(0.0, 0.0, 2.0, 1.0)
-            .crs(Some("EPSG:4326"));
-        let uint64_expected = RasterSpec::d2(4, 1)
-            .band_values(&[10u64, 20, P53, P53])
-            .nodata(P53)
-            .bbox(0.0, 0.0, 4.0, 1.0)
-            .crs(Some("EPSG:4326"));
-        assert_raster_scalar_equals(
-            &reproject(&uint64_source, &reference, "NearestNeighbor"),
-            &uint64_expected,
-        );
-    }
-
-    #[test]
-    fn int64_uint64_nonnearest_resampling_errors() {
-        // Bilinear/cubic resample in a floating working type, so they'd lose
-        // precision on 64-bit integers; those combinations error up front.
+    fn int64_uint64_rejected() {
+        // GDAL's warp routes 64-bit integers through a floating working type, so
+        // no resampling method preserves them exactly. Both dtypes are rejected
+        // up front regardless of algorithm — nearest and bilinear both error.
         let reference = RasterSpec::d2(2, 2)
             .band_values(&[0u8; 4])
             .bbox(0.0, 0.0, 2.0, 2.0)
@@ -768,49 +598,16 @@ mod tests {
             .crs(Some("EPSG:4326"));
 
         for source in [&int64_source, &uint64_source] {
-            for alg in ["Bilinear", "Cubic"] {
+            for alg in ["NearestNeighbor", "Bilinear"] {
                 let err = tester()
                     .invoke_scalar_scalar_scalar(source, &reference, alg)
                     .unwrap_err()
                     .to_string();
                 assert!(
-                    err.contains("requires nearest-neighbor resampling"),
+                    err.contains("does not support Int64/UInt64 rasters"),
                     "got: {err}"
                 );
             }
-        }
-    }
-
-    #[test]
-    fn int64_uint64_nodata_above_f64_precision_errors() {
-        // A 64-bit nodata past f64's exact range (u64::MAX; 2^53 + 1 for int64)
-        // can't be carried through the warp's double, so those rasters error
-        // even under nearest resampling.
-        let reference = RasterSpec::d2(2, 2)
-            .band_values(&[0u8; 4])
-            .bbox(0.0, 0.0, 2.0, 2.0)
-            .crs(Some("EPSG:4326"));
-
-        let uint64_source = RasterSpec::d2(2, 2)
-            .band_values(&[1u64, 2, 3, 4])
-            .nodata(u64::MAX)
-            .bbox(0.0, 0.0, 2.0, 2.0)
-            .crs(Some("EPSG:4326"));
-        let int64_source = RasterSpec::d2(2, 2)
-            .band_values(&[1i64, 2, 3, 4])
-            .nodata((1i64 << 53) + 1)
-            .bbox(0.0, 0.0, 2.0, 2.0)
-            .crs(Some("EPSG:4326"));
-
-        for source in [&uint64_source, &int64_source] {
-            let err = tester()
-                .invoke_scalar_scalar_scalar(source, &reference, "NearestNeighbor")
-                .unwrap_err()
-                .to_string();
-            assert!(
-                err.contains("not exactly representable as a 64-bit float"),
-                "got: {err}"
-            );
         }
     }
 }

--- a/rust/sedona-raster-gdal/src/rs_reproject_match.rs
+++ b/rust/sedona-raster-gdal/src/rs_reproject_match.rs
@@ -27,10 +27,13 @@
 //! The reference raster contributes only its grid — transform, dimensions, and
 //! CRS — never its pixels.
 //!
-//! Int64/UInt64 input rasters are rejected up front: GDAL's warp kernels don't
-//! handle 64-bit integer pixels well, and such a band's nodata can't round-trip
-//! through the `f64` the warp path uses (`bytes_to_f64` rejects it). Rejecting
-//! keeps the behavior identical with or without nodata; cast to a supported
+//! Int64/UInt64 input rasters are supported only where GDAL warps them
+//! exactly. Nearest-neighbor resampling is a pure value copy (no arithmetic),
+//! so it preserves 64-bit integer pixels bit for bit; the other algorithms
+//! resample in a floating working type and lose precision above 2^53. The warp
+//! also carries nodata as a `double`, so a 64-bit nodata must be absent or
+//! round-trip exactly through `f64` (magnitude ≤ 2^53). Non-nearest resampling
+//! or a nodata that isn't f64-exact is rejected up front; cast to a supported
 //! type first.
 
 use std::sync::Arc;
@@ -256,17 +259,28 @@ fn reproject_match(
 
     let band_count = raster.bands().len();
 
-    // GDAL's warp kernels don't handle 64-bit integer pixels well, and an
-    // Int64/UInt64 nodata can't round-trip through the f64 the warp path uses
-    // (`bytes_to_f64` rejects it). Reject these dtypes up front so the behavior
-    // is the same with or without nodata rather than mis-warping silently.
+    // GDAL warps Int64/UInt64 pixels exactly only under nearest-neighbor
+    // resampling — a pure value copy with no arithmetic, so it preserves 64-bit
+    // integers, whereas bilinear/cubic and the rest resample in a floating
+    // working type and lose precision above 2^53. The warp also carries nodata
+    // as a double, so a 64-bit nodata must be absent or round-trip exactly
+    // through f64. Allow the exact cases; reject only the lossy ones.
     for i in 0..band_count {
-        if let Some(BandDataType::Int64 | BandDataType::UInt64) = raster.band_data_type(i) {
+        let Some(dtype) = raster.band_data_type(i) else {
+            continue;
+        };
+        if !matches!(dtype, BandDataType::Int64 | BandDataType::UInt64) {
+            continue;
+        }
+        if alg != ResampleAlg::NearestNeighbour {
             return exec_err!(
-                "RS_ReprojectMatch does not support Int64/UInt64 rasters (their nodata \
-                 cannot be represented exactly in the double the warp requires); cast to \
-                 a supported type first"
+                "RS_ReprojectMatch requires nearest-neighbor resampling for Int64/UInt64 \
+                 rasters (other methods resample in a floating working type and lose \
+                 precision); pass the nearest-neighbor algorithm or cast to a supported type."
             );
+        }
+        if let Some(nodata) = raster.band_nodata(i) {
+            reject_lossy_int64_nodata(nodata, dtype)?;
         }
     }
 
@@ -286,6 +300,47 @@ fn reproject_match(
         warp_memory_limit_bytes,
     };
     append_warped_nd_from_dataset(gdal, &src_dataset, &layout, builder, &warp_grid)
+}
+
+/// Reject an Int64/UInt64 band whose nodata cannot round-trip through `f64`.
+///
+/// The warp carries nodata as a `double` (the destination pre-fill and GDAL's
+/// warp options both), so a 64-bit nodata whose magnitude exceeds 2^53 cannot
+/// be represented exactly. `nodata` is the band's little-endian nodata bytes;
+/// `dtype` must be `Int64` or `UInt64` (other types are validated elsewhere).
+fn reject_lossy_int64_nodata(nodata: &[u8], dtype: BandDataType) -> Result<()> {
+    let bytes: [u8; 8] = match nodata.try_into() {
+        Ok(bytes) => bytes,
+        Err(_) => {
+            return sedona_internal_err!(
+                "RS_ReprojectMatch: {dtype:?} nodata must be 8 bytes, got {}",
+                nodata.len()
+            );
+        }
+    };
+    // Compare the f64 round-trip in a wider integer so the float-to-int cast
+    // can't saturate: `u64::MAX as f64` rounds up to 2^64 and `2^64 as u64`
+    // would clamp back to `u64::MAX` (and `i64::MAX as f64` likewise to 2^63),
+    // faking a round-trip — but 2^64 / 2^63 land exactly in u128 / i128.
+    let (value, exact) = match dtype {
+        BandDataType::Int64 => {
+            let v = i64::from_le_bytes(bytes);
+            (v.to_string(), (v as f64) as i128 == v as i128)
+        }
+        BandDataType::UInt64 => {
+            let v = u64::from_le_bytes(bytes);
+            (v.to_string(), (v as f64) as u128 == v as u128)
+        }
+        _ => return Ok(()),
+    };
+    if !exact {
+        return exec_err!(
+            "RS_ReprojectMatch cannot reproject an Int64/UInt64 raster whose nodata value \
+             {value} is not exactly representable as a 64-bit float (the warp carries nodata \
+             as a double); use a nodata magnitude ≤ 2^53 or a different type."
+        );
+    }
+    Ok(())
 }
 
 /// Map an algorithm name (case-insensitive) to a GDAL [`ResampleAlg`]. An empty
@@ -580,15 +635,129 @@ mod tests {
     }
 
     #[test]
-    fn int64_and_uint64_rasters_are_rejected() {
-        // GDAL's warp path can't represent an Int64/UInt64 nodata exactly, so
-        // these dtypes are rejected up front (regardless of nodata) rather than
-        // silently mis-warped. Both 64-bit integer dtypes error the same way.
+    fn int64_uint64_nearest_no_nodata_is_exact() {
+        // Nearest resampling is a pure value copy, so 64-bit integers survive
+        // exactly — even magnitudes past f64's 2^53 precision (i64::MAX/MIN,
+        // u64::MAX). A 2x nearest upsample replicates each source pixel into a
+        // 2x2 block, so the whole output is bit-exact.
+        let reference = RasterSpec::d2(4, 4)
+            .band_values(&[0u8; 16])
+            .bbox(0.0, 0.0, 4.0, 4.0)
+            .crs(Some("EPSG:4326"));
+
+        let int64_source = RasterSpec::d2(2, 2)
+            .band_values(&[i64::MAX, i64::MIN, 3, 4])
+            .bbox(0.0, 0.0, 4.0, 4.0)
+            .crs(Some("EPSG:4326"));
+        let int64_expected = RasterSpec::d2(4, 4)
+            .band_values(&[
+                i64::MAX,
+                i64::MAX,
+                i64::MIN,
+                i64::MIN, //
+                i64::MAX,
+                i64::MAX,
+                i64::MIN,
+                i64::MIN, //
+                3,
+                3,
+                4,
+                4, //
+                3,
+                3,
+                4,
+                4, //
+            ])
+            .bbox(0.0, 0.0, 4.0, 4.0)
+            .crs(Some("EPSG:4326"));
+        assert_raster_scalar_equals(
+            &reproject(&int64_source, &reference, "NearestNeighbor"),
+            &int64_expected,
+        );
+
+        let uint64_source = RasterSpec::d2(2, 2)
+            .band_values(&[u64::MAX, 2, 3, 4])
+            .bbox(0.0, 0.0, 4.0, 4.0)
+            .crs(Some("EPSG:4326"));
+        let uint64_expected = RasterSpec::d2(4, 4)
+            .band_values(&[
+                u64::MAX,
+                u64::MAX,
+                2,
+                2, //
+                u64::MAX,
+                u64::MAX,
+                2,
+                2, //
+                3,
+                3,
+                4,
+                4, //
+                3,
+                3,
+                4,
+                4, //
+            ])
+            .bbox(0.0, 0.0, 4.0, 4.0)
+            .crs(Some("EPSG:4326"));
+        assert_raster_scalar_equals(
+            &reproject(&uint64_source, &reference, "NearestNeighbor"),
+            &uint64_expected,
+        );
+    }
+
+    #[test]
+    fn int64_uint64_nearest_representable_nodata_fills_uncovered() {
+        // With an f64-exact nodata (0 for int64; 2^53, the largest exact
+        // magnitude, for uint64) the allowed nearest path copies covered cells
+        // exactly and fills the uncovered overhang with the input nodata. The
+        // reference spans x[0,4] at the input's resolution; the input covers
+        // x[0,2], so the right half is uncovered.
+        const P53: u64 = 1 << 53; // 9_007_199_254_740_992, exactly f64-representable
+        let reference = RasterSpec::d2(4, 1)
+            .band_values(&[0u8; 4])
+            .bbox(0.0, 0.0, 4.0, 1.0)
+            .crs(Some("EPSG:4326"));
+
+        let int64_source = RasterSpec::d2(2, 1)
+            .band_values(&[10i64, 20])
+            .nodata(0i64)
+            .bbox(0.0, 0.0, 2.0, 1.0)
+            .crs(Some("EPSG:4326"));
+        let int64_expected = RasterSpec::d2(4, 1)
+            .band_values(&[10i64, 20, 0, 0])
+            .nodata(0i64)
+            .bbox(0.0, 0.0, 4.0, 1.0)
+            .crs(Some("EPSG:4326"));
+        assert_raster_scalar_equals(
+            &reproject(&int64_source, &reference, "NearestNeighbor"),
+            &int64_expected,
+        );
+
+        let uint64_source = RasterSpec::d2(2, 1)
+            .band_values(&[10u64, 20])
+            .nodata(P53)
+            .bbox(0.0, 0.0, 2.0, 1.0)
+            .crs(Some("EPSG:4326"));
+        let uint64_expected = RasterSpec::d2(4, 1)
+            .band_values(&[10u64, 20, P53, P53])
+            .nodata(P53)
+            .bbox(0.0, 0.0, 4.0, 1.0)
+            .crs(Some("EPSG:4326"));
+        assert_raster_scalar_equals(
+            &reproject(&uint64_source, &reference, "NearestNeighbor"),
+            &uint64_expected,
+        );
+    }
+
+    #[test]
+    fn int64_uint64_nonnearest_resampling_errors() {
+        // Bilinear/cubic resample in a floating working type, so they'd lose
+        // precision on 64-bit integers; those combinations error up front.
         let reference = RasterSpec::d2(2, 2)
             .band_values(&[0u8; 4])
             .bbox(0.0, 0.0, 2.0, 2.0)
             .crs(Some("EPSG:4326"));
-
         let int64_source = RasterSpec::d2(2, 2)
             .band_values(&[1i64, 2, 3, 4])
             .bbox(0.0, 0.0, 2.0, 2.0)
@@ -598,12 +767,50 @@ mod tests {
             .bbox(0.0, 0.0, 2.0, 2.0)
             .crs(Some("EPSG:4326"));
 
-        for source in [int64_source, uint64_source] {
+        for source in [&int64_source, &uint64_source] {
+            for alg in ["Bilinear", "Cubic"] {
+                let err = tester()
+                    .invoke_scalar_scalar_scalar(source, &reference, alg)
+                    .unwrap_err()
+                    .to_string();
+                assert!(
+                    err.contains("requires nearest-neighbor resampling"),
+                    "got: {err}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn int64_uint64_nodata_above_f64_precision_errors() {
+        // A 64-bit nodata past f64's exact range (u64::MAX; 2^53 + 1 for int64)
+        // can't be carried through the warp's double, so those rasters error
+        // even under nearest resampling.
+        let reference = RasterSpec::d2(2, 2)
+            .band_values(&[0u8; 4])
+            .bbox(0.0, 0.0, 2.0, 2.0)
+            .crs(Some("EPSG:4326"));
+
+        let uint64_source = RasterSpec::d2(2, 2)
+            .band_values(&[1u64, 2, 3, 4])
+            .nodata(u64::MAX)
+            .bbox(0.0, 0.0, 2.0, 2.0)
+            .crs(Some("EPSG:4326"));
+        let int64_source = RasterSpec::d2(2, 2)
+            .band_values(&[1i64, 2, 3, 4])
+            .nodata((1i64 << 53) + 1)
+            .bbox(0.0, 0.0, 2.0, 2.0)
+            .crs(Some("EPSG:4326"));
+
+        for source in [&uint64_source, &int64_source] {
             let err = tester()
-                .invoke_scalar_scalar_scalar(&source, &reference, "NearestNeighbor")
+                .invoke_scalar_scalar_scalar(source, &reference, "NearestNeighbor")
                 .unwrap_err()
                 .to_string();
-            assert!(err.contains("Int64/UInt64"), "got: {err}");
+            assert!(
+                err.contains("not exactly representable as a 64-bit float"),
+                "got: {err}"
+            );
         }
     }
 }

--- a/rust/sedona-raster-gdal/src/rs_reproject_match.rs
+++ b/rust/sedona-raster-gdal/src/rs_reproject_match.rs
@@ -1,0 +1,538 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! RS_ReprojectMatch UDF - Reproject a raster onto a reference raster's grid.
+//!
+//! Reprojects the input raster onto the reference raster's CRS, pixel grid, and
+//! envelope: the output always has the *same* extent, resolution, dimensions,
+//! and CRS as the reference (in the spirit of `rioxarray`'s `reproject_match`).
+//! The input's band count/order, per-band data type, and nodata are preserved.
+//! Pixel values are recomputed by GDAL's warp (`GDALReprojectImage`); output
+//! cells the reprojected input footprint does not cover are filled with nodata.
+//!
+//! The reference raster contributes only its grid — transform, dimensions, and
+//! CRS — never its pixels.
+
+use std::sync::Arc;
+
+use arrow_array::ArrayRef;
+use arrow_schema::DataType;
+use datafusion_common::cast::as_string_array;
+use datafusion_common::config::ConfigOptions;
+use datafusion_common::error::Result;
+use datafusion_common::{exec_err, ScalarValue};
+use datafusion_expr::{ColumnarValue, Volatility};
+
+use sedona_common::sedona_internal_err;
+use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
+use sedona_gdal::geo_transform::GeoTransform;
+use sedona_gdal::raster::types::ResampleAlg;
+use sedona_raster::array::RasterRefImpl;
+use sedona_raster::builder::RasterBuilder;
+use sedona_raster::traits::RasterRef;
+use sedona_raster_functions::rs_ensure_loaded::{
+    NEEDS_PIXELS_METADATA_KEY, RETURNS_BYTES_METADATA_KEY,
+};
+use sedona_raster_functions::RasterExecutor;
+use sedona_schema::datatypes::{SedonaType, RASTER};
+use sedona_schema::matchers::ArgMatcher;
+
+use crate::gdal_common::{raster_ref_to_gdal_mem, with_gdal, GdalBandLayout};
+use crate::gdal_dataset_provider::configure_thread_local_options;
+use crate::utils::{append_warped_nd_from_dataset, WarpGrid};
+
+/// RS_ReprojectMatch() scalar UDF implementation.
+///
+/// Reprojects `raster` onto `reference`'s CRS + grid + envelope.
+///
+/// Signatures (matching Apache Sedona (Spark)):
+/// - `RS_ReprojectMatch(raster, reference)` — 2 args (algorithm defaults to
+///   `NearestNeighbor`)
+/// - `RS_ReprojectMatch(raster, reference, algorithm)` — 3 args
+pub fn rs_reproject_match_udf() -> SedonaScalarUDF {
+    SedonaScalarUDF::new(
+        "rs_reprojectmatch",
+        vec![
+            Arc::new(RsReprojectMatch { arg_count: 2 }),
+            Arc::new(RsReprojectMatch { arg_count: 3 }),
+        ],
+        Volatility::Immutable,
+    )
+    // Reads band pixels (so the planner materializes OutDb rasters via
+    // RS_EnsureLoaded first) and emits a fresh InDb raster (so its output is
+    // already loaded and isn't wrapped again).
+    .with_metadata(NEEDS_PIXELS_METADATA_KEY, "true")
+    .with_metadata(RETURNS_BYTES_METADATA_KEY, "true")
+}
+
+/// Kernel implementation for RS_ReprojectMatch.
+#[derive(Debug)]
+struct RsReprojectMatch {
+    /// Number of arguments in the matched signature (2 or 3).
+    arg_count: usize,
+}
+
+impl SedonaScalarKernel for RsReprojectMatch {
+    fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
+        let matchers = match self.arg_count {
+            2 => vec![ArgMatcher::is_raster(), ArgMatcher::is_raster()],
+            3 => vec![
+                ArgMatcher::is_raster(),
+                ArgMatcher::is_raster(),
+                ArgMatcher::is_string(),
+            ],
+            _ => {
+                return sedona_internal_err!(
+                    "RS_ReprojectMatch: unexpected arg_count {}",
+                    self.arg_count
+                );
+            }
+        };
+        ArgMatcher::new(matchers, RASTER).match_args(args)
+    }
+
+    fn invoke_batch(
+        &self,
+        arg_types: &[SedonaType],
+        args: &[ColumnarValue],
+    ) -> Result<ColumnarValue> {
+        self.invoke_batch_from_args(arg_types, args, &SedonaType::Arrow(DataType::Null), 0, None)
+    }
+
+    fn invoke_batch_from_args(
+        &self,
+        arg_types: &[SedonaType],
+        args: &[ColumnarValue],
+        _return_type: &SedonaType,
+        _num_rows: usize,
+        config_options: Option<&ConfigOptions>,
+    ) -> Result<ColumnarValue> {
+        let num_iterations = RasterExecutor::num_iterations_over(args);
+
+        // Algorithm string at index 2 (when arg_count == 3); otherwise the
+        // Spark default `NearestNeighbor`. Expand to an array so a per-row
+        // column and a scalar are handled identically.
+        let algorithm_array = if self.arg_count >= 3 {
+            args[2]
+                .clone()
+                .cast_to(&DataType::Utf8, None)?
+                .into_array(num_iterations)?
+        } else {
+            ScalarValue::Utf8(Some("NearestNeighbor".to_string()))
+                .to_array_of_size(num_iterations)?
+        };
+        let algorithm_array = as_string_array(&algorithm_array)?.clone();
+        let mut algorithm_iter = algorithm_array.iter();
+
+        let mut builder = RasterBuilder::new(num_iterations);
+
+        // The executor iterates the (raster, reference) pair; the algorithm
+        // column is advanced in lockstep below.
+        let exec_arg_types = vec![arg_types[0].clone(), arg_types[1].clone()];
+        let exec_args = vec![args[0].clone(), args[1].clone()];
+        let executor =
+            RasterExecutor::new_with_num_iterations(&exec_arg_types, &exec_args, num_iterations);
+
+        with_gdal(|gdal| {
+            configure_thread_local_options(gdal, config_options)?;
+            executor.execute_raster_raster_void(|_i, raster_opt, reference_opt| {
+                let algorithm = algorithm_iter.next().flatten();
+                // A NULL input, NULL reference, or NULL algorithm yields a NULL
+                // output row (SQL semantics).
+                let (Some(raster), Some(reference), Some(algorithm)) =
+                    (raster_opt, reference_opt, algorithm)
+                else {
+                    builder.append_null()?;
+                    return Ok(());
+                };
+
+                let alg = parse_algorithm(algorithm)?;
+                reproject_match(gdal, raster, reference, alg, &mut builder)?;
+                Ok(())
+            })?;
+
+            let out: ArrayRef = Arc::new(builder.finish()?);
+            RasterExecutor::finish_over(args, out)
+        })
+    }
+}
+
+/// Reproject `raster` onto `reference`'s grid, appending the result to `builder`.
+///
+/// The output grid — transform, dimensions, and CRS — is the reference's; only
+/// the input's pixels (warped) and band structure survive.
+fn reproject_match(
+    gdal: &sedona_gdal::gdal::Gdal,
+    raster: &RasterRefImpl<'_>,
+    reference: &RasterRefImpl<'_>,
+    alg: ResampleAlg,
+    builder: &mut RasterBuilder,
+) -> Result<()> {
+    let src_width = raster.width()?;
+    let src_height = raster.height()?;
+    if src_width <= 0 || src_height <= 0 {
+        return exec_err!(
+            "RS_ReprojectMatch: input raster has non-positive dimensions {src_width}x{src_height}"
+        );
+    }
+
+    let ref_width = reference.width()?;
+    let ref_height = reference.height()?;
+    if ref_width <= 0 || ref_height <= 0 {
+        return exec_err!(
+            "RS_ReprojectMatch: reference raster has non-positive dimensions \
+             {ref_width}x{ref_height}"
+        );
+    }
+
+    // Reprojecting between an unknown CRS and a real one is undefined; require
+    // that either both carry a CRS or neither does (a same-space regrid).
+    match (raster.crs(), reference.crs()) {
+        (Some(_), None) => {
+            return exec_err!(
+                "RS_ReprojectMatch: input raster has a CRS but the reference does not; \
+                 cannot reproject onto a CRS-less grid"
+            );
+        }
+        (None, Some(_)) => {
+            return exec_err!(
+                "RS_ReprojectMatch: reference raster has a CRS but the input does not; \
+                 cannot reproject a CRS-less raster onto it"
+            );
+        }
+        _ => {}
+    }
+
+    let ref_transform = reference.transform();
+    if ref_transform.len() != 6 {
+        return sedona_internal_err!(
+            "RS_ReprojectMatch: reference transform has {} elements, expected 6",
+            ref_transform.len()
+        );
+    }
+    let mut transform: GeoTransform = [0.0; 6];
+    transform.copy_from_slice(ref_transform);
+
+    let band_count = raster.bands().len();
+    let band_indices: Vec<usize> = (1..=band_count).collect();
+    let layout = GdalBandLayout::from_raster(raster, &band_indices)?;
+    // SAFETY: the returned dataset references `raster`'s band bytes zero-copy;
+    // it is only read below (via warp) and dropped before `reproject_match`
+    // returns, so `raster` outlives it.
+    let src_dataset = unsafe { raster_ref_to_gdal_mem(gdal, raster, &band_indices)? };
+
+    let warp_grid = WarpGrid {
+        transform,
+        width: ref_width as usize,
+        height: ref_height as usize,
+        crs: reference.crs(),
+        alg,
+    };
+    append_warped_nd_from_dataset(gdal, &src_dataset, &layout, builder, &warp_grid)
+}
+
+/// Map an algorithm name (case-insensitive) to a GDAL [`ResampleAlg`]. An empty
+/// string defaults to nearest neighbour (matching Sedona Spark).
+///
+/// Accepts the GDAL names plus the Spark spellings (American `NearestNeighbor`
+/// and `Bicubic`, which GDAL calls `Cubic`). The algorithms without a warp
+/// equivalent (Gauss) are not accepted.
+fn parse_algorithm(name: &str) -> Result<ResampleAlg> {
+    if name.is_empty() {
+        return Ok(ResampleAlg::NearestNeighbour);
+    }
+    let alg = match name.to_ascii_lowercase().as_str() {
+        "nearestneighbor" | "nearestneighbour" | "nearest" | "near" => {
+            ResampleAlg::NearestNeighbour
+        }
+        "bilinear" => ResampleAlg::Bilinear,
+        "cubic" | "bicubic" => ResampleAlg::Cubic,
+        "cubicspline" => ResampleAlg::CubicSpline,
+        "lanczos" => ResampleAlg::Lanczos,
+        "average" => ResampleAlg::Average,
+        "mode" => ResampleAlg::Mode,
+        _ => {
+            return exec_err!(
+                "RS_ReprojectMatch: unknown algorithm {name:?}; expected one of \
+                 NearestNeighbor, Bilinear, Cubic, CubicSpline, Lanczos, Average, Mode"
+            );
+        }
+    };
+    Ok(alg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sedona_testing::raster_spec::{
+        assert_raster_scalar_equals, assert_rasters_equal, raster_array, RasterSpec,
+    };
+    use sedona_testing::testers::ScalarUdfTester;
+
+    fn tester() -> ScalarUdfTester {
+        ScalarUdfTester::new(
+            rs_reproject_match_udf().into(),
+            vec![RASTER, RASTER, SedonaType::Arrow(DataType::Utf8)],
+        )
+    }
+
+    fn tester2() -> ScalarUdfTester {
+        ScalarUdfTester::new(rs_reproject_match_udf().into(), vec![RASTER, RASTER])
+    }
+
+    /// Invoke `RS_ReprojectMatch(raster, reference, algorithm)` on two scalar
+    /// rasters and return the resulting scalar.
+    fn reproject(source: &RasterSpec, reference: &RasterSpec, algorithm: &str) -> ScalarValue {
+        tester()
+            .invoke_scalar_scalar_scalar(source, reference, algorithm)
+            .unwrap()
+    }
+
+    #[test]
+    fn match_same_grid_and_crs_is_identity() {
+        // Reprojecting onto a reference that already has the input's grid and CRS
+        // exercises the full warp path but round-trips the raster unchanged.
+        let source = RasterSpec::d2(2, 2)
+            .band_values(&[1u8, 2, 3, 4])
+            .nodata(0u8)
+            .bbox(0.0, 0.0, 2.0, 2.0)
+            .crs(Some("EPSG:4326"));
+        // Reference: same grid, different (irrelevant) pixel values.
+        let reference = RasterSpec::d2(2, 2)
+            .band_values(&[9u8, 9, 9, 9])
+            .bbox(0.0, 0.0, 2.0, 2.0)
+            .crs(Some("EPSG:4326"));
+
+        let result = reproject(&source, &reference, "NearestNeighbor");
+        assert_raster_scalar_equals(&result, &source);
+    }
+
+    #[test]
+    fn match_reference_grid_upsamples_onto_finer_grid() {
+        // Same CRS, but the reference is a finer 4x4 grid over the same extent.
+        // A nearest 2x upsample replicates each source pixel into a 2x2 block —
+        // unambiguous, so bit-exact — and the output takes the reference's grid.
+        let source = RasterSpec::d2(2, 2)
+            .band_values(&[10u8, 20, 30, 40])
+            .bbox(0.0, 0.0, 4.0, 4.0)
+            .crs(Some("EPSG:4326"));
+        let reference = RasterSpec::d2(4, 4)
+            .band_values(&(0u8..16).collect::<Vec<_>>())
+            .bbox(0.0, 0.0, 4.0, 4.0)
+            .crs(Some("EPSG:4326"));
+
+        let result = reproject(&source, &reference, "NearestNeighbor");
+
+        let expected = RasterSpec::d2(4, 4)
+            .band_values(&[
+                10u8, 10, 20, 20, //
+                10, 10, 20, 20, //
+                30, 30, 40, 40, //
+                30, 30, 40, 40, //
+            ])
+            .bbox(0.0, 0.0, 4.0, 4.0)
+            .crs(Some("EPSG:4326"));
+        assert_raster_scalar_equals(&result, &expected);
+    }
+
+    #[test]
+    fn match_reprojects_onto_reference_crs_and_grid() {
+        // The input is EPSG:4326; the reference defines an EPSG:3857 grid. The
+        // exact reprojected pixels are checked against rasterio in the Python
+        // parity tests; here we pin the structural result — the output takes the
+        // reference's CRS, transform, and dimensions exactly.
+        let source = RasterSpec::d2(4, 4)
+            .band_values(&(0u8..16).collect::<Vec<_>>())
+            .nodata(255u8)
+            .bbox(10.0, 40.0, 14.0, 44.0)
+            .crs(Some("EPSG:4326"));
+        // A north-up Web Mercator grid covering roughly the same footprint.
+        let reference = RasterSpec::d2(4, 4)
+            .band_values(&[0u8; 16])
+            .transform([1_113_194.9, 111_319.5, 0.0, 5_465_442.2, 0.0, -111_319.5])
+            .crs(Some("EPSG:3857"));
+
+        let result = reproject(&source, &reference, "NearestNeighbor");
+
+        let ScalarValue::Struct(struct_array) = &result else {
+            panic!("expected a raster struct scalar, got {result:?}");
+        };
+        let rasters = sedona_raster::array::RasterStructArray::try_new(struct_array).unwrap();
+        let out = rasters.get(0).unwrap();
+        let m = out.metadata();
+
+        assert_eq!(out.crs(), Some("EPSG:3857"));
+        assert_eq!(m.width(), 4);
+        assert_eq!(m.height(), 4);
+        // The output grid is the reference's grid, verbatim.
+        assert_eq!(m.upper_left_x(), 1_113_194.9);
+        assert_eq!(m.upper_left_y(), 5_465_442.2);
+        assert_eq!(m.scale_x(), 111_319.5);
+        assert_eq!(m.scale_y(), -111_319.5);
+    }
+
+    #[test]
+    fn uncovered_reference_cells_become_nodata() {
+        // The reference grid extends past the input footprint on the right: the
+        // input covers x[0,2] but the reference spans x[0,4] at the input's
+        // resolution and CRS. The uncovered right column reads back as nodata.
+        let source = RasterSpec::d2(2, 1)
+            .band_values(&[10u8, 20])
+            .nodata(255u8)
+            .bbox(0.0, 0.0, 2.0, 1.0)
+            .crs(Some("EPSG:4326"));
+        let reference = RasterSpec::d2(4, 1)
+            .band_values(&[0u8, 0, 0, 0])
+            .bbox(0.0, 0.0, 4.0, 1.0)
+            .crs(Some("EPSG:4326"));
+
+        let result = reproject(&source, &reference, "NearestNeighbor");
+
+        // Reference cell centers x = 0.5, 1.5, 2.5, 3.5; the last two are past
+        // the input's right edge (x = 2), so they fill with the input's nodata.
+        let expected = RasterSpec::d2(4, 1)
+            .band_values(&[10u8, 20, 255, 255])
+            .nodata(255u8)
+            .bbox(0.0, 0.0, 4.0, 1.0)
+            .crs(Some("EPSG:4326"));
+        assert_raster_scalar_equals(&result, &expected);
+    }
+
+    #[test]
+    fn multiband_reproject_preserves_band_order() {
+        // Every input band is warped onto the reference grid and band
+        // order/count/nodata preserved. Two-band 2x2 -> 4x4 upsample.
+        let source = RasterSpec::d2(2, 2)
+            .band_values(&[10u8, 20, 30, 40])
+            .nodata(0u8)
+            .band_values(&[1u8, 2, 3, 4])
+            .bbox(0.0, 0.0, 4.0, 4.0)
+            .crs(Some("EPSG:4326"));
+        let reference = RasterSpec::d2(4, 4)
+            .band_values(&[0u8; 16])
+            .bbox(0.0, 0.0, 4.0, 4.0)
+            .crs(Some("EPSG:4326"));
+
+        let result = reproject(&source, &reference, "NearestNeighbor");
+
+        let expected = RasterSpec::d2(4, 4)
+            .band_values(&[
+                10u8, 10, 20, 20, 10, 10, 20, 20, 30, 30, 40, 40, 30, 30, 40, 40,
+            ])
+            .nodata(0u8)
+            .band_values(&[1u8, 1, 2, 2, 1, 1, 2, 2, 3, 3, 4, 4, 3, 3, 4, 4])
+            .bbox(0.0, 0.0, 4.0, 4.0)
+            .crs(Some("EPSG:4326"));
+        assert_raster_scalar_equals(&result, &expected);
+    }
+
+    #[test]
+    fn two_arg_overload_defaults_to_nearest() {
+        // RS_ReprojectMatch(raster, reference) — algorithm defaults to nearest.
+        let source = RasterSpec::d2(2, 2)
+            .band_values(&[10u8, 20, 30, 40])
+            .bbox(0.0, 0.0, 4.0, 4.0)
+            .crs(Some("EPSG:4326"));
+        let reference = RasterSpec::d2(4, 4)
+            .band_values(&[0u8; 16])
+            .bbox(0.0, 0.0, 4.0, 4.0)
+            .crs(Some("EPSG:4326"));
+
+        let result = tester2().invoke_scalar_scalar(&source, &reference).unwrap();
+
+        let expected = RasterSpec::d2(4, 4)
+            .band_values(&[
+                10u8, 10, 20, 20, 10, 10, 20, 20, 30, 30, 40, 40, 30, 30, 40, 40,
+            ])
+            .bbox(0.0, 0.0, 4.0, 4.0)
+            .crs(Some("EPSG:4326"));
+        assert_raster_scalar_equals(&result, &expected);
+    }
+
+    #[test]
+    fn null_input_or_reference_yields_null() {
+        let source = RasterSpec::d2(2, 2)
+            .band_values(&[10u8, 20, 30, 40])
+            .bbox(0.0, 0.0, 4.0, 4.0)
+            .crs(Some("EPSG:4326"));
+        let reference = RasterSpec::d2(4, 4)
+            .band_values(&[0u8; 16])
+            .bbox(0.0, 0.0, 4.0, 4.0)
+            .crs(Some("EPSG:4326"));
+
+        // A per-row input column (row 1 NULL) over a scalar reference +
+        // algorithm: the NULL input row must produce a NULL output row.
+        let result = tester()
+            .invoke_array_scalar_scalar(
+                Arc::new(raster_array(vec![Some(source.clone()), None])),
+                &reference,
+                "NearestNeighbor",
+            )
+            .unwrap();
+
+        let expected = vec![
+            Some(
+                RasterSpec::d2(4, 4)
+                    .band_values(&[
+                        10u8, 10, 20, 20, 10, 10, 20, 20, 30, 30, 40, 40, 30, 30, 40, 40,
+                    ])
+                    .bbox(0.0, 0.0, 4.0, 4.0)
+                    .crs(Some("EPSG:4326")),
+            ),
+            None,
+        ];
+        assert_rasters_equal(&result, &expected);
+    }
+
+    #[test]
+    fn one_sided_crs_errors() {
+        // Input has a CRS, reference does not: reprojecting onto a CRS-less grid
+        // is undefined and must error rather than silently mis-warp.
+        let source = RasterSpec::d2(2, 2)
+            .band_values(&[10u8, 20, 30, 40])
+            .bbox(0.0, 0.0, 4.0, 4.0)
+            .crs(Some("EPSG:4326"));
+        let reference = RasterSpec::d2(4, 4)
+            .band_values(&[0u8; 16])
+            .bbox(0.0, 0.0, 4.0, 4.0)
+            .crs(None);
+
+        let err = tester()
+            .invoke_scalar_scalar_scalar(&source, &reference, "NearestNeighbor")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("reference does not"), "got: {err}");
+    }
+
+    #[test]
+    fn unknown_algorithm_errors() {
+        let source = RasterSpec::d2(2, 2)
+            .band_values(&[10u8, 20, 30, 40])
+            .bbox(0.0, 0.0, 4.0, 4.0)
+            .crs(Some("EPSG:4326"));
+        let reference = RasterSpec::d2(4, 4)
+            .band_values(&[0u8; 16])
+            .bbox(0.0, 0.0, 4.0, 4.0)
+            .crs(Some("EPSG:4326"));
+
+        let err = tester()
+            .invoke_scalar_scalar_scalar(&source, &reference, "sinc")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("unknown algorithm"), "got: {err}");
+    }
+}

--- a/rust/sedona-raster-gdal/src/utils.rs
+++ b/rust/sedona-raster-gdal/src/utils.rs
@@ -222,6 +222,9 @@ pub struct WarpGrid<'a> {
     pub height: usize,
     pub crs: Option<&'a str>,
     pub alg: ResampleAlg,
+    /// GDAL's working-memory cache size (bytes) for the warp; `0.0` uses
+    /// GDAL's own default.
+    pub warp_memory_limit_bytes: f64,
 }
 
 /// Warp every band of `src_dataset` into `grid`, appending the result as a
@@ -283,8 +286,13 @@ pub fn append_warped_nd_from_dataset(
 
     // Reproject when the CRS differs; a same-CRS warp is a pure regrid that fills
     // grown/shifted areas with the pre-filled nodata.
-    gdal.reproject_image(src_dataset, &dst_dataset, grid.alg)
-        .map_err(convert_gdal_err)?;
+    gdal.reproject_image(
+        src_dataset,
+        &dst_dataset,
+        grid.alg,
+        grid.warp_memory_limit_bytes,
+    )
+    .map_err(convert_gdal_err)?;
 
     let metadata = grid.transform.to_raster_metadata(out_width, out_height);
     // Read the warped buffers back out (native read, no further resampling),

--- a/rust/sedona-raster-gdal/src/utils.rs
+++ b/rust/sedona-raster-gdal/src/utils.rs
@@ -24,16 +24,19 @@ use datafusion_common::exec_datafusion_err;
 use sedona_gdal::dataset::Dataset;
 use sedona_gdal::gdal::Gdal;
 use sedona_gdal::gdal_dyn_bindgen::{GDAL_OF_RASTER, GDAL_OF_READONLY};
+use sedona_gdal::geo_transform::GeoTransform;
+use sedona_gdal::mem::MemDatasetBuilder;
 use sedona_gdal::raster::types::DatasetOptions;
+use sedona_gdal::raster::types::ResampleAlg;
 use sedona_gdal::spatial_ref::SpatialRef;
 
 use sedona_raster::builder::RasterBuilder;
-use sedona_raster::traits::BandMetadata;
+use sedona_raster::traits::{BandMetadata, RasterMetadata};
 use sedona_schema::raster::StorageType;
 
 use crate::gdal_common::{
-    band_nodata_to_bytes, gdal_to_band_data_type, normalize_outdb_source_path, GdalBandLayout,
-    RasterMetadataFromGdalGeoTransform,
+    band_data_type_to_gdal, band_nodata_to_bytes, convert_gdal_err, gdal_to_band_data_type,
+    normalize_outdb_source_path, GdalBandLayout, RasterMetadataFromGdalGeoTransform,
 };
 
 /// Append a GDAL dataset as a single in-db raster to the provided [`RasterBuilder`].
@@ -202,8 +205,129 @@ pub fn append_nd_from_dataset(
         .ok()
         .and_then(|sr: SpatialRef| sr.to_projjson().ok());
 
+    append_nd_from_dataset_inner(dataset, layout, builder, &metadata, crs.as_deref(), None)
+}
+
+/// The output grid a warp writes into: geotransform, pixel dimensions, target
+/// CRS, and the resampling algorithm.
+///
+/// The warp path can move the output origin off the source grid, grow the
+/// extent past the source footprint, and change the CRS — so `crs` here is the
+/// *destination* CRS (equal to the source CRS for a same-CRS regrid, or the
+/// reprojection target). `crs` is carried through rather than read back from
+/// GDAL so a caller can preserve the exact CRS string it was given.
+pub struct WarpGrid<'a> {
+    pub transform: GeoTransform,
+    pub width: usize,
+    pub height: usize,
+    pub crs: Option<&'a str>,
+    pub alg: ResampleAlg,
+}
+
+/// Warp every band of `src_dataset` into `grid`, appending the result as a
+/// single **N-D** in-db raster regrouped per `layout`.
+///
+/// The destination is a MEM dataset whose band buffers are pre-filled with each
+/// band's nodata value (zero when a band has none), so output cells the
+/// (reprojected) source footprint does not cover — the extent can grow past the
+/// source, or shift under a reprojection — read back as nodata rather than as an
+/// accidental zero (`GDALReprojectImage` writes only covered pixels). GDAL warps
+/// into those buffers; the warped bytes are then regrouped into N-D bands via
+/// [`append_nd_from_dataset_inner`], carrying `grid.crs` through verbatim rather
+/// than round-tripping it back out of GDAL.
+pub fn append_warped_nd_from_dataset(
+    gdal: &Gdal,
+    src_dataset: &Dataset,
+    layout: &GdalBandLayout,
+    builder: &mut RasterBuilder,
+    grid: &WarpGrid<'_>,
+) -> Result<()> {
+    let out_width = grid.width;
+    let out_height = grid.height;
+
+    // One owned, nodata-pre-filled buffer per source band, its planes
+    // concatenated plane-major; the destination's DATAPOINTER bands point into
+    // sub-ranges of these. `band_buffers` must outlive `dst_dataset`, so it is
+    // declared first (locals drop in reverse order).
+    let mut band_buffers: Vec<Vec<u8>> = Vec::with_capacity(layout.bands.len());
+    for plan in &layout.bands {
+        let plane_bytes = out_width * out_height * plan.data_type.byte_size();
+        let total = plane_bytes.checked_mul(plan.plane_count).ok_or_else(|| {
+            exec_datafusion_err!("warped band size overflow ({out_width}x{out_height})")
+        })?;
+        band_buffers.push(filled_with_nodata(total, plan.nodata.as_deref()));
+    }
+
+    let mut dst_builder = MemDatasetBuilder::new(out_width, out_height);
+    for (plan, buffer) in layout.bands.iter().zip(band_buffers.iter_mut()) {
+        let gdal_type = band_data_type_to_gdal(&plan.data_type);
+        let plane_bytes = out_width * out_height * plan.data_type.byte_size();
+        for plane in 0..plan.plane_count {
+            let ptr = buffer[plane * plane_bytes..].as_mut_ptr();
+            // SAFETY: each plane sub-range holds exactly `plane_bytes` valid,
+            // writable bytes aligned for the band type, and `band_buffers`
+            // outlives `dst_dataset`.
+            unsafe {
+                dst_builder = dst_builder.add_band(gdal_type, ptr);
+            }
+        }
+    }
+    // SAFETY: the DATAPOINTER buffers in `band_buffers` outlive `dst_dataset`.
+    let dst_dataset = unsafe { dst_builder.build(gdal).map_err(convert_gdal_err)? };
+    dst_dataset
+        .set_geo_transform(&grid.transform)
+        .map_err(convert_gdal_err)?;
+    if let Some(crs) = grid.crs {
+        dst_dataset.set_projection(crs).map_err(convert_gdal_err)?;
+    }
+
+    // Reproject when the CRS differs; a same-CRS warp is a pure regrid that fills
+    // grown/shifted areas with the pre-filled nodata.
+    gdal.reproject_image(src_dataset, &dst_dataset, grid.alg)
+        .map_err(convert_gdal_err)?;
+
+    let metadata = grid.transform.to_raster_metadata(out_width, out_height);
+    // Read the warped buffers back out (native read, no further resampling),
+    // regrouping the flat GDAL bands into N-D raster bands.
+    append_nd_from_dataset_inner(&dst_dataset, layout, builder, &metadata, grid.crs, None)
+}
+
+/// Allocate a `total`-byte buffer pre-filled with the little-endian `nodata`
+/// byte pattern, or zeros when a band has no nodata. `total` is a whole number
+/// of pixels, so the pattern always tiles exactly.
+fn filled_with_nodata(total: usize, nodata: Option<&[u8]>) -> Vec<u8> {
+    match nodata {
+        Some(nd) if !nd.is_empty() && total.is_multiple_of(nd.len()) => {
+            let mut buf = Vec::with_capacity(total);
+            while buf.len() < total {
+                buf.extend_from_slice(nd);
+            }
+            buf
+        }
+        _ => vec![0u8; total],
+    }
+}
+
+/// Regroup a GDAL dataset's flat band list into N-D raster bands per `layout`,
+/// reading each plane at the `metadata` grid size. With `alg = None` the read is
+/// native (`out` == source size, an identity materialization); with `alg =
+/// Some(_)` the full source window is resampled into the (possibly different)
+/// `metadata` grid. The output geotransform/spatial grid come from `metadata`
+/// and the CRS from `crs`.
+fn append_nd_from_dataset_inner(
+    dataset: &Dataset,
+    layout: &GdalBandLayout,
+    builder: &mut RasterBuilder,
+    metadata: &RasterMetadata,
+    crs: Option<&str>,
+    alg: Option<ResampleAlg>,
+) -> Result<()> {
+    let (src_width, src_height) = dataset.raster_size();
+    let out_width = metadata.width as usize;
+    let out_height = metadata.height as usize;
+
     builder
-        .start_raster(&metadata, crs.as_deref())
+        .start_raster(metadata, crs)
         .map_err(|e| exec_datafusion_err!("Failed to start raster: {}", e))?;
 
     let total_planes: usize = layout.bands.iter().map(|b| b.plane_count).sum();
@@ -217,10 +341,10 @@ pub fn append_nd_from_dataset(
     let mut gdal_band = 1;
     for plan in &layout.bands {
         let dim_names: Vec<&str> = plan.dim_names.iter().map(String::as_str).collect();
-        // shape = [non-spatial..., height, width] — spatial from the dataset.
+        // shape = [non-spatial..., height, width] — spatial from the output grid.
         let mut shape = plan.nonspatial_shape.clone();
-        shape.push(height as i64);
-        shape.push(width as i64);
+        shape.push(out_height as i64);
+        shape.push(out_width as i64);
 
         builder
             .start_band_nd(
@@ -234,14 +358,20 @@ pub fn append_nd_from_dataset(
             )
             .map_err(|e| exec_datafusion_err!("Failed to start band: {}", e))?;
 
-        let mut band_data: Vec<u8> =
-            Vec::with_capacity(plan.plane_count * width * height * plan.data_type.byte_size());
+        let mut band_data: Vec<u8> = Vec::with_capacity(
+            plan.plane_count * out_width * out_height * plan.data_type.byte_size(),
+        );
         for _ in 0..plan.plane_count {
             let band = dataset
                 .rasterband(gdal_band)
                 .map_err(|e| exec_datafusion_err!("Failed to get band {}: {}", gdal_band, e))?;
             let plane = band
-                .read_as_bytes((0, 0), (width, height), (width, height), None)
+                .read_as_bytes(
+                    (0, 0),
+                    (src_width, src_height),
+                    (out_width, out_height),
+                    alg,
+                )
                 .map_err(|e| {
                     exec_datafusion_err!("Failed to read band {} data: {}", gdal_band, e)
                 })?;

--- a/rust/sedona-raster-gdal/src/utils.rs
+++ b/rust/sedona-raster-gdal/src/utils.rs
@@ -36,7 +36,8 @@ use sedona_schema::raster::StorageType;
 
 use crate::gdal_common::{
     band_data_type_to_gdal, band_nodata_to_bytes, convert_gdal_err, gdal_to_band_data_type,
-    normalize_outdb_source_path, GdalBandLayout, RasterMetadataFromGdalGeoTransform,
+    normalize_outdb_source_path, set_band_nodata_from_bytes, GdalBandLayout,
+    RasterMetadataFromGdalGeoTransform,
 };
 
 /// Append a GDAL dataset as a single in-db raster to the provided [`RasterBuilder`].
@@ -282,6 +283,23 @@ pub fn append_warped_nd_from_dataset(
         .map_err(convert_gdal_err)?;
     if let Some(crs) = grid.crs {
         dst_dataset.set_projection(crs).map_err(convert_gdal_err)?;
+    }
+
+    // Record each band's nodata on the destination in its native type. Walk the
+    // dst bands in the same band-major / plane order as the add loop above.
+    // `set_band_nodata_from_bytes` uses the exact Int64/UInt64 setters rather
+    // than routing through a lossy f64, so a large 64-bit nodata stays exact.
+    let mut dst_band_index = 0usize;
+    for plan in &layout.bands {
+        for _ in 0..plan.plane_count {
+            dst_band_index += 1;
+            if let Some(nodata) = plan.nodata.as_deref() {
+                let band = dst_dataset
+                    .rasterband(dst_band_index)
+                    .map_err(convert_gdal_err)?;
+                set_band_nodata_from_bytes(&band, Some(nodata))?;
+            }
+        }
     }
 
     // Reproject when the CRS differs; a same-CRS warp is a pure regrid that fills


### PR DESCRIPTION
Adds `RS_ReprojectMatch(raster, reference[, algorithm])`, reprojecting a raster onto a reference raster's CRS, grid, and envelope (rioxarray `reproject_match` semantics). Positional overloads match Sedona Spark verbatim.