### PR TITLE
test(python/sedonadb): DialectEngine parity harness + inline-deviation RS_ZonalStats spike

### DIFF
--- a/python/sedonadb/python/sedonadb/raster_testing.py
+++ b/python/sedonadb/python/sedonadb/raster_testing.py
@@ -361,10 +361,10 @@ class RasterEngine:
         self._not_implemented("from_binary")
 
 
-class DialectEngine(RasterEngine):
+class SedonaDialectEngine(RasterEngine):
     """A `RasterEngine` that runs the RS_* function under test as SQL.
 
-    SedonaDB and Sedona Spark are both dialect engines: an operation is one
+    SedonaDB and Sedona Spark both implement the Sedona SQL dialect: an operation is one
     RS_* call, and the compatibility contract the parity tests exist to protect
     is that the identical call runs on both ("Spark SQL runs unchanged in
     SedonaDB"). To make that contract structural rather than a coincidence, the
@@ -509,7 +509,7 @@ class DialectEngine(RasterEngine):
         )
 
 
-class SedonaDB(DialectEngine):
+class SedonaDB(SedonaDialectEngine):
     """Runs `RS_*` on a SedonaDB connection — the engine under test."""
 
     def __init__(self, con=None):
@@ -528,7 +528,7 @@ class SedonaDB(DialectEngine):
         """Whether this SedonaDB build registers the RS_* function `probe_sql`
         calls — the runtime gate for a parity module.
 
-        The `DialectEngine` harness methods are pure SQL construction and exist
+        The `SedonaDialectEngine` harness methods are pure SQL construction and exist
         whether or not the underlying function is compiled in, so a module can't
         gate on the method's presence. It runs a trivial call instead: a
         planning-time "Invalid function" error means the build predates the
@@ -722,7 +722,7 @@ class SedonaDB(DialectEngine):
         return decode_raster(result[0])
 
 
-class SedonaSpark(DialectEngine):
+class SedonaSpark(SedonaDialectEngine):
     """Runs Sedona Spark SQL `RS_*` functions — the compatibility-target dialect.
 
     Bootstraps one local SparkSession per process with

--- a/python/sedonadb/python/sedonadb/raster_testing.py
+++ b/python/sedonadb/python/sedonadb/raster_testing.py
@@ -280,18 +280,49 @@ class RasterEngine:
         path,
         geometry_wkt: str,
         *,
-        band: int = 1,
+        band: Optional[int] = None,
         stat: str = "mean",
         all_touched: bool = False,
+        exclude_nodata: bool = True,
+        lenient: bool = True,
     ) -> Optional[float]:
         """One summary statistic over the band's pixels inside a WKT zone.
 
-        `stat` is one of count, sum, mean, min, max, median, or the sample
-        (ddof=1) stddev and variance. Pixels valued at the band's nodata are
-        excluded. Pixel selection follows the same centroid/all_touched rule
-        as `clip`.
+        Which of `RS_ZonalStats`'s positional overloads runs is chosen by which
+        optional parameters are set: `band=None` omits the band argument (the
+        3-argument `(raster, zone, stat_type)` overload, which resolves to band
+        1 on a single-band raster); a set `band` selects the 4-argument overload;
+        `all_touched`, then `exclude_nodata`, then `lenient` extend it to the 5-,
+        6-, and 7-argument overloads.
+
+        `stat` is one of count, sum, mean, median, mode, min, max, or the sample
+        (ddof=1) stddev and variance. With `exclude_nodata` (the default) pixels
+        equal to the band's nodata are skipped. Pixel selection follows the same
+        centroid/all_touched rule as `clip`. With `lenient` (the default) a zone
+        that misses the raster yields None instead of an error.
         """
         self._not_implemented("zonal_stats")
+
+    def zonal_stats_all(
+        self,
+        path,
+        geometry_wkt: str,
+        *,
+        band: Optional[int] = None,
+        all_touched: bool = False,
+        exclude_nodata: bool = True,
+        lenient: bool = True,
+    ) -> Optional[Mapping[str, Any]]:
+        """Every summary statistic over the band's pixels inside a WKT zone.
+
+        The `RS_ZonalStatsAll` overload ladder mirrors `zonal_stats` minus the
+        `stat_type` argument: `(raster, zone)`, `(raster, zone, band)`, then
+        `+all_touched`, `+exclude_nodata`, `+lenient`. Returns a mapping of the
+        struct fields in `ZONAL_ALL_FIELDS` order — `count` (an integer pixel
+        count) then the Float64 statistics — or None when `lenient` and the zone
+        misses the raster.
+        """
+        self._not_implemented("zonal_stats_all")
 
     def tile_explode(
         self, path, tile_width: int, tile_height: int
@@ -330,7 +361,155 @@ class RasterEngine:
         self._not_implemented("from_binary")
 
 
-class SedonaDB(RasterEngine):
+class DialectEngine(RasterEngine):
+    """A `RasterEngine` that runs the RS_* function under test as SQL.
+
+    SedonaDB and Sedona Spark are both dialect engines: an operation is one
+    RS_* call, and the compatibility contract the parity tests exist to protect
+    is that the identical call runs on both ("Spark SQL runs unchanged in
+    SedonaDB"). To make that contract structural rather than a coincidence, the
+    argument string is built in exactly one place — the `*_expr` generators
+    below — and both dialects execute whatever those return. A dialect subclass
+    supplies only its per-engine I/O: how a GeoTIFF path becomes a `rast` column
+    and how a scalar / struct result is decoded (`_run_scalar` / `_run_struct`).
+    The two dialects therefore cannot emit different SQL for the same operation.
+
+    Only RS_ZonalStats / RS_ZonalStatsAll are routed through this shared surface;
+    the other operations keep their existing per-dialect implementations.
+    """
+
+    def _run_scalar(self, path, expr: str) -> Optional[float]:
+        """Execute a scalar-valued RS_* `expr` over a `rast` column from `path`."""
+        self._not_implemented("_run_scalar")
+
+    def _run_struct(self, path, expr: str) -> Optional[Mapping[str, Any]]:
+        """Execute a struct-valued RS_* `expr` over a `rast` column from `path`,
+        returning a mapping in `ZONAL_ALL_FIELDS` order (None for a NULL result)."""
+        self._not_implemented("_run_struct")
+
+    @staticmethod
+    def _zonal_args(
+        geometry_wkt, *, band, stat, all_touched, exclude_nodata, lenient
+    ) -> List[str]:
+        """The RS_ZonalStats / RS_ZonalStatsAll positional argument list, as SQL
+        text, following Apache Sedona Spark's overload ladder verbatim.
+
+        The two required arguments are the `rast` column and an
+        `ST_GeomFromText('...')` zone (a constructor both dialects spell the same
+        way). `band` is appended when set; `stat` (a statistic name, or None for
+        RS_ZonalStatsAll, which has no stat argument) follows it. The optional
+        `all_touched`/`exclude_nodata`/`lenient` flags append the shortest suffix
+        that covers every non-default value — and, since they are the 5th+
+        arguments, require an explicit `band`."""
+        args = ["rast", f"ST_GeomFromText('{geometry_wkt}')"]
+        if band is not None:
+            args.append(str(int(band)))
+        if stat is not None:
+            args.append(f"'{stat}'")
+        flags = [all_touched, exclude_nodata, lenient]
+        defaults = [False, True, True]
+        depth = 0
+        for i, (value, default) in enumerate(zip(flags, defaults)):
+            if value != default:
+                depth = i + 1
+        if depth:
+            if band is None:
+                raise ValueError(
+                    "RS_ZonalStats needs an explicit band to pass the "
+                    "all_touched/exclude_nodata/lenient flags"
+                )
+            args += [str(bool(flags[i])).lower() for i in range(depth)]
+        return args
+
+    @classmethod
+    def zonal_stats_expr(
+        cls,
+        geometry_wkt,
+        *,
+        band=None,
+        stat="mean",
+        all_touched=False,
+        exclude_nodata=True,
+        lenient=True,
+    ) -> str:
+        """The exact `RS_ZonalStats(...)` SQL fragment both dialects run."""
+        args = cls._zonal_args(
+            geometry_wkt,
+            band=band,
+            stat=stat,
+            all_touched=all_touched,
+            exclude_nodata=exclude_nodata,
+            lenient=lenient,
+        )
+        return f"RS_ZonalStats({', '.join(args)})"
+
+    @classmethod
+    def zonal_stats_all_expr(
+        cls,
+        geometry_wkt,
+        *,
+        band=None,
+        all_touched=False,
+        exclude_nodata=True,
+        lenient=True,
+    ) -> str:
+        """The exact `RS_ZonalStatsAll(...)` SQL fragment both dialects run."""
+        args = cls._zonal_args(
+            geometry_wkt,
+            band=band,
+            stat=None,
+            all_touched=all_touched,
+            exclude_nodata=exclude_nodata,
+            lenient=lenient,
+        )
+        return f"RS_ZonalStatsAll({', '.join(args)})"
+
+    def zonal_stats(
+        self,
+        path,
+        geometry_wkt,
+        *,
+        band=None,
+        stat="mean",
+        all_touched=False,
+        exclude_nodata=True,
+        lenient=True,
+    ):
+        return self._run_scalar(
+            path,
+            self.zonal_stats_expr(
+                geometry_wkt,
+                band=band,
+                stat=stat,
+                all_touched=all_touched,
+                exclude_nodata=exclude_nodata,
+                lenient=lenient,
+            ),
+        )
+
+    def zonal_stats_all(
+        self,
+        path,
+        geometry_wkt,
+        *,
+        band=None,
+        all_touched=False,
+        exclude_nodata=True,
+        lenient=True,
+    ):
+        return self._run_struct(
+            path,
+            self.zonal_stats_all_expr(
+                geometry_wkt,
+                band=band,
+                all_touched=all_touched,
+                exclude_nodata=exclude_nodata,
+                lenient=lenient,
+            ),
+        )
+
+
+class SedonaDB(DialectEngine):
     """Runs `RS_*` on a SedonaDB connection — the engine under test."""
 
     def __init__(self, con=None):
@@ -343,6 +522,49 @@ class SedonaDB(RasterEngine):
         # Never skip on the engine under test: a construction failure here is
         # a bug, not a missing optional backend.
         return cls(*args, **kwargs)
+
+    @classmethod
+    def registers_function(cls, probe_sql: str) -> bool:
+        """Whether this SedonaDB build registers the RS_* function `probe_sql`
+        calls — the runtime gate for a parity module.
+
+        The `DialectEngine` harness methods are pure SQL construction and exist
+        whether or not the underlying function is compiled in, so a module can't
+        gate on the method's presence. It runs a trivial call instead: a
+        planning-time "Invalid function" error means the build predates the
+        function (skip the module); any other outcome — success, or an
+        argument/CRS error from the probe call — means it is registered."""
+        try:
+            cls()._con.sql(probe_sql).to_arrow_table()
+        except Exception as e:
+            return "invalid function" not in str(e).lower()
+        return True
+
+    def _rast_view(self, path) -> str:
+        """Register the GeoTIFF at `path` as a one-row view exposing a `rast`
+        column and return a query prefix that reads from it.
+
+        `rast` is derived from a table column (`RS_FromPath(path)`), not a
+        literal, so a kernel over it runs its real array path — literals
+        constant-fold. The view name is fixed and overwritten each call; the
+        session connection is reused across the suite."""
+        name = "_zonal_parity_input"
+        self._con.create_data_frame(
+            pa.table({"path": pa.array([str(path)], type=pa.utf8())})
+        ).to_view(name, overwrite=True)
+        return f"(SELECT RS_FromPath(path) AS rast FROM {name})"
+
+    def _run_scalar(self, path, expr):
+        result = self._con.sql(
+            f"SELECT {expr} AS v FROM {self._rast_view(path)}"
+        ).to_arrow_table()["v"]
+        return result[0].as_py()
+
+    def _run_struct(self, path, expr):
+        result = self._con.sql(
+            f"SELECT {expr} AS r FROM {self._rast_view(path)}"
+        ).to_arrow_table()["r"]
+        return result[0].as_py() if result[0].is_valid else None
 
     def clip(
         self, path, geometry_wkt, *, band=0, all_touched=False, nodata=None, crop=True
@@ -500,7 +722,7 @@ class SedonaDB(RasterEngine):
         return decode_raster(result[0])
 
 
-class SedonaSpark(RasterEngine):
+class SedonaSpark(DialectEngine):
     """Runs Sedona Spark SQL `RS_*` functions — the compatibility-target dialect.
 
     Bootstraps one local SparkSession per process with
@@ -757,14 +979,17 @@ class SedonaSpark(RasterEngine):
             f"false, '{algorithm}')",
         )
 
-    def zonal_stats(
-        self, path, geometry_wkt, *, band=1, stat="mean", all_touched=False
-    ):
-        return self._scalar(
-            self._raster_df(path),
-            f"RS_ZonalStats(rast, ST_GeomFromText('{geometry_wkt}'), {band}, "
-            f"'{stat}', {str(all_touched).lower()})",
-        )
+    def _run_scalar(self, path, expr):
+        return self._scalar(self._raster_df(path), expr)
+
+    def _run_struct(self, path, expr):
+        row = self._scalar(self._raster_df(path), expr)
+        if row is None:
+            return None
+        # Sedona Spark returns a uniform Double[] in field order (so its count is
+        # a float, not the Int64 SedonaDB records); the dict comparison is by
+        # value, so the numeric count still matches.
+        return dict(zip(ZONAL_ALL_FIELDS, row))
 
     def tile_explode(self, path, tile_width, tile_height):
         df = self._raster_df(path)
@@ -1037,16 +1262,56 @@ class Rasterio(RasterEngine):
             )
 
     def zonal_stats(
-        self, path, geometry_wkt, *, band=1, stat="mean", all_touched=False
+        self,
+        path,
+        geometry_wkt,
+        *,
+        band=None,
+        stat="mean",
+        all_touched=False,
+        exclude_nodata=True,
+        lenient=True,
     ):
+        values = self._zone_values(
+            path, geometry_wkt, band, all_touched, exclude_nodata
+        )
+        if values.size == 0:
+            # An empty selection makes count 0 and every other statistic NULL
+            # (Sedona's empty-zone shortcut); comparisons here use zones that
+            # select pixels, so this only guards a degenerate case.
+            return 0.0 if stat == "count" else None
+        return float(_STAT_REDUCERS[stat](values))
+
+    def zonal_stats_all(
+        self,
+        path,
+        geometry_wkt,
+        *,
+        band=None,
+        all_touched=False,
+        exclude_nodata=True,
+        lenient=True,
+    ):
+        values = self._zone_values(
+            path, geometry_wkt, band, all_touched, exclude_nodata
+        )
+        return _reduce_all_stats(values)
+
+    def _zone_values(self, path, geometry_wkt, band, all_touched, exclude_nodata):
+        """The band's pixel values selected by the zone, in float64.
+
+        `band=None` resolves to band 1 (matching the subject's single-band
+        default for the band-less overload). Pixels equal to the band nodata are
+        dropped only when `exclude_nodata`."""
         import rasterio
         import rasterio.features
         import shapely
 
+        b = 1 if band is None else band
         geom = shapely.from_wkt(geometry_wkt)
         with rasterio.open(str(path)) as src:
-            data = src.read(band)
-            nodata = src.nodatavals[band - 1]
+            data = src.read(b)
+            nodata = src.nodatavals[b - 1]
             inside = rasterio.features.geometry_mask(
                 [geom],
                 out_shape=(src.height, src.width),
@@ -1055,23 +1320,12 @@ class Rasterio(RasterEngine):
                 invert=True,
             )
         values = data[inside].astype(np.float64)
-        if nodata is not None:
+        if exclude_nodata and nodata is not None:
             if math.isnan(nodata):
                 values = values[~np.isnan(values)]
             else:
                 values = values[values != nodata]
-        # Sedona's stddev/variance are the sample statistics (ddof=1).
-        reducers = {
-            "count": np.size,
-            "sum": np.sum,
-            "mean": np.mean,
-            "min": np.min,
-            "max": np.max,
-            "stddev": lambda v: v.std(ddof=1),
-            "variance": lambda v: v.var(ddof=1),
-            "median": np.median,
-        }
-        return float(reducers[stat](values))
+        return values
 
     def tile_explode(self, path, tile_width, tile_height):
         import rasterio
@@ -1109,6 +1363,68 @@ class Rasterio(RasterEngine):
 
     def from_binary(self, data):
         return decode_geotiff_bytes(data)
+
+
+# RS_ZonalStatsAll struct fields, in the order the Rust kernel emits them
+# (count first, then the Float64 statistics). Both the Sedona Spark decoder and
+# the parity test read the struct through this list, so it is defined once.
+ZONAL_ALL_FIELDS = [
+    "count",
+    "sum",
+    "mean",
+    "median",
+    "mode",
+    "stddev",
+    "variance",
+    "min",
+    "max",
+]
+
+
+def _mode(values: "np.ndarray") -> float:
+    """The most frequent value, breaking ties toward the larger (matching
+    Sedona's `StatUtils.mode`). `np.unique` returns values ascending, so the
+    max of the tied-most-frequent values is the larger mode."""
+    uniques, counts = np.unique(values, return_counts=True)
+    return float(uniques[counts == counts.max()].max())
+
+
+# RS_ZonalStats statistic name -> reducer over the selected float64 values.
+# stddev/variance are the sample (ddof=1) statistics Sedona computes; a single
+# value yields variance 0. count is an integer pixel count.
+_STAT_REDUCERS = {
+    "count": lambda v: int(v.size),
+    "sum": np.sum,
+    "mean": np.mean,
+    "median": np.median,
+    "mode": _mode,
+    "stddev": lambda v: v.std(ddof=1) if v.size > 1 else 0.0,
+    "variance": lambda v: v.var(ddof=1) if v.size > 1 else 0.0,
+    "min": np.min,
+    "max": np.max,
+}
+
+
+def _reduce_all_stats(values: "np.ndarray") -> Optional[Mapping[str, Any]]:
+    """Every RS_ZonalStatsAll field over the selected values.
+
+    An empty selection is `count = 0` with every other field None (Sedona's
+    empty-zone shortcut). `count` is an integer; the rest are floats."""
+    n = int(values.size)
+    if n == 0:
+        return {field: (0 if field == "count" else None) for field in ZONAL_ALL_FIELDS}
+    variance = float(values.var(ddof=1)) if n > 1 else 0.0
+    return {
+        "count": n,
+        "sum": float(values.sum()),
+        "mean": float(values.mean()),
+        "median": float(np.median(values)),
+        "mode": _mode(values),
+        "stddev": math.sqrt(variance),
+        "variance": variance,
+        "min": float(values.min()),
+        "max": float(values.max()),
+    }
 
 
 def _is_nodata(sampled, nodata) -> bool:

--- a/python/sedonadb/tests/functions/test_rs_zonalstats.py
+++ b/python/sedonadb/tests/functions/test_rs_zonalstats.py
@@ -30,7 +30,7 @@ Two design choices distinguish this module from the first parity modules:
 - Known divergences are declared **inline**, as an `xfail`/`skip` mark on the
   parametrized case, not in a separate deviations ledger — so reading one case
   shows both what it asserts and where an engine is expected to disagree.
-- SedonaDB and Sedona Spark are both `DialectEngine`s: `zonal_stats` /
+- SedonaDB and Sedona Spark are both `SedonaDialectEngine`s: `zonal_stats` /
   `zonal_stats_all` build one RS_* argument string (via the shared
   `zonal_stats_expr` / `zonal_stats_all_expr` generators) that both dialects
   execute unchanged. `test_zonal_stats_sql_runs_unchanged_on_both_dialects`
@@ -41,9 +41,9 @@ import pyarrow as pa
 import pytest
 
 from sedonadb.raster_testing import (
-    DialectEngine,
     Rasterio,
     SedonaDB,
+    SedonaDialectEngine,
     SedonaSpark,
     ZONAL_ALL_FIELDS,
     random_raster_data,
@@ -81,6 +81,33 @@ GEOM_TRIANGLE = "POLYGON ((102.7 497.4, 112.4 496.9, 104.2 483.7, 102.7 497.4))"
 GEOM_OUTSIDE = "POLYGON ((200 495, 210 495, 210 485, 200 485, 200 495))"
 
 STATS = ["count", "sum", "mean", "min", "max", "stddev", "variance", "median", "mode"]
+
+# count is an integer pixel count and min/max/mode are pass-through pixel values,
+# so once the subject and the comparator select the same pixel set these are
+# bit-identical — asserted with exact equality. approx here would hide a real
+# selection or tie-break divergence. Only the accumulating stats (sum, mean,
+# median, stddev, variance) warrant a tolerance, because engines reduce in
+# different orders.
+EXACT_STATS = frozenset({"count", "min", "max", "mode"})
+
+
+def assert_stat_equal(got, expected, stat):
+    """Assert one RS_ZonalStats result against a comparator: exact equality for
+    the selection/count stats in `EXACT_STATS`, approx (rel=1e-9) for the
+    accumulating ones."""
+    if stat in EXACT_STATS:
+        assert got == expected, stat
+    else:
+        assert got == pytest.approx(expected, rel=1e-9), stat
+
+
+def assert_all_stats_equal(got, expected):
+    """Assert an RS_ZonalStatsAll struct field-by-field against a comparator,
+    keying each field on `EXACT_STATS`: exact for count/min/max/mode, approx
+    (rel=1e-9) for the accumulating stats."""
+    for field in ZONAL_ALL_FIELDS:
+        assert_stat_equal(got[field], expected[field], field)
+
 
 # Sedona Spark's scanline rasterizer mis-places x-intercepts on non-square pixels
 # and drops some center-inside pixels along diagonal edges, where GDAL (which
@@ -138,10 +165,11 @@ def test_rs_zonalstats_matches_comparators(
     expected = comparator.zonal_stats(
         tiff, wkt, band=2, stat=stat, all_touched=all_touched
     )
-    # Engines reduce in different orders, so exact float equality is not
-    # attainable; 1e-9 passes summation noise and still fails any semantic
-    # mismatch (selection, nodata handling, ddof).
-    assert got == pytest.approx(expected, rel=1e-9), (wkt, all_touched, stat)
+    # count/min/max/mode are asserted exactly (same pixel set => bit-identical);
+    # the accumulating stats get approx, since engines reduce in different orders
+    # (1e-9 passes summation noise and still fails any semantic mismatch —
+    # selection, nodata handling, ddof).
+    assert_stat_equal(got, expected, stat)
 
 
 @pytest.mark.parametrize("stat", ["count", "mean", "max"])
@@ -160,7 +188,7 @@ def test_rs_zonalstats_band_default_matches_comparators(
     )
     got = subject.zonal_stats(tiff, GEOM_RECT, stat=stat)
     expected = comparator.zonal_stats(tiff, GEOM_RECT, stat=stat)
-    assert got == pytest.approx(expected, rel=1e-9), stat
+    assert_stat_equal(got, expected, stat)
 
 
 @pytest.mark.parametrize("stat", ["count", "sum"])
@@ -179,7 +207,7 @@ def test_rs_zonalstats_excludes_nodata(subject, comparator, tmp_path, stat):
 
     got = subject.zonal_stats(tiff, GEOM_RECT, stat=stat)
     expected = comparator.zonal_stats(tiff, GEOM_RECT, stat=stat)
-    assert got == pytest.approx(expected, rel=1e-9), stat
+    assert_stat_equal(got, expected, stat)
 
 
 @pytest.mark.parametrize("stat", ["count", "sum"])
@@ -202,7 +230,7 @@ def test_rs_zonalstats_include_nodata_matches_comparators(
     expected = comparator.zonal_stats(
         tiff, GEOM_RECT, band=1, stat=stat, exclude_nodata=False
     )
-    assert got == pytest.approx(expected, rel=1e-9), stat
+    assert_stat_equal(got, expected, stat)
 
 
 def test_rs_zonalstats_lenient_false_computes(subject, comparator, tmp_path):
@@ -216,7 +244,7 @@ def test_rs_zonalstats_lenient_false_computes(subject, comparator, tmp_path):
     )
     got = subject.zonal_stats(tiff, GEOM_RECT, band=1, stat="mean", lenient=False)
     expected = comparator.zonal_stats(tiff, GEOM_RECT, band=1, stat="mean")
-    assert got == pytest.approx(expected, rel=1e-9)
+    assert_stat_equal(got, expected, "mean")
 
 
 def test_rs_zonalstats_lenient_false_errors_on_disjoint_zone(con, tmp_path):
@@ -320,11 +348,11 @@ def test_rs_zonalstatsall_matches_comparators(
     expected = comparator.zonal_stats_all(
         tiff, GEOM_RECT, band=2, all_touched=all_touched
     )
-    assert got["count"] == expected["count"]
-    assert got["mode"] == pytest.approx(expected["mode"]), "mode tie-break"
-    assert got["mode"] == pytest.approx(50.0), "planted repeat is the mode"
-    for field in ZONAL_ALL_FIELDS:
-        assert got[field] == pytest.approx(expected[field], rel=1e-9), field
+    # count/min/max/mode match bit-for-bit (same pixel set); the accumulating
+    # stats get approx. mode is now exact, so the frequency tie-break is pinned
+    # exactly against both the comparator and the planted repeat.
+    assert_all_stats_equal(got, expected)
+    assert got["mode"] == 50.0, "planted repeat is the mode"
 
 
 def test_rs_zonalstatsall_count_field_is_int64(con, tmp_path):
@@ -359,11 +387,18 @@ def test_rs_zonalstatsall_count_field_is_int64(con, tmp_path):
 
 
 # The SQL-surface parity contract: one corpus of RS_* argument strings, produced
-# by the shared DialectEngine generators, that must parse and execute identically
+# by the shared SedonaDialectEngine generators, that must parse and execute identically
 # on both dialects. `kind` picks the scalar or struct generator; `kwargs` walks
 # the overload ladder. Expected literals pin the exact generated surface so drift
 # is caught even on a machine without Spark.
 CONTRACT_CALLS = [
+    # Band-less overloads (no band argument): on this single-band fixture they
+    # resolve to band 1 rather than raising the multiband error.
+    (
+        "scalar",
+        {"stat": "count"},
+        f"RS_ZonalStats(rast, ST_GeomFromText('{GEOM_RECT}'), 'count')",
+    ),
     (
         "scalar",
         {"band": 1, "stat": "count"},
@@ -378,6 +413,11 @@ CONTRACT_CALLS = [
         "scalar",
         {"band": 1, "stat": "sum", "exclude_nodata": False},
         f"RS_ZonalStats(rast, ST_GeomFromText('{GEOM_RECT}'), 1, 'sum', false, false)",
+    ),
+    (
+        "struct",
+        {},
+        f"RS_ZonalStatsAll(rast, ST_GeomFromText('{GEOM_RECT}'))",
     ),
     (
         "struct",
@@ -407,9 +447,9 @@ def test_zonal_stats_sql_runs_unchanged_on_both_dialects(
     parses and executes); the Spark arm skips via `create_or_skip` when the jars
     are absent, so on a jar-less machine this proves only the SedonaDB half."""
     if kind == "scalar":
-        expr = DialectEngine.zonal_stats_expr(GEOM_RECT, **kwargs)
+        expr = SedonaDialectEngine.zonal_stats_expr(GEOM_RECT, **kwargs)
     else:
-        expr = DialectEngine.zonal_stats_all_expr(GEOM_RECT, **kwargs)
+        expr = SedonaDialectEngine.zonal_stats_all_expr(GEOM_RECT, **kwargs)
     assert expr == expected_sql
 
     tiff = tmp_path / "contract.tif"
@@ -428,13 +468,9 @@ def test_zonal_stats_sql_runs_unchanged_on_both_dialects(
 
     spark = SedonaSpark.create_or_skip()
     if kind == "scalar":
-        assert spark._run_scalar(tiff, expr) == pytest.approx(db_result, rel=1e-9)
+        assert_stat_equal(spark._run_scalar(tiff, expr), db_result, kwargs["stat"])
     else:
-        spark_result = spark._run_struct(tiff, expr)
-        for field in ZONAL_ALL_FIELDS:
-            assert spark_result[field] == pytest.approx(db_result[field], rel=1e-9), (
-                field
-            )
+        assert_all_stats_equal(spark._run_struct(tiff, expr), db_result)
 
 
 def test_rs_zonalstats_sql_smoke(con, tmp_path):

--- a/python/sedonadb/tests/functions/test_rs_zonalstats.py
+++ b/python/sedonadb/tests/functions/test_rs_zonalstats.py
@@ -15,26 +15,37 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""RS_ZonalStats parity against geometry_mask + numpy reductions.
+"""RS_ZonalStats / RS_ZonalStatsAll parity across their Sedona Spark overloads.
 
-The rasterio comparator selects pixels with
-`rasterio.features.geometry_mask`, drops pixels valued at the band nodata,
-and reduces in float64. stddev/variance are the sample (ddof=1) statistics —
-that is what Sedona computes. The diagonal-edged zone under the centroid
-rule is on the Sedona Spark deviation ledger (its scanline rasterizer
-mis-places x-intercepts on non-square pixels and drops some center-inside
-pixels there, apache/sedona#3111). Zones that select no pixels are not
-compared here.
+The rasterio reference selects pixels with `rasterio.features.geometry_mask`,
+optionally drops pixels valued at the band nodata, and reduces in float64.
+stddev/variance are the sample (ddof=1) statistics Sedona computes; mode breaks
+ties toward the larger value. The overload ladder is exercised by which optional
+arguments each call passes: `band` omitted is the band-less overload (resolves to
+band 1 on a single-band raster, errors on a multiband one); a set `band`, then
+`all_touched`, `exclude_nodata`, `lenient` select the longer overloads.
+
+Two design choices distinguish this module from the first parity modules:
+
+- Known divergences are declared **inline**, as an `xfail`/`skip` mark on the
+  parametrized case, not in a separate deviations ledger — so reading one case
+  shows both what it asserts and where an engine is expected to disagree.
+- SedonaDB and Sedona Spark are both `DialectEngine`s: `zonal_stats` /
+  `zonal_stats_all` build one RS_* argument string (via the shared
+  `zonal_stats_expr` / `zonal_stats_all_expr` generators) that both dialects
+  execute unchanged. `test_zonal_stats_sql_runs_unchanged_on_both_dialects`
+  asserts that compatibility contract directly.
 """
 
 import pyarrow as pa
 import pytest
 
 from sedonadb.raster_testing import (
-    Deviation,
+    DialectEngine,
+    Rasterio,
     SedonaDB,
     SedonaSpark,
-    expect_deviations,
+    ZONAL_ALL_FIELDS,
     random_raster_data,
     write_geotiff,
 )
@@ -42,56 +53,80 @@ from sedonadb.raster_testing import (
 pytest.importorskip("rasterio")
 pytest.importorskip("shapely")
 
+# The harness `zonal_stats` methods are pure SQL construction and exist whether
+# or not RS_ZonalStats is compiled in, so the module gates on the function being
+# registered in this SedonaDB build (see `SedonaDB.registers_function`) rather
+# than on the method's presence. Band 1 is named because RS_Example is
+# multiband; a CRS error from the probe still means the function is registered.
 pytestmark = pytest.mark.skipif(
-    not SedonaDB.implements("zonal_stats"),
-    reason="RS_ZonalStats is not implemented in SedonaDB (the parity subject)",
+    not SedonaDB.registers_function(
+        "SELECT RS_ZonalStats(RS_Example(), "
+        "ST_GeomFromText('POLYGON ((43 79, 60 79, 60 60, 43 60, 43 79))'), 1, 'count')"
+    ),
+    reason="RS_ZonalStats is not registered in this SedonaDB build (the parity subject)",
 )
 
-# GDAL-order geotransform: origin (100, 500), 2-wide by 3-tall north-up
-# pixels; with a 7x6 raster the extent is x in [100, 114], y in [482, 500].
+# GDAL-order geotransform: origin (100, 500), 2-wide by 3-tall north-up pixels;
+# with a 7x6 raster the extent is x in [100, 114], y in [482, 500].
 GDAL_TRANSFORM = (100.0, 2.0, 0.0, 500.0, 0.0, -3.0)
 HEIGHT, WIDTH = 6, 7
 GEOM_RECT = (
     "POLYGON ((102.6 495.8, 109.3 495.8, 109.3 485.9, 102.6 485.9, 102.6 495.8))"
 )
 # Diagonal edges make all_touched matter, while staying clear of the corner
-# pixels where the fixture plants the dtype extremes (a float64 extreme in
-# the zone would push the squared-deviation statistics to infinity).
+# pixels where the fixture plants the dtype extremes (a float64 extreme in the
+# zone would push the squared-deviation statistics to infinity).
 GEOM_TRIANGLE = "POLYGON ((102.7 497.4, 112.4 496.9, 104.2 483.7, 102.7 497.4))"
+# A zone entirely outside the raster extent (x > 114) — selects no pixels.
+GEOM_OUTSIDE = "POLYGON ((200 495, 210 495, 210 485, 200 485, 200 495))"
 
-STATS = ["count", "sum", "mean", "min", "max", "stddev", "variance", "median"]
+STATS = ["count", "sum", "mean", "min", "max", "stddev", "variance", "median", "mode"]
 
-DEVIATIONS = [
-    Deviation(
+# Sedona Spark's scanline rasterizer mis-places x-intercepts on non-square pixels
+# and drops some center-inside pixels along diagonal edges, where GDAL (which
+# both SedonaDB and rasterio burn through) selects every center-inside pixel. It
+# is therefore expected to disagree on the diagonal zone under the centroid rule.
+SPARK_DIAGONAL_XFAIL = pytest.mark.xfail(
+    strict=True,
+    reason="Sedona's scanline rasterizer drops center-inside pixels along "
+    "diagonal edges under the centroid rule; GDAL selects every "
+    "center-inside pixel (https://github.com/apache/sedona/issues/3111)",
+)
+
+# (comparator engine, zone, all_touched). Every comparator runs on every zone;
+# the one combination Sedona Spark is known to get wrong carries its xfail right
+# here, beside the case, rather than in a separate ledger the reader must chase.
+COMPARATOR_CASES = [
+    pytest.param(Rasterio, GEOM_RECT, False, id="rasterio-rect-centroid"),
+    pytest.param(Rasterio, GEOM_RECT, True, id="rasterio-rect-touched"),
+    pytest.param(Rasterio, GEOM_TRIANGLE, False, id="rasterio-triangle-centroid"),
+    pytest.param(Rasterio, GEOM_TRIANGLE, True, id="rasterio-triangle-touched"),
+    pytest.param(SedonaSpark, GEOM_RECT, False, id="spark-rect-centroid"),
+    pytest.param(SedonaSpark, GEOM_RECT, True, id="spark-rect-touched"),
+    pytest.param(
         SedonaSpark,
-        "zonal_stats",
-        matches=lambda p: p.get("wkt") == GEOM_TRIANGLE and not p.get("all_touched"),
-        reason="Sedona's scanline rasterizer mis-places x-intercepts on "
-        "non-square pixels and drops some center-inside pixels along "
-        "diagonal edges; GDAL selects every center-inside pixel "
-        "(https://github.com/apache/sedona/issues/3111)",
+        GEOM_TRIANGLE,
+        False,
+        id="spark-triangle-centroid",
+        marks=SPARK_DIAGONAL_XFAIL,
     ),
+    pytest.param(SedonaSpark, GEOM_TRIANGLE, True, id="spark-triangle-touched"),
 ]
 
 
 @pytest.mark.parametrize("stat", STATS)
-@pytest.mark.parametrize(
-    ("wkt", "all_touched"),
-    [
-        (GEOM_RECT, False),
-        (GEOM_RECT, True),
-        (GEOM_TRIANGLE, False),
-        (GEOM_TRIANGLE, True),
-    ],
-    ids=["rect-centroid", "rect-touched", "triangle-centroid", "triangle-touched"],
-)
+@pytest.mark.parametrize(("comparator_cls", "wkt", "all_touched"), COMPARATOR_CASES)
 def test_rs_zonalstats_matches_comparators(
-    subject, comparator, request, tmp_path, wkt, all_touched, stat
+    subject, tmp_path, comparator_cls, wkt, all_touched, stat
 ):
-    """Every statistic over the float64 fixture, on both selection rules.
-    The zone stays clear of the corners so the planted dtype extremes don't
-    collapse sums to infinity."""
-    expect_deviations(request, comparator, "zonal_stats", DEVIATIONS)
+    """Every statistic over the float64 fixture, on both selection rules and both
+    comparators. The zone stays clear of the corners so the planted dtype
+    extremes don't collapse sums to infinity. mode on all-distinct pixels is the
+    largest value (its tie-break), which both engines agree on.
+
+    The comparator is a parametrized case (not the shared `comparator` fixture)
+    so the one known Sedona Spark divergence can be marked xfail inline above."""
+    comparator = comparator_cls.create_or_skip()
     tiff = tmp_path / "zonal.tif"
     write_geotiff(
         tiff,
@@ -109,10 +144,29 @@ def test_rs_zonalstats_matches_comparators(
     assert got == pytest.approx(expected, rel=1e-9), (wkt, all_touched, stat)
 
 
+@pytest.mark.parametrize("stat", ["count", "mean", "max"])
+def test_rs_zonalstats_band_default_matches_comparators(
+    subject, comparator, tmp_path, stat
+):
+    """The band-less overload (band omitted) resolves to band 1 on a single-band
+    raster. Comparing the subject's 3-argument call against the comparator with
+    `band=None` pins that band-1 default. No zone here diverges, so the shared
+    `comparator` fixture covers both engines."""
+    tiff = tmp_path / "zonal_singleband.tif"
+    write_geotiff(
+        tiff,
+        random_raster_data("float64", bands=1, height=HEIGHT, width=WIDTH),
+        gdal_transform=GDAL_TRANSFORM,
+    )
+    got = subject.zonal_stats(tiff, GEOM_RECT, stat=stat)
+    expected = comparator.zonal_stats(tiff, GEOM_RECT, stat=stat)
+    assert got == pytest.approx(expected, rel=1e-9), stat
+
+
 @pytest.mark.parametrize("stat", ["count", "sum"])
 def test_rs_zonalstats_excludes_nodata(subject, comparator, tmp_path, stat):
-    """A pixel valued at the band nodata inside the zone is excluded from
-    the reduction by every engine."""
+    """A pixel valued at the band nodata inside the zone is excluded from the
+    reduction by every engine (exclude_nodata defaults to true)."""
     tiff = tmp_path / "zonal_nodata.tif"
     write_geotiff(
         tiff,
@@ -128,35 +182,78 @@ def test_rs_zonalstats_excludes_nodata(subject, comparator, tmp_path, stat):
     assert got == pytest.approx(expected, rel=1e-9), stat
 
 
-def _invoke_zonalstats(con, tiff, wkt, *, all_stats, options=None):
-    """Invoke RS_ZonalStats ('sum') or RS_ZonalStatsAll over a one-row table
-    and return the Arrow result.
+@pytest.mark.parametrize("stat", ["count", "sum"])
+def test_rs_zonalstats_include_nodata_matches_comparators(
+    subject, comparator, tmp_path, stat
+):
+    """The 6-argument overload with exclude_nodata=false keeps the nodata-valued
+    pixel in the reduction. Comparing against the comparator with the same flag
+    pins that the pixel is counted, not skipped — the opposite of the default."""
+    tiff = tmp_path / "zonal_include_nodata.tif"
+    write_geotiff(
+        tiff,
+        random_raster_data(
+            "uint8", bands=1, height=HEIGHT, width=WIDTH, plants={(2, 3): 200}
+        ),
+        gdal_transform=GDAL_TRANSFORM,
+        nodata=200.0,
+    )
+    got = subject.zonal_stats(tiff, GEOM_RECT, band=1, stat=stat, exclude_nodata=False)
+    expected = comparator.zonal_stats(
+        tiff, GEOM_RECT, band=1, stat=stat, exclude_nodata=False
+    )
+    assert got == pytest.approx(expected, rel=1e-9), stat
 
-    Arguments travel as table columns so the kernel runs its real array path
-    (literals constant-fold). The argument surface — `(raster, zone, stat,
-    options)` for RS_ZonalStats and `(raster, zone, options)` for
-    RS_ZonalStatsAll, with `band` inside the JSON `options` — mirrors the
-    RS_ZonalStats function tests. These invoke the subject (SedonaDB) directly
-    because the harness `zonal_stats` op exposes only a single scalar statistic,
-    not the all-stats struct or the band-unspecified path.
-    """
-    columns = {
-        "path": pa.array([str(tiff)], pa.utf8()),
-        "wkt": pa.array([wkt], pa.utf8()),
-    }
-    if not all_stats:
-        columns["stat"] = pa.array(["sum"], pa.utf8())
-    if options is not None:
-        columns["options"] = pa.array([options], pa.utf8())
-    df = con.create_data_frame(pa.table(columns))
-    raster = df.path.funcs.rs_frompath()
-    geom = con.funcs.st_geomfromtext(df.wkt)
-    tail = [df.options] if options is not None else []
-    if all_stats:
-        expr = raster.funcs.rs_zonalstatsall(geom, *tail)
-    else:
-        expr = raster.funcs.rs_zonalstats(geom, df.stat, *tail)
-    return df.select(r=expr).to_arrow_table()
+
+def test_rs_zonalstats_lenient_false_computes(subject, comparator, tmp_path):
+    """With lenient=false (the 7-argument overload) an intersecting zone still
+    computes normally — lenient only governs the non-intersecting case."""
+    tiff = tmp_path / "zonal_lenient.tif"
+    write_geotiff(
+        tiff,
+        random_raster_data("float64", bands=1, height=HEIGHT, width=WIDTH),
+        gdal_transform=GDAL_TRANSFORM,
+    )
+    got = subject.zonal_stats(tiff, GEOM_RECT, band=1, stat="mean", lenient=False)
+    expected = comparator.zonal_stats(tiff, GEOM_RECT, band=1, stat="mean")
+    assert got == pytest.approx(expected, rel=1e-9)
+
+
+def test_rs_zonalstats_lenient_false_errors_on_disjoint_zone(con, tmp_path):
+    """A zone that misses the raster raises with lenient=false, where the default
+    lenient=true returns NULL.
+
+    This is a subject-error case (the parity subject itself raises), so a plain
+    `pytest.raises` on the subject is the right shape. Arguments travel as table
+    columns so the kernel runs its real array path."""
+    tiff = tmp_path / "zonal_disjoint.tif"
+    write_geotiff(
+        tiff,
+        random_raster_data("float64", bands=1, height=HEIGHT, width=WIDTH),
+        gdal_transform=GDAL_TRANSFORM,
+    )
+    table = pa.table(
+        {
+            "path": pa.array([str(tiff)], pa.utf8()),
+            "wkt": pa.array([GEOM_OUTSIDE], pa.utf8()),
+            "band": pa.array([1], pa.int32()),
+            "stat": pa.array(["mean"], pa.utf8()),
+            "all_touched": pa.array([False], pa.bool_()),
+            "exclude_nodata": pa.array([True], pa.bool_()),
+            "lenient": pa.array([False], pa.bool_()),
+        }
+    )
+    df = con.create_data_frame(table)
+    expr = df.path.funcs.rs_frompath().funcs.rs_zonalstats(
+        con.funcs.st_geomfromtext(df.wkt),
+        df.band,
+        df.stat,
+        df.all_touched,
+        df.exclude_nodata,
+        df.lenient,
+    )
+    with pytest.raises(Exception, match="does not intersect"):
+        df.select(v=expr).to_arrow_table()
 
 
 @pytest.mark.parametrize(
@@ -168,42 +265,189 @@ def test_multiband_raster_requires_band_option(con, tmp_path, all_stats):
 
     Sedona Spark defaults to band 1 here (the documented divergence); asserting
     the raise pins SedonaDB's stricter contract — an ambiguous multiband
-    selection is an error, not a silent band-1 pick.
-
-    This is a subject-error case (the parity subject itself raises), so a plain
-    `pytest.raises` on the subject is the right shape; it does not go through the
-    comparator/deviation ledger. A ledger-integrated "subject_error" Deviation
-    kind that also captured the Spark band-1 default declaratively would be a
-    possible future enhancement.
-    """
-    tiff = tmp_path / "multiband.tif"
+    selection is an error, not a silent band-1 pick. This is a subject-error case
+    (the parity subject itself raises), so a plain `pytest.raises` on the subject
+    is the right shape. The raster travels as a table column so the kernel runs
+    its real array path."""
+    tiff = tmp_path / "zonal_multiband.tif"
     write_geotiff(
         tiff,
         random_raster_data("float64", bands=2, height=HEIGHT, width=WIDTH),
         gdal_transform=GDAL_TRANSFORM,
     )
+    df = con.create_data_frame(
+        pa.table(
+            {
+                "path": pa.array([str(tiff)], pa.utf8()),
+                "wkt": pa.array([GEOM_RECT], pa.utf8()),
+            }
+        )
+    )
+    raster = df.path.funcs.rs_frompath()
+    geom = con.funcs.st_geomfromtext(df.wkt)
     # GEOM_RECT intersects the raster, so band resolution — not a
     # no-intersection short-circuit — is what fails.
-    with pytest.raises(Exception, match="option to choose one"):
-        _invoke_zonalstats(con, tiff, GEOM_RECT, all_stats=all_stats)
+    if all_stats:
+        expr = raster.funcs.rs_zonalstatsall(geom)
+    else:
+        expr = raster.funcs.rs_zonalstats(geom, "mean")
+    with pytest.raises(Exception, match="choose one"):
+        df.select(r=expr).to_arrow_table()
 
 
-def test_zonalstatsall_count_field_is_int64(con, tmp_path):
+@pytest.mark.parametrize("all_touched", [False, True], ids=["centroid", "touched"])
+def test_rs_zonalstatsall_matches_comparators(
+    subject, comparator, tmp_path, all_touched
+):
+    """RS_ZonalStatsAll returns every statistic as one struct. A repeated value
+    is planted inside the zone so `mode` is that value (not merely the largest
+    distinct one), exercising the frequency tie-break; the rest match the scalar
+    reductions. GEOM_RECT is used (not the diagonal zone), so the shared
+    `comparator` fixture covers both engines without a divergence."""
+    tiff = tmp_path / "zonalall.tif"
+    write_geotiff(
+        tiff,
+        random_raster_data(
+            "float64",
+            bands=2,
+            height=HEIGHT,
+            width=WIDTH,
+            plants={(2, 2): 50.0, (2, 3): 50.0, (3, 2): 50.0},
+        ),
+        gdal_transform=GDAL_TRANSFORM,
+    )
+    got = subject.zonal_stats_all(tiff, GEOM_RECT, band=2, all_touched=all_touched)
+    expected = comparator.zonal_stats_all(
+        tiff, GEOM_RECT, band=2, all_touched=all_touched
+    )
+    assert got["count"] == expected["count"]
+    assert got["mode"] == pytest.approx(expected["mode"]), "mode tie-break"
+    assert got["mode"] == pytest.approx(50.0), "planted repeat is the mode"
+    for field in ZONAL_ALL_FIELDS:
+        assert got[field] == pytest.approx(expected[field], rel=1e-9), field
+
+
+def test_rs_zonalstatsall_count_field_is_int64(con, tmp_path):
     """RS_ZonalStatsAll returns `count` as an Int64 pixel count.
 
     Sedona Spark returns a uniform `Double[]` for every statistic, so its count
     is a floating-point value; SedonaDB keeps count as an integer. Pinning the
     Arrow struct field type guards that contract (the rest of the struct is
-    Float64).
-    """
-    tiff = tmp_path / "singleband.tif"
+    Float64). The raster travels as a table column so the kernel runs its real
+    array path."""
+    tiff = tmp_path / "zonalall_singleband.tif"
     write_geotiff(
         tiff,
         random_raster_data("float64", bands=1, height=HEIGHT, width=WIDTH),
         gdal_transform=GDAL_TRANSFORM,
     )
-    table = _invoke_zonalstats(
-        con, tiff, GEOM_RECT, all_stats=True, options='{"band": 1}'
+    df = con.create_data_frame(
+        pa.table(
+            {
+                "path": pa.array([str(tiff)], pa.utf8()),
+                "wkt": pa.array([GEOM_RECT], pa.utf8()),
+                "band": pa.array([1], pa.int32()),
+            }
+        )
     )
+    expr = df.path.funcs.rs_frompath().funcs.rs_zonalstatsall(
+        con.funcs.st_geomfromtext(df.wkt), df.band
+    )
+    table = df.select(r=expr).to_arrow_table()
     struct_type = table.schema.field("r").type
     assert struct_type.field("count").type == pa.int64()
+
+
+# The SQL-surface parity contract: one corpus of RS_* argument strings, produced
+# by the shared DialectEngine generators, that must parse and execute identically
+# on both dialects. `kind` picks the scalar or struct generator; `kwargs` walks
+# the overload ladder. Expected literals pin the exact generated surface so drift
+# is caught even on a machine without Spark.
+CONTRACT_CALLS = [
+    (
+        "scalar",
+        {"band": 1, "stat": "count"},
+        f"RS_ZonalStats(rast, ST_GeomFromText('{GEOM_RECT}'), 1, 'count')",
+    ),
+    (
+        "scalar",
+        {"band": 1, "stat": "mean", "all_touched": True},
+        f"RS_ZonalStats(rast, ST_GeomFromText('{GEOM_RECT}'), 1, 'mean', true)",
+    ),
+    (
+        "scalar",
+        {"band": 1, "stat": "sum", "exclude_nodata": False},
+        f"RS_ZonalStats(rast, ST_GeomFromText('{GEOM_RECT}'), 1, 'sum', false, false)",
+    ),
+    (
+        "struct",
+        {"band": 1},
+        f"RS_ZonalStatsAll(rast, ST_GeomFromText('{GEOM_RECT}'), 1)",
+    ),
+    (
+        "struct",
+        {"band": 1, "all_touched": True},
+        f"RS_ZonalStatsAll(rast, ST_GeomFromText('{GEOM_RECT}'), 1, true)",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("kind", "kwargs", "expected_sql"),
+    CONTRACT_CALLS,
+    ids=[call[2] for call in CONTRACT_CALLS],
+)
+def test_zonal_stats_sql_runs_unchanged_on_both_dialects(
+    subject, tmp_path, kind, kwargs, expected_sql
+):
+    """The compatibility contract asserted directly: the byte-identical RS_* call
+    string built by the shared generator both (a) matches the expected surface
+    and (b) parses and executes on SedonaDB and Sedona Spark alike, with matching
+    results. The SedonaDB arm runs unconditionally (proving the generated string
+    parses and executes); the Spark arm skips via `create_or_skip` when the jars
+    are absent, so on a jar-less machine this proves only the SedonaDB half."""
+    if kind == "scalar":
+        expr = DialectEngine.zonal_stats_expr(GEOM_RECT, **kwargs)
+    else:
+        expr = DialectEngine.zonal_stats_all_expr(GEOM_RECT, **kwargs)
+    assert expr == expected_sql
+
+    tiff = tmp_path / "contract.tif"
+    write_geotiff(
+        tiff,
+        random_raster_data("float64", bands=1, height=HEIGHT, width=WIDTH),
+        gdal_transform=GDAL_TRANSFORM,
+    )
+    # Both dialects execute the SAME `expr` string; only the I/O around it differs.
+    if kind == "scalar":
+        db_result = subject._run_scalar(tiff, expr)
+        assert db_result is not None
+    else:
+        db_result = subject._run_struct(tiff, expr)
+        assert db_result is not None and db_result["count"] > 0
+
+    spark = SedonaSpark.create_or_skip()
+    if kind == "scalar":
+        assert spark._run_scalar(tiff, expr) == pytest.approx(db_result, rel=1e-9)
+    else:
+        spark_result = spark._run_struct(tiff, expr)
+        for field in ZONAL_ALL_FIELDS:
+            assert spark_result[field] == pytest.approx(db_result[field], rel=1e-9), (
+                field
+            )
+
+
+def test_rs_zonalstats_sql_smoke(con, tmp_path):
+    """One SQL-text invocation keeps the parser path covered (everything else
+    routes through the expression API or the dialect generators)."""
+    tiff = tmp_path / "zonal_smoke.tif"
+    write_geotiff(
+        tiff,
+        random_raster_data("uint8", bands=1, height=HEIGHT, width=WIDTH),
+        gdal_transform=GDAL_TRANSFORM,
+    )
+    tab = con.sql(
+        "SELECT RS_ZonalStats(RS_FromPath($1), ST_GeomFromText($2), 1, 'count') AS c",
+        params=(str(tiff), GEOM_RECT),
+    ).to_arrow_table()
+    assert tab["c"][0].as_py() > 0


### PR DESCRIPTION
Design spike: reworks the RS_ZonalStats / RS_ZonalStatsAll parity tests and their harness support to (1) declare known engine divergences inline on the parametrized case rather than in a separate deviations ledger, (2) build each RS_* call string once on a shared `DialectEngine` base so SedonaDB and Sedona Spark cannot silently emit different SQL, and (3) assert that shared surface directly with a cross-dialect contract test.