### PR TITLE
feat(rust/sedona-spatial-join-raster): raster–vector spatial join (RS_Intersects/Contains/Within)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6454,7 +6454,6 @@ dependencies = [
  "rstest",
  "sedona-common",
  "sedona-expr",
- "sedona-functions",
  "sedona-geometry",
  "sedona-proj",
  "sedona-query-planner",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5763,6 +5763,7 @@ dependencies = [
  "sedona-spatial-join",
  "sedona-spatial-join-geography",
  "sedona-spatial-join-gpu",
+ "sedona-spatial-join-raster",
  "sedona-testing",
  "sedona-tg",
  "serde",
@@ -6437,6 +6438,32 @@ dependencies = [
  "tokio",
  "wkb",
  "wkt 0.14.0",
+]
+
+[[package]]
+name = "sedona-spatial-join-raster"
+version = "0.4.0"
+dependencies = [
+ "arrow-array",
+ "arrow-schema",
+ "datafusion",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-plan",
+ "rstest",
+ "sedona-common",
+ "sedona-expr",
+ "sedona-functions",
+ "sedona-geometry",
+ "sedona-proj",
+ "sedona-query-planner",
+ "sedona-raster",
+ "sedona-raster-functions",
+ "sedona-schema",
+ "sedona-spatial-join",
+ "sedona-testing",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ members = [
     "rust/sedona-spatial-join",
     "rust/sedona-spatial-join-geography",
     "rust/sedona-spatial-join-gpu",
+    "rust/sedona-spatial-join-raster",
     "rust/sedona-query-planner",
     "rust/sedona-testing",
     "rust/sedona",
@@ -162,6 +163,7 @@ sedona-schema = { version = "0.4.0", path = "rust/sedona-schema" }
 sedona-spatial-join = { version = "0.4.0", path = "rust/sedona-spatial-join" }
 sedona-spatial-join-gpu = { version = "0.4.0", path = "rust/sedona-spatial-join-gpu" }
 sedona-spatial-join-geography = { version = "0.4.0", path = "rust/sedona-spatial-join-geography" }
+sedona-spatial-join-raster = { version = "0.4.0", path = "rust/sedona-spatial-join-raster" }
 sedona-query-planner = { version = "0.4.0", path = "rust/sedona-query-planner" }
 sedona-testing = { version = "0.4.0", path = "rust/sedona-testing" }
 

--- a/docs/reference/sql/rs_intersects.qmd
+++ b/docs/reference/sql/rs_intersects.qmd
@@ -40,6 +40,11 @@ transformation fails, the extent of both sides are transformed to WGS 84 as a fa
 If either argument has no CRS set, the comparison is performed directly without
 CRS transformation.
 
+Across CRSes the convex hull is the straight-chord polygon through the raster's
+four reprojected corners; edge curvature is not modeled, so for large-extent
+rasters between very different CRSes the hull can slightly under-cover the true
+footprint. Same-CRS comparisons are exact.
+
 ## Examples
 
 ```sql

--- a/docs/reference/sql/rs_intersects.qmd
+++ b/docs/reference/sql/rs_intersects.qmd
@@ -40,10 +40,10 @@ transformation fails, the extent of both sides are transformed to WGS 84 as a fa
 If either argument has no CRS set, the comparison is performed directly without
 CRS transformation.
 
-Across CRSes the convex hull is the straight-chord polygon through the raster's
-four reprojected corners; edge curvature is not modeled, so for large-extent
-rasters between very different CRSes the hull can slightly under-cover the true
-footprint. Same-CRS comparisons are exact.
+Across CRSes a reprojected raster footprint is densified with about 10 points
+per edge before it is reprojected, so it follows the curve of each edge instead
+of chording straight through the four reprojected corners. Same-CRS comparisons
+are exact.
 
 ## Examples
 

--- a/rust/sedona-functions/src/st_segmentize.rs
+++ b/rust/sedona-functions/src/st_segmentize.rs
@@ -31,6 +31,7 @@ use sedona_expr::{
 };
 use sedona_geometry::{
     error::SedonaGeometryError,
+    interpolate::lerp,
     wkb_factory::{
         write_wkb_coord_trait, write_wkb_geometrycollection_header, write_wkb_linestring_header,
         write_wkb_multilinestring_header, write_wkb_multipolygon_header, write_wkb_polygon_header,
@@ -312,8 +313,8 @@ fn write_interpolated_2d<C: CoordTrait<T = f64>>(
 
     for i in 1..=num_segments {
         let t = i as f64 / num_segments as f64;
-        writer.write_all(&(x1 + t * (x2 - x1)).to_le_bytes())?;
-        writer.write_all(&(y1 + t * (y2 - y1)).to_le_bytes())?;
+        writer.write_all(&lerp(x1, x2, t).to_le_bytes())?;
+        writer.write_all(&lerp(y1, y2, t).to_le_bytes())?;
     }
     Ok(())
 }
@@ -334,9 +335,9 @@ fn write_interpolated_3d<C: CoordTrait<T = f64>>(
 
     for i in 1..=num_segments {
         let t = i as f64 / num_segments as f64;
-        writer.write_all(&(x1 + t * (x2 - x1)).to_le_bytes())?;
-        writer.write_all(&(y1 + t * (y2 - y1)).to_le_bytes())?;
-        writer.write_all(&(d1 + t * (d2 - d1)).to_le_bytes())?;
+        writer.write_all(&lerp(x1, x2, t).to_le_bytes())?;
+        writer.write_all(&lerp(y1, y2, t).to_le_bytes())?;
+        writer.write_all(&lerp(d1, d2, t).to_le_bytes())?;
     }
     Ok(())
 }
@@ -359,10 +360,10 @@ fn write_interpolated_4d<C: CoordTrait<T = f64>>(
 
     for i in 1..=num_segments {
         let t = i as f64 / num_segments as f64;
-        writer.write_all(&(x1 + t * (x2 - x1)).to_le_bytes())?;
-        writer.write_all(&(y1 + t * (y2 - y1)).to_le_bytes())?;
-        writer.write_all(&(z1 + t * (z2 - z1)).to_le_bytes())?;
-        writer.write_all(&(m1 + t * (m2 - m1)).to_le_bytes())?;
+        writer.write_all(&lerp(x1, x2, t).to_le_bytes())?;
+        writer.write_all(&lerp(y1, y2, t).to_le_bytes())?;
+        writer.write_all(&lerp(z1, z2, t).to_le_bytes())?;
+        writer.write_all(&lerp(m1, m2, t).to_le_bytes())?;
     }
     Ok(())
 }

--- a/rust/sedona-geometry/src/interpolate.rs
+++ b/rust/sedona-geometry/src/interpolate.rs
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Linear interpolation helpers shared by geometry densification paths
+//! (`ST_Segmentize`, reprojected raster footprints).
+
+/// Linearly interpolate between `a` and `b` at parameter `t`.
+///
+/// `lerp(a, b, 0.0) == a` and `lerp(a, b, 1.0) == b`. This is the single-scalar
+/// primitive behind every densification path so the interpolation math is not
+/// re-derived per caller (per-dimension `ST_Segmentize` interpolation, per-axis
+/// footprint densification).
+#[inline]
+pub fn lerp(a: f64, b: f64, t: f64) -> f64 {
+    a + t * (b - a)
+}
+
+/// Append `n` evenly spaced interior points of the segment from `start` to `end`
+/// to `out` — the points at parameters `t = 1/(n+1), 2/(n+1), …, n/(n+1)`.
+///
+/// Neither endpoint is emitted; the caller owns `start` and `end`. Densifying a
+/// polygon edge this way makes the polygon follow the curved image of that
+/// straight edge under a nonlinear reprojection instead of chording across it.
+/// `out` is appended to (not cleared) so a ring can be assembled edge by edge
+/// into a caller-managed scratch buffer.
+pub fn densify_segment(start: (f64, f64), end: (f64, f64), n: usize, out: &mut Vec<(f64, f64)>) {
+    for i in 1..=n {
+        let t = i as f64 / (n + 1) as f64;
+        out.push((lerp(start.0, end.0, t), lerp(start.1, end.1, t)));
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn lerp_hits_endpoints_and_midpoint() {
+        assert_eq!(lerp(2.0, 6.0, 0.0), 2.0);
+        assert_eq!(lerp(2.0, 6.0, 1.0), 6.0);
+        assert_eq!(lerp(2.0, 6.0, 0.5), 4.0);
+        assert_eq!(lerp(2.0, 6.0, 0.25), 3.0);
+    }
+
+    #[test]
+    fn densify_segment_emits_evenly_spaced_interior_points() {
+        let mut out = Vec::new();
+        densify_segment((0.0, 0.0), (4.0, 8.0), 3, &mut out);
+        // Interior points at t = 1/4, 2/4, 3/4 (endpoints excluded).
+        assert_eq!(out, vec![(1.0, 2.0), (2.0, 4.0), (3.0, 6.0)]);
+    }
+
+    #[test]
+    fn densify_segment_zero_points_is_noop() {
+        let mut out = vec![(9.0, 9.0)];
+        densify_segment((0.0, 0.0), (1.0, 1.0), 0, &mut out);
+        assert_eq!(out, vec![(9.0, 9.0)]);
+    }
+}

--- a/rust/sedona-geometry/src/lib.rs
+++ b/rust/sedona-geometry/src/lib.rs
@@ -19,6 +19,7 @@ pub mod bounding_box;
 pub mod bounds;
 pub mod error;
 pub mod ewkb_factory;
+pub mod interpolate;
 pub mod interval;
 pub mod is_empty;
 pub mod point_count;

--- a/rust/sedona-query-planner/src/spatial_expr_utils.rs
+++ b/rust/sedona-query-planner/src/spatial_expr_utils.rs
@@ -71,6 +71,9 @@ pub(crate) fn collect_spatial_predicate_names(expr: &Expr) -> HashSet<String> {
                         | "st_equals"
                         | "st_dwithin"
                         | "st_knn"
+                        | "rs_intersects"
+                        | "rs_contains"
+                        | "rs_within"
                 ) {
                     acc.insert(func_name);
                 }
@@ -627,7 +630,7 @@ mod tests {
     use datafusion_physical_expr::{PhysicalExpr, ScalarFunctionExpr};
     use datafusion_physical_plan::joins::utils::ColumnIndex;
     use datafusion_physical_plan::joins::utils::JoinFilter;
-    use sedona_schema::datatypes::WKB_GEOMETRY;
+    use sedona_schema::datatypes::{RASTER, WKB_GEOMETRY};
     use std::sync::Arc;
 
     // Helper function to create a test schema
@@ -2293,6 +2296,30 @@ mod tests {
         });
         let names = collect_spatial_predicate_names(&non_spatial_and);
         assert!(names.is_empty());
+    }
+
+    #[test]
+    fn test_collect_spatial_predicate_names_raster() {
+        // Raster-geometry predicates are recognized as spatial predicates so their joins
+        // route through the spatial-join planner (and fall back to nested-loop join).
+        for name in ["rs_intersects", "rs_contains", "rs_within"] {
+            let udf = Arc::new(ScalarUDF::from(SimpleScalarUDF::new(
+                name,
+                vec![
+                    RASTER.storage_type().clone(),
+                    WKB_GEOMETRY.storage_type().clone(),
+                ],
+                DataType::Boolean,
+                datafusion_expr::Volatility::Immutable,
+                Arc::new(|_| Ok(ColumnarValue::Scalar(ScalarValue::Boolean(Some(true))))),
+            )));
+            let expr = Expr::ScalarFunction(datafusion_expr::expr::ScalarFunction {
+                func: udf,
+                args: vec![col("raster"), col("geom")],
+            });
+            let names = collect_spatial_predicate_names(&expr);
+            assert_eq!(names, HashSet::from([name.to_string()]));
+        }
     }
 
     #[test]

--- a/rust/sedona-query-planner/src/spatial_predicate.rs
+++ b/rust/sedona-query-planner/src/spatial_predicate.rs
@@ -190,16 +190,19 @@ impl SpatialRelationType {
     /// Converts a function name string to a SpatialRelationType.
     ///
     /// # Arguments
-    /// * `name` - The spatial function name (e.g., "st_intersects", "st_contains")
+    /// * `name` - The spatial function name (e.g., "st_intersects", "st_contains").
+    ///   Raster-geometry predicates (`rs_intersects`, `rs_contains`, `rs_within`)
+    ///   map to the same relation variants; `invert()` handles the Contains/Within
+    ///   swap when the join arguments are on opposite sides.
     ///
     /// # Returns
     /// * `Some(SpatialRelationType)` if the name is recognized
     /// * `None` if the name is not a valid spatial relation function
     pub fn from_name(name: &str) -> Option<Self> {
         match name {
-            "st_intersects" => Some(SpatialRelationType::Intersects),
-            "st_contains" => Some(SpatialRelationType::Contains),
-            "st_within" => Some(SpatialRelationType::Within),
+            "st_intersects" | "rs_intersects" => Some(SpatialRelationType::Intersects),
+            "st_contains" | "rs_contains" => Some(SpatialRelationType::Contains),
+            "st_within" | "rs_within" => Some(SpatialRelationType::Within),
             "st_covers" => Some(SpatialRelationType::Covers),
             "st_coveredby" | "st_covered_by" => Some(SpatialRelationType::CoveredBy),
             "st_touches" => Some(SpatialRelationType::Touches),
@@ -529,6 +532,38 @@ mod tests {
             .expect("expected Column");
         assert_eq!(col.name(), name);
         assert_eq!(col.index(), index);
+    }
+
+    #[test]
+    fn from_name_recognizes_raster_predicates() {
+        // Raster-geometry predicates reuse the geometry relation variants; `invert()`
+        // handles the Contains/Within swap when the join arguments are on opposite sides.
+        assert_eq!(
+            SpatialRelationType::from_name("rs_intersects"),
+            Some(SpatialRelationType::Intersects)
+        );
+        assert_eq!(
+            SpatialRelationType::from_name("rs_contains"),
+            Some(SpatialRelationType::Contains)
+        );
+        assert_eq!(
+            SpatialRelationType::from_name("rs_within"),
+            Some(SpatialRelationType::Within)
+        );
+
+        // Matches the ST_ variants they mirror.
+        assert_eq!(
+            SpatialRelationType::from_name("rs_intersects"),
+            SpatialRelationType::from_name("st_intersects")
+        );
+        assert_eq!(
+            SpatialRelationType::from_name("rs_contains"),
+            SpatialRelationType::from_name("st_contains")
+        );
+        assert_eq!(
+            SpatialRelationType::from_name("rs_within"),
+            SpatialRelationType::from_name("st_within")
+        );
     }
 
     #[test]

--- a/rust/sedona-raster-functions/src/footprint.rs
+++ b/rust/sedona-raster-functions/src/footprint.rs
@@ -43,16 +43,28 @@ pub fn raster_footprint_corners(raster: &dyn RasterRef) -> [(f64, f64); 4] {
     ]
 }
 
-/// Write WKB for the convex-hull polygon of the raster footprint.
+/// Write WKB for the convex-hull polygon through four footprint `corners`.
 ///
-/// The ring is the four [`raster_footprint_corners`] closed back to the
-/// upper-left corner. This can be used to build Binary arrays, as the arrow-rs
-/// `BinaryBuilder` implements [`std::io::Write`].
-pub fn write_convexhull_wkb(raster: &dyn RasterRef, out: &mut impl std::io::Write) -> Result<()> {
-    let [ul, ur, lr, ll] = raster_footprint_corners(raster);
+/// `corners` are in ring order (upper-left, upper-right, lower-right,
+/// lower-left, as produced by [`raster_footprint_corners`]); the ring is closed
+/// back to the first corner. Shared by the native footprint (corners in the
+/// raster's own CRS) and the reprojected footprint (corners transformed into
+/// another CRS), so both paths emit byte-identical polygon WKB. This can be used
+/// to build Binary arrays, as the arrow-rs `BinaryBuilder` implements
+/// [`std::io::Write`].
+pub fn write_footprint_wkb(corners: [(f64, f64); 4], out: &mut impl std::io::Write) -> Result<()> {
+    let [ul, ur, lr, ll] = corners;
 
     write_wkb_polygon(out, [ul, ur, lr, ll, ul].into_iter())
         .map_err(|e| DataFusionError::External(e.into()))?;
 
     Ok(())
+}
+
+/// Write WKB for the convex-hull polygon of the raster footprint.
+///
+/// The ring is the four [`raster_footprint_corners`] closed back to the
+/// upper-left corner.
+pub fn write_convexhull_wkb(raster: &dyn RasterRef, out: &mut impl std::io::Write) -> Result<()> {
+    write_footprint_wkb(raster_footprint_corners(raster), out)
 }

--- a/rust/sedona-raster-functions/src/footprint.rs
+++ b/rust/sedona-raster-functions/src/footprint.rs
@@ -23,9 +23,21 @@
 //! corner is computed individually rather than assumed axis-aligned.
 
 use datafusion_common::{DataFusionError, Result};
+use sedona_geometry::interpolate::densify_segment;
 use sedona_geometry::wkb_factory::write_wkb_polygon;
 use sedona_raster::affine_transformation::to_world_coordinate;
 use sedona_raster::traits::RasterRef;
+
+/// Number of interior points interpolated along each footprint edge when a
+/// footprint is densified before reprojection.
+///
+/// Reprojecting a footprint bends its straight edges into curves, so a footprint
+/// described only by its four corners chords across each curve and under-/over-
+/// covers the true extent. Densifying each edge with a handful of interior points
+/// (~10 per edge is a common, cheap choice) and reprojecting every point makes
+/// the reprojected footprint follow the curve. A footprint left in its own CRS
+/// has exact straight edges and needs no densification.
+pub const FOOTPRINT_POINTS_PER_EDGE: usize = 10;
 
 /// The four corners of a raster's footprint in world coordinates.
 ///
@@ -67,4 +79,87 @@ pub fn write_footprint_wkb(corners: [(f64, f64); 4], out: &mut impl std::io::Wri
 /// upper-left corner.
 pub fn write_convexhull_wkb(raster: &dyn RasterRef, out: &mut impl std::io::Write) -> Result<()> {
     write_footprint_wkb(raster_footprint_corners(raster), out)
+}
+
+/// Fill `ring` with a closed, densified footprint ring through four `corners`.
+///
+/// `corners` are in ring order (upper-left, upper-right, lower-right, lower-left,
+/// as produced by [`raster_footprint_corners`]). Each edge contributes its start
+/// corner followed by [`FOOTPRINT_POINTS_PER_EDGE`] interior points, and the ring
+/// is closed back to the upper-left corner. `ring` is cleared first and is a
+/// caller-managed scratch buffer so densifying many rasters allocates once.
+///
+/// Densify in the CRS where the footprint has exact straight edges (its own),
+/// then reproject every point of the returned ring: the reprojected ring then
+/// follows the curved image of each edge instead of chording across it.
+pub fn densify_footprint_ring(corners: [(f64, f64); 4], ring: &mut Vec<(f64, f64)>) {
+    ring.clear();
+    let [ul, ur, lr, ll] = corners;
+    for (start, end) in [(ul, ur), (ur, lr), (lr, ll), (ll, ul)] {
+        ring.push(start);
+        densify_segment(start, end, FOOTPRINT_POINTS_PER_EDGE, ring);
+    }
+    ring.push(ul);
+}
+
+/// Write WKB for the polygon through a pre-closed footprint `ring` (last point
+/// equal to the first), as produced by [`densify_footprint_ring`].
+///
+/// Companion to [`write_footprint_wkb`] for the variable-length densified ring;
+/// both emit a single-ring polygon and can build Binary arrays, as the arrow-rs
+/// `BinaryBuilder` implements [`std::io::Write`].
+pub fn write_footprint_ring_wkb(ring: &[(f64, f64)], out: &mut impl std::io::Write) -> Result<()> {
+    write_wkb_polygon(out, ring.iter().copied())
+        .map_err(|e| DataFusionError::External(e.into()))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Index of each corner in a densified ring: the start of edge `k` sits after
+    /// `k` corners and `k * FOOTPRINT_POINTS_PER_EDGE` interior points.
+    fn corner_index(k: usize) -> usize {
+        k * (FOOTPRINT_POINTS_PER_EDGE + 1)
+    }
+
+    #[test]
+    fn densify_footprint_ring_layout_and_coords() {
+        // Axis-aligned 10x10 square in ring order (UL, UR, LR, LL).
+        let corners = [(0.0, 10.0), (10.0, 10.0), (10.0, 0.0), (0.0, 0.0)];
+        let mut ring = Vec::new();
+        densify_footprint_ring(corners, &mut ring);
+
+        // 4 corners + 4 * FOOTPRINT_POINTS_PER_EDGE interior + 1 closing point.
+        assert_eq!(ring.len(), 4 * (FOOTPRINT_POINTS_PER_EDGE + 1) + 1);
+
+        // Corners land exactly on the interpolated ring, in order, and the ring
+        // closes back to the upper-left corner.
+        assert_eq!(ring[corner_index(0)], corners[0]);
+        assert_eq!(ring[corner_index(1)], corners[1]);
+        assert_eq!(ring[corner_index(2)], corners[2]);
+        assert_eq!(ring[corner_index(3)], corners[3]);
+        assert_eq!(*ring.last().unwrap(), corners[0]);
+
+        // The first edge (UL -> UR) runs along y = 10 with x strictly increasing
+        // through the interior points, spaced at t = i / (points_per_edge + 1).
+        for i in 1..=FOOTPRINT_POINTS_PER_EDGE {
+            let (x, y) = ring[corner_index(0) + i];
+            let t = i as f64 / (FOOTPRINT_POINTS_PER_EDGE + 1) as f64;
+            assert!((x - 10.0 * t).abs() < 1e-12, "x={x} t={t}");
+            assert_eq!(y, 10.0);
+        }
+    }
+
+    #[test]
+    fn densify_footprint_ring_reuses_scratch() {
+        let mut ring = vec![(42.0, 42.0)];
+        let corners = [(0.0, 1.0), (1.0, 1.0), (1.0, 0.0), (0.0, 0.0)];
+        densify_footprint_ring(corners, &mut ring);
+        // Pre-existing scratch content is cleared, not appended to.
+        assert_eq!(ring.len(), 4 * (FOOTPRINT_POINTS_PER_EDGE + 1) + 1);
+        assert_eq!(ring[0], corners[0]);
+    }
 }

--- a/rust/sedona-raster-functions/src/footprint.rs
+++ b/rust/sedona-raster-functions/src/footprint.rs
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Raster footprint helpers shared by the raster spatial-predicate kernels and
+//! the optimized raster spatial join.
+//!
+//! A raster's footprint is the convex hull of its four corners in world
+//! coordinates. Because the affine geotransform may include skew/rotation, each
+//! corner is computed individually rather than assumed axis-aligned.
+
+use datafusion_common::{DataFusionError, Result};
+use sedona_geometry::wkb_factory::write_wkb_polygon;
+use sedona_raster::affine_transformation::to_world_coordinate;
+use sedona_raster::traits::RasterRef;
+
+/// The four corners of a raster's footprint in world coordinates.
+///
+/// Returned in ring order: upper-left `(0, 0)`, upper-right `(width, 0)`,
+/// lower-right `(width, height)`, lower-left `(0, height)`.
+pub fn raster_footprint_corners(raster: &dyn RasterRef) -> [(f64, f64); 4] {
+    let width = raster.metadata().width();
+    let height = raster.metadata().height();
+
+    [
+        to_world_coordinate(raster, 0, 0),
+        to_world_coordinate(raster, width, 0),
+        to_world_coordinate(raster, width, height),
+        to_world_coordinate(raster, 0, height),
+    ]
+}
+
+/// Write WKB for the convex-hull polygon of the raster footprint.
+///
+/// The ring is the four [`raster_footprint_corners`] closed back to the
+/// upper-left corner. This can be used to build Binary arrays, as the arrow-rs
+/// `BinaryBuilder` implements [`std::io::Write`].
+pub fn write_convexhull_wkb(raster: &dyn RasterRef, out: &mut impl std::io::Write) -> Result<()> {
+    let [ul, ur, lr, ll] = raster_footprint_corners(raster);
+
+    write_wkb_polygon(out, [ul, ur, lr, ll, ul].into_iter())
+        .map_err(|e| DataFusionError::External(e.into()))?;
+
+    Ok(())
+}

--- a/rust/sedona-raster-functions/src/rs_convexhull.rs
+++ b/rust/sedona-raster-functions/src/rs_convexhull.rs
@@ -17,16 +17,14 @@
 use std::sync::Arc;
 
 use crate::executor::RasterExecutor;
+use crate::footprint::write_convexhull_wkb;
 use arrow_array::builder::{BinaryBuilder, StringViewBuilder};
-use datafusion_common::DataFusionError;
 use datafusion_common::Result;
 use datafusion_common::ScalarValue;
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_expr::item_crs::make_item_crs;
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_geometry::types::Edges;
-use sedona_geometry::wkb_factory::write_wkb_polygon;
-use sedona_raster::affine_transformation::to_world_coordinate;
 use sedona_raster::traits::RasterRef;
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
 
@@ -99,31 +97,6 @@ impl SedonaScalarKernel for RsConvexHull {
             None,
         )
     }
-}
-
-/// Write WKB for a convex hull polygon for the raster
-///
-/// For a raster, the convex hull is the polygon formed by the four corners
-/// of the raster in world coordinates. Due to skew/rotation in the affine
-/// transformation, each corner must be computed individually.
-fn write_convexhull_wkb(raster: &dyn RasterRef, out: &mut impl std::io::Write) -> Result<()> {
-    let width = raster.metadata().width();
-    let height = raster.metadata().height();
-
-    // Compute the four corners in pixel coordinates:
-    // Upper-left (0, 0), Upper-right (width, 0), Lower-right (width, height), Lower-left (0, height)
-    let (ulx, uly) = to_world_coordinate(raster, 0, 0);
-    let (urx, ury) = to_world_coordinate(raster, width, 0);
-    let (lrx, lry) = to_world_coordinate(raster, width, height);
-    let (llx, lly) = to_world_coordinate(raster, 0, height);
-
-    write_wkb_polygon(
-        out,
-        [(ulx, uly), (urx, ury), (lrx, lry), (llx, lly), (ulx, uly)].into_iter(),
-    )
-    .map_err(|e| DataFusionError::External(e.into()))?;
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/rust/sedona-raster-functions/src/rs_spatial_predicates.rs
+++ b/rust/sedona-raster-functions/src/rs_spatial_predicates.rs
@@ -23,7 +23,7 @@
 //!
 //! CRS transformation rules:
 //! - If neither side has a CRS, the comparison is performed directly without CRS transformation
-//! - If one side has a CRS but the other does not, an error is returned
+//! - If exactly one side has a CRS, the missing side is assumed to be WGS84 (matching Sedona Spark)
 //! - If both sides are in the same CRS, perform the relationship test directly
 //! - For raster/geometry pairs, the geometry is transformed into the raster's CRS
 //! - For raster/raster pairs, the second raster is transformed into the first's CRS
@@ -38,14 +38,13 @@ use crate::footprint::write_convexhull_wkb;
 use arrow_array::builder::BooleanBuilder;
 use arrow_schema::DataType;
 use datafusion_common::exec_datafusion_err;
-use datafusion_common::exec_err;
 use datafusion_common::Result;
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_geometry::transform::CrsEngine;
 use sedona_proj::transform::with_global_proj_engine;
 use sedona_raster::traits::RasterRef;
-use sedona_schema::crs::{lnglat, CrsRef};
+use sedona_schema::crs::{lnglat, CoordinateReferenceSystem, CrsRef};
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
 use sedona_tg::tg;
 
@@ -304,7 +303,8 @@ impl<Op: tg::BinaryPredicate + Send + Sync> RsSpatialPredicate<Op> {
 ///
 /// Rules:
 /// - If neither side has a CRS, compare directly without transformation
-/// - If one side has a CRS but the other does not, return an error
+/// - If exactly one side has a CRS, assume the missing side is WGS84 and fall
+///   through to the equal-/different-CRS logic below (matching Sedona Spark)
 /// - If both same CRS, compare directly
 /// - Otherwise, try transforming one side to the other's CRS for comparison.
 ///   If that fails, transform both to WGS84 and compare.
@@ -316,24 +316,54 @@ fn evaluate_predicate_with_crs<Op: tg::BinaryPredicate>(
     from_a_to_b: bool,
     engine: &dyn CrsEngine,
 ) -> Result<bool> {
-    // If either side has no CRS, compare directly without transformation.
-    let (crs_a, crs_b) = match (crs_a, crs_b) {
-        (Some(a), Some(b)) => (a, b),
-        (None, None) => return evaluate_predicate::<Op>(wkb_a, wkb_b),
-        (Some(_), None) => {
-            return exec_err!(
-                "Cannot evaluate spatial predicate: \
-                left geometry has CRS but right geometry does not"
+    match (crs_a, crs_b) {
+        (Some(crs_a), Some(crs_b)) => {
+            compare_in_crs::<Op>(wkb_a, crs_a, wkb_b, crs_b, from_a_to_b, engine)
+        }
+        // Neither side has a CRS: both are in the same (unknown) frame, so compare
+        // directly without transformation.
+        (None, None) => evaluate_predicate::<Op>(wkb_a, wkb_b),
+        // Exactly one side has a CRS: assume the missing side is WGS84 (matching
+        // Sedona Spark) and compare in the resulting CRS pair. Only these arms
+        // materialize the lnglat CRS, so the common paths avoid the allocation.
+        (Some(crs_a), None) => {
+            let lnglat_crs = lnglat().expect("lnglat() should always return Some");
+            compare_in_crs::<Op>(
+                wkb_a,
+                crs_a,
+                wkb_b,
+                lnglat_crs.as_ref(),
+                from_a_to_b,
+                engine,
             )
         }
-        (None, Some(_)) => {
-            return exec_err!(
-                "Cannot evaluate spatial predicate: \
-                right geometry has CRS but left geometry does not"
+        (None, Some(crs_b)) => {
+            let lnglat_crs = lnglat().expect("lnglat() should always return Some");
+            compare_in_crs::<Op>(
+                wkb_a,
+                lnglat_crs.as_ref(),
+                wkb_b,
+                crs_b,
+                from_a_to_b,
+                engine,
             )
         }
-    };
+    }
+}
 
+/// Evaluate a spatial predicate between two WKB geometries that both carry a CRS.
+///
+/// Equal CRSes compare directly; otherwise one side is transformed into the
+/// other's CRS per `from_a_to_b`, falling back to transforming both sides to
+/// WGS84 when the preferred transform fails.
+fn compare_in_crs<Op: tg::BinaryPredicate>(
+    wkb_a: &[u8],
+    crs_a: &(dyn CoordinateReferenceSystem + Send + Sync),
+    wkb_b: &[u8],
+    crs_b: &(dyn CoordinateReferenceSystem + Send + Sync),
+    from_a_to_b: bool,
+    engine: &dyn CrsEngine,
+) -> Result<bool> {
     // If both CRSes are equal, compare directly.
     if crs_a.crs_equals(crs_b) {
         return evaluate_predicate::<Op>(wkb_a, wkb_b);
@@ -414,7 +444,13 @@ mod tests {
     ///
     /// If `crs` is `None`, the raster has no CRS.
     fn build_unit_raster(crs: Option<&str>) -> arrow_array::StructArray {
-        let mut builder = RasterBuilder::new(1);
+        build_unit_rasters(crs, 1)
+    }
+
+    /// Build an array of `count` identical 1×1 rasters covering (0,0) to (1,1),
+    /// each with `crs` (or none). Useful for pairing with a multi-row operand.
+    fn build_unit_rasters(crs: Option<&str>, count: usize) -> arrow_array::StructArray {
+        let mut builder = RasterBuilder::new(count);
         let metadata = RasterMetadata {
             width: 1,
             height: 1,
@@ -425,19 +461,21 @@ mod tests {
             skew_x: 0.0,
             skew_y: 0.0,
         };
-        builder.start_raster(&metadata, crs).unwrap();
-        builder
-            .start_band(BandMetadata {
-                datatype: BandDataType::UInt8,
-                nodata_value: None,
-                storage_type: StorageType::InDb,
-                outdb_url: None,
-                outdb_band_id: None,
-            })
-            .unwrap();
-        builder.band_data_writer().append_value([0u8]);
-        builder.finish_band().unwrap();
-        builder.finish_raster().unwrap();
+        for _ in 0..count {
+            builder.start_raster(&metadata, crs).unwrap();
+            builder
+                .start_band(BandMetadata {
+                    datatype: BandDataType::UInt8,
+                    nodata_value: None,
+                    storage_type: StorageType::InDb,
+                    outdb_url: None,
+                    outdb_band_id: None,
+                })
+                .unwrap();
+            builder.band_data_writer().append_value([0u8]);
+            builder.finish_band().unwrap();
+            builder.finish_raster().unwrap();
+        }
         builder.finish().unwrap()
     }
 
@@ -674,52 +712,113 @@ mod tests {
         assert_array_equal(&result, &expected);
     }
 
-    /// When one side has a CRS but the other does not, an error must be returned.
+    /// When exactly one side has a CRS, the missing side is assumed to be WGS84
+    /// (matching Sedona Spark). The result must equal tagging that side
+    /// explicitly as WGS84, so an untagged operand and a 4326-tagged one give
+    /// the same answer.
     ///
-    /// Covers three overloads:
+    /// Covers all three overloads against a WGS84 raster covering (0,0)–(1,1):
     /// - (raster with CRS, geometry without CRS) — raster_geom
-    /// - (geometry with CRS, raster without CRS) — geom_raster
+    /// - (geometry without/with CRS, raster with/without CRS) — geom_raster
     /// - (raster with CRS, raster without CRS) — raster_raster
     #[test]
-    fn rs_intersects_crs_mismatch_one_missing_errors() {
-        let rasters_with_crs = build_unit_raster(Some("OGC:CRS84"));
-        let rasters_no_crs = build_unit_raster(None);
-
-        // raster (has CRS) + geometry (no CRS)
+    fn rs_intersects_one_missing_crs_assumes_wgs84() {
         let udf = rs_intersects_udf();
-        let tester = ScalarUdfTester::new(udf.clone().into(), vec![RASTER, WKB_GEOMETRY]);
-        let geoms = create_geom_array(&[Some("POINT (0.5 0.5)")], &WKB_GEOMETRY);
-        let err = tester
-            .invoke_arrays(vec![Arc::new(rasters_with_crs.clone()), geoms])
-            .unwrap_err();
-        assert!(
-            err.message().contains("has CRS but"),
-            "unexpected error: {err}"
-        );
+        let wgs84_geom = SedonaType::Wkb(Edges::Planar, lnglat());
 
-        // geometry (has CRS) + raster (no CRS)
-        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
-        let tester = ScalarUdfTester::new(udf.clone().into(), vec![geom_type.clone(), RASTER]);
-        let geoms = create_geom_array(&[Some("POINT (0.5 0.5)")], &geom_type);
-        let err = tester
-            .invoke_arrays(vec![geoms, Arc::new(rasters_no_crs.clone())])
-            .unwrap_err();
-        assert!(
-            err.message().contains("has CRS but"),
-            "unexpected error: {err}"
-        );
+        // Invoke rs_intersects over the given operand types/arrays.
+        let run = |types: Vec<SedonaType>, arrays: Vec<ArrayRef>| -> ArrayRef {
+            ScalarUdfTester::new(udf.clone().into(), types)
+                .invoke_arrays(arrays)
+                .unwrap()
+        };
+        // Two unit rasters covering (0,0)–(1,1), paired with a point inside and a
+        // point outside.
+        let rasters = |crs: Option<&str>| build_unit_rasters(crs, 2);
+        let points = |ty: &SedonaType| {
+            create_geom_array(&[Some("POINT (0.5 0.5)"), Some("POINT (5 5)")], ty)
+        };
+        let expected: ArrayRef = create_array!(Boolean, [Some(true), Some(false)]);
 
-        // raster (has CRS) + raster (no CRS)
-        let tester = ScalarUdfTester::new(udf.into(), vec![RASTER, RASTER]);
-        let err = tester
-            .invoke_arrays(vec![
-                Arc::new(rasters_with_crs.clone()),
-                Arc::new(rasters_no_crs.clone()),
-            ])
-            .unwrap_err();
-        assert!(
-            err.message().contains("has CRS but"),
-            "unexpected error: {err}"
+        // raster_geom: WGS84 raster vs untagged geometry == vs 4326-tagged geometry.
+        let rg_untagged = run(
+            vec![RASTER, WKB_GEOMETRY],
+            vec![Arc::new(rasters(Some("OGC:CRS84"))), points(&WKB_GEOMETRY)],
         );
+        let rg_tagged = run(
+            vec![RASTER, wgs84_geom.clone()],
+            vec![Arc::new(rasters(Some("OGC:CRS84"))), points(&wgs84_geom)],
+        );
+        assert_array_equal(&rg_untagged, &expected);
+        assert_array_equal(&rg_tagged, &rg_untagged);
+
+        // geom_raster: 4326-tagged geometry vs untagged raster == vs WGS84 raster.
+        let gr_untagged_raster = run(
+            vec![wgs84_geom.clone(), RASTER],
+            vec![points(&wgs84_geom), Arc::new(rasters(None))],
+        );
+        let gr_tagged_raster = run(
+            vec![wgs84_geom.clone(), RASTER],
+            vec![points(&wgs84_geom), Arc::new(rasters(Some("OGC:CRS84")))],
+        );
+        assert_array_equal(&gr_untagged_raster, &expected);
+        assert_array_equal(&gr_tagged_raster, &gr_untagged_raster);
+
+        // raster_raster: WGS84 raster vs untagged raster == vs WGS84 raster (both
+        // cover (0,0)–(1,1), so they intersect).
+        let rr_untagged = run(
+            vec![RASTER, RASTER],
+            vec![
+                Arc::new(rasters(Some("OGC:CRS84"))),
+                Arc::new(rasters(None)),
+            ],
+        );
+        let rr_tagged = run(
+            vec![RASTER, RASTER],
+            vec![
+                Arc::new(rasters(Some("OGC:CRS84"))),
+                Arc::new(rasters(Some("OGC:CRS84"))),
+            ],
+        );
+        let expected_rr: ArrayRef = create_array!(Boolean, [Some(true), Some(true)]);
+        assert_array_equal(&rr_untagged, &expected_rr);
+        assert_array_equal(&rr_tagged, &rr_untagged);
+    }
+
+    /// The assume-WGS84 rule also holds when the present side is not WGS84: an
+    /// untagged raster compared against an EPSG:3857 geometry reprojects as if
+    /// the raster were tagged WGS84. This exercises the transform path rather
+    /// than the equal-CRS fast path.
+    #[test]
+    fn rs_intersects_one_missing_crs_assumes_wgs84_reprojects() {
+        let udf = rs_intersects_udf();
+        let geom_3857 = SedonaType::Wkb(Edges::Planar, deserialize_crs("EPSG:3857").unwrap());
+
+        // build_unit_raster covers WGS84 (0,0)–(1,1). Express a point inside it
+        // (WGS84 0.5,0.5) and one outside it (WGS84 5,5) in EPSG:3857.
+        let point_3857 = |lng: f64, lat: f64| {
+            let (x, y) = with_global_proj_engine(|engine| {
+                crs_transform_coord((lng, lat), "OGC:CRS84", "EPSG:3857", engine)
+            })
+            .unwrap();
+            format!("POINT ({x} {y})")
+        };
+        let inside = point_3857(0.5, 0.5);
+        let outside = point_3857(5.0, 5.0);
+
+        let run = |raster_crs: Option<&str>| -> ArrayRef {
+            ScalarUdfTester::new(udf.clone().into(), vec![geom_3857.clone(), RASTER])
+                .invoke_arrays(vec![
+                    create_geom_array(&[Some(inside.as_str()), Some(outside.as_str())], &geom_3857),
+                    Arc::new(build_unit_rasters(raster_crs, 2)),
+                ])
+                .unwrap()
+        };
+
+        let expected: ArrayRef = create_array!(Boolean, [Some(true), Some(false)]);
+        let untagged = run(None); // raster assumed WGS84
+        let tagged = run(Some("OGC:CRS84")); // raster explicitly WGS84
+        assert_array_equal(&untagged, &expected);
+        assert_array_equal(&tagged, &untagged);
     }
 }

--- a/rust/sedona-raster-functions/src/rs_spatial_predicates.rs
+++ b/rust/sedona-raster-functions/src/rs_spatial_predicates.rs
@@ -33,17 +33,18 @@ use std::sync::Arc;
 
 use crate::crs_utils::crs_transform_wkb;
 use crate::crs_utils::resolve_crs;
+use crate::crs_utils::with_crs_engine;
 use crate::executor::RasterExecutor;
 use crate::footprint::write_convexhull_wkb;
 use arrow_array::builder::BooleanBuilder;
 use arrow_schema::DataType;
+use datafusion_common::config::ConfigOptions;
 use datafusion_common::exec_datafusion_err;
 use datafusion_common::exec_err;
 use datafusion_common::Result;
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_geometry::transform::CrsEngine;
-use sedona_proj::transform::with_global_proj_engine;
 use sedona_raster::traits::RasterRef;
 use sedona_schema::crs::{lnglat, CrsRef};
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
@@ -165,10 +166,27 @@ impl<Op: tg::BinaryPredicate + Send + Sync> SedonaScalarKernel for RsSpatialPred
         arg_types: &[SedonaType],
         args: &[ColumnarValue],
     ) -> Result<ColumnarValue> {
+        self.invoke_batch_from_args(
+            arg_types,
+            args,
+            &SedonaType::Arrow(DataType::Boolean),
+            0,
+            None,
+        )
+    }
+
+    fn invoke_batch_from_args(
+        &self,
+        arg_types: &[SedonaType],
+        args: &[ColumnarValue],
+        _return_type: &SedonaType,
+        _num_rows: usize,
+        config_options: Option<&ConfigOptions>,
+    ) -> Result<ColumnarValue> {
         match self.arg_order {
-            ArgOrder::RasterGeom => self.invoke_raster_geom(arg_types, args),
-            ArgOrder::GeomRaster => self.invoke_geom_raster(arg_types, args),
-            ArgOrder::RasterRaster => self.invoke_raster_raster(arg_types, args),
+            ArgOrder::RasterGeom => self.invoke_raster_geom(arg_types, args, config_options),
+            ArgOrder::GeomRaster => self.invoke_geom_raster(arg_types, args, config_options),
+            ArgOrder::RasterRaster => self.invoke_raster_raster(arg_types, args, config_options),
         }
     }
 }
@@ -179,6 +197,7 @@ impl<Op: tg::BinaryPredicate + Send + Sync> RsSpatialPredicate<Op> {
         &self,
         arg_types: &[SedonaType],
         args: &[ColumnarValue],
+        config_options: Option<&ConfigOptions>,
     ) -> Result<ColumnarValue> {
         // Ensure executor always sees (raster, geom)
         let exec_arg_types = vec![arg_types[0].clone(), arg_types[1].clone()];
@@ -187,7 +206,7 @@ impl<Op: tg::BinaryPredicate + Send + Sync> RsSpatialPredicate<Op> {
         let mut builder = BooleanBuilder::with_capacity(executor.num_iterations());
         let mut raster_wkb = Vec::with_capacity(CONVEXHULL_WKB_SIZE);
 
-        with_global_proj_engine(|engine| {
+        with_crs_engine(config_options, |engine| {
             executor.execute_raster_wkb_crs_void(|raster_opt, maybe_wkb, geom_crs| {
                 match (raster_opt, maybe_wkb) {
                     (Some(raster), Some(geom_wkb)) => {
@@ -219,6 +238,7 @@ impl<Op: tg::BinaryPredicate + Send + Sync> RsSpatialPredicate<Op> {
         &self,
         arg_types: &[SedonaType],
         args: &[ColumnarValue],
+        config_options: Option<&ConfigOptions>,
     ) -> Result<ColumnarValue> {
         // Reorder so executor always sees (raster, geom)
         let exec_arg_types = vec![arg_types[1].clone(), arg_types[0].clone()];
@@ -227,7 +247,7 @@ impl<Op: tg::BinaryPredicate + Send + Sync> RsSpatialPredicate<Op> {
         let mut builder = BooleanBuilder::with_capacity(executor.num_iterations());
         let mut raster_wkb = Vec::with_capacity(CONVEXHULL_WKB_SIZE);
 
-        with_global_proj_engine(|engine| {
+        with_crs_engine(config_options, |engine| {
             executor.execute_raster_wkb_crs_void(|raster_opt, maybe_wkb, geom_crs| {
                 match (raster_opt, maybe_wkb) {
                     (Some(raster), Some(geom_wkb)) => {
@@ -260,6 +280,7 @@ impl<Op: tg::BinaryPredicate + Send + Sync> RsSpatialPredicate<Op> {
         &self,
         arg_types: &[SedonaType],
         args: &[ColumnarValue],
+        config_options: Option<&ConfigOptions>,
     ) -> Result<ColumnarValue> {
         // Ensure executor always sees (raster, raster)
         let exec_arg_types = vec![arg_types[0].clone(), arg_types[1].clone()];
@@ -269,7 +290,7 @@ impl<Op: tg::BinaryPredicate + Send + Sync> RsSpatialPredicate<Op> {
         let mut wkb0 = Vec::with_capacity(CONVEXHULL_WKB_SIZE);
         let mut wkb1 = Vec::with_capacity(CONVEXHULL_WKB_SIZE);
 
-        with_global_proj_engine(|engine| {
+        with_crs_engine(config_options, |engine| {
             executor.execute_raster_raster_void(|_i, r0_opt, r1_opt| {
                 match (r0_opt, r1_opt) {
                     (Some(r0), Some(r1)) => {
@@ -381,6 +402,7 @@ mod tests {
     use datafusion_expr::ScalarUDF;
     use rstest::rstest;
     use sedona_geometry::types::Edges;
+    use sedona_proj::transform::{with_global_proj_engine, LazyProjEngine};
     use sedona_raster::builder::RasterBuilder;
     use sedona_raster::traits::{BandMetadata, RasterMetadata};
     use sedona_schema::crs::deserialize_crs;
@@ -495,7 +517,10 @@ mod tests {
     fn rs_intersects_raster_geom_crs_mismatch() {
         let udf = rs_intersects_udf();
         let geom_type = SedonaType::Wkb(Edges::Planar, deserialize_crs("EPSG:3857").unwrap());
-        let tester = ScalarUdfTester::new(udf.into(), vec![RASTER, geom_type.clone()]);
+        // This overload reprojects (EPSG:3857 geometry vs the raster's OGC:CRS84),
+        // so the session must carry a real CRS engine.
+        let tester = ScalarUdfTester::new(udf.into(), vec![RASTER, geom_type.clone()])
+            .with_crs_engine(Arc::new(LazyProjEngine));
 
         let rasters = generate_test_rasters(3, Some(0)).unwrap();
         let (x, y) = with_global_proj_engine(|engine| {

--- a/rust/sedona-raster-functions/src/rs_spatial_predicates.rs
+++ b/rust/sedona-raster-functions/src/rs_spatial_predicates.rs
@@ -34,18 +34,16 @@ use std::sync::Arc;
 use crate::crs_utils::crs_transform_wkb;
 use crate::crs_utils::resolve_crs;
 use crate::executor::RasterExecutor;
+use crate::footprint::write_convexhull_wkb;
 use arrow_array::builder::BooleanBuilder;
 use arrow_schema::DataType;
 use datafusion_common::exec_datafusion_err;
 use datafusion_common::exec_err;
-use datafusion_common::DataFusionError;
 use datafusion_common::Result;
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_geometry::transform::CrsEngine;
-use sedona_geometry::wkb_factory::write_wkb_polygon;
 use sedona_proj::transform::with_global_proj_engine;
-use sedona_raster::affine_transformation::to_world_coordinate;
 use sedona_raster::traits::RasterRef;
 use sedona_schema::crs::{lnglat, CrsRef};
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
@@ -375,29 +373,11 @@ fn evaluate_predicate<Op: tg::BinaryPredicate>(wkb_a: &[u8], wkb_b: &[u8]) -> Re
 ///       = 9 + 4 + 80 = 93
 const CONVEXHULL_WKB_SIZE: usize = 93;
 
-/// Create WKB for a convex hull polygon for the raster
-fn write_convexhull_wkb(raster: &dyn RasterRef, out: &mut impl std::io::Write) -> Result<()> {
-    let width = raster.metadata().width();
-    let height = raster.metadata().height();
-
-    let (ulx, uly) = to_world_coordinate(raster, 0, 0);
-    let (urx, ury) = to_world_coordinate(raster, width, 0);
-    let (lrx, lry) = to_world_coordinate(raster, width, height);
-    let (llx, lly) = to_world_coordinate(raster, 0, height);
-
-    write_wkb_polygon(
-        out,
-        [(ulx, uly), (urx, ury), (lrx, lry), (llx, lly), (ulx, uly)].into_iter(),
-    )
-    .map_err(|e| DataFusionError::External(e.into()))?;
-
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use arrow_array::{create_array, ArrayRef};
+    use datafusion_common::DataFusionError;
     use datafusion_expr::ScalarUDF;
     use rstest::rstest;
     use sedona_geometry::types::Edges;

--- a/rust/sedona-raster-functions/src/rs_spatial_predicates.rs
+++ b/rust/sedona-raster-functions/src/rs_spatial_predicates.rs
@@ -23,7 +23,7 @@
 //!
 //! CRS transformation rules:
 //! - If neither side has a CRS, the comparison is performed directly without CRS transformation
-//! - If exactly one side has a CRS, the missing side is assumed to be WGS84 (matching Sedona Spark)
+//! - If one side has a CRS but the other does not, an error is returned
 //! - If both sides are in the same CRS, perform the relationship test directly
 //! - For raster/geometry pairs, the geometry is transformed into the raster's CRS
 //! - For raster/raster pairs, the second raster is transformed into the first's CRS
@@ -38,13 +38,14 @@ use crate::footprint::write_convexhull_wkb;
 use arrow_array::builder::BooleanBuilder;
 use arrow_schema::DataType;
 use datafusion_common::exec_datafusion_err;
+use datafusion_common::exec_err;
 use datafusion_common::Result;
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_geometry::transform::CrsEngine;
 use sedona_proj::transform::with_global_proj_engine;
 use sedona_raster::traits::RasterRef;
-use sedona_schema::crs::{lnglat, CoordinateReferenceSystem, CrsRef};
+use sedona_schema::crs::{lnglat, CrsRef};
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
 use sedona_tg::tg;
 
@@ -303,8 +304,7 @@ impl<Op: tg::BinaryPredicate + Send + Sync> RsSpatialPredicate<Op> {
 ///
 /// Rules:
 /// - If neither side has a CRS, compare directly without transformation
-/// - If exactly one side has a CRS, assume the missing side is WGS84 and fall
-///   through to the equal-/different-CRS logic below (matching Sedona Spark)
+/// - If one side has a CRS but the other does not, return an error
 /// - If both same CRS, compare directly
 /// - Otherwise, try transforming one side to the other's CRS for comparison.
 ///   If that fails, transform both to WGS84 and compare.
@@ -316,54 +316,24 @@ fn evaluate_predicate_with_crs<Op: tg::BinaryPredicate>(
     from_a_to_b: bool,
     engine: &dyn CrsEngine,
 ) -> Result<bool> {
-    match (crs_a, crs_b) {
-        (Some(crs_a), Some(crs_b)) => {
-            compare_in_crs::<Op>(wkb_a, crs_a, wkb_b, crs_b, from_a_to_b, engine)
-        }
-        // Neither side has a CRS: both are in the same (unknown) frame, so compare
-        // directly without transformation.
-        (None, None) => evaluate_predicate::<Op>(wkb_a, wkb_b),
-        // Exactly one side has a CRS: assume the missing side is WGS84 (matching
-        // Sedona Spark) and compare in the resulting CRS pair. Only these arms
-        // materialize the lnglat CRS, so the common paths avoid the allocation.
-        (Some(crs_a), None) => {
-            let lnglat_crs = lnglat().expect("lnglat() should always return Some");
-            compare_in_crs::<Op>(
-                wkb_a,
-                crs_a,
-                wkb_b,
-                lnglat_crs.as_ref(),
-                from_a_to_b,
-                engine,
+    // If either side has no CRS, compare directly without transformation.
+    let (crs_a, crs_b) = match (crs_a, crs_b) {
+        (Some(a), Some(b)) => (a, b),
+        (None, None) => return evaluate_predicate::<Op>(wkb_a, wkb_b),
+        (Some(_), None) => {
+            return exec_err!(
+                "Cannot evaluate spatial predicate: \
+                left geometry has CRS but right geometry does not"
             )
         }
-        (None, Some(crs_b)) => {
-            let lnglat_crs = lnglat().expect("lnglat() should always return Some");
-            compare_in_crs::<Op>(
-                wkb_a,
-                lnglat_crs.as_ref(),
-                wkb_b,
-                crs_b,
-                from_a_to_b,
-                engine,
+        (None, Some(_)) => {
+            return exec_err!(
+                "Cannot evaluate spatial predicate: \
+                right geometry has CRS but left geometry does not"
             )
         }
-    }
-}
+    };
 
-/// Evaluate a spatial predicate between two WKB geometries that both carry a CRS.
-///
-/// Equal CRSes compare directly; otherwise one side is transformed into the
-/// other's CRS per `from_a_to_b`, falling back to transforming both sides to
-/// WGS84 when the preferred transform fails.
-fn compare_in_crs<Op: tg::BinaryPredicate>(
-    wkb_a: &[u8],
-    crs_a: &(dyn CoordinateReferenceSystem + Send + Sync),
-    wkb_b: &[u8],
-    crs_b: &(dyn CoordinateReferenceSystem + Send + Sync),
-    from_a_to_b: bool,
-    engine: &dyn CrsEngine,
-) -> Result<bool> {
     // If both CRSes are equal, compare directly.
     if crs_a.crs_equals(crs_b) {
         return evaluate_predicate::<Op>(wkb_a, wkb_b);
@@ -444,13 +414,7 @@ mod tests {
     ///
     /// If `crs` is `None`, the raster has no CRS.
     fn build_unit_raster(crs: Option<&str>) -> arrow_array::StructArray {
-        build_unit_rasters(crs, 1)
-    }
-
-    /// Build an array of `count` identical 1×1 rasters covering (0,0) to (1,1),
-    /// each with `crs` (or none). Useful for pairing with a multi-row operand.
-    fn build_unit_rasters(crs: Option<&str>, count: usize) -> arrow_array::StructArray {
-        let mut builder = RasterBuilder::new(count);
+        let mut builder = RasterBuilder::new(1);
         let metadata = RasterMetadata {
             width: 1,
             height: 1,
@@ -461,21 +425,19 @@ mod tests {
             skew_x: 0.0,
             skew_y: 0.0,
         };
-        for _ in 0..count {
-            builder.start_raster(&metadata, crs).unwrap();
-            builder
-                .start_band(BandMetadata {
-                    datatype: BandDataType::UInt8,
-                    nodata_value: None,
-                    storage_type: StorageType::InDb,
-                    outdb_url: None,
-                    outdb_band_id: None,
-                })
-                .unwrap();
-            builder.band_data_writer().append_value([0u8]);
-            builder.finish_band().unwrap();
-            builder.finish_raster().unwrap();
-        }
+        builder.start_raster(&metadata, crs).unwrap();
+        builder
+            .start_band(BandMetadata {
+                datatype: BandDataType::UInt8,
+                nodata_value: None,
+                storage_type: StorageType::InDb,
+                outdb_url: None,
+                outdb_band_id: None,
+            })
+            .unwrap();
+        builder.band_data_writer().append_value([0u8]);
+        builder.finish_band().unwrap();
+        builder.finish_raster().unwrap();
         builder.finish().unwrap()
     }
 
@@ -712,113 +674,52 @@ mod tests {
         assert_array_equal(&result, &expected);
     }
 
-    /// When exactly one side has a CRS, the missing side is assumed to be WGS84
-    /// (matching Sedona Spark). The result must equal tagging that side
-    /// explicitly as WGS84, so an untagged operand and a 4326-tagged one give
-    /// the same answer.
+    /// When one side has a CRS but the other does not, an error must be returned.
     ///
-    /// Covers all three overloads against a WGS84 raster covering (0,0)–(1,1):
+    /// Covers three overloads:
     /// - (raster with CRS, geometry without CRS) — raster_geom
-    /// - (geometry without/with CRS, raster with/without CRS) — geom_raster
+    /// - (geometry with CRS, raster without CRS) — geom_raster
     /// - (raster with CRS, raster without CRS) — raster_raster
     #[test]
-    fn rs_intersects_one_missing_crs_assumes_wgs84() {
+    fn rs_intersects_crs_mismatch_one_missing_errors() {
+        let rasters_with_crs = build_unit_raster(Some("OGC:CRS84"));
+        let rasters_no_crs = build_unit_raster(None);
+
+        // raster (has CRS) + geometry (no CRS)
         let udf = rs_intersects_udf();
-        let wgs84_geom = SedonaType::Wkb(Edges::Planar, lnglat());
-
-        // Invoke rs_intersects over the given operand types/arrays.
-        let run = |types: Vec<SedonaType>, arrays: Vec<ArrayRef>| -> ArrayRef {
-            ScalarUdfTester::new(udf.clone().into(), types)
-                .invoke_arrays(arrays)
-                .unwrap()
-        };
-        // Two unit rasters covering (0,0)–(1,1), paired with a point inside and a
-        // point outside.
-        let rasters = |crs: Option<&str>| build_unit_rasters(crs, 2);
-        let points = |ty: &SedonaType| {
-            create_geom_array(&[Some("POINT (0.5 0.5)"), Some("POINT (5 5)")], ty)
-        };
-        let expected: ArrayRef = create_array!(Boolean, [Some(true), Some(false)]);
-
-        // raster_geom: WGS84 raster vs untagged geometry == vs 4326-tagged geometry.
-        let rg_untagged = run(
-            vec![RASTER, WKB_GEOMETRY],
-            vec![Arc::new(rasters(Some("OGC:CRS84"))), points(&WKB_GEOMETRY)],
+        let tester = ScalarUdfTester::new(udf.clone().into(), vec![RASTER, WKB_GEOMETRY]);
+        let geoms = create_geom_array(&[Some("POINT (0.5 0.5)")], &WKB_GEOMETRY);
+        let err = tester
+            .invoke_arrays(vec![Arc::new(rasters_with_crs.clone()), geoms])
+            .unwrap_err();
+        assert!(
+            err.message().contains("has CRS but"),
+            "unexpected error: {err}"
         );
-        let rg_tagged = run(
-            vec![RASTER, wgs84_geom.clone()],
-            vec![Arc::new(rasters(Some("OGC:CRS84"))), points(&wgs84_geom)],
+
+        // geometry (has CRS) + raster (no CRS)
+        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
+        let tester = ScalarUdfTester::new(udf.clone().into(), vec![geom_type.clone(), RASTER]);
+        let geoms = create_geom_array(&[Some("POINT (0.5 0.5)")], &geom_type);
+        let err = tester
+            .invoke_arrays(vec![geoms, Arc::new(rasters_no_crs.clone())])
+            .unwrap_err();
+        assert!(
+            err.message().contains("has CRS but"),
+            "unexpected error: {err}"
         );
-        assert_array_equal(&rg_untagged, &expected);
-        assert_array_equal(&rg_tagged, &rg_untagged);
 
-        // geom_raster: 4326-tagged geometry vs untagged raster == vs WGS84 raster.
-        let gr_untagged_raster = run(
-            vec![wgs84_geom.clone(), RASTER],
-            vec![points(&wgs84_geom), Arc::new(rasters(None))],
+        // raster (has CRS) + raster (no CRS)
+        let tester = ScalarUdfTester::new(udf.into(), vec![RASTER, RASTER]);
+        let err = tester
+            .invoke_arrays(vec![
+                Arc::new(rasters_with_crs.clone()),
+                Arc::new(rasters_no_crs.clone()),
+            ])
+            .unwrap_err();
+        assert!(
+            err.message().contains("has CRS but"),
+            "unexpected error: {err}"
         );
-        let gr_tagged_raster = run(
-            vec![wgs84_geom.clone(), RASTER],
-            vec![points(&wgs84_geom), Arc::new(rasters(Some("OGC:CRS84")))],
-        );
-        assert_array_equal(&gr_untagged_raster, &expected);
-        assert_array_equal(&gr_tagged_raster, &gr_untagged_raster);
-
-        // raster_raster: WGS84 raster vs untagged raster == vs WGS84 raster (both
-        // cover (0,0)–(1,1), so they intersect).
-        let rr_untagged = run(
-            vec![RASTER, RASTER],
-            vec![
-                Arc::new(rasters(Some("OGC:CRS84"))),
-                Arc::new(rasters(None)),
-            ],
-        );
-        let rr_tagged = run(
-            vec![RASTER, RASTER],
-            vec![
-                Arc::new(rasters(Some("OGC:CRS84"))),
-                Arc::new(rasters(Some("OGC:CRS84"))),
-            ],
-        );
-        let expected_rr: ArrayRef = create_array!(Boolean, [Some(true), Some(true)]);
-        assert_array_equal(&rr_untagged, &expected_rr);
-        assert_array_equal(&rr_tagged, &rr_untagged);
-    }
-
-    /// The assume-WGS84 rule also holds when the present side is not WGS84: an
-    /// untagged raster compared against an EPSG:3857 geometry reprojects as if
-    /// the raster were tagged WGS84. This exercises the transform path rather
-    /// than the equal-CRS fast path.
-    #[test]
-    fn rs_intersects_one_missing_crs_assumes_wgs84_reprojects() {
-        let udf = rs_intersects_udf();
-        let geom_3857 = SedonaType::Wkb(Edges::Planar, deserialize_crs("EPSG:3857").unwrap());
-
-        // build_unit_raster covers WGS84 (0,0)–(1,1). Express a point inside it
-        // (WGS84 0.5,0.5) and one outside it (WGS84 5,5) in EPSG:3857.
-        let point_3857 = |lng: f64, lat: f64| {
-            let (x, y) = with_global_proj_engine(|engine| {
-                crs_transform_coord((lng, lat), "OGC:CRS84", "EPSG:3857", engine)
-            })
-            .unwrap();
-            format!("POINT ({x} {y})")
-        };
-        let inside = point_3857(0.5, 0.5);
-        let outside = point_3857(5.0, 5.0);
-
-        let run = |raster_crs: Option<&str>| -> ArrayRef {
-            ScalarUdfTester::new(udf.clone().into(), vec![geom_3857.clone(), RASTER])
-                .invoke_arrays(vec![
-                    create_geom_array(&[Some(inside.as_str()), Some(outside.as_str())], &geom_3857),
-                    Arc::new(build_unit_rasters(raster_crs, 2)),
-                ])
-                .unwrap()
-        };
-
-        let expected: ArrayRef = create_array!(Boolean, [Some(true), Some(false)]);
-        let untagged = run(None); // raster assumed WGS84
-        let tagged = run(Some("OGC:CRS84")); // raster explicitly WGS84
-        assert_array_equal(&untagged, &expected);
-        assert_array_equal(&tagged, &untagged);
     }
 }

--- a/rust/sedona-spatial-join-raster/Cargo.toml
+++ b/rust/sedona-spatial-join-raster/Cargo.toml
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+[package]
+name = "sedona-spatial-join-raster"
+version.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description.workspace = true
+readme.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+arrow-array = { workspace = true }
+arrow-schema = { workspace = true }
+datafusion = { workspace = true }
+datafusion-common = { workspace = true }
+datafusion-expr = { workspace = true }
+datafusion-physical-expr = { workspace = true }
+datafusion-physical-plan = { workspace = true }
+sedona-common = { workspace = true }
+sedona-expr = { workspace = true }
+sedona-geometry = { workspace = true }
+sedona-proj = { workspace = true }
+sedona-query-planner = { workspace = true }
+sedona-raster = { workspace = true }
+sedona-raster-functions = { workspace = true }
+sedona-schema = { workspace = true }
+sedona-spatial-join = { workspace = true }
+
+[dev-dependencies]
+arrow-array = { workspace = true }
+datafusion = { workspace = true, features = ["sql"] }
+datafusion-common = { workspace = true }
+datafusion-expr = { workspace = true }
+rstest = { workspace = true }
+sedona-functions = { workspace = true }
+sedona-proj = { workspace = true, features = ["proj-sys"] }
+sedona-testing = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/rust/sedona-spatial-join-raster/Cargo.toml
+++ b/rust/sedona-spatial-join-raster/Cargo.toml
@@ -30,7 +30,6 @@ rust-version.workspace = true
 [dependencies]
 arrow-array = { workspace = true }
 arrow-schema = { workspace = true }
-datafusion = { workspace = true }
 datafusion-common = { workspace = true }
 datafusion-expr = { workspace = true }
 datafusion-physical-expr = { workspace = true }
@@ -51,7 +50,6 @@ datafusion = { workspace = true, features = ["sql"] }
 datafusion-common = { workspace = true }
 datafusion-expr = { workspace = true }
 rstest = { workspace = true }
-sedona-functions = { workspace = true }
 sedona-proj = { workspace = true, features = ["proj-sys"] }
 sedona-testing = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/rust/sedona-spatial-join-raster/src/join_provider.rs
+++ b/rust/sedona-spatial-join-raster/src/join_provider.rs
@@ -28,7 +28,6 @@ use sedona_geometry::{
     interval::{Interval, IntervalTrait},
     transform::CrsEngine,
 };
-use sedona_proj::transform::with_global_proj_engine;
 use sedona_raster::array::RasterStructArray;
 use sedona_raster::traits::RasterRef;
 use sedona_raster_functions::crs_utils::resolve_crs;
@@ -50,18 +49,21 @@ use sedona_spatial_join::{
 ///
 /// The R-tree index builder and the memory estimate delegate to the default
 /// provider; only the operand evaluator is raster-aware. The factory it produces
-/// reprojects raster footprints into `target_crs` (the geometry operand's CRS).
+/// reprojects raster footprints into `target_crs` (the geometry operand's CRS)
+/// using the session's [`CrsEngine`], captured at plan time.
 #[derive(Debug)]
 pub(crate) struct RasterJoinProvider {
     default: DefaultSpatialJoinProvider,
     target_crs: Crs,
+    engine: Arc<dyn CrsEngine + Send + Sync>,
 }
 
 impl RasterJoinProvider {
-    pub(crate) fn new(target_crs: Crs) -> Self {
+    pub(crate) fn new(target_crs: Crs, engine: Arc<dyn CrsEngine + Send + Sync>) -> Self {
         Self {
             default: DefaultSpatialJoinProvider,
             target_crs,
+            engine,
         }
     }
 }
@@ -114,6 +116,7 @@ impl SpatialJoinProvider for RasterJoinProvider {
     fn evaluated_array_factory(&self) -> Arc<dyn EvaluatedGeometryArrayFactory> {
         Arc::new(RasterGeometryArrayFactory {
             target_crs: self.target_crs.clone(),
+            engine: self.engine.clone(),
         })
     }
 }
@@ -137,6 +140,9 @@ struct RasterGeometryArrayFactory {
     /// footprints are reprojected into it. `None` when the geometry operand
     /// carries no CRS (the raster operand must then also be CRS-less).
     target_crs: Crs,
+    /// The session's CRS engine, used to reproject raster footprints into
+    /// `target_crs`.
+    engine: Arc<dyn CrsEngine + Send + Sync>,
 }
 
 impl EvaluatedGeometryArrayFactory for RasterGeometryArrayFactory {
@@ -180,23 +186,21 @@ impl RasterGeometryArrayFactory {
         let mut builder = BinaryBuilder::with_capacity(num_rows, num_rows * 96);
         let mut rects = Vec::with_capacity(num_rows);
 
-        with_global_proj_engine(|engine| {
-            for i in 0..num_rows {
-                // A null raster produces a null footprint that never matches.
-                if rasters.is_null(i) {
-                    builder.append_null();
-                    rects.push(Bounds2D::empty());
-                    continue;
-                }
-
-                let raster = rasters
-                    .get(i)
-                    .map_err(|e| exec_datafusion_err!("Failed to read raster row {i}: {e}"))?;
-                let rect = self.append_footprint(&raster, engine, &mut builder)?;
-                rects.push(rect);
+        let engine: &dyn CrsEngine = self.engine.as_ref();
+        for i in 0..num_rows {
+            // A null raster produces a null footprint that never matches.
+            if rasters.is_null(i) {
+                builder.append_null();
+                rects.push(Bounds2D::empty());
+                continue;
             }
-            Ok(())
-        })?;
+
+            let raster = rasters
+                .get(i)
+                .map_err(|e| exec_datafusion_err!("Failed to read raster row {i}: {e}"))?;
+            let rect = self.append_footprint(&raster, engine, &mut builder)?;
+            rects.push(rect);
+        }
 
         let footprint_array: ArrayRef = Arc::new(builder.finish());
         EvaluatedGeometryArray::try_new_with_rects(footprint_array, rects, &WKB_GEOMETRY)
@@ -317,6 +321,14 @@ fn bounds_from_coords(coords: &[(f64, f64)]) -> Bounds2D {
 #[cfg(test)]
 mod test {
     use super::*;
+    use sedona_proj::transform::LazyProjEngine;
+
+    /// The session's default CRS engine. The same-CRS / no-CRS / one-sided-CRS
+    /// paths exercised by these tests never invoke it (reprojection is tested
+    /// separately with a mock engine below), so any engine works here.
+    fn test_engine() -> Arc<dyn CrsEngine + Send + Sync> {
+        Arc::new(LazyProjEngine)
+    }
 
     #[test]
     fn bounds_from_coords_covers_corners() {
@@ -393,6 +405,7 @@ mod test {
 
         let factory = RasterGeometryArrayFactory {
             target_crs: lnglat(),
+            engine: test_engine(),
         };
         let evaluated = factory.evaluate_raster(Arc::new(rasters)).unwrap();
         let footprints = evaluated
@@ -422,7 +435,10 @@ mod test {
     #[test]
     fn raster_with_crs_but_crsless_target_errors() {
         let rasters = build_unit_raster(Some("OGC:CRS84"));
-        let factory = RasterGeometryArrayFactory { target_crs: None };
+        let factory = RasterGeometryArrayFactory {
+            target_crs: None,
+            engine: test_engine(),
+        };
         let err = factory.evaluate_raster(Arc::new(rasters)).err().unwrap();
         assert!(err.message().contains("has a CRS but"), "unexpected: {err}");
     }
@@ -434,6 +450,7 @@ mod test {
         let rasters = build_unit_raster(None);
         let factory = RasterGeometryArrayFactory {
             target_crs: lnglat(),
+            engine: test_engine(),
         };
         let err = factory.evaluate_raster(Arc::new(rasters)).err().unwrap();
         assert!(err.message().contains("has a CRS but"), "unexpected: {err}");
@@ -451,7 +468,10 @@ mod test {
             write_convexhull_wkb(&raster0, &mut expected_wkb).unwrap();
         }
 
-        let factory = RasterGeometryArrayFactory { target_crs: None };
+        let factory = RasterGeometryArrayFactory {
+            target_crs: None,
+            engine: test_engine(),
+        };
         let evaluated = factory
             .try_new_evaluated_array(Arc::new(rasters), &RASTER, None)
             .unwrap();

--- a/rust/sedona-spatial-join-raster/src/join_provider.rs
+++ b/rust/sedona-spatial-join-raster/src/join_provider.rs
@@ -18,7 +18,7 @@
 use std::sync::Arc;
 
 use arrow_array::{builder::BinaryBuilder, Array, ArrayRef, StructArray};
-use datafusion_common::{exec_datafusion_err, exec_err, JoinType, Result};
+use datafusion_common::{exec_datafusion_err, JoinType, Result};
 use datafusion_expr::ColumnarValue;
 use sedona_common::{sedona_internal_datafusion_err, sedona_internal_err, SpatialJoinOptions};
 use sedona_expr::statistics::GeoStatistics;
@@ -28,7 +28,11 @@ use sedona_raster::array::RasterStructArray;
 use sedona_raster::traits::RasterRef;
 use sedona_raster_functions::crs_utils::resolve_crs;
 use sedona_raster_functions::footprint::{raster_footprint_corners, write_convexhull_wkb};
-use sedona_schema::{crs::Crs, datatypes::SedonaType, datatypes::WKB_GEOMETRY};
+use sedona_schema::{
+    crs::{lnglat, CoordinateReferenceSystem, Crs},
+    datatypes::SedonaType,
+    datatypes::WKB_GEOMETRY,
+};
 use sedona_spatial_join::{
     index::{spatial_index_builder::SpatialJoinBuildMetrics, SpatialIndexBuilder},
     join_provider::{DefaultSpatialJoinProvider, SpatialJoinProvider},
@@ -112,8 +116,9 @@ impl SpatialJoinProvider for RasterJoinProvider {
 #[derive(Debug)]
 struct RasterGeometryArrayFactory {
     /// The geometry operand's CRS: the common CRS this join compares in. Raster
-    /// footprints are reprojected into it. `None` when the geometry operand
-    /// carries no CRS (the raster operand must then also be CRS-less).
+    /// footprints are reprojected into it. WGS84 when the geometry operand carries
+    /// no CRS — a missing CRS is assumed WGS84 (matching the `RS_*` kernel and
+    /// Sedona Spark), so the CRS-less geometry is compared as-is in a WGS84 frame.
     target_crs: Crs,
 }
 
@@ -158,6 +163,11 @@ impl RasterGeometryArrayFactory {
         let mut builder = BinaryBuilder::with_capacity(num_rows, num_rows * 96);
         let mut rects = Vec::with_capacity(num_rows);
 
+        // A missing CRS on either side is assumed to be WGS84 (matching the `RS_*`
+        // kernel and Sedona Spark); resolve it once rather than per row.
+        let lnglat_crs = lnglat();
+        let wgs84 = lnglat_crs.as_deref().expect("lnglat() is always Some");
+
         with_global_proj_engine(|engine| {
             for i in 0..num_rows {
                 // A null raster produces a null footprint that never matches.
@@ -170,7 +180,7 @@ impl RasterGeometryArrayFactory {
                 let raster = rasters
                     .get(i)
                     .map_err(|e| exec_datafusion_err!("Failed to read raster row {i}: {e}"))?;
-                let rect = self.append_footprint(&raster, engine, &mut builder)?;
+                let rect = self.append_footprint(&raster, wgs84, engine, &mut builder)?;
                 rects.push(rect);
             }
             Ok(())
@@ -181,75 +191,73 @@ impl RasterGeometryArrayFactory {
     }
 
     /// Append one raster's footprint WKB to `builder` and return its bounding
-    /// rectangle, reconciling the raster's CRS against the target CRS.
+    /// rectangle, reconciling the raster's CRS against the target CRS. `wgs84` is
+    /// the WGS84 CRS a missing side is assumed to be.
     ///
-    /// CRS rules mirror the `RS_*` kernel: equal (or both-absent) CRS compares
-    /// directly; a genuine CRS difference reprojects the footprint's four corners
-    /// into the target CRS; a one-sided CRS is an error. The footprint is always
-    /// the convex hull of the four corners — projection curvature along the edges
-    /// is not modeled (see the type-level note on [`RasterGeometryArrayFactory`]).
+    /// CRS rules mirror the `RS_*` kernel: a missing CRS on either side is assumed
+    /// to be WGS84 (matching Sedona Spark), after which an equal CRS compares
+    /// directly and a genuine CRS difference reprojects the footprint's four
+    /// corners into the target CRS. The footprint is always the convex hull of the
+    /// four corners — projection curvature along the edges is not modeled (see the
+    /// type-level note on [`RasterGeometryArrayFactory`]).
     fn append_footprint(
         &self,
         raster: &dyn RasterRef,
+        wgs84: &(dyn CoordinateReferenceSystem + Send + Sync),
         engine: &dyn CrsEngine,
         builder: &mut BinaryBuilder,
     ) -> Result<Bounds2D> {
         let raster_crs = resolve_crs(raster.crs())?;
         let corners = raster_footprint_corners(raster);
 
-        match (raster_crs.as_deref(), self.target_crs.as_deref()) {
-            // No CRS on either side, or identical CRS: compare directly. The
-            // footprint is byte-identical to the one the `RS_*` kernel builds.
-            (None, None) => {
-                write_convexhull_wkb(raster, builder)?;
-                builder.append_value([]);
-                Ok(bounds_from_coords(&corners))
-            }
-            (Some(raster_crs), Some(target_crs)) if raster_crs.crs_equals(target_crs) => {
-                write_convexhull_wkb(raster, builder)?;
-                builder.append_value([]);
-                Ok(bounds_from_coords(&corners))
-            }
-            // Genuine CRS difference: reproject the four corners into the target
-            // CRS and emit their convex hull.
-            (Some(raster_crs), Some(target_crs)) => {
-                let transform = engine
-                    .get_transform_crs_to_crs(
-                        &raster_crs.to_crs_string(),
-                        &target_crs.to_crs_string(),
-                        None,
-                        "",
-                    )
-                    .map_err(|e| exec_datafusion_err!("CRS transform error: {e}"))?;
+        // Assume WGS84 for whichever side lacks a CRS, then compare in the target
+        // frame. Both-absent and same-CRS collapse to a direct comparison.
+        let raster_crs = raster_crs.as_deref().unwrap_or(wgs84);
+        let target_crs = self.target_crs.as_deref().unwrap_or(wgs84);
 
-                let mut hull = corners;
-                for corner in hull.iter_mut() {
-                    transform
-                        .transform_coord(corner)
-                        .map_err(|e| exec_datafusion_err!("Transform error: {e}"))?;
-                }
-
-                // Closed ring: the four reprojected corners plus the first repeated.
-                write_wkb_polygon(
-                    builder,
-                    [hull[0], hull[1], hull[2], hull[3], hull[0]].into_iter(),
-                )
-                .map_err(|e| exec_datafusion_err!("Failed to write footprint WKB: {e}"))?;
-                builder.append_value([]);
-                Ok(bounds_from_coords(&hull))
-            }
-            (Some(_), None) => {
-                exec_err!(
-                    "Cannot evaluate spatial predicate: raster has a CRS but the geometry does not"
-                )
-            }
-            (None, Some(_)) => {
-                exec_err!(
-                    "Cannot evaluate spatial predicate: geometry has a CRS but the raster does not"
-                )
-            }
+        if raster_crs.crs_equals(target_crs) {
+            // Same (possibly assumed-WGS84) CRS: compare directly. The footprint is
+            // byte-identical to the one the `RS_*` kernel builds.
+            write_convexhull_wkb(raster, builder)?;
+            builder.append_value([]);
+            Ok(bounds_from_coords(&corners))
+        } else {
+            // Genuine CRS difference: reproject the four corners into the target CRS
+            // and emit their convex hull.
+            append_reprojected_footprint(corners, raster_crs, target_crs, engine, builder)
         }
     }
+}
+
+/// Reproject a raster's four `corners` from `from_crs` to `to_crs`, append the
+/// convex hull of the reprojected corners to `builder`, and return its bounding
+/// rectangle.
+fn append_reprojected_footprint(
+    corners: [(f64, f64); 4],
+    from_crs: &(dyn CoordinateReferenceSystem + Send + Sync),
+    to_crs: &(dyn CoordinateReferenceSystem + Send + Sync),
+    engine: &dyn CrsEngine,
+    builder: &mut BinaryBuilder,
+) -> Result<Bounds2D> {
+    let transform = engine
+        .get_transform_crs_to_crs(&from_crs.to_crs_string(), &to_crs.to_crs_string(), None, "")
+        .map_err(|e| exec_datafusion_err!("CRS transform error: {e}"))?;
+
+    let mut hull = corners;
+    for corner in hull.iter_mut() {
+        transform
+            .transform_coord(corner)
+            .map_err(|e| exec_datafusion_err!("Transform error: {e}"))?;
+    }
+
+    // Closed ring: the four reprojected corners plus the first repeated.
+    write_wkb_polygon(
+        builder,
+        [hull[0], hull[1], hull[2], hull[3], hull[0]].into_iter(),
+    )
+    .map_err(|e| exec_datafusion_err!("Failed to write footprint WKB: {e}"))?;
+    builder.append_value([]);
+    Ok(bounds_from_coords(&hull))
 }
 
 /// Bounding rectangle of a set of coordinates. [`Bounds2D::new`] enlarges the
@@ -291,7 +299,7 @@ mod test {
     use arrow_array::BinaryArray;
     use sedona_raster::builder::RasterBuilder;
     use sedona_raster::traits::{BandMetadata, RasterMetadata};
-    use sedona_schema::crs::lnglat;
+    use sedona_schema::crs::{deserialize_crs, lnglat};
     use sedona_schema::datatypes::RASTER;
     use sedona_schema::raster::{BandDataType, StorageType};
     use sedona_testing::rasters::generate_test_rasters;
@@ -323,6 +331,29 @@ mod test {
         builder.finish_band().unwrap();
         builder.finish_raster().unwrap();
         builder.finish().unwrap()
+    }
+
+    /// Footprint WKB the factory produces for row 0 of a single-row raster,
+    /// comparing footprints against `target_crs`.
+    fn footprint_bytes(target_crs: Crs, raster: arrow_array::StructArray) -> Vec<u8> {
+        let factory = RasterGeometryArrayFactory { target_crs };
+        let evaluated = factory.evaluate_raster(Arc::new(raster)).unwrap();
+        evaluated
+            .geometry_array()
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .unwrap()
+            .value(0)
+            .to_vec()
+    }
+
+    /// The native (non-reprojected) convex-hull footprint the `RS_*` kernel builds
+    /// for row 0 of `raster`.
+    fn native_hull(raster: &arrow_array::StructArray) -> Vec<u8> {
+        let arr = RasterStructArray::try_new(raster).unwrap();
+        let mut wkb = Vec::new();
+        write_convexhull_wkb(&arr.get(0).unwrap(), &mut wkb).unwrap();
+        wkb
     }
 
     /// Same-CRS: the footprint is byte-identical to the `RS_*` kernel's convex
@@ -366,26 +397,55 @@ mod test {
         assert!((max_y as f64) >= 3.08);
     }
 
-    /// A raster with a CRS joined against a CRS-less geometry (target CRS
-    /// `None`) is a one-sided CRS: it must error rather than silently compare.
+    /// A raster with a CRS joined against a CRS-less geometry (target CRS `None`)
+    /// no longer errors: the missing target CRS is assumed to be WGS84 (matching
+    /// the `RS_*` kernel and Sedona Spark). The WGS84 raster then compares
+    /// directly, giving the kernel's native hull and matching an explicit WGS84
+    /// target.
     #[test]
-    fn raster_with_crs_but_crsless_target_errors() {
-        let rasters = build_unit_raster(Some("OGC:CRS84"));
-        let factory = RasterGeometryArrayFactory { target_crs: None };
-        let err = factory.evaluate_raster(Arc::new(rasters)).err().unwrap();
-        assert!(err.message().contains("has a CRS but"), "unexpected: {err}");
+    fn raster_with_crs_and_crsless_target_assumes_wgs84() {
+        let expected = native_hull(&build_unit_raster(Some("OGC:CRS84")));
+
+        let assumed = footprint_bytes(None, build_unit_raster(Some("OGC:CRS84")));
+        let tagged = footprint_bytes(lnglat(), build_unit_raster(Some("OGC:CRS84")));
+
+        assert_eq!(
+            assumed, expected,
+            "assumed-WGS84 target compares directly (native hull)"
+        );
+        assert_eq!(
+            assumed, tagged,
+            "assumed WGS84 must match an explicit WGS84 target"
+        );
     }
 
-    /// A CRS-less raster joined against a geometry that has a CRS is also a
-    /// one-sided CRS and must error.
+    /// A CRS-less raster joined against a geometry that has a CRS also assumes
+    /// WGS84 for the raster. Against a WGS84 target it compares directly; against a
+    /// non-WGS84 target it reprojects WGS84 -> target, matching a raster explicitly
+    /// tagged WGS84.
     #[test]
-    fn crsless_raster_with_crs_target_errors() {
-        let rasters = build_unit_raster(None);
-        let factory = RasterGeometryArrayFactory {
-            target_crs: lnglat(),
-        };
-        let err = factory.evaluate_raster(Arc::new(rasters)).err().unwrap();
-        assert!(err.message().contains("has a CRS but"), "unexpected: {err}");
+    fn crsless_raster_assumes_wgs84() {
+        let native = native_hull(&build_unit_raster(None));
+
+        // WGS84 target: the assumed-WGS84 raster compares directly (native hull).
+        let direct = footprint_bytes(lnglat(), build_unit_raster(None));
+        assert_eq!(
+            direct, native,
+            "assumed-WGS84 raster vs WGS84 target compares directly"
+        );
+
+        // Non-WGS84 target: reproject WGS84 -> target, matching an explicit tag.
+        let epsg_3857 = deserialize_crs("EPSG:3857").unwrap();
+        let assumed = footprint_bytes(epsg_3857.clone(), build_unit_raster(None));
+        let tagged = footprint_bytes(epsg_3857, build_unit_raster(Some("OGC:CRS84")));
+        assert_eq!(
+            assumed, tagged,
+            "assumed WGS84 must match an explicit WGS84 tag under reprojection"
+        );
+        assert_ne!(
+            assumed, native,
+            "reprojection to EPSG:3857 must change the footprint"
+        );
     }
 
     /// A CRS-less raster with a CRS-less geometry compares directly (no error,

--- a/rust/sedona-spatial-join-raster/src/join_provider.rs
+++ b/rust/sedona-spatial-join-raster/src/join_provider.rs
@@ -37,23 +37,6 @@ use sedona_spatial_join::{
     SpatialPredicate,
 };
 
-/// Number of interpolated points added to each footprint edge before
-/// reprojection.
-///
-/// A raster footprint is a 4-corner ring whose edges are straight lines in the
-/// raster's native CRS. Reprojecting only the corners would draw straight lines
-/// between the reprojected corners, missing the curvature a projection change
-/// introduces along an edge. Interpolating `K` intermediate points per edge and
-/// reprojecting each one approximates that curve as a polyline; the maximum
-/// deviation from the true reprojected edge falls off like `1 / (K + 1)^2`.
-///
-/// `K = 16` (a 69-vertex reprojected ring) keeps that deviation well below a
-/// pixel for the projected extents these joins target while bounding the
-/// per-row vertex count. The reprojected footprint is an approximation either
-/// way, so cross-CRS results are verified against a reference implementation
-/// rather than asserted bit-exact against the nested-loop kernel.
-const DENSIFY_POINTS_PER_EDGE: usize = 16;
-
 /// [`SpatialJoinProvider`] for raster/geometry spatial joins.
 ///
 /// The R-tree index builder and the memory estimate delegate to the default
@@ -116,9 +99,16 @@ impl SpatialJoinProvider for RasterJoinProvider {
 /// Evaluates the operands of a raster/geometry spatial predicate.
 ///
 /// The same factory sees both operands of the join. A raster operand is turned
-/// into its reprojected footprint (see [`RasterGeometryArrayFactory::evaluate_raster`]);
-/// a geometry operand is evaluated with the default planar behavior, since the
-/// geometry is already in the target CRS.
+/// into its footprint — the convex hull of the raster's four corners
+/// (see [`RasterGeometryArrayFactory::evaluate_raster`]) — and a geometry operand
+/// is evaluated with the default planar behavior, since the geometry is already
+/// in the target CRS.
+///
+/// Cross-CRS raster footprints are indexed and refined as the convex hull of the
+/// raster's four reprojected corners; projection curvature along the edges is not
+/// modeled, so for large-extent rasters reprojected between very different CRSs
+/// the hull can slightly under-cover the true footprint (rare missed matches at
+/// the extreme edges). Same-CRS joins are exact.
 #[derive(Debug)]
 struct RasterGeometryArrayFactory {
     /// The geometry operand's CRS: the common CRS this join compares in. Raster
@@ -167,7 +157,6 @@ impl RasterGeometryArrayFactory {
         let num_rows = rasters.len();
         let mut builder = BinaryBuilder::with_capacity(num_rows, num_rows * 96);
         let mut rects = Vec::with_capacity(num_rows);
-        let mut ring: Vec<(f64, f64)> = Vec::new();
 
         with_global_proj_engine(|engine| {
             for i in 0..num_rows {
@@ -181,7 +170,7 @@ impl RasterGeometryArrayFactory {
                 let raster = rasters
                     .get(i)
                     .map_err(|e| exec_datafusion_err!("Failed to read raster row {i}: {e}"))?;
-                let rect = self.append_footprint(&raster, engine, &mut builder, &mut ring)?;
+                let rect = self.append_footprint(&raster, engine, &mut builder)?;
                 rects.push(rect);
             }
             Ok(())
@@ -195,14 +184,15 @@ impl RasterGeometryArrayFactory {
     /// rectangle, reconciling the raster's CRS against the target CRS.
     ///
     /// CRS rules mirror the `RS_*` kernel: equal (or both-absent) CRS compares
-    /// directly; a genuine CRS difference reprojects the (densified) footprint;
-    /// a one-sided CRS is an error.
+    /// directly; a genuine CRS difference reprojects the footprint's four corners
+    /// into the target CRS; a one-sided CRS is an error. The footprint is always
+    /// the convex hull of the four corners — projection curvature along the edges
+    /// is not modeled (see the type-level note on [`RasterGeometryArrayFactory`]).
     fn append_footprint(
         &self,
         raster: &dyn RasterRef,
         engine: &dyn CrsEngine,
         builder: &mut BinaryBuilder,
-        ring: &mut Vec<(f64, f64)>,
     ) -> Result<Bounds2D> {
         let raster_crs = resolve_crs(raster.crs())?;
         let corners = raster_footprint_corners(raster);
@@ -220,8 +210,8 @@ impl RasterGeometryArrayFactory {
                 builder.append_value([]);
                 Ok(bounds_from_coords(&corners))
             }
-            // Genuine CRS difference: densify the native footprint edges, then
-            // reproject every ring vertex into the target CRS.
+            // Genuine CRS difference: reproject the four corners into the target
+            // CRS and emit their convex hull.
             (Some(raster_crs), Some(target_crs)) => {
                 let transform = engine
                     .get_transform_crs_to_crs(
@@ -232,17 +222,21 @@ impl RasterGeometryArrayFactory {
                     )
                     .map_err(|e| exec_datafusion_err!("CRS transform error: {e}"))?;
 
-                densify_ring(&corners, ring);
-                for point in ring.iter_mut() {
+                let mut hull = corners;
+                for corner in hull.iter_mut() {
                     transform
-                        .transform_coord(point)
+                        .transform_coord(corner)
                         .map_err(|e| exec_datafusion_err!("Transform error: {e}"))?;
                 }
 
-                write_wkb_polygon(builder, ring.iter().copied())
-                    .map_err(|e| exec_datafusion_err!("Failed to write footprint WKB: {e}"))?;
+                // Closed ring: the four reprojected corners plus the first repeated.
+                write_wkb_polygon(
+                    builder,
+                    [hull[0], hull[1], hull[2], hull[3], hull[0]].into_iter(),
+                )
+                .map_err(|e| exec_datafusion_err!("Failed to write footprint WKB: {e}"))?;
                 builder.append_value([]);
-                Ok(bounds_from_coords(ring))
+                Ok(bounds_from_coords(&hull))
             }
             (Some(_), None) => {
                 exec_err!(
@@ -256,26 +250,6 @@ impl RasterGeometryArrayFactory {
             }
         }
     }
-}
-
-/// Build a densified ring (native coordinates) from four footprint corners.
-///
-/// For each of the four edges the start vertex is emitted followed by
-/// [`DENSIFY_POINTS_PER_EDGE`] evenly spaced interior points; the ring is then
-/// closed by repeating the first corner. The resulting length is
-/// `4 * (1 + DENSIFY_POINTS_PER_EDGE) + 1`.
-fn densify_ring(corners: &[(f64, f64); 4], out: &mut Vec<(f64, f64)>) {
-    out.clear();
-    for i in 0..4 {
-        let (ax, ay) = corners[i];
-        let (bx, by) = corners[(i + 1) % 4];
-        out.push((ax, ay));
-        for k in 1..=DENSIFY_POINTS_PER_EDGE {
-            let t = k as f64 / (DENSIFY_POINTS_PER_EDGE as f64 + 1.0);
-            out.push((ax + t * (bx - ax), ay + t * (by - ay)));
-        }
-    }
-    out.push(corners[0]);
 }
 
 /// Bounding rectangle of a set of coordinates. [`Bounds2D::new`] enlarges the
@@ -298,34 +272,6 @@ fn bounds_from_coords(coords: &[(f64, f64)]) -> Bounds2D {
 #[cfg(test)]
 mod test {
     use super::*;
-
-    #[test]
-    fn densify_ring_vertex_count() {
-        // Unit square corners: upper-left, upper-right, lower-right, lower-left.
-        let corners = [(0.0, 1.0), (1.0, 1.0), (1.0, 0.0), (0.0, 0.0)];
-        let mut ring = Vec::new();
-        densify_ring(&corners, &mut ring);
-
-        // 4 edges * (start vertex + 16 interior points) + 1 closing vertex.
-        assert_eq!(ring.len(), 4 * (1 + DENSIFY_POINTS_PER_EDGE) + 1);
-        assert_eq!(ring.len(), 69);
-
-        // The ring starts and ends at the upper-left corner.
-        assert_eq!(ring[0], (0.0, 1.0));
-        assert_eq!(*ring.last().unwrap(), (0.0, 1.0));
-
-        // Every densified vertex lies on a footprint edge (unit square), so all
-        // coordinates stay within [0, 1].
-        for &(x, y) in &ring {
-            assert!((0.0..=1.0).contains(&x));
-            assert!((0.0..=1.0).contains(&y));
-        }
-
-        // The first interior point on the top edge is 1/17 of the way from the
-        // upper-left to the upper-right corner.
-        let t = 1.0 / (DENSIFY_POINTS_PER_EDGE as f64 + 1.0);
-        assert_eq!(ring[1], (t, 1.0));
-    }
 
     #[test]
     fn bounds_from_coords_covers_corners() {

--- a/rust/sedona-spatial-join-raster/src/join_provider.rs
+++ b/rust/sedona-spatial-join-raster/src/join_provider.rs
@@ -1,0 +1,468 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use arrow_array::{builder::BinaryBuilder, Array, ArrayRef, StructArray};
+use datafusion_common::{exec_datafusion_err, exec_err, JoinType, Result};
+use datafusion_expr::ColumnarValue;
+use sedona_common::{sedona_internal_datafusion_err, sedona_internal_err, SpatialJoinOptions};
+use sedona_expr::statistics::GeoStatistics;
+use sedona_geometry::{transform::CrsEngine, wkb_factory::write_wkb_polygon};
+use sedona_proj::transform::with_global_proj_engine;
+use sedona_raster::array::RasterStructArray;
+use sedona_raster::traits::RasterRef;
+use sedona_raster_functions::crs_utils::resolve_crs;
+use sedona_raster_functions::footprint::{raster_footprint_corners, write_convexhull_wkb};
+use sedona_schema::{crs::Crs, datatypes::SedonaType, datatypes::WKB_GEOMETRY};
+use sedona_spatial_join::{
+    index::{spatial_index_builder::SpatialJoinBuildMetrics, SpatialIndexBuilder},
+    join_provider::{DefaultSpatialJoinProvider, SpatialJoinProvider},
+    operand_evaluator::{EvaluatedGeometryArray, EvaluatedGeometryArrayFactory},
+    utils::bounds::Bounds2D,
+    SpatialPredicate,
+};
+
+/// Number of interpolated points added to each footprint edge before
+/// reprojection.
+///
+/// A raster footprint is a 4-corner ring whose edges are straight lines in the
+/// raster's native CRS. Reprojecting only the corners would draw straight lines
+/// between the reprojected corners, missing the curvature a projection change
+/// introduces along an edge. Interpolating `K` intermediate points per edge and
+/// reprojecting each one approximates that curve as a polyline; the maximum
+/// deviation from the true reprojected edge falls off like `1 / (K + 1)^2`.
+///
+/// `K = 16` (a 69-vertex reprojected ring) keeps that deviation well below a
+/// pixel for the projected extents these joins target while bounding the
+/// per-row vertex count. The reprojected footprint is an approximation either
+/// way, so cross-CRS results are verified against a reference implementation
+/// rather than asserted bit-exact against the nested-loop kernel.
+const DENSIFY_POINTS_PER_EDGE: usize = 16;
+
+/// [`SpatialJoinProvider`] for raster/geometry spatial joins.
+///
+/// The R-tree index builder and the memory estimate delegate to the default
+/// provider; only the operand evaluator is raster-aware. The factory it produces
+/// reprojects raster footprints into `target_crs` (the geometry operand's CRS).
+#[derive(Debug)]
+pub(crate) struct RasterJoinProvider {
+    default: DefaultSpatialJoinProvider,
+    target_crs: Crs,
+}
+
+impl RasterJoinProvider {
+    pub(crate) fn new(target_crs: Crs) -> Self {
+        Self {
+            default: DefaultSpatialJoinProvider,
+            target_crs,
+        }
+    }
+}
+
+impl SpatialJoinProvider for RasterJoinProvider {
+    fn try_new_spatial_index_builder(
+        &self,
+        schema: arrow_schema::SchemaRef,
+        spatial_predicate: SpatialPredicate,
+        options: SpatialJoinOptions,
+        join_type: JoinType,
+        probe_threads_count: usize,
+        metrics: SpatialJoinBuildMetrics,
+    ) -> Result<Box<dyn SpatialIndexBuilder>> {
+        // Footprints are ordinary planar WKB polygons, so the default R-tree
+        // builder and WKB refiner apply unchanged.
+        self.default.try_new_spatial_index_builder(
+            schema,
+            spatial_predicate,
+            options,
+            join_type,
+            probe_threads_count,
+            metrics,
+        )
+    }
+
+    fn estimate_extra_memory_usage(
+        &self,
+        geo_stats: &GeoStatistics,
+        spatial_predicate: &SpatialPredicate,
+        options: &SpatialJoinOptions,
+    ) -> usize {
+        self.default
+            .estimate_extra_memory_usage(geo_stats, spatial_predicate, options)
+    }
+
+    fn evaluated_array_factory(&self) -> Arc<dyn EvaluatedGeometryArrayFactory> {
+        Arc::new(RasterGeometryArrayFactory {
+            target_crs: self.target_crs.clone(),
+        })
+    }
+}
+
+/// Evaluates the operands of a raster/geometry spatial predicate.
+///
+/// The same factory sees both operands of the join. A raster operand is turned
+/// into its reprojected footprint (see [`RasterGeometryArrayFactory::evaluate_raster`]);
+/// a geometry operand is evaluated with the default planar behavior, since the
+/// geometry is already in the target CRS.
+#[derive(Debug)]
+struct RasterGeometryArrayFactory {
+    /// The geometry operand's CRS: the common CRS this join compares in. Raster
+    /// footprints are reprojected into it. `None` when the geometry operand
+    /// carries no CRS (the raster operand must then also be CRS-less).
+    target_crs: Crs,
+}
+
+impl EvaluatedGeometryArrayFactory for RasterGeometryArrayFactory {
+    fn try_new_evaluated_array(
+        &self,
+        geometry_array: ArrayRef,
+        sedona_type: &SedonaType,
+        distance_columnar_value: Option<&ColumnarValue>,
+    ) -> Result<EvaluatedGeometryArray> {
+        // Relation predicates (Intersects/Contains/Within) carry no distance;
+        // this factory is only wired up for those by the raster planner.
+        if distance_columnar_value.is_some() {
+            return sedona_internal_err!(
+                "Raster spatial joins do not support a distance predicate"
+            );
+        }
+
+        match sedona_type {
+            SedonaType::Raster => self.evaluate_raster(geometry_array),
+            // The geometry operand is already in the target CRS, so its default
+            // planar evaluation (Cartesian WKB bounds + WKB) is exactly right.
+            _ => EvaluatedGeometryArray::try_new(geometry_array, sedona_type),
+        }
+    }
+}
+
+impl RasterGeometryArrayFactory {
+    /// Evaluate a raster struct array into footprint polygons plus bounding
+    /// rectangles, reprojecting each footprint into the target CRS.
+    fn evaluate_raster(&self, raster_array: ArrayRef) -> Result<EvaluatedGeometryArray> {
+        let struct_array = raster_array
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .ok_or_else(|| {
+                sedona_internal_datafusion_err!("Expected StructArray for raster operand")
+            })?;
+        let rasters = RasterStructArray::try_new(struct_array)
+            .map_err(|e| exec_datafusion_err!("Failed to read raster array: {e}"))?;
+
+        let num_rows = rasters.len();
+        let mut builder = BinaryBuilder::with_capacity(num_rows, num_rows * 96);
+        let mut rects = Vec::with_capacity(num_rows);
+        let mut ring: Vec<(f64, f64)> = Vec::new();
+
+        with_global_proj_engine(|engine| {
+            for i in 0..num_rows {
+                // A null raster produces a null footprint that never matches.
+                if rasters.is_null(i) {
+                    builder.append_null();
+                    rects.push(Bounds2D::empty());
+                    continue;
+                }
+
+                let raster = rasters
+                    .get(i)
+                    .map_err(|e| exec_datafusion_err!("Failed to read raster row {i}: {e}"))?;
+                let rect = self.append_footprint(&raster, engine, &mut builder, &mut ring)?;
+                rects.push(rect);
+            }
+            Ok(())
+        })?;
+
+        let footprint_array: ArrayRef = Arc::new(builder.finish());
+        EvaluatedGeometryArray::try_new_with_rects(footprint_array, rects, &WKB_GEOMETRY)
+    }
+
+    /// Append one raster's footprint WKB to `builder` and return its bounding
+    /// rectangle, reconciling the raster's CRS against the target CRS.
+    ///
+    /// CRS rules mirror the `RS_*` kernel: equal (or both-absent) CRS compares
+    /// directly; a genuine CRS difference reprojects the (densified) footprint;
+    /// a one-sided CRS is an error.
+    fn append_footprint(
+        &self,
+        raster: &dyn RasterRef,
+        engine: &dyn CrsEngine,
+        builder: &mut BinaryBuilder,
+        ring: &mut Vec<(f64, f64)>,
+    ) -> Result<Bounds2D> {
+        let raster_crs = resolve_crs(raster.crs())?;
+        let corners = raster_footprint_corners(raster);
+
+        match (raster_crs.as_deref(), self.target_crs.as_deref()) {
+            // No CRS on either side, or identical CRS: compare directly. The
+            // footprint is byte-identical to the one the `RS_*` kernel builds.
+            (None, None) => {
+                write_convexhull_wkb(raster, builder)?;
+                builder.append_value([]);
+                Ok(bounds_from_coords(&corners))
+            }
+            (Some(raster_crs), Some(target_crs)) if raster_crs.crs_equals(target_crs) => {
+                write_convexhull_wkb(raster, builder)?;
+                builder.append_value([]);
+                Ok(bounds_from_coords(&corners))
+            }
+            // Genuine CRS difference: densify the native footprint edges, then
+            // reproject every ring vertex into the target CRS.
+            (Some(raster_crs), Some(target_crs)) => {
+                let transform = engine
+                    .get_transform_crs_to_crs(
+                        &raster_crs.to_crs_string(),
+                        &target_crs.to_crs_string(),
+                        None,
+                        "",
+                    )
+                    .map_err(|e| exec_datafusion_err!("CRS transform error: {e}"))?;
+
+                densify_ring(&corners, ring);
+                for point in ring.iter_mut() {
+                    transform
+                        .transform_coord(point)
+                        .map_err(|e| exec_datafusion_err!("Transform error: {e}"))?;
+                }
+
+                write_wkb_polygon(builder, ring.iter().copied())
+                    .map_err(|e| exec_datafusion_err!("Failed to write footprint WKB: {e}"))?;
+                builder.append_value([]);
+                Ok(bounds_from_coords(ring))
+            }
+            (Some(_), None) => {
+                exec_err!(
+                    "Cannot evaluate spatial predicate: raster has a CRS but the geometry does not"
+                )
+            }
+            (None, Some(_)) => {
+                exec_err!(
+                    "Cannot evaluate spatial predicate: geometry has a CRS but the raster does not"
+                )
+            }
+        }
+    }
+}
+
+/// Build a densified ring (native coordinates) from four footprint corners.
+///
+/// For each of the four edges the start vertex is emitted followed by
+/// [`DENSIFY_POINTS_PER_EDGE`] evenly spaced interior points; the ring is then
+/// closed by repeating the first corner. The resulting length is
+/// `4 * (1 + DENSIFY_POINTS_PER_EDGE) + 1`.
+fn densify_ring(corners: &[(f64, f64); 4], out: &mut Vec<(f64, f64)>) {
+    out.clear();
+    for i in 0..4 {
+        let (ax, ay) = corners[i];
+        let (bx, by) = corners[(i + 1) % 4];
+        out.push((ax, ay));
+        for k in 1..=DENSIFY_POINTS_PER_EDGE {
+            let t = k as f64 / (DENSIFY_POINTS_PER_EDGE as f64 + 1.0);
+            out.push((ax + t * (bx - ax), ay + t * (by - ay)));
+        }
+    }
+    out.push(corners[0]);
+}
+
+/// Bounding rectangle of a set of coordinates. [`Bounds2D::new`] enlarges the
+/// f32 bounds outward so the rectangle conservatively contains every input
+/// coordinate.
+fn bounds_from_coords(coords: &[(f64, f64)]) -> Bounds2D {
+    let mut min_x = f64::INFINITY;
+    let mut max_x = f64::NEG_INFINITY;
+    let mut min_y = f64::INFINITY;
+    let mut max_y = f64::NEG_INFINITY;
+    for &(x, y) in coords {
+        min_x = min_x.min(x);
+        max_x = max_x.max(x);
+        min_y = min_y.min(y);
+        max_y = max_y.max(y);
+    }
+    Bounds2D::new((min_x, max_x), (min_y, max_y))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn densify_ring_vertex_count() {
+        // Unit square corners: upper-left, upper-right, lower-right, lower-left.
+        let corners = [(0.0, 1.0), (1.0, 1.0), (1.0, 0.0), (0.0, 0.0)];
+        let mut ring = Vec::new();
+        densify_ring(&corners, &mut ring);
+
+        // 4 edges * (start vertex + 16 interior points) + 1 closing vertex.
+        assert_eq!(ring.len(), 4 * (1 + DENSIFY_POINTS_PER_EDGE) + 1);
+        assert_eq!(ring.len(), 69);
+
+        // The ring starts and ends at the upper-left corner.
+        assert_eq!(ring[0], (0.0, 1.0));
+        assert_eq!(*ring.last().unwrap(), (0.0, 1.0));
+
+        // Every densified vertex lies on a footprint edge (unit square), so all
+        // coordinates stay within [0, 1].
+        for &(x, y) in &ring {
+            assert!((0.0..=1.0).contains(&x));
+            assert!((0.0..=1.0).contains(&y));
+        }
+
+        // The first interior point on the top edge is 1/17 of the way from the
+        // upper-left to the upper-right corner.
+        let t = 1.0 / (DENSIFY_POINTS_PER_EDGE as f64 + 1.0);
+        assert_eq!(ring[1], (t, 1.0));
+    }
+
+    #[test]
+    fn bounds_from_coords_covers_corners() {
+        let corners = [(2.0, 3.08), (2.29, 2.4), (2.09, 3.0), (2.2, 2.48)];
+        let bounds = bounds_from_coords(&corners);
+        let ((min_x, max_x), (min_y, max_y)) = bounds.into_inner();
+
+        // f32 bounds must conservatively contain the f64 extent.
+        assert!((min_x as f64) <= 2.0);
+        assert!((max_x as f64) >= 2.29);
+        assert!((min_y as f64) <= 2.4);
+        assert!((max_y as f64) >= 3.08);
+    }
+
+    // --- Evaluator tests over real rasters -------------------------------
+
+    use arrow_array::BinaryArray;
+    use sedona_raster::builder::RasterBuilder;
+    use sedona_raster::traits::{BandMetadata, RasterMetadata};
+    use sedona_schema::crs::lnglat;
+    use sedona_schema::datatypes::RASTER;
+    use sedona_schema::raster::{BandDataType, StorageType};
+    use sedona_testing::rasters::generate_test_rasters;
+
+    /// A 1x1 raster over world coords (0,0)-(1,1), with `crs` (or none).
+    fn build_unit_raster(crs: Option<&str>) -> arrow_array::StructArray {
+        let mut builder = RasterBuilder::new(1);
+        let metadata = RasterMetadata {
+            width: 1,
+            height: 1,
+            upperleft_x: 0.0,
+            upperleft_y: 1.0,
+            scale_x: 1.0,
+            scale_y: -1.0,
+            skew_x: 0.0,
+            skew_y: 0.0,
+        };
+        builder.start_raster(&metadata, crs).unwrap();
+        builder
+            .start_band(BandMetadata {
+                datatype: BandDataType::UInt8,
+                nodata_value: None,
+                storage_type: StorageType::InDb,
+                outdb_url: None,
+                outdb_band_id: None,
+            })
+            .unwrap();
+        builder.band_data_writer().append_value([0u8]);
+        builder.finish_band().unwrap();
+        builder.finish_raster().unwrap();
+        builder.finish().unwrap()
+    }
+
+    /// Same-CRS: the footprint is byte-identical to the `RS_*` kernel's convex
+    /// hull, its MBR covers the hand-computed corners of raster 1, and a null
+    /// raster yields a null footprint with an empty rect.
+    #[test]
+    fn same_crs_footprint_matches_kernel_and_bounds() {
+        let rasters = generate_test_rasters(3, Some(0)).unwrap();
+
+        // Expected footprint bytes for raster 1, straight from the shared kernel helper.
+        let mut expected_wkb = Vec::new();
+        {
+            let arr = RasterStructArray::try_new(&rasters).unwrap();
+            let raster1 = arr.get(1).unwrap();
+            write_convexhull_wkb(&raster1, &mut expected_wkb).unwrap();
+        }
+
+        let factory = RasterGeometryArrayFactory {
+            target_crs: lnglat(),
+        };
+        let evaluated = factory.evaluate_raster(Arc::new(rasters)).unwrap();
+        let footprints = evaluated
+            .geometry_array()
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .unwrap();
+
+        // Null raster -> null footprint, empty rect.
+        assert!(footprints.is_null(0));
+        assert!(evaluated.rect(0).is_empty());
+
+        // Same-CRS footprint is byte-identical to the kernel's convex hull.
+        assert_eq!(footprints.value(1), expected_wkb.as_slice());
+
+        // Raster 1's footprint corners (from GDAL): (2.0, 3.0), (2.2, 3.08),
+        // (2.29, 2.48), (2.09, 2.4). The MBR must conservatively cover them.
+        let ((min_x, max_x), (min_y, max_y)) = evaluated.rect(1).clone().into_inner();
+        assert!((min_x as f64) <= 2.0);
+        assert!((max_x as f64) >= 2.29);
+        assert!((min_y as f64) <= 2.4);
+        assert!((max_y as f64) >= 3.08);
+    }
+
+    /// A raster with a CRS joined against a CRS-less geometry (target CRS
+    /// `None`) is a one-sided CRS: it must error rather than silently compare.
+    #[test]
+    fn raster_with_crs_but_crsless_target_errors() {
+        let rasters = build_unit_raster(Some("OGC:CRS84"));
+        let factory = RasterGeometryArrayFactory { target_crs: None };
+        let err = factory.evaluate_raster(Arc::new(rasters)).err().unwrap();
+        assert!(err.message().contains("has a CRS but"), "unexpected: {err}");
+    }
+
+    /// A CRS-less raster joined against a geometry that has a CRS is also a
+    /// one-sided CRS and must error.
+    #[test]
+    fn crsless_raster_with_crs_target_errors() {
+        let rasters = build_unit_raster(None);
+        let factory = RasterGeometryArrayFactory {
+            target_crs: lnglat(),
+        };
+        let err = factory.evaluate_raster(Arc::new(rasters)).err().unwrap();
+        assert!(err.message().contains("has a CRS but"), "unexpected: {err}");
+    }
+
+    /// A CRS-less raster with a CRS-less geometry compares directly (no error,
+    /// no reprojection): the footprint is the native convex hull.
+    #[test]
+    fn crsless_both_sides_compares_directly() {
+        let rasters = build_unit_raster(None);
+        let mut expected_wkb = Vec::new();
+        {
+            let arr = RasterStructArray::try_new(&rasters).unwrap();
+            let raster0 = arr.get(0).unwrap();
+            write_convexhull_wkb(&raster0, &mut expected_wkb).unwrap();
+        }
+
+        let factory = RasterGeometryArrayFactory { target_crs: None };
+        let evaluated = factory
+            .try_new_evaluated_array(Arc::new(rasters), &RASTER, None)
+            .unwrap();
+        let footprints = evaluated
+            .geometry_array()
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .unwrap();
+        assert_eq!(footprints.value(0), expected_wkb.as_slice());
+    }
+}

--- a/rust/sedona-spatial-join-raster/src/join_provider.rs
+++ b/rust/sedona-spatial-join-raster/src/join_provider.rs
@@ -18,7 +18,7 @@
 use std::sync::Arc;
 
 use arrow_array::{builder::BinaryBuilder, Array, ArrayRef, StructArray};
-use datafusion_common::{exec_datafusion_err, JoinType, Result};
+use datafusion_common::{exec_datafusion_err, exec_err, JoinType, Result};
 use datafusion_expr::ColumnarValue;
 use sedona_common::{sedona_internal_datafusion_err, sedona_internal_err, SpatialJoinOptions};
 use sedona_expr::statistics::GeoStatistics;
@@ -28,11 +28,7 @@ use sedona_raster::array::RasterStructArray;
 use sedona_raster::traits::RasterRef;
 use sedona_raster_functions::crs_utils::resolve_crs;
 use sedona_raster_functions::footprint::{raster_footprint_corners, write_convexhull_wkb};
-use sedona_schema::{
-    crs::{lnglat, CoordinateReferenceSystem, Crs},
-    datatypes::SedonaType,
-    datatypes::WKB_GEOMETRY,
-};
+use sedona_schema::{crs::Crs, datatypes::SedonaType, datatypes::WKB_GEOMETRY};
 use sedona_spatial_join::{
     index::{spatial_index_builder::SpatialJoinBuildMetrics, SpatialIndexBuilder},
     join_provider::{DefaultSpatialJoinProvider, SpatialJoinProvider},
@@ -116,9 +112,8 @@ impl SpatialJoinProvider for RasterJoinProvider {
 #[derive(Debug)]
 struct RasterGeometryArrayFactory {
     /// The geometry operand's CRS: the common CRS this join compares in. Raster
-    /// footprints are reprojected into it. WGS84 when the geometry operand carries
-    /// no CRS — a missing CRS is assumed WGS84 (matching the `RS_*` kernel and
-    /// Sedona Spark), so the CRS-less geometry is compared as-is in a WGS84 frame.
+    /// footprints are reprojected into it. `None` when the geometry operand
+    /// carries no CRS (the raster operand must then also be CRS-less).
     target_crs: Crs,
 }
 
@@ -163,11 +158,6 @@ impl RasterGeometryArrayFactory {
         let mut builder = BinaryBuilder::with_capacity(num_rows, num_rows * 96);
         let mut rects = Vec::with_capacity(num_rows);
 
-        // A missing CRS on either side is assumed to be WGS84 (matching the `RS_*`
-        // kernel and Sedona Spark); resolve it once rather than per row.
-        let lnglat_crs = lnglat();
-        let wgs84 = lnglat_crs.as_deref().expect("lnglat() is always Some");
-
         with_global_proj_engine(|engine| {
             for i in 0..num_rows {
                 // A null raster produces a null footprint that never matches.
@@ -180,7 +170,7 @@ impl RasterGeometryArrayFactory {
                 let raster = rasters
                     .get(i)
                     .map_err(|e| exec_datafusion_err!("Failed to read raster row {i}: {e}"))?;
-                let rect = self.append_footprint(&raster, wgs84, engine, &mut builder)?;
+                let rect = self.append_footprint(&raster, engine, &mut builder)?;
                 rects.push(rect);
             }
             Ok(())
@@ -191,73 +181,75 @@ impl RasterGeometryArrayFactory {
     }
 
     /// Append one raster's footprint WKB to `builder` and return its bounding
-    /// rectangle, reconciling the raster's CRS against the target CRS. `wgs84` is
-    /// the WGS84 CRS a missing side is assumed to be.
+    /// rectangle, reconciling the raster's CRS against the target CRS.
     ///
-    /// CRS rules mirror the `RS_*` kernel: a missing CRS on either side is assumed
-    /// to be WGS84 (matching Sedona Spark), after which an equal CRS compares
-    /// directly and a genuine CRS difference reprojects the footprint's four
-    /// corners into the target CRS. The footprint is always the convex hull of the
-    /// four corners — projection curvature along the edges is not modeled (see the
-    /// type-level note on [`RasterGeometryArrayFactory`]).
+    /// CRS rules mirror the `RS_*` kernel: equal (or both-absent) CRS compares
+    /// directly; a genuine CRS difference reprojects the footprint's four corners
+    /// into the target CRS; a one-sided CRS is an error. The footprint is always
+    /// the convex hull of the four corners — projection curvature along the edges
+    /// is not modeled (see the type-level note on [`RasterGeometryArrayFactory`]).
     fn append_footprint(
         &self,
         raster: &dyn RasterRef,
-        wgs84: &(dyn CoordinateReferenceSystem + Send + Sync),
         engine: &dyn CrsEngine,
         builder: &mut BinaryBuilder,
     ) -> Result<Bounds2D> {
         let raster_crs = resolve_crs(raster.crs())?;
         let corners = raster_footprint_corners(raster);
 
-        // Assume WGS84 for whichever side lacks a CRS, then compare in the target
-        // frame. Both-absent and same-CRS collapse to a direct comparison.
-        let raster_crs = raster_crs.as_deref().unwrap_or(wgs84);
-        let target_crs = self.target_crs.as_deref().unwrap_or(wgs84);
+        match (raster_crs.as_deref(), self.target_crs.as_deref()) {
+            // No CRS on either side, or identical CRS: compare directly. The
+            // footprint is byte-identical to the one the `RS_*` kernel builds.
+            (None, None) => {
+                write_convexhull_wkb(raster, builder)?;
+                builder.append_value([]);
+                Ok(bounds_from_coords(&corners))
+            }
+            (Some(raster_crs), Some(target_crs)) if raster_crs.crs_equals(target_crs) => {
+                write_convexhull_wkb(raster, builder)?;
+                builder.append_value([]);
+                Ok(bounds_from_coords(&corners))
+            }
+            // Genuine CRS difference: reproject the four corners into the target
+            // CRS and emit their convex hull.
+            (Some(raster_crs), Some(target_crs)) => {
+                let transform = engine
+                    .get_transform_crs_to_crs(
+                        &raster_crs.to_crs_string(),
+                        &target_crs.to_crs_string(),
+                        None,
+                        "",
+                    )
+                    .map_err(|e| exec_datafusion_err!("CRS transform error: {e}"))?;
 
-        if raster_crs.crs_equals(target_crs) {
-            // Same (possibly assumed-WGS84) CRS: compare directly. The footprint is
-            // byte-identical to the one the `RS_*` kernel builds.
-            write_convexhull_wkb(raster, builder)?;
-            builder.append_value([]);
-            Ok(bounds_from_coords(&corners))
-        } else {
-            // Genuine CRS difference: reproject the four corners into the target CRS
-            // and emit their convex hull.
-            append_reprojected_footprint(corners, raster_crs, target_crs, engine, builder)
+                let mut hull = corners;
+                for corner in hull.iter_mut() {
+                    transform
+                        .transform_coord(corner)
+                        .map_err(|e| exec_datafusion_err!("Transform error: {e}"))?;
+                }
+
+                // Closed ring: the four reprojected corners plus the first repeated.
+                write_wkb_polygon(
+                    builder,
+                    [hull[0], hull[1], hull[2], hull[3], hull[0]].into_iter(),
+                )
+                .map_err(|e| exec_datafusion_err!("Failed to write footprint WKB: {e}"))?;
+                builder.append_value([]);
+                Ok(bounds_from_coords(&hull))
+            }
+            (Some(_), None) => {
+                exec_err!(
+                    "Cannot evaluate spatial predicate: raster has a CRS but the geometry does not"
+                )
+            }
+            (None, Some(_)) => {
+                exec_err!(
+                    "Cannot evaluate spatial predicate: geometry has a CRS but the raster does not"
+                )
+            }
         }
     }
-}
-
-/// Reproject a raster's four `corners` from `from_crs` to `to_crs`, append the
-/// convex hull of the reprojected corners to `builder`, and return its bounding
-/// rectangle.
-fn append_reprojected_footprint(
-    corners: [(f64, f64); 4],
-    from_crs: &(dyn CoordinateReferenceSystem + Send + Sync),
-    to_crs: &(dyn CoordinateReferenceSystem + Send + Sync),
-    engine: &dyn CrsEngine,
-    builder: &mut BinaryBuilder,
-) -> Result<Bounds2D> {
-    let transform = engine
-        .get_transform_crs_to_crs(&from_crs.to_crs_string(), &to_crs.to_crs_string(), None, "")
-        .map_err(|e| exec_datafusion_err!("CRS transform error: {e}"))?;
-
-    let mut hull = corners;
-    for corner in hull.iter_mut() {
-        transform
-            .transform_coord(corner)
-            .map_err(|e| exec_datafusion_err!("Transform error: {e}"))?;
-    }
-
-    // Closed ring: the four reprojected corners plus the first repeated.
-    write_wkb_polygon(
-        builder,
-        [hull[0], hull[1], hull[2], hull[3], hull[0]].into_iter(),
-    )
-    .map_err(|e| exec_datafusion_err!("Failed to write footprint WKB: {e}"))?;
-    builder.append_value([]);
-    Ok(bounds_from_coords(&hull))
 }
 
 /// Bounding rectangle of a set of coordinates. [`Bounds2D::new`] enlarges the
@@ -299,7 +291,7 @@ mod test {
     use arrow_array::BinaryArray;
     use sedona_raster::builder::RasterBuilder;
     use sedona_raster::traits::{BandMetadata, RasterMetadata};
-    use sedona_schema::crs::{deserialize_crs, lnglat};
+    use sedona_schema::crs::lnglat;
     use sedona_schema::datatypes::RASTER;
     use sedona_schema::raster::{BandDataType, StorageType};
     use sedona_testing::rasters::generate_test_rasters;
@@ -331,29 +323,6 @@ mod test {
         builder.finish_band().unwrap();
         builder.finish_raster().unwrap();
         builder.finish().unwrap()
-    }
-
-    /// Footprint WKB the factory produces for row 0 of a single-row raster,
-    /// comparing footprints against `target_crs`.
-    fn footprint_bytes(target_crs: Crs, raster: arrow_array::StructArray) -> Vec<u8> {
-        let factory = RasterGeometryArrayFactory { target_crs };
-        let evaluated = factory.evaluate_raster(Arc::new(raster)).unwrap();
-        evaluated
-            .geometry_array()
-            .as_any()
-            .downcast_ref::<BinaryArray>()
-            .unwrap()
-            .value(0)
-            .to_vec()
-    }
-
-    /// The native (non-reprojected) convex-hull footprint the `RS_*` kernel builds
-    /// for row 0 of `raster`.
-    fn native_hull(raster: &arrow_array::StructArray) -> Vec<u8> {
-        let arr = RasterStructArray::try_new(raster).unwrap();
-        let mut wkb = Vec::new();
-        write_convexhull_wkb(&arr.get(0).unwrap(), &mut wkb).unwrap();
-        wkb
     }
 
     /// Same-CRS: the footprint is byte-identical to the `RS_*` kernel's convex
@@ -397,55 +366,26 @@ mod test {
         assert!((max_y as f64) >= 3.08);
     }
 
-    /// A raster with a CRS joined against a CRS-less geometry (target CRS `None`)
-    /// no longer errors: the missing target CRS is assumed to be WGS84 (matching
-    /// the `RS_*` kernel and Sedona Spark). The WGS84 raster then compares
-    /// directly, giving the kernel's native hull and matching an explicit WGS84
-    /// target.
+    /// A raster with a CRS joined against a CRS-less geometry (target CRS
+    /// `None`) is a one-sided CRS: it must error rather than silently compare.
     #[test]
-    fn raster_with_crs_and_crsless_target_assumes_wgs84() {
-        let expected = native_hull(&build_unit_raster(Some("OGC:CRS84")));
-
-        let assumed = footprint_bytes(None, build_unit_raster(Some("OGC:CRS84")));
-        let tagged = footprint_bytes(lnglat(), build_unit_raster(Some("OGC:CRS84")));
-
-        assert_eq!(
-            assumed, expected,
-            "assumed-WGS84 target compares directly (native hull)"
-        );
-        assert_eq!(
-            assumed, tagged,
-            "assumed WGS84 must match an explicit WGS84 target"
-        );
+    fn raster_with_crs_but_crsless_target_errors() {
+        let rasters = build_unit_raster(Some("OGC:CRS84"));
+        let factory = RasterGeometryArrayFactory { target_crs: None };
+        let err = factory.evaluate_raster(Arc::new(rasters)).err().unwrap();
+        assert!(err.message().contains("has a CRS but"), "unexpected: {err}");
     }
 
-    /// A CRS-less raster joined against a geometry that has a CRS also assumes
-    /// WGS84 for the raster. Against a WGS84 target it compares directly; against a
-    /// non-WGS84 target it reprojects WGS84 -> target, matching a raster explicitly
-    /// tagged WGS84.
+    /// A CRS-less raster joined against a geometry that has a CRS is also a
+    /// one-sided CRS and must error.
     #[test]
-    fn crsless_raster_assumes_wgs84() {
-        let native = native_hull(&build_unit_raster(None));
-
-        // WGS84 target: the assumed-WGS84 raster compares directly (native hull).
-        let direct = footprint_bytes(lnglat(), build_unit_raster(None));
-        assert_eq!(
-            direct, native,
-            "assumed-WGS84 raster vs WGS84 target compares directly"
-        );
-
-        // Non-WGS84 target: reproject WGS84 -> target, matching an explicit tag.
-        let epsg_3857 = deserialize_crs("EPSG:3857").unwrap();
-        let assumed = footprint_bytes(epsg_3857.clone(), build_unit_raster(None));
-        let tagged = footprint_bytes(epsg_3857, build_unit_raster(Some("OGC:CRS84")));
-        assert_eq!(
-            assumed, tagged,
-            "assumed WGS84 must match an explicit WGS84 tag under reprojection"
-        );
-        assert_ne!(
-            assumed, native,
-            "reprojection to EPSG:3857 must change the footprint"
-        );
+    fn crsless_raster_with_crs_target_errors() {
+        let rasters = build_unit_raster(None);
+        let factory = RasterGeometryArrayFactory {
+            target_crs: lnglat(),
+        };
+        let err = factory.evaluate_raster(Arc::new(rasters)).err().unwrap();
+        assert!(err.message().contains("has a CRS but"), "unexpected: {err}");
     }
 
     /// A CRS-less raster with a CRS-less geometry compares directly (no error,

--- a/rust/sedona-spatial-join-raster/src/join_provider.rs
+++ b/rust/sedona-spatial-join-raster/src/join_provider.rs
@@ -31,7 +31,9 @@ use sedona_geometry::{
 use sedona_raster::array::RasterStructArray;
 use sedona_raster::traits::RasterRef;
 use sedona_raster_functions::crs_utils::resolve_crs;
-use sedona_raster_functions::footprint::{raster_footprint_corners, write_footprint_wkb};
+use sedona_raster_functions::footprint::{
+    densify_footprint_ring, raster_footprint_corners, write_footprint_ring_wkb, write_footprint_wkb,
+};
 use sedona_schema::{
     crs::{CoordinateReferenceSystem, Crs},
     datatypes::SedonaType,
@@ -124,16 +126,17 @@ impl SpatialJoinProvider for RasterJoinProvider {
 /// Evaluates the operands of a raster/geometry spatial predicate.
 ///
 /// The same factory sees both operands of the join. A raster operand is turned
-/// into its footprint — the convex hull of the raster's four corners
+/// into its footprint — the polygon through the raster's four corners
 /// (see [`RasterGeometryArrayFactory::evaluate_raster`]) — and a geometry operand
 /// is evaluated with the default planar behavior, since the geometry is already
 /// in the target CRS.
 ///
-/// Cross-CRS raster footprints are indexed and refined as the convex hull of the
-/// raster's four reprojected corners; projection curvature along the edges is not
-/// modeled, so for large-extent rasters reprojected between very different CRSs
-/// the hull can slightly under-cover the true footprint (rare missed matches at
-/// the extreme edges). Same-CRS joins are exact.
+/// A cross-CRS raster footprint densifies each of its four edges
+/// ([`FOOTPRINT_POINTS_PER_EDGE`] interior points) in the raster's own CRS, where
+/// the edges are exact straight lines, then reprojects every densified point into
+/// the target CRS. The indexed and refined footprint therefore follows the
+/// curved image of each edge rather than chording straight across it. Same-CRS
+/// joins keep the exact four-corner footprint (no reprojection, no densification).
 #[derive(Debug)]
 struct RasterGeometryArrayFactory {
     /// The geometry operand's CRS: the common CRS this join compares in. Raster
@@ -186,6 +189,10 @@ impl RasterGeometryArrayFactory {
         let mut builder = BinaryBuilder::with_capacity(num_rows, num_rows * 96);
         let mut rects = Vec::with_capacity(num_rows);
 
+        // Reused across rows so densifying each cross-CRS footprint (below)
+        // allocates its point ring once, not per raster.
+        let mut ring = Vec::new();
+
         let engine: &dyn CrsEngine = self.engine.as_ref();
         for i in 0..num_rows {
             // A null raster produces a null footprint that never matches.
@@ -198,7 +205,7 @@ impl RasterGeometryArrayFactory {
             let raster = rasters
                 .get(i)
                 .map_err(|e| exec_datafusion_err!("Failed to read raster row {i}: {e}"))?;
-            let rect = self.append_footprint(&raster, engine, &mut builder)?;
+            let rect = self.append_footprint(&raster, engine, &mut ring, &mut builder)?;
             rects.push(rect);
         }
 
@@ -210,14 +217,17 @@ impl RasterGeometryArrayFactory {
     /// rectangle, reconciling the raster's CRS against the target CRS.
     ///
     /// CRS rules mirror the `RS_*` kernel: equal (or both-absent) CRS compares
-    /// directly; a genuine CRS difference reprojects the footprint's four corners
-    /// into the target CRS; a one-sided CRS is an error. The footprint is always
-    /// the convex hull of the four corners — projection curvature along the edges
-    /// is not modeled (see the type-level note on [`RasterGeometryArrayFactory`]).
+    /// directly; a genuine CRS difference densifies and reprojects the footprint
+    /// into the target CRS; a one-sided CRS is an error. Same-CRS footprints are
+    /// the exact four-corner polygon; cross-CRS footprints densify each edge
+    /// before reprojection so they follow its curve (see the type-level note on
+    /// [`RasterGeometryArrayFactory`]). `ring` is scratch space reused across rows
+    /// for the densified reprojected ring.
     fn append_footprint(
         &self,
         raster: &dyn RasterRef,
         engine: &dyn CrsEngine,
+        ring: &mut Vec<(f64, f64)>,
         builder: &mut BinaryBuilder,
     ) -> Result<Bounds2D> {
         let raster_crs = resolve_crs(raster.crs())?;
@@ -236,10 +246,10 @@ impl RasterGeometryArrayFactory {
                 builder.append_value([]);
                 Ok(bounds_from_coords(&corners))
             }
-            // Genuine CRS difference: reproject the four corners into the target
-            // CRS and emit their convex hull.
+            // Genuine CRS difference: densify each edge in the raster's own CRS
+            // and reproject every point into the target CRS.
             (Some(raster_crs), Some(target_crs)) => {
-                append_reprojected_footprint(corners, raster_crs, target_crs, engine, builder)
+                append_reprojected_footprint(corners, raster_crs, target_crs, engine, ring, builder)
             }
             (Some(_), None) => {
                 exec_err!(
@@ -255,22 +265,29 @@ impl RasterGeometryArrayFactory {
     }
 }
 
-/// Reproject a raster's four `corners` from `from_crs` to `to_crs`, append the
-/// convex hull of the reprojected corners to `builder`, and return its bounding
-/// rectangle.
+/// Densify a raster's four `corners` in `from_crs`, reproject every densified
+/// point to `to_crs`, append the resulting footprint polygon to `builder`, and
+/// return its bounding rectangle.
 ///
-/// A transform that cannot be built, a transform that fails on a corner, or a
-/// reprojected corner that is non-finite yields a *null* footprint for this row
-/// (`append_null()` + [`Bounds2D::empty`], mirroring the null-raster path) so the
-/// row contributes no matches — rather than writing a garbage footprint/MBR or
-/// aborting the whole join. Recovering a failed reprojection via a WGS84 fallback
-/// (as the `RS_*` kernel does for the comparison as a whole) is a separate open
-/// question and is not attempted here.
+/// The footprint is densified while it is still in the raster's own CRS, where
+/// each edge is an exact straight line, and every densified point is then
+/// reprojected — so the reprojected ring follows the curved image of each edge
+/// instead of chording straight across it. `ring` is caller-managed scratch
+/// space for the densified ring.
+///
+/// A transform that cannot be built, a transform that fails on any densified
+/// point, or a reprojected point that is non-finite yields a *null* footprint for
+/// this row (`append_null()` + [`Bounds2D::empty`], mirroring the null-raster
+/// path) so the row contributes no matches — rather than writing a garbage
+/// footprint/MBR or aborting the whole join. Recovering a failed reprojection via
+/// a WGS84 fallback (as the `RS_*` kernel does for the comparison as a whole) is a
+/// separate open question and is not attempted here.
 fn append_reprojected_footprint(
     corners: [(f64, f64); 4],
     from_crs: &(dyn CoordinateReferenceSystem + Send + Sync),
     to_crs: &(dyn CoordinateReferenceSystem + Send + Sync),
     engine: &dyn CrsEngine,
+    ring: &mut Vec<(f64, f64)>,
     builder: &mut BinaryBuilder,
 ) -> Result<Bounds2D> {
     let Ok(transform) = engine.get_transform_crs_to_crs(
@@ -283,25 +300,27 @@ fn append_reprojected_footprint(
         return Ok(Bounds2D::empty());
     };
 
-    let mut hull = corners;
-    for corner in hull.iter_mut() {
-        if transform.transform_coord(corner).is_err() {
+    // Densify the four-corner ring in the native CRS (exact straight edges),
+    // then reproject every point so the footprint follows the reprojected curve.
+    densify_footprint_ring(corners, ring);
+    for point in ring.iter_mut() {
+        if transform.transform_coord(point).is_err() {
             builder.append_null();
             return Ok(Bounds2D::empty());
         }
     }
 
-    // A non-finite reprojected corner (e.g. a corner outside the target
+    // A single non-finite reprojected point (e.g. a point outside the target
     // projection's valid domain) would poison the footprint WKB and its MBR, so
     // emit a null footprint for this row instead of writing garbage.
-    if hull.iter().any(|(x, y)| !x.is_finite() || !y.is_finite()) {
+    if ring.iter().any(|(x, y)| !x.is_finite() || !y.is_finite()) {
         builder.append_null();
         return Ok(Bounds2D::empty());
     }
 
-    write_footprint_wkb(hull, builder)?;
+    write_footprint_ring_wkb(ring, builder)?;
     builder.append_value([]);
-    Ok(bounds_from_coords(&hull))
+    Ok(bounds_from_coords(ring))
 }
 
 /// Bounding rectangle of a set of coordinates, accumulated as f64 [`Interval`]s
@@ -545,11 +564,11 @@ mod test {
     }
 
     /// A footprint reprojection that fails — the transform can't be built, a
-    /// corner transform errors, or a reprojected corner is non-finite — yields a
-    /// null footprint with an empty MBR for that row (mirroring the null-raster
-    /// path) rather than writing a garbage footprint/MBR or aborting the whole
-    /// join. A transform that succeeds with finite corners still produces a real,
-    /// non-null footprint.
+    /// densified point's transform errors, or a reprojected point is non-finite —
+    /// yields a null footprint with an empty MBR for that row (mirroring the
+    /// null-raster path) rather than writing a garbage footprint/MBR or aborting
+    /// the whole join. A transform that succeeds with finite points still produces
+    /// a real, non-null footprint.
     #[test]
     fn failed_reprojection_yields_null_footprint() {
         let crs = lnglat();
@@ -558,9 +577,11 @@ mod test {
 
         for fate in [None, Some(CornerFate::Error), Some(CornerFate::NonFinite)] {
             let engine = MockEngine { fate };
+            let mut ring = Vec::new();
             let mut builder = BinaryBuilder::new();
             let bounds =
-                append_reprojected_footprint(corners, crs, crs, &engine, &mut builder).unwrap();
+                append_reprojected_footprint(corners, crs, crs, &engine, &mut ring, &mut builder)
+                    .unwrap();
             let footprints = builder.finish();
             assert!(
                 footprints.is_null(0),
@@ -576,9 +597,11 @@ mod test {
         let engine = MockEngine {
             fate: Some(CornerFate::Identity),
         };
+        let mut ring = Vec::new();
         let mut builder = BinaryBuilder::new();
         let bounds =
-            append_reprojected_footprint(corners, crs, crs, &engine, &mut builder).unwrap();
+            append_reprojected_footprint(corners, crs, crs, &engine, &mut ring, &mut builder)
+                .unwrap();
         let footprints = builder.finish();
         assert!(
             !footprints.is_null(0),

--- a/rust/sedona-spatial-join-raster/src/join_provider.rs
+++ b/rust/sedona-spatial-join-raster/src/join_provider.rs
@@ -20,15 +20,24 @@ use std::sync::Arc;
 use arrow_array::{builder::BinaryBuilder, Array, ArrayRef, StructArray};
 use datafusion_common::{exec_datafusion_err, exec_err, JoinType, Result};
 use datafusion_expr::ColumnarValue;
-use sedona_common::{sedona_internal_datafusion_err, sedona_internal_err, SpatialJoinOptions};
+use sedona_common::{
+    sedona_internal_datafusion_err, sedona_internal_err, SpatialJoinOptions, SpatialLibrary,
+};
 use sedona_expr::statistics::GeoStatistics;
-use sedona_geometry::{transform::CrsEngine, wkb_factory::write_wkb_polygon};
+use sedona_geometry::{
+    interval::{Interval, IntervalTrait},
+    transform::CrsEngine,
+};
 use sedona_proj::transform::with_global_proj_engine;
 use sedona_raster::array::RasterStructArray;
 use sedona_raster::traits::RasterRef;
 use sedona_raster_functions::crs_utils::resolve_crs;
-use sedona_raster_functions::footprint::{raster_footprint_corners, write_convexhull_wkb};
-use sedona_schema::{crs::Crs, datatypes::SedonaType, datatypes::WKB_GEOMETRY};
+use sedona_raster_functions::footprint::{raster_footprint_corners, write_footprint_wkb};
+use sedona_schema::{
+    crs::{CoordinateReferenceSystem, Crs},
+    datatypes::SedonaType,
+    datatypes::WKB_GEOMETRY,
+};
 use sedona_spatial_join::{
     index::{spatial_index_builder::SpatialJoinBuildMetrics, SpatialIndexBuilder},
     join_provider::{DefaultSpatialJoinProvider, SpatialJoinProvider},
@@ -57,6 +66,14 @@ impl RasterJoinProvider {
     }
 }
 
+/// Pin the join's refiner to `tg`, the engine the `RS_*` predicate kernel uses,
+/// so the accelerated join and the kernel resolve boundary/touching cases
+/// identically regardless of the session's `spatial_join.spatial_library`.
+fn pin_refiner_to_tg(mut options: SpatialJoinOptions) -> SpatialJoinOptions {
+    options.spatial_library = SpatialLibrary::Tg;
+    options
+}
+
 impl SpatialJoinProvider for RasterJoinProvider {
     fn try_new_spatial_index_builder(
         &self,
@@ -72,7 +89,7 @@ impl SpatialJoinProvider for RasterJoinProvider {
         self.default.try_new_spatial_index_builder(
             schema,
             spatial_predicate,
-            options,
+            pin_refiner_to_tg(options),
             join_type,
             probe_threads_count,
             metrics,
@@ -85,8 +102,13 @@ impl SpatialJoinProvider for RasterJoinProvider {
         spatial_predicate: &SpatialPredicate,
         options: &SpatialJoinOptions,
     ) -> usize {
-        self.default
-            .estimate_extra_memory_usage(geo_stats, spatial_predicate, options)
+        // Match the refiner the join actually uses (pinned to `tg`) so the memory
+        // estimate reflects it.
+        self.default.estimate_extra_memory_usage(
+            geo_stats,
+            spatial_predicate,
+            &pin_refiner_to_tg(options.clone()),
+        )
     }
 
     fn evaluated_array_factory(&self) -> Arc<dyn EvaluatedGeometryArrayFactory> {
@@ -201,42 +223,19 @@ impl RasterGeometryArrayFactory {
             // No CRS on either side, or identical CRS: compare directly. The
             // footprint is byte-identical to the one the `RS_*` kernel builds.
             (None, None) => {
-                write_convexhull_wkb(raster, builder)?;
+                write_footprint_wkb(corners, builder)?;
                 builder.append_value([]);
                 Ok(bounds_from_coords(&corners))
             }
             (Some(raster_crs), Some(target_crs)) if raster_crs.crs_equals(target_crs) => {
-                write_convexhull_wkb(raster, builder)?;
+                write_footprint_wkb(corners, builder)?;
                 builder.append_value([]);
                 Ok(bounds_from_coords(&corners))
             }
             // Genuine CRS difference: reproject the four corners into the target
             // CRS and emit their convex hull.
             (Some(raster_crs), Some(target_crs)) => {
-                let transform = engine
-                    .get_transform_crs_to_crs(
-                        &raster_crs.to_crs_string(),
-                        &target_crs.to_crs_string(),
-                        None,
-                        "",
-                    )
-                    .map_err(|e| exec_datafusion_err!("CRS transform error: {e}"))?;
-
-                let mut hull = corners;
-                for corner in hull.iter_mut() {
-                    transform
-                        .transform_coord(corner)
-                        .map_err(|e| exec_datafusion_err!("Transform error: {e}"))?;
-                }
-
-                // Closed ring: the four reprojected corners plus the first repeated.
-                write_wkb_polygon(
-                    builder,
-                    [hull[0], hull[1], hull[2], hull[3], hull[0]].into_iter(),
-                )
-                .map_err(|e| exec_datafusion_err!("Failed to write footprint WKB: {e}"))?;
-                builder.append_value([]);
-                Ok(bounds_from_coords(&hull))
+                append_reprojected_footprint(corners, raster_crs, target_crs, engine, builder)
             }
             (Some(_), None) => {
                 exec_err!(
@@ -252,21 +251,67 @@ impl RasterGeometryArrayFactory {
     }
 }
 
-/// Bounding rectangle of a set of coordinates. [`Bounds2D::new`] enlarges the
-/// f32 bounds outward so the rectangle conservatively contains every input
-/// coordinate.
-fn bounds_from_coords(coords: &[(f64, f64)]) -> Bounds2D {
-    let mut min_x = f64::INFINITY;
-    let mut max_x = f64::NEG_INFINITY;
-    let mut min_y = f64::INFINITY;
-    let mut max_y = f64::NEG_INFINITY;
-    for &(x, y) in coords {
-        min_x = min_x.min(x);
-        max_x = max_x.max(x);
-        min_y = min_y.min(y);
-        max_y = max_y.max(y);
+/// Reproject a raster's four `corners` from `from_crs` to `to_crs`, append the
+/// convex hull of the reprojected corners to `builder`, and return its bounding
+/// rectangle.
+///
+/// A transform that cannot be built, a transform that fails on a corner, or a
+/// reprojected corner that is non-finite yields a *null* footprint for this row
+/// (`append_null()` + [`Bounds2D::empty`], mirroring the null-raster path) so the
+/// row contributes no matches — rather than writing a garbage footprint/MBR or
+/// aborting the whole join. Recovering a failed reprojection via a WGS84 fallback
+/// (as the `RS_*` kernel does for the comparison as a whole) is a separate open
+/// question and is not attempted here.
+fn append_reprojected_footprint(
+    corners: [(f64, f64); 4],
+    from_crs: &(dyn CoordinateReferenceSystem + Send + Sync),
+    to_crs: &(dyn CoordinateReferenceSystem + Send + Sync),
+    engine: &dyn CrsEngine,
+    builder: &mut BinaryBuilder,
+) -> Result<Bounds2D> {
+    let Ok(transform) = engine.get_transform_crs_to_crs(
+        &from_crs.to_crs_string(),
+        &to_crs.to_crs_string(),
+        None,
+        "",
+    ) else {
+        builder.append_null();
+        return Ok(Bounds2D::empty());
+    };
+
+    let mut hull = corners;
+    for corner in hull.iter_mut() {
+        if transform.transform_coord(corner).is_err() {
+            builder.append_null();
+            return Ok(Bounds2D::empty());
+        }
     }
-    Bounds2D::new((min_x, max_x), (min_y, max_y))
+
+    // A non-finite reprojected corner (e.g. a corner outside the target
+    // projection's valid domain) would poison the footprint WKB and its MBR, so
+    // emit a null footprint for this row instead of writing garbage.
+    if hull.iter().any(|(x, y)| !x.is_finite() || !y.is_finite()) {
+        builder.append_null();
+        return Ok(Bounds2D::empty());
+    }
+
+    write_footprint_wkb(hull, builder)?;
+    builder.append_value([]);
+    Ok(bounds_from_coords(&hull))
+}
+
+/// Bounding rectangle of a set of coordinates, accumulated as f64 [`Interval`]s
+/// (the same primitive the geometry operand's bounds use). [`Bounds2D::new`]
+/// enlarges the f32 bounds outward so the rectangle conservatively contains
+/// every input coordinate.
+fn bounds_from_coords(coords: &[(f64, f64)]) -> Bounds2D {
+    let mut x = Interval::empty();
+    let mut y = Interval::empty();
+    for &(cx, cy) in coords {
+        x.update_value(cx);
+        y.update_value(cy);
+    }
+    Bounds2D::new(x, y)
 }
 
 #[cfg(test)]
@@ -288,9 +333,15 @@ mod test {
 
     // --- Evaluator tests over real rasters -------------------------------
 
+    use std::rc::Rc;
+
     use arrow_array::BinaryArray;
+    use sedona_geometry::bounding_box::BoundingBox;
+    use sedona_geometry::error::SedonaGeometryError;
+    use sedona_geometry::transform::CrsTransform;
     use sedona_raster::builder::RasterBuilder;
     use sedona_raster::traits::{BandMetadata, RasterMetadata};
+    use sedona_raster_functions::footprint::write_convexhull_wkb;
     use sedona_schema::crs::lnglat;
     use sedona_schema::datatypes::RASTER;
     use sedona_schema::raster::{BandDataType, StorageType};
@@ -410,5 +461,109 @@ mod test {
             .downcast_ref::<BinaryArray>()
             .unwrap();
         assert_eq!(footprints.value(0), expected_wkb.as_slice());
+    }
+
+    /// How a [`MockTransform`] treats each corner it is asked to reproject.
+    #[derive(Debug, Clone, Copy)]
+    enum CornerFate {
+        /// Leave the coordinate unchanged (a well-behaved transform).
+        Identity,
+        /// Reproject the corner to a non-finite coordinate.
+        NonFinite,
+        /// Fail while transforming the corner.
+        Error,
+    }
+
+    #[derive(Debug)]
+    struct MockTransform(CornerFate);
+
+    impl CrsTransform for MockTransform {
+        fn transform_coord(&self, coord: &mut (f64, f64)) -> Result<(), SedonaGeometryError> {
+            match self.0 {
+                CornerFate::Identity => Ok(()),
+                CornerFate::NonFinite => {
+                    coord.1 = f64::INFINITY;
+                    Ok(())
+                }
+                CornerFate::Error => Err(SedonaGeometryError::Invalid("boom".to_string())),
+            }
+        }
+    }
+
+    /// A [`CrsEngine`] that hands back a [`MockTransform`], or fails to build a
+    /// transform at all when `fate` is `None`.
+    #[derive(Debug)]
+    struct MockEngine {
+        fate: Option<CornerFate>,
+    }
+
+    impl CrsEngine for MockEngine {
+        fn get_transform_crs_to_crs(
+            &self,
+            _from: &str,
+            _to: &str,
+            _area_of_interest: Option<BoundingBox>,
+            _options: &str,
+        ) -> Result<Rc<dyn CrsTransform>, SedonaGeometryError> {
+            match self.fate {
+                Some(fate) => Ok(Rc::new(MockTransform(fate))),
+                None => Err(SedonaGeometryError::Invalid("no transform".to_string())),
+            }
+        }
+
+        fn get_transform_pipeline(
+            &self,
+            _pipeline: &str,
+            _options: &str,
+        ) -> Result<Rc<dyn CrsTransform>, SedonaGeometryError> {
+            Err(SedonaGeometryError::Unknown)
+        }
+
+        fn to_projjson(&self, _crs_string: &str) -> Result<String, SedonaGeometryError> {
+            Err(SedonaGeometryError::Unknown)
+        }
+    }
+
+    /// A footprint reprojection that fails — the transform can't be built, a
+    /// corner transform errors, or a reprojected corner is non-finite — yields a
+    /// null footprint with an empty MBR for that row (mirroring the null-raster
+    /// path) rather than writing a garbage footprint/MBR or aborting the whole
+    /// join. A transform that succeeds with finite corners still produces a real,
+    /// non-null footprint.
+    #[test]
+    fn failed_reprojection_yields_null_footprint() {
+        let crs = lnglat();
+        let crs = crs.as_deref().unwrap();
+        let corners = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)];
+
+        for fate in [None, Some(CornerFate::Error), Some(CornerFate::NonFinite)] {
+            let engine = MockEngine { fate };
+            let mut builder = BinaryBuilder::new();
+            let bounds =
+                append_reprojected_footprint(corners, crs, crs, &engine, &mut builder).unwrap();
+            let footprints = builder.finish();
+            assert!(
+                footprints.is_null(0),
+                "a failed reprojection ({fate:?}) must produce a null footprint"
+            );
+            assert!(
+                bounds.is_empty(),
+                "a null footprint ({fate:?}) must have an empty MBR so it never matches"
+            );
+        }
+
+        // A finite transform still produces a real footprint with a non-empty MBR.
+        let engine = MockEngine {
+            fate: Some(CornerFate::Identity),
+        };
+        let mut builder = BinaryBuilder::new();
+        let bounds =
+            append_reprojected_footprint(corners, crs, crs, &engine, &mut builder).unwrap();
+        let footprints = builder.finish();
+        assert!(
+            !footprints.is_null(0),
+            "a finite reprojection must produce a real footprint"
+        );
+        assert!(!bounds.is_empty());
     }
 }

--- a/rust/sedona-spatial-join-raster/src/lib.rs
+++ b/rust/sedona-spatial-join-raster/src/lib.rs
@@ -19,10 +19,16 @@
 //!
 //! A raster/geometry spatial predicate (`RS_Intersects`, `RS_Contains`,
 //! `RS_Within`) is accelerated by evaluating each raster into its footprint (the
-//! convex hull of its corners) as a WKB polygon plus a bounding rectangle. The
-//! footprint is reprojected into the geometry operand's CRS so the R-tree filter
-//! and the WKB refiner — both unchanged from the default planar spatial join —
-//! compare footprints and geometries in a common CRS.
+//! convex hull of its four corners) as a WKB polygon plus a bounding rectangle.
+//! The footprint is reprojected into the geometry operand's CRS so the R-tree
+//! filter and the WKB refiner — both unchanged from the default planar spatial
+//! join — compare footprints and geometries in a common CRS.
+//!
+//! Cross-CRS raster footprints are indexed and refined as the convex hull of the
+//! raster's four reprojected corners; projection curvature along the edges is not
+//! modeled, so for large-extent rasters reprojected between very different CRSs
+//! the hull can slightly under-cover the true footprint (rare missed matches at
+//! the extreme edges). Same-CRS joins are exact.
 
 mod join_provider;
 pub mod physical_planner;

--- a/rust/sedona-spatial-join-raster/src/lib.rs
+++ b/rust/sedona-spatial-join-raster/src/lib.rs
@@ -24,12 +24,6 @@
 //! filter and the WKB refiner — both unchanged from the default planar spatial
 //! join — compare footprints and geometries in a common CRS.
 //!
-//! A missing CRS on exactly one side is assumed to be WGS84 (matching the `RS_*`
-//! predicate kernels and Sedona Spark). The cross-CRS comparison frame is
-//! SedonaDB's — the raster footprint is reprojected into the geometry operand's
-//! CRS — which differs from Sedona Spark's WGS84 frame, but the two are
-//! result-equivalent except within a thin band along the raster's reprojected edge.
-//!
 //! Cross-CRS raster footprints are indexed and refined as the convex hull of the
 //! raster's four reprojected corners; projection curvature along the edges is not
 //! modeled, so for large-extent rasters reprojected between very different CRSs

--- a/rust/sedona-spatial-join-raster/src/lib.rs
+++ b/rust/sedona-spatial-join-raster/src/lib.rs
@@ -15,33 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-pub mod crs_utils;
-mod executor;
-pub use executor::RasterExecutor;
-pub mod footprint;
-pub mod register;
-pub mod rs_band_accessors;
-pub mod rs_bandpath;
-pub mod rs_convexhull;
-pub mod rs_dim_band;
-pub mod rs_dimensions;
-pub mod rs_ensure_loaded;
-pub mod rs_envelope;
-pub mod rs_example;
-pub mod rs_georeference;
-pub mod rs_geotransform;
-pub mod rs_isempty;
-pub mod rs_numbands;
-pub mod rs_pixel_functions;
-pub mod rs_rastercoordinate;
-pub mod rs_set_band_nodata;
-pub mod rs_set_georeference;
-pub mod rs_setsrid;
-pub mod rs_size;
-pub mod rs_slice;
-pub mod rs_spatial_predicates;
-pub mod rs_srid;
-pub mod rs_value;
-pub mod rs_values;
-pub mod rs_worldcoordinate;
-mod sampling;
+//! Optimized spatial joins with a raster operand.
+//!
+//! A raster/geometry spatial predicate (`RS_Intersects`, `RS_Contains`,
+//! `RS_Within`) is accelerated by evaluating each raster into its footprint (the
+//! convex hull of its corners) as a WKB polygon plus a bounding rectangle. The
+//! footprint is reprojected into the geometry operand's CRS so the R-tree filter
+//! and the WKB refiner — both unchanged from the default planar spatial join —
+//! compare footprints and geometries in a common CRS.
+
+mod join_provider;
+pub mod physical_planner;

--- a/rust/sedona-spatial-join-raster/src/lib.rs
+++ b/rust/sedona-spatial-join-raster/src/lib.rs
@@ -19,16 +19,18 @@
 //!
 //! A raster/geometry spatial predicate (`RS_Intersects`, `RS_Contains`,
 //! `RS_Within`) is accelerated by evaluating each raster into its footprint (the
-//! convex hull of its four corners) as a WKB polygon plus a bounding rectangle.
-//! The footprint is reprojected into the geometry operand's CRS so the R-tree
-//! filter and the WKB refiner — both unchanged from the default planar spatial
-//! join — compare footprints and geometries in a common CRS.
+//! polygon through the raster's four corners) as a WKB polygon plus a bounding
+//! rectangle. The footprint is reprojected into the geometry operand's CRS so the
+//! R-tree filter and the WKB refiner — both unchanged from the default planar
+//! spatial join — compare footprints and geometries in a common CRS.
 //!
-//! Cross-CRS raster footprints are indexed and refined as the convex hull of the
-//! raster's four reprojected corners; projection curvature along the edges is not
-//! modeled, so for large-extent rasters reprojected between very different CRSs
-//! the hull can slightly under-cover the true footprint (rare missed matches at
-//! the extreme edges). Same-CRS joins are exact.
+//! A cross-CRS raster footprint densifies each of its four edges (~10 interior
+//! points) in the raster's own CRS, where the edges are exact straight lines,
+//! then reprojects every densified point into the target CRS. The indexed and
+//! refined footprint therefore follows the curved image of each edge rather than
+//! chording straight across it. Same-CRS joins keep the exact four-corner
+//! footprint (no reprojection, no densification). Antimeridian crossings and
+//! geodesic edges are not modeled.
 
 mod join_provider;
 pub mod physical_planner;

--- a/rust/sedona-spatial-join-raster/src/lib.rs
+++ b/rust/sedona-spatial-join-raster/src/lib.rs
@@ -24,6 +24,12 @@
 //! filter and the WKB refiner — both unchanged from the default planar spatial
 //! join — compare footprints and geometries in a common CRS.
 //!
+//! A missing CRS on exactly one side is assumed to be WGS84 (matching the `RS_*`
+//! predicate kernels and Sedona Spark). The cross-CRS comparison frame is
+//! SedonaDB's — the raster footprint is reprojected into the geometry operand's
+//! CRS — which differs from Sedona Spark's WGS84 frame, but the two are
+//! result-equivalent except within a thin band along the raster's reprojected edge.
+//!
 //! Cross-CRS raster footprints are indexed and refined as the convex hull of the
 //! raster's four reprojected corners; projection curvature along the edges is not
 //! modeled, so for large-extent rasters reprojected between very different CRSs

--- a/rust/sedona-spatial-join-raster/src/physical_planner.rs
+++ b/rust/sedona-spatial-join-raster/src/physical_planner.rs
@@ -1,0 +1,300 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use arrow_schema::Schema;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion_common::Result;
+use datafusion_physical_expr::PhysicalExpr;
+use sedona_query_planner::{
+    spatial_join_physical_planner::{PlanSpatialJoinArgs, SpatialJoinPhysicalPlanner},
+    spatial_predicate::{RelationPredicate, SpatialPredicate, SpatialRelationType},
+};
+use sedona_schema::{crs::Crs, datatypes::SedonaType, matchers::ArgMatcher};
+use sedona_spatial_join::{
+    physical_planner::{repartition_probe_side, should_swap_join_order},
+    SpatialJoinExec,
+};
+
+use crate::join_provider::RasterJoinProvider;
+
+/// [`SpatialJoinPhysicalPlanner`] implementation for raster/geometry spatial joins.
+///
+/// Handles `RS_Intersects`/`RS_Contains`/`RS_Within` predicates where exactly one
+/// operand is a raster and the other is a planar geometry, producing an optimized
+/// [`SpatialJoinExec`] backed by a [`RasterJoinProvider`]. All other predicates
+/// (including raster/raster, for which there is no fixed common CRS to compare in)
+/// are declined with `None` so they fall back to the nested-loop join.
+#[derive(Debug)]
+pub struct RasterSpatialJoinPhysicalPlanner;
+
+impl RasterSpatialJoinPhysicalPlanner {
+    /// Create a new raster join planner.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for RasterSpatialJoinPhysicalPlanner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SpatialJoinPhysicalPlanner for RasterSpatialJoinPhysicalPlanner {
+    fn plan_spatial_join(
+        &self,
+        args: &PlanSpatialJoinArgs<'_>,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        let Some(target_crs) = raster_geometry_target_crs(
+            args.spatial_predicate,
+            &args.physical_left.schema(),
+            &args.physical_right.schema(),
+        )?
+        else {
+            return Ok(None);
+        };
+
+        let should_swap = args.join_type.supports_swap()
+            && should_swap_join_order(
+                args.join_options,
+                args.physical_left.as_ref(),
+                args.physical_right.as_ref(),
+            )?;
+
+        // Repartition the probe side when enabled, mirroring the default planner.
+        let (physical_left, physical_right) = if args.join_options.repartition_probe_side {
+            repartition_probe_side(
+                args.physical_left.clone(),
+                args.physical_right.clone(),
+                args.spatial_predicate,
+                should_swap,
+            )?
+        } else {
+            (args.physical_left.clone(), args.physical_right.clone())
+        };
+
+        let exec = SpatialJoinExec::try_new(
+            physical_left,
+            physical_right,
+            args.spatial_predicate.clone(),
+            args.remainder.cloned(),
+            args.join_type,
+            None,
+            args.join_options,
+        )?
+        .with_spatial_join_provider(Arc::new(RasterJoinProvider::new(target_crs)));
+
+        if should_swap {
+            exec.swap_inputs().map(Some)
+        } else {
+            Ok(Some(Arc::new(exec) as Arc<dyn ExecutionPlan>))
+        }
+    }
+}
+
+/// Return the target CRS (the geometry operand's CRS) when `spatial_predicate`
+/// is a raster/geometry relation this planner can accelerate, or `None` when it
+/// should fall through to another planner.
+///
+/// Handled: a `Relation` predicate of `Intersects`/`Contains`/`Within` with
+/// exactly one raster operand and one planar-geometry operand. The returned
+/// [`Crs`] is the geometry operand's schema CRS, which is `None` when the
+/// geometry carries no CRS.
+fn raster_geometry_target_crs(
+    spatial_predicate: &SpatialPredicate,
+    left_schema: &Schema,
+    right_schema: &Schema,
+) -> Result<Option<Crs>> {
+    let SpatialPredicate::Relation(RelationPredicate {
+        left,
+        right,
+        relation_type,
+    }) = spatial_predicate
+    else {
+        return Ok(None);
+    };
+
+    if !matches!(
+        relation_type,
+        SpatialRelationType::Intersects
+            | SpatialRelationType::Contains
+            | SpatialRelationType::Within
+    ) {
+        return Ok(None);
+    }
+
+    let left_type = operand_sedona_type(left, left_schema)?;
+    let right_type = operand_sedona_type(right, right_schema)?;
+
+    let is_geometry = ArgMatcher::is_geometry();
+    let target = match (
+        matches!(left_type, SedonaType::Raster),
+        matches!(right_type, SedonaType::Raster),
+    ) {
+        // Exactly one raster operand; the other must be a planar geometry.
+        (true, false) if is_geometry.match_type(&right_type) => Some(right_type.crs().clone()),
+        (false, true) if is_geometry.match_type(&left_type) => Some(left_type.crs().clone()),
+        // raster/raster (no fixed common CRS), geometry/geometry, geography, or
+        // item-crs operands are left to other planners / the nested-loop fallback.
+        _ => None,
+    };
+
+    Ok(target)
+}
+
+/// Resolve the [`SedonaType`] an operand expression evaluates to against `schema`.
+fn operand_sedona_type(expr: &Arc<dyn PhysicalExpr>, schema: &Schema) -> Result<SedonaType> {
+    let return_field = expr.return_field(schema)?;
+    SedonaType::from_storage_field(&return_field)
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use arrow_schema::Schema;
+    use datafusion_physical_expr::{expressions::Column, PhysicalExpr};
+    use sedona_geometry::types::Edges;
+    use sedona_query_planner::spatial_predicate::{
+        RelationPredicate, SpatialPredicate, SpatialRelationType,
+    };
+    use sedona_schema::crs::{deserialize_crs, lnglat};
+    use sedona_schema::datatypes::{SedonaType, RASTER, WKB_GEOMETRY};
+
+    use super::raster_geometry_target_crs;
+
+    fn schema_with(field_name: &str, sedona_type: &SedonaType) -> Arc<Schema> {
+        Arc::new(Schema::new(vec![sedona_type
+            .to_storage_field(field_name, true)
+            .unwrap()]))
+    }
+
+    fn col(name: &str) -> Arc<dyn PhysicalExpr> {
+        Arc::new(Column::new(name, 0))
+    }
+
+    fn relation(
+        left: Arc<dyn PhysicalExpr>,
+        right: Arc<dyn PhysicalExpr>,
+        relation_type: SpatialRelationType,
+    ) -> SpatialPredicate {
+        SpatialPredicate::Relation(RelationPredicate::new(left, right, relation_type))
+    }
+
+    #[test]
+    fn raster_geometry_resolves_geometry_crs_as_target() {
+        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
+        let raster_schema = schema_with("raster", &RASTER);
+        let geom_schema = schema_with("geom", &geom_type);
+
+        // (raster, geometry): target is the geometry's CRS.
+        let pred = relation(col("raster"), col("geom"), SpatialRelationType::Intersects);
+        let target = raster_geometry_target_crs(&pred, &raster_schema, &geom_schema)
+            .unwrap()
+            .expect("raster/geometry should be handled");
+        assert!(target
+            .as_deref()
+            .unwrap()
+            .crs_equals(lnglat().as_deref().unwrap()));
+
+        // (geometry, raster): still resolves to the geometry's CRS.
+        let pred = relation(col("geom"), col("raster"), SpatialRelationType::Contains);
+        let target = raster_geometry_target_crs(&pred, &geom_schema, &raster_schema)
+            .unwrap()
+            .expect("geometry/raster should be handled");
+        assert!(target
+            .as_deref()
+            .unwrap()
+            .crs_equals(lnglat().as_deref().unwrap()));
+    }
+
+    #[test]
+    fn crs_less_geometry_yields_crs_less_target() {
+        let raster_schema = schema_with("raster", &RASTER);
+        let geom_schema = schema_with("geom", &WKB_GEOMETRY);
+
+        let pred = relation(col("raster"), col("geom"), SpatialRelationType::Within);
+        let target = raster_geometry_target_crs(&pred, &raster_schema, &geom_schema)
+            .unwrap()
+            .expect("raster/geometry should be handled");
+        assert!(
+            target.is_none(),
+            "CRS-less geometry means a CRS-less target"
+        );
+    }
+
+    #[test]
+    fn different_geometry_crs_is_carried_through() {
+        let geom_type = SedonaType::Wkb(Edges::Planar, deserialize_crs("EPSG:3857").unwrap());
+        let raster_schema = schema_with("raster", &RASTER);
+        let geom_schema = schema_with("geom", &geom_type);
+
+        let pred = relation(col("geom"), col("raster"), SpatialRelationType::Intersects);
+        let target = raster_geometry_target_crs(&pred, &geom_schema, &raster_schema)
+            .unwrap()
+            .expect("raster/geometry should be handled");
+        assert!(target
+            .as_deref()
+            .unwrap()
+            .crs_equals(deserialize_crs("EPSG:3857").unwrap().as_deref().unwrap()));
+    }
+
+    #[test]
+    fn raster_raster_is_declined() {
+        let raster_schema = schema_with("raster", &RASTER);
+        let pred = relation(
+            col("raster"),
+            col("raster"),
+            SpatialRelationType::Intersects,
+        );
+        assert!(
+            raster_geometry_target_crs(&pred, &raster_schema, &raster_schema)
+                .unwrap()
+                .is_none(),
+            "raster/raster has no fixed common CRS and must be declined"
+        );
+    }
+
+    #[test]
+    fn geometry_geometry_is_declined() {
+        let geom_schema = schema_with("geom", &WKB_GEOMETRY);
+        let pred = relation(col("geom"), col("geom"), SpatialRelationType::Intersects);
+        assert!(
+            raster_geometry_target_crs(&pred, &geom_schema, &geom_schema)
+                .unwrap()
+                .is_none(),
+            "pure geometry predicates are left to the default planner"
+        );
+    }
+
+    #[test]
+    fn unsupported_relation_type_is_declined() {
+        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
+        let raster_schema = schema_with("raster", &RASTER);
+        let geom_schema = schema_with("geom", &geom_type);
+
+        // Equals is not an RS_ predicate.
+        let pred = relation(col("raster"), col("geom"), SpatialRelationType::Equals);
+        assert!(
+            raster_geometry_target_crs(&pred, &raster_schema, &geom_schema)
+                .unwrap()
+                .is_none()
+        );
+    }
+}

--- a/rust/sedona-spatial-join-raster/src/physical_planner.rs
+++ b/rust/sedona-spatial-join-raster/src/physical_planner.rs
@@ -25,11 +25,7 @@ use sedona_query_planner::{
     spatial_join_physical_planner::{PlanSpatialJoinArgs, SpatialJoinPhysicalPlanner},
     spatial_predicate::{RelationPredicate, SpatialPredicate, SpatialRelationType},
 };
-use sedona_schema::{
-    crs::{lnglat, Crs},
-    datatypes::SedonaType,
-    matchers::ArgMatcher,
-};
+use sedona_schema::{crs::Crs, datatypes::SedonaType, matchers::ArgMatcher};
 use sedona_spatial_join::{
     physical_planner::{repartition_probe_side, should_swap_join_order},
     SpatialJoinExec,
@@ -118,9 +114,8 @@ impl SpatialJoinPhysicalPlanner for RasterSpatialJoinPhysicalPlanner {
 ///
 /// Handled: a `Relation` predicate of `Intersects`/`Contains`/`Within` with
 /// exactly one raster operand and one planar-geometry operand. The returned
-/// [`Crs`] is the geometry operand's schema CRS, defaulting to WGS84 when the
-/// geometry carries no CRS (a missing CRS is assumed WGS84, matching the `RS_*`
-/// kernel and Sedona Spark).
+/// [`Crs`] is the geometry operand's schema CRS, which is `None` when the
+/// geometry carries no CRS.
 fn raster_geometry_target_crs(
     spatial_predicate: &SpatialPredicate,
     left_schema: &Schema,
@@ -153,26 +148,14 @@ fn raster_geometry_target_crs(
         matches!(right_type, SedonaType::Raster),
     ) {
         // Exactly one raster operand; the other must be a planar geometry.
-        (true, false) if is_geometry.match_type(&right_type) => {
-            Some(geometry_operand_target_crs(right_type.crs()))
-        }
-        (false, true) if is_geometry.match_type(&left_type) => {
-            Some(geometry_operand_target_crs(left_type.crs()))
-        }
+        (true, false) if is_geometry.match_type(&right_type) => Some(right_type.crs().clone()),
+        (false, true) if is_geometry.match_type(&left_type) => Some(left_type.crs().clone()),
         // raster/raster (no fixed common CRS), geometry/geometry, geography, or
         // item-crs operands are left to other planners / the nested-loop fallback.
         _ => None,
     };
 
     Ok(target)
-}
-
-/// The CRS the raster join compares in for a geometry operand: the operand's own
-/// CRS, or WGS84 when it carries none. A missing CRS is assumed to be WGS84
-/// (matching the `RS_*` kernel and Sedona Spark); the CRS-less geometry's
-/// coordinates are compared as-is, now in a WGS84 frame.
-fn geometry_operand_target_crs(crs: &Crs) -> Crs {
-    crs.clone().or_else(lnglat)
 }
 
 /// Resolve the [`SedonaType`] an operand expression evaluates to against `schema`.
@@ -242,7 +225,7 @@ mod test {
     }
 
     #[test]
-    fn crs_less_geometry_yields_wgs84_target() {
+    fn crs_less_geometry_yields_crs_less_target() {
         let raster_schema = schema_with("raster", &RASTER);
         let geom_schema = schema_with("geom", &WKB_GEOMETRY);
 
@@ -250,14 +233,9 @@ mod test {
         let target = raster_geometry_target_crs(&pred, &raster_schema, &geom_schema)
             .unwrap()
             .expect("raster/geometry should be handled");
-        // A CRS-less geometry is assumed to be WGS84, so the join compares in a
-        // WGS84 frame rather than declining to a CRS-less target.
         assert!(
-            target
-                .as_deref()
-                .expect("CRS-less geometry defaults to a WGS84 target")
-                .crs_equals(lnglat().as_deref().unwrap()),
-            "CRS-less geometry means a WGS84 target"
+            target.is_none(),
+            "CRS-less geometry means a CRS-less target"
         );
     }
 

--- a/rust/sedona-spatial-join-raster/src/physical_planner.rs
+++ b/rust/sedona-spatial-join-raster/src/physical_planner.rs
@@ -21,6 +21,9 @@ use arrow_schema::Schema;
 use datafusion_common::Result;
 use datafusion_physical_expr::PhysicalExpr;
 use datafusion_physical_plan::ExecutionPlan;
+use sedona_common::SedonaOptions;
+use sedona_geometry::transform::CrsEngine;
+use sedona_proj::transform::LazyProjEngine;
 use sedona_query_planner::{
     spatial_join_physical_planner::{PlanSpatialJoinArgs, SpatialJoinPhysicalPlanner},
     spatial_predicate::{RelationPredicate, SpatialPredicate, SpatialRelationType},
@@ -89,6 +92,17 @@ impl SpatialJoinPhysicalPlanner for RasterSpatialJoinPhysicalPlanner {
             (args.physical_left.clone(), args.physical_right.clone())
         };
 
+        // Capture the session's CRS engine at plan time so raster footprint
+        // reprojection honors a user-injected engine. Absent a SedonaOptions
+        // extension, fall back to the process-global PROJ engine via
+        // LazyProjEngine (the same default the session registers).
+        let engine: Arc<dyn CrsEngine + Send + Sync> = args
+            .options
+            .extensions
+            .get::<SedonaOptions>()
+            .map(|opts| opts.runtime.crs_engine().clone())
+            .unwrap_or_else(|| Arc::new(LazyProjEngine));
+
         let exec = SpatialJoinExec::try_new(
             physical_left,
             physical_right,
@@ -98,7 +112,7 @@ impl SpatialJoinPhysicalPlanner for RasterSpatialJoinPhysicalPlanner {
             None,
             args.join_options,
         )?
-        .with_spatial_join_provider(Arc::new(RasterJoinProvider::new(target_crs)));
+        .with_spatial_join_provider(Arc::new(RasterJoinProvider::new(target_crs, engine)));
 
         if should_swap {
             exec.swap_inputs().map(Some)

--- a/rust/sedona-spatial-join-raster/src/physical_planner.rs
+++ b/rust/sedona-spatial-join-raster/src/physical_planner.rs
@@ -25,7 +25,11 @@ use sedona_query_planner::{
     spatial_join_physical_planner::{PlanSpatialJoinArgs, SpatialJoinPhysicalPlanner},
     spatial_predicate::{RelationPredicate, SpatialPredicate, SpatialRelationType},
 };
-use sedona_schema::{crs::Crs, datatypes::SedonaType, matchers::ArgMatcher};
+use sedona_schema::{
+    crs::{lnglat, Crs},
+    datatypes::SedonaType,
+    matchers::ArgMatcher,
+};
 use sedona_spatial_join::{
     physical_planner::{repartition_probe_side, should_swap_join_order},
     SpatialJoinExec,
@@ -114,8 +118,9 @@ impl SpatialJoinPhysicalPlanner for RasterSpatialJoinPhysicalPlanner {
 ///
 /// Handled: a `Relation` predicate of `Intersects`/`Contains`/`Within` with
 /// exactly one raster operand and one planar-geometry operand. The returned
-/// [`Crs`] is the geometry operand's schema CRS, which is `None` when the
-/// geometry carries no CRS.
+/// [`Crs`] is the geometry operand's schema CRS, defaulting to WGS84 when the
+/// geometry carries no CRS (a missing CRS is assumed WGS84, matching the `RS_*`
+/// kernel and Sedona Spark).
 fn raster_geometry_target_crs(
     spatial_predicate: &SpatialPredicate,
     left_schema: &Schema,
@@ -148,14 +153,26 @@ fn raster_geometry_target_crs(
         matches!(right_type, SedonaType::Raster),
     ) {
         // Exactly one raster operand; the other must be a planar geometry.
-        (true, false) if is_geometry.match_type(&right_type) => Some(right_type.crs().clone()),
-        (false, true) if is_geometry.match_type(&left_type) => Some(left_type.crs().clone()),
+        (true, false) if is_geometry.match_type(&right_type) => {
+            Some(geometry_operand_target_crs(right_type.crs()))
+        }
+        (false, true) if is_geometry.match_type(&left_type) => {
+            Some(geometry_operand_target_crs(left_type.crs()))
+        }
         // raster/raster (no fixed common CRS), geometry/geometry, geography, or
         // item-crs operands are left to other planners / the nested-loop fallback.
         _ => None,
     };
 
     Ok(target)
+}
+
+/// The CRS the raster join compares in for a geometry operand: the operand's own
+/// CRS, or WGS84 when it carries none. A missing CRS is assumed to be WGS84
+/// (matching the `RS_*` kernel and Sedona Spark); the CRS-less geometry's
+/// coordinates are compared as-is, now in a WGS84 frame.
+fn geometry_operand_target_crs(crs: &Crs) -> Crs {
+    crs.clone().or_else(lnglat)
 }
 
 /// Resolve the [`SedonaType`] an operand expression evaluates to against `schema`.
@@ -225,7 +242,7 @@ mod test {
     }
 
     #[test]
-    fn crs_less_geometry_yields_crs_less_target() {
+    fn crs_less_geometry_yields_wgs84_target() {
         let raster_schema = schema_with("raster", &RASTER);
         let geom_schema = schema_with("geom", &WKB_GEOMETRY);
 
@@ -233,9 +250,14 @@ mod test {
         let target = raster_geometry_target_crs(&pred, &raster_schema, &geom_schema)
             .unwrap()
             .expect("raster/geometry should be handled");
+        // A CRS-less geometry is assumed to be WGS84, so the join compares in a
+        // WGS84 frame rather than declining to a CRS-less target.
         assert!(
-            target.is_none(),
-            "CRS-less geometry means a CRS-less target"
+            target
+                .as_deref()
+                .expect("CRS-less geometry defaults to a WGS84 target")
+                .crs_equals(lnglat().as_deref().unwrap()),
+            "CRS-less geometry means a WGS84 target"
         );
     }
 

--- a/rust/sedona-spatial-join-raster/src/physical_planner.rs
+++ b/rust/sedona-spatial-join-raster/src/physical_planner.rs
@@ -18,9 +18,9 @@
 use std::sync::Arc;
 
 use arrow_schema::Schema;
-use datafusion::physical_plan::ExecutionPlan;
 use datafusion_common::Result;
 use datafusion_physical_expr::PhysicalExpr;
+use datafusion_physical_plan::ExecutionPlan;
 use sedona_query_planner::{
     spatial_join_physical_planner::{PlanSpatialJoinArgs, SpatialJoinPhysicalPlanner},
     spatial_predicate::{RelationPredicate, SpatialPredicate, SpatialRelationType},

--- a/rust/sedona-spatial-join-raster/tests/spatial_join_integration.rs
+++ b/rust/sedona-spatial-join-raster/tests/spatial_join_integration.rs
@@ -57,14 +57,14 @@ use sedona_query_planner::{
 };
 use sedona_raster::affine_transformation::to_world_coordinate;
 use sedona_raster::array::RasterStructArray;
-use sedona_raster::builder::RasterBuilder;
-use sedona_raster::traits::{BandMetadata, RasterMetadata, RasterRef};
+use sedona_raster::traits::RasterRef;
 use sedona_schema::crs::lnglat;
 use sedona_schema::datatypes::{SedonaType, RASTER};
-use sedona_schema::raster::{BandDataType, StorageType};
+use sedona_schema::raster::BandDataType;
 use sedona_spatial_join::SpatialJoinExec;
 use sedona_spatial_join_raster::physical_planner::RasterSpatialJoinPhysicalPlanner;
 use sedona_testing::create::create_array;
+use sedona_testing::raster_spec::RasterSpec;
 use sedona_testing::rasters::generate_test_rasters;
 
 /// Geometry type sharing the CRS that `generate_test_rasters` stamps on its
@@ -404,29 +404,10 @@ async fn cross_crs_matches_constructed_reference() -> Result<()> {
 /// A 4x4 raster in EPSG:3857 with skew, so its footprint is a non-axis-aligned
 /// quadrilateral whose edges curve when reprojected to lng/lat.
 fn build_skewed_raster_3857() -> StructArray {
-    let mut builder = RasterBuilder::new(1);
-    let metadata = RasterMetadata {
-        width: 4,
-        height: 4,
-        upperleft_x: 0.0,
-        upperleft_y: 2_000_000.0,
-        scale_x: 100_000.0,
-        scale_y: -100_000.0,
-        skew_x: 30_000.0,
-        skew_y: 20_000.0,
-    };
-    builder.start_raster(&metadata, Some("EPSG:3857")).unwrap();
-    builder
-        .start_band(BandMetadata {
-            datatype: BandDataType::UInt8,
-            nodata_value: None,
-            storage_type: StorageType::InDb,
-            outdb_url: None,
-            outdb_band_id: None,
-        })
-        .unwrap();
-    builder.band_data_writer().append_value([0u8; 16]);
-    builder.finish_band().unwrap();
-    builder.finish_raster().unwrap();
-    builder.finish().unwrap()
+    RasterSpec::d2(4, 4)
+        .crs(Some("EPSG:3857"))
+        // GDAL geotransform [origin_x, scale_x, skew_x, origin_y, skew_y, scale_y].
+        .transform([0.0, 100_000.0, 30_000.0, 2_000_000.0, 20_000.0, -100_000.0])
+        .band(BandDataType::UInt8)
+        .build()
 }

--- a/rust/sedona-spatial-join-raster/tests/spatial_join_integration.rs
+++ b/rust/sedona-spatial-join-raster/tests/spatial_join_integration.rs
@@ -1,0 +1,432 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Integration tests for raster/geometry spatial joins.
+//!
+//! The strict-parity tests run the same query two ways over the same data:
+//!
+//! * **Optimized** — the raster extension planner turns the `RS_*` join into a
+//!   `SpatialJoinExec` that evaluates each raster into its (reprojected)
+//!   footprint polygon.
+//! * **Nested-loop** — with the spatial-join optimizer/planner absent, the join
+//!   stays a `NestedLoopJoinExec` that evaluates the `RS_*` UDF kernel directly.
+//!
+//! When the rasters and the geometry share a CRS (as they do here — both are
+//! lng/lat) neither side reprojects, and both refine with the same `tg` engine,
+//! so the two row sets must be byte-identical. This asserts the accelerated path
+//! does not silently diverge from the established kernel.
+//!
+//! `proj-sys` is enabled as a dev-dependency, so the `RS_*` kernel's global PROJ
+//! engine initializes for the nested-loop side.
+
+use std::sync::Arc;
+
+use arrow_array::{Int32Array, RecordBatch, StructArray};
+use arrow_schema::{Field, Schema};
+use datafusion::{
+    catalog::MemTable,
+    execution::SessionStateBuilder,
+    physical_plan::{displayable, ExecutionPlan},
+    prelude::{SessionConfig, SessionContext},
+};
+use datafusion_common::cast::as_int32_array;
+use datafusion_common::tree_node::{TreeNode, TreeNodeRecursion};
+use datafusion_common::Result;
+use rstest::rstest;
+use sedona_common::option::SpatialJoinOptions;
+use sedona_common::SedonaOptions;
+use sedona_geometry::transform::CrsEngine;
+use sedona_geometry::types::Edges;
+use sedona_proj::transform::with_global_proj_engine;
+use sedona_query_planner::{
+    optimizer::register_spatial_join_logical_optimizer, query_planner::SedonaQueryPlanner,
+};
+use sedona_raster::affine_transformation::to_world_coordinate;
+use sedona_raster::array::RasterStructArray;
+use sedona_raster::builder::RasterBuilder;
+use sedona_raster::traits::{BandMetadata, RasterMetadata, RasterRef};
+use sedona_schema::crs::lnglat;
+use sedona_schema::datatypes::{SedonaType, RASTER};
+use sedona_schema::raster::{BandDataType, StorageType};
+use sedona_spatial_join::SpatialJoinExec;
+use sedona_spatial_join_raster::physical_planner::RasterSpatialJoinPhysicalPlanner;
+use sedona_testing::create::create_array;
+use sedona_testing::rasters::generate_test_rasters;
+
+/// Geometry type sharing the CRS that `generate_test_rasters` stamps on its
+/// rasters (lng/lat), so the predicate compares in a common CRS.
+fn geom_type() -> SedonaType {
+    SedonaType::Wkb(Edges::Planar, lnglat())
+}
+
+/// Register a raster table `r(rid INT, raster RASTER)`.
+///
+/// `generate_test_rasters(3, Some(0))` yields: rid 0 a null raster, rid 1 a
+/// footprint over x∈[2.0, 2.29] y∈[2.4, 3.08], rid 2 over x∈[3.0, 3.84]
+/// y∈[2.4, 4.24]. All non-null rasters carry the lng/lat CRS.
+fn register_raster_table(ctx: &SessionContext) -> Result<()> {
+    let rasters = generate_test_rasters(3, Some(0)).unwrap();
+    let rid = Int32Array::from(vec![0, 1, 2]);
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("rid", arrow_schema::DataType::Int32, false),
+        RASTER.to_storage_field("raster", true)?,
+    ]));
+    let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(rid), Arc::new(rasters)])?;
+    let table = MemTable::try_new(schema, vec![vec![batch]])?;
+    ctx.register_table("r", Arc::new(table))?;
+    Ok(())
+}
+
+/// Register a geometry table `g(gid INT, geom GEOMETRY)` covering centers,
+/// corners/edges, an enclosing polygon, a non-intersecting zone, and a null.
+fn register_geom_table(ctx: &SessionContext) -> Result<()> {
+    let geom_type = geom_type();
+    let gid = Int32Array::from(vec![10, 20, 30, 40, 50, 60, 70]);
+    let geom = create_array(
+        &[
+            Some("POINT (2.15 2.75)"),                       // inside raster 1
+            Some("POINT (3.4 3.2)"),                         // inside raster 2
+            Some("POINT (2.0 3.0)"),                         // on a raster-1 corner (boundary/edge)
+            Some("POINT (0 0)"),                             // outside all rasters
+            Some("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))"), // encloses rasters 1 and 2
+            Some("POLYGON ((2.0 2.4, 2.29 2.4, 2.29 3.08, 2.0 3.08, 2.0 2.4))"), // around raster 1
+            None,                                            // null geometry never matches
+        ],
+        &geom_type,
+    );
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("gid", arrow_schema::DataType::Int32, false),
+        geom_type.to_storage_field("geom", true)?,
+    ]));
+    let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(gid), geom])?;
+    let table = MemTable::try_new(schema, vec![vec![batch]])?;
+    ctx.register_table("g", Arc::new(table))?;
+    Ok(())
+}
+
+/// Build a context with the raster UDFs registered but no tables. When
+/// `optimized`, the spatial-join logical optimizer and the raster physical
+/// planner are registered (and spatial join enabled), producing a
+/// `SpatialJoinExec`. Otherwise the join stays a `NestedLoopJoinExec`.
+fn build_context(optimized: bool) -> Result<SessionContext> {
+    let mut session_config = SessionConfig::from_env()?.with_batch_size(16);
+    session_config = session_config.with_option_extension(SedonaOptions::default());
+
+    let mut state_builder = SessionStateBuilder::new();
+    if optimized {
+        state_builder = register_spatial_join_logical_optimizer(state_builder)?;
+        state_builder = state_builder.with_query_planner(Arc::new(
+            SedonaQueryPlanner::new().with_spatial_join_physical_planner(Arc::new(
+                RasterSpatialJoinPhysicalPlanner::new(),
+            )),
+        ));
+        let opts = session_config
+            .options_mut()
+            .extensions
+            .get_mut::<SedonaOptions>()
+            .unwrap();
+        opts.spatial_join = SpatialJoinOptions::default();
+    }
+
+    let state = state_builder.with_config(session_config).build();
+    let ctx = SessionContext::new_with_state(state);
+
+    // Register the raster functions (RS_Intersects/RS_Contains/RS_Within).
+    let function_set = sedona_raster_functions::register::default_function_set();
+    function_set.scalar_udfs().for_each(|udf| {
+        ctx.register_udf(udf.clone().into());
+    });
+
+    Ok(ctx)
+}
+
+/// Build a context with the same-CRS `r`/`g` tables registered.
+fn setup_context(optimized: bool) -> Result<SessionContext> {
+    let ctx = build_context(optimized)?;
+    register_raster_table(&ctx)?;
+    register_geom_table(&ctx)?;
+    Ok(ctx)
+}
+
+fn count_spatial_join_execs(plan: &Arc<dyn ExecutionPlan>) -> Result<usize> {
+    let mut count = 0;
+    plan.apply(|node| {
+        if node.as_any().downcast_ref::<SpatialJoinExec>().is_some() {
+            count += 1;
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })?;
+    Ok(count)
+}
+
+async fn run_query(optimized: bool, sql: &str) -> Result<RecordBatch> {
+    let ctx = setup_context(optimized)?;
+    let df = ctx.sql(sql).await?;
+    let schema = df.schema().as_arrow().clone();
+    let plan = df.clone().create_physical_plan().await?;
+
+    let num_spatial_joins = count_spatial_join_execs(&plan)?;
+    let physical_str = displayable(plan.as_ref()).indent(true).to_string();
+    if optimized {
+        assert_eq!(
+            num_spatial_joins, 1,
+            "expected an optimized SpatialJoinExec, got:\n{physical_str}"
+        );
+    } else {
+        assert_eq!(
+            num_spatial_joins, 0,
+            "nested-loop baseline should not contain SpatialJoinExec, got:\n{physical_str}"
+        );
+        assert!(
+            physical_str.contains("NestedLoopJoinExec"),
+            "nested-loop baseline should use NestedLoopJoinExec, got:\n{physical_str}"
+        );
+    }
+
+    let batches = df.collect().await?;
+    Ok(datafusion::arrow::compute::concat_batches(
+        &Arc::new(schema),
+        &batches,
+    )?)
+}
+
+/// Assert the optimized `SpatialJoinExec` returns byte-identical rows to the
+/// nested-loop kernel for a same-CRS raster/geometry join. Covers all three
+/// `RS_*` predicates, both operand orderings, and inner/left/right joins.
+#[rstest]
+#[tokio::test]
+async fn same_crs_strict_parity(
+    #[values("RS_Intersects", "RS_Contains", "RS_Within")] func: &str,
+    #[values("r.raster, g.geom", "g.geom, r.raster")] operands: &str,
+    #[values("INNER JOIN", "LEFT OUTER JOIN", "RIGHT OUTER JOIN")] join_type: &str,
+) -> Result<()> {
+    let sql = format!(
+        "SELECT r.rid, g.gid FROM r {join_type} g ON {func}({operands}) ORDER BY r.rid, g.gid"
+    );
+
+    let optimized = run_query(true, &sql).await?;
+    let nested_loop = run_query(false, &sql).await?;
+
+    assert_eq!(
+        optimized, nested_loop,
+        "optimized SpatialJoinExec must match the nested-loop kernel exactly for {sql}"
+    );
+    Ok(())
+}
+
+/// Anchor the parity comparison to hand-computed rows so a bug shared by both
+/// paths cannot pass. `RS_Intersects(raster, geom)` inner join: raster 1 meets
+/// its center point (gid 10), the enclosing polygon (gid 50), and its bbox
+/// polygon (gid 60), plus the corner point (gid 30); raster 2 meets its center
+/// (gid 20) and the enclosing polygon (gid 50). The null raster (rid 0) and the
+/// null geometry (gid 70) never match.
+#[tokio::test]
+async fn intersects_produces_expected_rows() -> Result<()> {
+    let sql = "SELECT r.rid, g.gid FROM r JOIN g ON RS_Intersects(r.raster, g.geom) \
+               ORDER BY r.rid, g.gid";
+    let result = run_query(true, sql).await?;
+
+    datafusion::assert_batches_eq!(
+        [
+            "+-----+-----+",
+            "| rid | gid |",
+            "+-----+-----+",
+            "| 1   | 10  |",
+            "| 1   | 30  |",
+            "| 1   | 50  |",
+            "| 1   | 60  |",
+            "| 2   | 20  |",
+            "| 2   | 50  |",
+            "+-----+-----+",
+        ],
+        &[result]
+    );
+    Ok(())
+}
+
+/// Cross-CRS: verify the accelerated path against an independent,
+/// construction-based reference. The raster is skewed in EPSG:3857 (so its
+/// footprint edges curve when reprojected to lng/lat, exercising densification);
+/// the geometry operand is lng/lat.
+///
+/// Test points are built by reprojecting native-3857 points of *known*
+/// membership into lng/lat: for the convex footprint quadrilateral, the centroid
+/// and the halfway-to-each-vertex points are strictly inside, while the
+/// reflection of the centroid through each vertex is strictly outside. Because a
+/// CRS transform is a homeomorphism, a point's inside/outside status relative to
+/// the footprint is preserved by reprojection, so the expected result is exact
+/// (no tolerance) and independent of how the accelerated path reprojects. The
+/// reference reprojects points (into the raster's space); the accelerated path
+/// reprojects the footprint (into the geometry's space) — opposite directions, so
+/// this catches a wrong transform direction as well as pipeline errors, checked
+/// against PROJ (the same engine a rasterio/geopandas reference would use).
+#[tokio::test]
+async fn cross_crs_matches_constructed_reference() -> Result<()> {
+    let raster = build_skewed_raster_3857();
+
+    // Footprint corners in the raster's native CRS (EPSG:3857). These are exact.
+    let corners = {
+        let rasters = RasterStructArray::try_new(&raster).unwrap();
+        let r = rasters.get(0).unwrap();
+        let w = r.metadata().width();
+        let h = r.metadata().height();
+        [
+            to_world_coordinate(&r, 0, 0),
+            to_world_coordinate(&r, w, 0),
+            to_world_coordinate(&r, w, h),
+            to_world_coordinate(&r, 0, h),
+        ]
+    };
+    let cx = corners.iter().map(|c| c.0).sum::<f64>() / 4.0;
+    let cy = corners.iter().map(|c| c.1).sum::<f64>() / 4.0;
+
+    // Native-3857 test points with membership known by construction.
+    let mut native_points: Vec<(i32, (f64, f64), bool)> = vec![(0, (cx, cy), true)];
+    for (i, &(x, y)) in corners.iter().enumerate() {
+        // Halfway from centroid to a vertex: strictly inside a convex polygon.
+        native_points.push((
+            10 + i as i32,
+            (cx + 0.5 * (x - cx), cy + 0.5 * (y - cy)),
+            true,
+        ));
+        // Reflection of the centroid through a vertex: strictly outside.
+        native_points.push((
+            20 + i as i32,
+            (cx + 2.0 * (x - cx), cy + 2.0 * (y - cy)),
+            false,
+        ));
+    }
+
+    // Reproject the native-3857 points into lng/lat to get the geometry coords.
+    let lnglat_crs = lnglat().unwrap().to_crs_string();
+    let projected: Vec<(i32, (f64, f64), bool)> = with_global_proj_engine(|engine| {
+        let transform = engine
+            .get_transform_crs_to_crs("EPSG:3857", &lnglat_crs, None, "")
+            .map_err(|e| datafusion_common::exec_datafusion_err!("{e}"))?;
+        native_points
+            .iter()
+            .map(|&(gid, pt, inside)| {
+                let mut c = pt;
+                transform
+                    .transform_coord(&mut c)
+                    .map_err(|e| datafusion_common::exec_datafusion_err!("{e}"))?;
+                Ok((gid, c, inside))
+            })
+            .collect::<Result<Vec<_>>>()
+    })?;
+
+    // Expected matches: the gids of the inside points.
+    let mut expected_inside: Vec<i32> = projected
+        .iter()
+        .filter(|&&(_, _, inside)| inside)
+        .map(|&(gid, _, _)| gid)
+        .collect();
+    expected_inside.sort_unstable();
+
+    // Build the lng/lat geometry table.
+    let geom_type = geom_type();
+    let gids: Vec<i32> = projected.iter().map(|&(gid, _, _)| gid).collect();
+    let wkts: Vec<String> = projected
+        .iter()
+        .map(|&(_, (lon, lat), _)| format!("POINT ({lon} {lat})"))
+        .collect();
+    let wkt_opts: Vec<Option<&str>> = wkts.iter().map(|w| Some(w.as_str())).collect();
+    let geom = create_array(&wkt_opts, &geom_type);
+    let geom_schema = Arc::new(Schema::new(vec![
+        Field::new("gid", arrow_schema::DataType::Int32, false),
+        geom_type.to_storage_field("geom", true)?,
+    ]));
+    let geom_batch = RecordBatch::try_new(
+        geom_schema.clone(),
+        vec![Arc::new(Int32Array::from(gids)), geom],
+    )?;
+
+    // Register the 3857 raster + lng/lat geometry tables in an optimized context.
+    let ctx = build_context(true)?;
+    let raster_schema = Arc::new(Schema::new(vec![RASTER.to_storage_field("raster", true)?]));
+    let raster_batch = RecordBatch::try_new(raster_schema.clone(), vec![Arc::new(raster)])?;
+    ctx.register_table(
+        "r",
+        Arc::new(MemTable::try_new(raster_schema, vec![vec![raster_batch]])?),
+    )?;
+    ctx.register_table(
+        "g",
+        Arc::new(MemTable::try_new(geom_schema, vec![vec![geom_batch]])?),
+    )?;
+
+    let sql = "SELECT g.gid FROM r JOIN g ON RS_Intersects(r.raster, g.geom) ORDER BY g.gid";
+    let df = ctx.sql(sql).await?;
+    let plan = df.clone().create_physical_plan().await?;
+    assert_eq!(
+        count_spatial_join_execs(&plan)?,
+        1,
+        "cross-CRS raster join should use the optimized SpatialJoinExec"
+    );
+    let batches = df.collect().await?;
+
+    let mut got: Vec<i32> = Vec::new();
+    for batch in &batches {
+        let col = as_int32_array(batch.column(0))?;
+        for i in 0..col.len() {
+            got.push(col.value(i));
+        }
+    }
+    got.sort_unstable();
+
+    assert_eq!(
+        got, expected_inside,
+        "cross-CRS accelerated join must match the constructed reference"
+    );
+
+    // Sanity: we exercised both inside (5) and outside (4) points.
+    assert_eq!(expected_inside.len(), 5);
+    assert_eq!(got.len(), 5);
+    assert_eq!(projected.len(), 9);
+    Ok(())
+}
+
+/// A 4x4 raster in EPSG:3857 with skew, so its footprint is a non-axis-aligned
+/// quadrilateral whose edges curve when reprojected to lng/lat.
+fn build_skewed_raster_3857() -> StructArray {
+    let mut builder = RasterBuilder::new(1);
+    let metadata = RasterMetadata {
+        width: 4,
+        height: 4,
+        upperleft_x: 0.0,
+        upperleft_y: 2_000_000.0,
+        scale_x: 100_000.0,
+        scale_y: -100_000.0,
+        skew_x: 30_000.0,
+        skew_y: 20_000.0,
+    };
+    builder.start_raster(&metadata, Some("EPSG:3857")).unwrap();
+    builder
+        .start_band(BandMetadata {
+            datatype: BandDataType::UInt8,
+            nodata_value: None,
+            storage_type: StorageType::InDb,
+            outdb_url: None,
+            outdb_band_id: None,
+        })
+        .unwrap();
+    builder.band_data_writer().append_value([0u8; 16]);
+    builder.finish_band().unwrap();
+    builder.finish_raster().unwrap();
+    builder.finish().unwrap()
+}

--- a/rust/sedona-spatial-join-raster/tests/spatial_join_integration.rs
+++ b/rust/sedona-spatial-join-raster/tests/spatial_join_integration.rs
@@ -261,27 +261,28 @@ async fn intersects_produces_expected_rows() -> Result<()> {
 }
 
 /// Cross-CRS: verify the accelerated path against an independent,
-/// construction-based reference. The raster is skewed in EPSG:3857 (so its
-/// footprint edges curve when reprojected to lng/lat, exercising densification);
-/// the geometry operand is lng/lat.
+/// construction-based reference. The raster is skewed in EPSG:3857; the geometry
+/// operand is lng/lat.
 ///
-/// Test points are built by reprojecting native-3857 points of *known*
-/// membership into lng/lat: for the convex footprint quadrilateral, the centroid
-/// and the halfway-to-each-vertex points are strictly inside, while the
-/// reflection of the centroid through each vertex is strictly outside. Because a
-/// CRS transform is a homeomorphism, a point's inside/outside status relative to
-/// the footprint is preserved by reprojection, so the expected result is exact
-/// (no tolerance) and independent of how the accelerated path reprojects. The
-/// reference reprojects points (into the raster's space); the accelerated path
-/// reprojects the footprint (into the geometry's space) — opposite directions, so
-/// this catches a wrong transform direction as well as pipeline errors, checked
-/// against PROJ (the same engine a rasterio/geopandas reference would use).
+/// The accelerated footprint is the convex hull of the raster's four corners
+/// reprojected into lng/lat (straight chords between reprojected corners — edge
+/// curvature is not modeled). The reference reprojects those same four corners
+/// into lng/lat to reconstruct that chord-quad, then builds test points whose
+/// membership is known by construction: the centroid and the halfway-to-each-
+/// vertex points are strictly inside the convex quad, while the reflection of the
+/// centroid through each vertex is strictly outside. These points sit well away
+/// from the edges, so the expected result is exact (no tolerance). The reference
+/// reprojects corners in the same 3857 -> lng/lat direction as the accelerated
+/// path, so a wrong transform direction places the accelerated hull elsewhere and
+/// none of the (correctly placed) inside points match — this validates transform
+/// direction and the footprint/refine pipeline against PROJ (the same engine a
+/// rasterio/geopandas reference would use).
 #[tokio::test]
 async fn cross_crs_matches_constructed_reference() -> Result<()> {
     let raster = build_skewed_raster_3857();
 
     // Footprint corners in the raster's native CRS (EPSG:3857). These are exact.
-    let corners = {
+    let native_corners = {
         let rasters = RasterStructArray::try_new(&raster).unwrap();
         let r = rasters.get(0).unwrap();
         let w = r.metadata().width();
@@ -293,43 +294,42 @@ async fn cross_crs_matches_constructed_reference() -> Result<()> {
             to_world_coordinate(&r, 0, h),
         ]
     };
-    let cx = corners.iter().map(|c| c.0).sum::<f64>() / 4.0;
-    let cy = corners.iter().map(|c| c.1).sum::<f64>() / 4.0;
 
-    // Native-3857 test points with membership known by construction.
-    let mut native_points: Vec<(i32, (f64, f64), bool)> = vec![(0, (cx, cy), true)];
-    for (i, &(x, y)) in corners.iter().enumerate() {
+    // Reproject the four corners into lng/lat. This is exactly the convex-hull
+    // footprint the accelerated path builds (straight chords between corners).
+    let lnglat_crs = lnglat().unwrap().to_crs_string();
+    let hull: [(f64, f64); 4] = with_global_proj_engine(|engine| {
+        let transform = engine
+            .get_transform_crs_to_crs("EPSG:3857", &lnglat_crs, None, "")
+            .map_err(|e| datafusion_common::exec_datafusion_err!("{e}"))?;
+        let mut hull = native_corners;
+        for corner in hull.iter_mut() {
+            transform
+                .transform_coord(corner)
+                .map_err(|e| datafusion_common::exec_datafusion_err!("{e}"))?;
+        }
+        Ok(hull)
+    })?;
+    let cx = hull.iter().map(|c| c.0).sum::<f64>() / 4.0;
+    let cy = hull.iter().map(|c| c.1).sum::<f64>() / 4.0;
+
+    // lng/lat test points with membership known by construction against the
+    // convex chord-quad `hull`.
+    let mut projected: Vec<(i32, (f64, f64), bool)> = vec![(0, (cx, cy), true)];
+    for (i, &(x, y)) in hull.iter().enumerate() {
         // Halfway from centroid to a vertex: strictly inside a convex polygon.
-        native_points.push((
+        projected.push((
             10 + i as i32,
             (cx + 0.5 * (x - cx), cy + 0.5 * (y - cy)),
             true,
         ));
         // Reflection of the centroid through a vertex: strictly outside.
-        native_points.push((
+        projected.push((
             20 + i as i32,
             (cx + 2.0 * (x - cx), cy + 2.0 * (y - cy)),
             false,
         ));
     }
-
-    // Reproject the native-3857 points into lng/lat to get the geometry coords.
-    let lnglat_crs = lnglat().unwrap().to_crs_string();
-    let projected: Vec<(i32, (f64, f64), bool)> = with_global_proj_engine(|engine| {
-        let transform = engine
-            .get_transform_crs_to_crs("EPSG:3857", &lnglat_crs, None, "")
-            .map_err(|e| datafusion_common::exec_datafusion_err!("{e}"))?;
-        native_points
-            .iter()
-            .map(|&(gid, pt, inside)| {
-                let mut c = pt;
-                transform
-                    .transform_coord(&mut c)
-                    .map_err(|e| datafusion_common::exec_datafusion_err!("{e}"))?;
-                Ok((gid, c, inside))
-            })
-            .collect::<Result<Vec<_>>>()
-    })?;
 
     // Expected matches: the gids of the inside points.
     let mut expected_inside: Vec<i32> = projected

--- a/rust/sedona-spatial-join-raster/tests/spatial_join_integration.rs
+++ b/rust/sedona-spatial-join-raster/tests/spatial_join_integration.rs
@@ -51,7 +51,7 @@ use sedona_common::option::SpatialJoinOptions;
 use sedona_common::SedonaOptions;
 use sedona_geometry::transform::CrsEngine;
 use sedona_geometry::types::Edges;
-use sedona_proj::transform::with_global_proj_engine;
+use sedona_proj::transform::{with_global_proj_engine, LazyProjEngine};
 use sedona_query_planner::{
     optimizer::register_spatial_join_logical_optimizer, query_planner::SedonaQueryPlanner,
 };
@@ -127,6 +127,18 @@ fn register_geom_table(ctx: &SessionContext) -> Result<()> {
 fn build_context(optimized: bool) -> Result<SessionContext> {
     let mut session_config = SessionConfig::from_env()?.with_batch_size(16);
     session_config = session_config.with_option_extension(SedonaOptions::default());
+
+    // Install a real CRS engine, mirroring the engine a normal session
+    // registers. Both the accelerated join and the RS_* kernel read the engine
+    // from the session options to reproject cross-CRS footprints/geometries.
+    {
+        let opts = session_config
+            .options_mut()
+            .extensions
+            .get_mut::<SedonaOptions>()
+            .unwrap();
+        opts.runtime = opts.runtime.with_crs_engine(Arc::new(LazyProjEngine));
+    }
 
     let mut state_builder = SessionStateBuilder::new();
     if optimized {

--- a/rust/sedona-spatial-join-raster/tests/spatial_join_integration.rs
+++ b/rust/sedona-spatial-join-raster/tests/spatial_join_integration.rs
@@ -58,6 +58,7 @@ use sedona_query_planner::{
 use sedona_raster::affine_transformation::to_world_coordinate;
 use sedona_raster::array::RasterStructArray;
 use sedona_raster::traits::RasterRef;
+use sedona_raster_functions::footprint::{densify_footprint_ring, FOOTPRINT_POINTS_PER_EDGE};
 use sedona_schema::crs::lnglat;
 use sedona_schema::datatypes::{SedonaType, RASTER};
 use sedona_schema::raster::BandDataType;
@@ -276,17 +277,18 @@ async fn intersects_produces_expected_rows() -> Result<()> {
 /// construction-based reference. The raster is skewed in EPSG:3857; the geometry
 /// operand is lng/lat.
 ///
-/// The accelerated footprint is the convex hull of the raster's four corners
-/// reprojected into lng/lat (straight chords between reprojected corners — edge
-/// curvature is not modeled). The reference reprojects those same four corners
-/// into lng/lat to reconstruct that chord-quad, then builds test points whose
-/// membership is known by construction: the centroid and the halfway-to-each-
-/// vertex points are strictly inside the convex quad, while the reflection of the
-/// centroid through each vertex is strictly outside. These points sit well away
-/// from the edges, so the expected result is exact (no tolerance). The reference
-/// reprojects corners in the same 3857 -> lng/lat direction as the accelerated
-/// path, so a wrong transform direction places the accelerated hull elsewhere and
-/// none of the (correctly placed) inside points match — this validates transform
+/// The accelerated footprint densifies each edge of the raster's four-corner quad
+/// in the native CRS and reprojects every point into lng/lat, so the footprint
+/// follows the curve of each reprojected edge rather than chording across it. The
+/// reference builds that same densified, reprojected ring, then places test
+/// points whose membership is known by construction: the centroid and the
+/// halfway-to-each-corner points are strictly inside the footprint, while the
+/// reflection of the centroid through each corner is strictly outside. These
+/// points sit well away from the edges, so the expected result is exact (no
+/// tolerance) no matter how finely the edges are modeled. The reference
+/// reprojects in the same 3857 -> lng/lat direction as the accelerated path, so a
+/// wrong transform direction places the accelerated footprint elsewhere and none
+/// of the (correctly placed) inside points match — this validates transform
 /// direction and the footprint/refine pipeline against PROJ (the same engine a
 /// rasterio/geopandas reference would use).
 #[tokio::test]
@@ -294,34 +296,37 @@ async fn cross_crs_matches_constructed_reference() -> Result<()> {
     let raster = build_skewed_raster_3857();
 
     // Footprint corners in the raster's native CRS (EPSG:3857). These are exact.
-    let native_corners = {
-        let rasters = RasterStructArray::try_new(&raster).unwrap();
-        let r = rasters.get(0).unwrap();
-        let w = r.metadata().width();
-        let h = r.metadata().height();
-        [
-            to_world_coordinate(&r, 0, 0),
-            to_world_coordinate(&r, w, 0),
-            to_world_coordinate(&r, w, h),
-            to_world_coordinate(&r, 0, h),
-        ]
-    };
+    let native_corners = skewed_raster_native_corners(&raster);
 
-    // Reproject the four corners into lng/lat. This is exactly the convex-hull
-    // footprint the accelerated path builds (straight chords between corners).
+    // Densify the four-corner footprint in the native CRS and reproject every
+    // point into lng/lat: this is exactly the footprint the accelerated path
+    // builds (each edge follows its reprojected curve, not a straight chord).
     let lnglat_crs = lnglat().unwrap().to_crs_string();
-    let hull: [(f64, f64); 4] = with_global_proj_engine(|engine| {
+    let ref_ring: Vec<(f64, f64)> = with_global_proj_engine(|engine| {
         let transform = engine
             .get_transform_crs_to_crs("EPSG:3857", &lnglat_crs, None, "")
             .map_err(|e| datafusion_common::exec_datafusion_err!("{e}"))?;
-        let mut hull = native_corners;
-        for corner in hull.iter_mut() {
+        let mut ring = Vec::new();
+        densify_footprint_ring(native_corners, &mut ring);
+        for point in ring.iter_mut() {
             transform
-                .transform_coord(corner)
+                .transform_coord(point)
                 .map_err(|e| datafusion_common::exec_datafusion_err!("{e}"))?;
         }
-        Ok(hull)
+        Ok(ring)
     })?;
+
+    // The four reprojected corners are the densified ring's vertices at the start
+    // of each edge. Test points are placed relative to these corners and the
+    // centroid — deep inside or far outside — so their membership is exact
+    // regardless of how finely the edges are modeled.
+    let corner_stride = FOOTPRINT_POINTS_PER_EDGE + 1;
+    let hull: [(f64, f64); 4] = [
+        ref_ring[0],
+        ref_ring[corner_stride],
+        ref_ring[2 * corner_stride],
+        ref_ring[3 * corner_stride],
+    ];
     let cx = hull.iter().map(|c| c.0).sum::<f64>() / 4.0;
     let cy = hull.iter().map(|c| c.1).sum::<f64>() / 4.0;
 
@@ -422,4 +427,173 @@ fn build_skewed_raster_3857() -> StructArray {
         .transform([0.0, 100_000.0, 30_000.0, 2_000_000.0, 20_000.0, -100_000.0])
         .band(BandDataType::UInt8)
         .build()
+}
+
+/// The four footprint corners of the single-row `raster` in its native CRS, in
+/// ring order (upper-left, upper-right, lower-right, lower-left).
+fn skewed_raster_native_corners(raster: &StructArray) -> [(f64, f64); 4] {
+    let rasters = RasterStructArray::try_new(raster).unwrap();
+    let r = rasters.get(0).unwrap();
+    let w = r.metadata().width();
+    let h = r.metadata().height();
+    [
+        to_world_coordinate(&r, 0, 0),
+        to_world_coordinate(&r, w, 0),
+        to_world_coordinate(&r, w, h),
+        to_world_coordinate(&r, 0, h),
+    ]
+}
+
+/// True if `p` lies inside (or on the boundary of) the convex quadrilateral
+/// `quad`, tested by requiring the cross product of each directed edge with the
+/// vector to `p` to keep a consistent sign.
+fn point_in_convex_quad(quad: &[(f64, f64); 4], p: (f64, f64)) -> bool {
+    let mut sign = 0.0f64;
+    for i in 0..4 {
+        let a = quad[i];
+        let b = quad[(i + 1) % 4];
+        let cross = (b.0 - a.0) * (p.1 - a.1) - (b.1 - a.1) * (p.0 - a.0);
+        if cross != 0.0 {
+            if sign == 0.0 {
+                sign = cross.signum();
+            } else if cross.signum() != sign {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// Densification catches a point in the sliver between a footprint edge's true
+/// reprojected curve and the straight chord through its two reprojected corners.
+///
+/// Reprojecting the skewed EPSG:3857 raster into lng/lat bows at least one edge
+/// outward: its true (curved) boundary bulges past the straight chord between the
+/// two reprojected corners. A point placed just inside that curve is inside the
+/// true footprint but outside the four-corner chord hull, so a join that only
+/// reprojected the corners would miss it. Because the accelerated join densifies
+/// each edge before reprojection, the footprint follows the curve and the point
+/// matches — the accuracy gain densification buys.
+#[tokio::test]
+async fn densification_catches_curved_edge_sliver() -> Result<()> {
+    let raster = build_skewed_raster_3857();
+    let native_corners = skewed_raster_native_corners(&raster);
+
+    // Reproject the four corners (the chord hull) and each edge's native midpoint
+    // (a point on the true reprojected curve) into lng/lat.
+    let lnglat_crs = lnglat().unwrap().to_crs_string();
+    let mut hull = native_corners;
+    let mut curve_mids = [(0.0, 0.0); 4];
+    with_global_proj_engine(|engine| {
+        let transform = engine
+            .get_transform_crs_to_crs("EPSG:3857", &lnglat_crs, None, "")
+            .map_err(|e| datafusion_common::exec_datafusion_err!("{e}"))?;
+        for corner in hull.iter_mut() {
+            transform
+                .transform_coord(corner)
+                .map_err(|e| datafusion_common::exec_datafusion_err!("{e}"))?;
+        }
+        for (e, mid) in curve_mids.iter_mut().enumerate() {
+            let a = native_corners[e];
+            let b = native_corners[(e + 1) % 4];
+            let mut m = ((a.0 + b.0) / 2.0, (a.1 + b.1) / 2.0);
+            transform
+                .transform_coord(&mut m)
+                .map_err(|e| datafusion_common::exec_datafusion_err!("{e}"))?;
+            *mid = m;
+        }
+        Ok(())
+    })?;
+
+    let cx = hull.iter().map(|c| c.0).sum::<f64>() / 4.0;
+    let cy = hull.iter().map(|c| c.1).sum::<f64>() / 4.0;
+
+    // Find the edge whose true curve bows farthest outward (its midpoint lies
+    // outside the chord hull) and build a point just inside that curve.
+    let mut best: Option<(f64, (f64, f64))> = None; // (outward depth, test point)
+    for e in 0..4 {
+        let a = hull[e];
+        let b = hull[(e + 1) % 4];
+        let curve_mid = curve_mids[e];
+        let dx = b.0 - a.0;
+        let dy = b.1 - a.1;
+        let len = (dx * dx + dy * dy).sqrt();
+        // Unit left normal of the chord a -> b.
+        let nx = -dy / len;
+        let ny = dx / len;
+        // Signed perpendicular offset of the curve midpoint and the centroid from
+        // the chord line. Opposite signs => the curve bows away from the centroid,
+        // i.e. outward past the chord hull.
+        let perp_curve = (curve_mid.0 - a.0) * nx + (curve_mid.1 - a.1) * ny;
+        let perp_centroid = (cx - a.0) * nx + (cy - a.1) * ny;
+        if perp_curve == 0.0 || perp_curve.signum() == perp_centroid.signum() {
+            continue; // straight or bows inward: no outward sliver on this edge
+        }
+        let depth = perp_curve.abs();
+        // Step from the true curve halfway back toward the interior: still outside
+        // the chord hull (< depth away), but inside the densified footprint (the
+        // densified edge hugs the true curve to within ~depth/100).
+        let inward = perp_centroid.signum();
+        let test_pt = (
+            curve_mid.0 + 0.5 * depth * nx * inward,
+            curve_mid.1 + 0.5 * depth * ny * inward,
+        );
+        let better = match best {
+            Some((d, _)) => depth > d,
+            None => true,
+        };
+        if better {
+            best = Some((depth, test_pt));
+        }
+    }
+
+    let (_, test_pt) = best.expect("reprojecting the skewed raster must bow an edge outward");
+
+    // The point is outside the four-corner chord hull: a join that reprojected
+    // only the corners would miss it.
+    assert!(
+        !point_in_convex_quad(&hull, test_pt),
+        "test point {test_pt:?} must lie outside the four-corner chord hull"
+    );
+
+    // Register the raster + the single sliver point in an optimized context.
+    let ctx = build_context(true)?;
+    let raster_schema = Arc::new(Schema::new(vec![RASTER.to_storage_field("raster", true)?]));
+    let raster_batch = RecordBatch::try_new(raster_schema.clone(), vec![Arc::new(raster)])?;
+    ctx.register_table(
+        "r",
+        Arc::new(MemTable::try_new(raster_schema, vec![vec![raster_batch]])?),
+    )?;
+
+    let geom_type = geom_type();
+    let wkt = format!("POINT ({} {})", test_pt.0, test_pt.1);
+    let geom = create_array(&[Some(wkt.as_str())], &geom_type);
+    let geom_schema = Arc::new(Schema::new(vec![
+        Field::new("gid", arrow_schema::DataType::Int32, false),
+        geom_type.to_storage_field("geom", true)?,
+    ]));
+    let geom_batch = RecordBatch::try_new(
+        geom_schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![1])), geom],
+    )?;
+    ctx.register_table(
+        "g",
+        Arc::new(MemTable::try_new(geom_schema, vec![vec![geom_batch]])?),
+    )?;
+
+    let sql = "SELECT g.gid FROM r JOIN g ON RS_Intersects(r.raster, g.geom)";
+    let df = ctx.sql(sql).await?;
+    let plan = df.clone().create_physical_plan().await?;
+    assert_eq!(
+        count_spatial_join_execs(&plan)?,
+        1,
+        "cross-CRS raster join should use the optimized SpatialJoinExec"
+    );
+    let batches = df.collect().await?;
+    let matched: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(
+        matched, 1,
+        "the densified footprint must match the sliver point that the four-corner chord hull misses"
+    );
+    Ok(())
 }

--- a/rust/sedona-spatial-join/src/physical_planner.rs
+++ b/rust/sedona-spatial-join/src/physical_planner.rs
@@ -66,6 +66,18 @@ impl SpatialJoinPhysicalPlanner for DefaultSpatialJoinPhysicalPlanner {
             return Ok(None);
         }
 
+        // Raster operands are recognized as spatial-join operands but cannot yet be
+        // evaluated into the geometry rectangles/WKB the optimized join requires.
+        // Returning `None` here routes such joins to the nested-loop fallback in the
+        // extension planner so they still produce correct results.
+        if predicate_has_raster_operand(
+            args.spatial_predicate,
+            &args.physical_left.schema(),
+            &args.physical_right.schema(),
+        )? {
+            return Ok(None);
+        }
+
         let should_swap = !matches!(
             args.spatial_predicate,
             SpatialPredicate::KNearestNeighbors(_)
@@ -206,20 +218,23 @@ pub fn is_spatial_predicate_supported(
     left_schema: &Schema,
     right_schema: &Schema,
 ) -> Result<bool> {
-    /// Only spatial predicates working with planar geometry are supported for optimization.
-    /// Geography (spherical) types are explicitly excluded and will not trigger optimized spatial joins.
-    fn is_geometry_type_supported(expr: &Arc<dyn PhysicalExpr>, schema: &Schema) -> Result<bool> {
-        let left_return_field = expr.return_field(schema)?;
-        let sedona_type = SedonaType::from_storage_field(&left_return_field)?;
-        let matcher = ArgMatcher::is_geometry();
-        Ok(matcher.match_type(&sedona_type))
+    /// A spatial-join operand is supported when it is a planar geometry or a raster.
+    /// Geography (spherical) types are explicitly excluded and will not trigger optimized
+    /// spatial joins. Raster operands are recognized here as valid spatial-join operands
+    /// so that raster-geometry and raster-raster predicates route through the spatial-join
+    /// planner; whether an operand can currently be evaluated is checked separately (see
+    /// [`predicate_has_raster_operand`]).
+    fn is_operand_type_supported(expr: &Arc<dyn PhysicalExpr>, schema: &Schema) -> Result<bool> {
+        let sedona_type = operand_sedona_type(expr, schema)?;
+        Ok(ArgMatcher::is_geometry().match_type(&sedona_type)
+            || matches!(sedona_type, SedonaType::Raster))
     }
 
     match spatial_predicate {
         SpatialPredicate::Relation(RelationPredicate { left, right, .. })
         | SpatialPredicate::Distance(DistancePredicate { left, right, .. }) => {
-            Ok(is_geometry_type_supported(left, left_schema)?
-                && is_geometry_type_supported(right, right_schema)?)
+            Ok(is_operand_type_supported(left, left_schema)?
+                && is_operand_type_supported(right, right_schema)?)
         }
         SpatialPredicate::KNearestNeighbors(KNNPredicate {
             left,
@@ -237,8 +252,61 @@ pub fn is_spatial_predicate_supported(
                     )
                 }
             };
-            Ok(is_geometry_type_supported(left, left_schema)?
-                && is_geometry_type_supported(right, right_schema)?)
+            Ok(is_operand_type_supported(left, left_schema)?
+                && is_operand_type_supported(right, right_schema)?)
+        }
+    }
+}
+
+/// Resolve the [`SedonaType`] an operand expression evaluates to against `schema`.
+fn operand_sedona_type(expr: &Arc<dyn PhysicalExpr>, schema: &Schema) -> Result<SedonaType> {
+    let return_field = expr.return_field(schema)?;
+    SedonaType::from_storage_field(&return_field)
+}
+
+/// Returns `true` when either operand of the predicate is a raster.
+///
+/// The optimized spatial join evaluates its operands into geometry bounding rectangles
+/// and WKB, which is not yet implemented for raster operands. Joins whose predicate has a
+/// raster operand are therefore routed to the nested-loop fallback until a raster operand
+/// evaluator exists.
+fn predicate_has_raster_operand(
+    spatial_predicate: &SpatialPredicate,
+    left_schema: &Schema,
+    right_schema: &Schema,
+) -> Result<bool> {
+    let is_raster = |expr: &Arc<dyn PhysicalExpr>, schema: &Schema| -> Result<bool> {
+        Ok(matches!(
+            operand_sedona_type(expr, schema)?,
+            SedonaType::Raster
+        ))
+    };
+
+    // Resolve each operand against the schema its columns belong to, mirroring the
+    // operand/schema pairing used by `is_spatial_predicate_supported` (KNN swaps the
+    // pairing according to the probe side).
+    match spatial_predicate {
+        SpatialPredicate::Relation(RelationPredicate { left, right, .. })
+        | SpatialPredicate::Distance(DistancePredicate { left, right, .. }) => {
+            Ok(is_raster(left, left_schema)? || is_raster(right, right_schema)?)
+        }
+        SpatialPredicate::KNearestNeighbors(KNNPredicate {
+            left,
+            right,
+            probe_side,
+            ..
+        }) => {
+            let (left, right) = match probe_side {
+                JoinSide::Left => (left, right),
+                JoinSide::Right => (right, left),
+                _ => {
+                    return sedona_internal_err!(
+                        "Invalid probe side in KNN predicate: {:?}",
+                        probe_side
+                    )
+                }
+            };
+            Ok(is_raster(left, left_schema)? || is_raster(right, right_schema)?)
         }
     }
 }
@@ -248,7 +316,7 @@ mod test {
     use arrow_schema::{DataType, Field};
     use datafusion_physical_expr::expressions::Column;
     use sedona_query_planner::spatial_predicate::SpatialRelationType;
-    use sedona_schema::datatypes::{WKB_GEOGRAPHY, WKB_GEOMETRY};
+    use sedona_schema::datatypes::{RASTER, WKB_GEOGRAPHY, WKB_GEOMETRY};
 
     use super::*;
 
@@ -280,6 +348,52 @@ mod test {
             !is_spatial_predicate_supported(&spatial_pred_geog, &geog_schema, &geog_schema)
                 .unwrap()
         );
+    }
+
+    #[test]
+    fn raster_operand_is_supported_type_but_routed_to_fallback() {
+        let raster_schema = Arc::new(Schema::new(vec![RASTER
+            .to_storage_field("raster", false)
+            .unwrap()]));
+        let geom_schema = Arc::new(Schema::new(vec![WKB_GEOMETRY
+            .to_storage_field("geom", false)
+            .unwrap()]));
+        let raster_expr = Arc::new(Column::new("raster", 0)) as Arc<dyn PhysicalExpr>;
+        let geom_expr = Arc::new(Column::new("geom", 0)) as Arc<dyn PhysicalExpr>;
+
+        // raster + geometry
+        let raster_geom = SpatialPredicate::Relation(RelationPredicate::new(
+            raster_expr.clone(),
+            geom_expr.clone(),
+            SpatialRelationType::Intersects,
+        ));
+        // The gate accepts a raster operand as a valid spatial-join operand type...
+        assert!(
+            is_spatial_predicate_supported(&raster_geom, &raster_schema, &geom_schema).unwrap()
+        );
+        // ...but the raster operand is detected and routed to the nested-loop fallback.
+        assert!(predicate_has_raster_operand(&raster_geom, &raster_schema, &geom_schema).unwrap());
+
+        // raster + raster
+        let raster_raster = SpatialPredicate::Relation(RelationPredicate::new(
+            raster_expr.clone(),
+            raster_expr.clone(),
+            SpatialRelationType::Intersects,
+        ));
+        assert!(
+            is_spatial_predicate_supported(&raster_raster, &raster_schema, &raster_schema).unwrap()
+        );
+        assert!(
+            predicate_has_raster_operand(&raster_raster, &raster_schema, &raster_schema).unwrap()
+        );
+
+        // Pure geometry predicates are not flagged as raster, so they keep the optimized path.
+        let geom_geom = SpatialPredicate::Relation(RelationPredicate::new(
+            geom_expr.clone(),
+            geom_expr.clone(),
+            SpatialRelationType::Intersects,
+        ));
+        assert!(!predicate_has_raster_operand(&geom_geom, &geom_schema, &geom_schema).unwrap());
     }
 
     #[test]

--- a/rust/sedona-spatial-join/src/physical_planner.rs
+++ b/rust/sedona-spatial-join/src/physical_planner.rs
@@ -66,18 +66,6 @@ impl SpatialJoinPhysicalPlanner for DefaultSpatialJoinPhysicalPlanner {
             return Ok(None);
         }
 
-        // Raster operands are recognized as spatial-join operands but cannot yet be
-        // evaluated into the geometry rectangles/WKB the optimized join requires.
-        // Returning `None` here routes such joins to the nested-loop fallback in the
-        // extension planner so they still produce correct results.
-        if predicate_has_raster_operand(
-            args.spatial_predicate,
-            &args.physical_left.schema(),
-            &args.physical_right.schema(),
-        )? {
-            return Ok(None);
-        }
-
         let should_swap = !matches!(
             args.spatial_predicate,
             SpatialPredicate::KNearestNeighbors(_)
@@ -218,16 +206,13 @@ pub fn is_spatial_predicate_supported(
     left_schema: &Schema,
     right_schema: &Schema,
 ) -> Result<bool> {
-    /// A spatial-join operand is supported when it is a planar geometry or a raster.
-    /// Geography (spherical) types are explicitly excluded and will not trigger optimized
-    /// spatial joins. Raster operands are recognized here as valid spatial-join operands
-    /// so that raster-geometry and raster-raster predicates route through the spatial-join
-    /// planner; whether an operand can currently be evaluated is checked separately (see
-    /// [`predicate_has_raster_operand`]).
+    /// A spatial-join operand is supported when it is a planar geometry. Geography
+    /// (spherical) and raster operands are excluded here; they are handled by their
+    /// own extension planners (`sedona-spatial-join-geography`,
+    /// `sedona-spatial-join-raster`) registered after this default planner.
     fn is_operand_type_supported(expr: &Arc<dyn PhysicalExpr>, schema: &Schema) -> Result<bool> {
         let sedona_type = operand_sedona_type(expr, schema)?;
-        Ok(ArgMatcher::is_geometry().match_type(&sedona_type)
-            || matches!(sedona_type, SedonaType::Raster))
+        Ok(ArgMatcher::is_geometry().match_type(&sedona_type))
     }
 
     match spatial_predicate {
@@ -262,53 +247,6 @@ pub fn is_spatial_predicate_supported(
 fn operand_sedona_type(expr: &Arc<dyn PhysicalExpr>, schema: &Schema) -> Result<SedonaType> {
     let return_field = expr.return_field(schema)?;
     SedonaType::from_storage_field(&return_field)
-}
-
-/// Returns `true` when either operand of the predicate is a raster.
-///
-/// The optimized spatial join evaluates its operands into geometry bounding rectangles
-/// and WKB, which is not yet implemented for raster operands. Joins whose predicate has a
-/// raster operand are therefore routed to the nested-loop fallback until a raster operand
-/// evaluator exists.
-fn predicate_has_raster_operand(
-    spatial_predicate: &SpatialPredicate,
-    left_schema: &Schema,
-    right_schema: &Schema,
-) -> Result<bool> {
-    let is_raster = |expr: &Arc<dyn PhysicalExpr>, schema: &Schema| -> Result<bool> {
-        Ok(matches!(
-            operand_sedona_type(expr, schema)?,
-            SedonaType::Raster
-        ))
-    };
-
-    // Resolve each operand against the schema its columns belong to, mirroring the
-    // operand/schema pairing used by `is_spatial_predicate_supported` (KNN swaps the
-    // pairing according to the probe side).
-    match spatial_predicate {
-        SpatialPredicate::Relation(RelationPredicate { left, right, .. })
-        | SpatialPredicate::Distance(DistancePredicate { left, right, .. }) => {
-            Ok(is_raster(left, left_schema)? || is_raster(right, right_schema)?)
-        }
-        SpatialPredicate::KNearestNeighbors(KNNPredicate {
-            left,
-            right,
-            probe_side,
-            ..
-        }) => {
-            let (left, right) = match probe_side {
-                JoinSide::Left => (left, right),
-                JoinSide::Right => (right, left),
-                _ => {
-                    return sedona_internal_err!(
-                        "Invalid probe side in KNN predicate: {:?}",
-                        probe_side
-                    )
-                }
-            };
-            Ok(is_raster(left, left_schema)? || is_raster(right, right_schema)?)
-        }
-    }
 }
 
 #[cfg(test)]
@@ -351,7 +289,9 @@ mod test {
     }
 
     #[test]
-    fn raster_operand_is_supported_type_but_routed_to_fallback() {
+    fn raster_operand_is_not_supported_by_default_planner() {
+        // Raster operands are declined by the default planner (returns None), so
+        // raster predicates fall through to the raster extension planner.
         let raster_schema = Arc::new(Schema::new(vec![RASTER
             .to_storage_field("raster", false)
             .unwrap()]));
@@ -367,12 +307,9 @@ mod test {
             geom_expr.clone(),
             SpatialRelationType::Intersects,
         ));
-        // The gate accepts a raster operand as a valid spatial-join operand type...
         assert!(
-            is_spatial_predicate_supported(&raster_geom, &raster_schema, &geom_schema).unwrap()
+            !is_spatial_predicate_supported(&raster_geom, &raster_schema, &geom_schema).unwrap()
         );
-        // ...but the raster operand is detected and routed to the nested-loop fallback.
-        assert!(predicate_has_raster_operand(&raster_geom, &raster_schema, &geom_schema).unwrap());
 
         // raster + raster
         let raster_raster = SpatialPredicate::Relation(RelationPredicate::new(
@@ -381,19 +318,9 @@ mod test {
             SpatialRelationType::Intersects,
         ));
         assert!(
-            is_spatial_predicate_supported(&raster_raster, &raster_schema, &raster_schema).unwrap()
+            !is_spatial_predicate_supported(&raster_raster, &raster_schema, &raster_schema)
+                .unwrap()
         );
-        assert!(
-            predicate_has_raster_operand(&raster_raster, &raster_schema, &raster_schema).unwrap()
-        );
-
-        // Pure geometry predicates are not flagged as raster, so they keep the optimized path.
-        let geom_geom = SpatialPredicate::Relation(RelationPredicate::new(
-            geom_expr.clone(),
-            geom_expr.clone(),
-            SpatialRelationType::Intersects,
-        ));
-        assert!(!predicate_has_raster_operand(&geom_geom, &geom_schema, &geom_schema).unwrap());
     }
 
     #[test]

--- a/rust/sedona-spatial-join/src/physical_planner.rs
+++ b/rust/sedona-spatial-join/src/physical_planner.rs
@@ -206,20 +206,20 @@ pub fn is_spatial_predicate_supported(
     left_schema: &Schema,
     right_schema: &Schema,
 ) -> Result<bool> {
-    /// A spatial-join operand is supported when it is a planar geometry. Geography
-    /// (spherical) and raster operands are excluded here; they are handled by their
-    /// own extension planners (`sedona-spatial-join-geography`,
-    /// `sedona-spatial-join-raster`) registered after this default planner.
-    fn is_operand_type_supported(expr: &Arc<dyn PhysicalExpr>, schema: &Schema) -> Result<bool> {
-        let sedona_type = operand_sedona_type(expr, schema)?;
-        Ok(ArgMatcher::is_geometry().match_type(&sedona_type))
+    /// Only spatial predicates working with planar geometry are supported for optimization.
+    /// Geography (spherical) types are explicitly excluded and will not trigger optimized spatial joins.
+    fn is_geometry_type_supported(expr: &Arc<dyn PhysicalExpr>, schema: &Schema) -> Result<bool> {
+        let left_return_field = expr.return_field(schema)?;
+        let sedona_type = SedonaType::from_storage_field(&left_return_field)?;
+        let matcher = ArgMatcher::is_geometry();
+        Ok(matcher.match_type(&sedona_type))
     }
 
     match spatial_predicate {
         SpatialPredicate::Relation(RelationPredicate { left, right, .. })
         | SpatialPredicate::Distance(DistancePredicate { left, right, .. }) => {
-            Ok(is_operand_type_supported(left, left_schema)?
-                && is_operand_type_supported(right, right_schema)?)
+            Ok(is_geometry_type_supported(left, left_schema)?
+                && is_geometry_type_supported(right, right_schema)?)
         }
         SpatialPredicate::KNearestNeighbors(KNNPredicate {
             left,
@@ -237,16 +237,10 @@ pub fn is_spatial_predicate_supported(
                     )
                 }
             };
-            Ok(is_operand_type_supported(left, left_schema)?
-                && is_operand_type_supported(right, right_schema)?)
+            Ok(is_geometry_type_supported(left, left_schema)?
+                && is_geometry_type_supported(right, right_schema)?)
         }
     }
-}
-
-/// Resolve the [`SedonaType`] an operand expression evaluates to against `schema`.
-fn operand_sedona_type(expr: &Arc<dyn PhysicalExpr>, schema: &Schema) -> Result<SedonaType> {
-    let return_field = expr.return_field(schema)?;
-    SedonaType::from_storage_field(&return_field)
 }
 
 #[cfg(test)]
@@ -254,7 +248,7 @@ mod test {
     use arrow_schema::{DataType, Field};
     use datafusion_physical_expr::expressions::Column;
     use sedona_query_planner::spatial_predicate::SpatialRelationType;
-    use sedona_schema::datatypes::{RASTER, WKB_GEOGRAPHY, WKB_GEOMETRY};
+    use sedona_schema::datatypes::{WKB_GEOGRAPHY, WKB_GEOMETRY};
 
     use super::*;
 
@@ -284,41 +278,6 @@ mod test {
         let spatial_pred_geog = SpatialPredicate::Relation(rel_pred_geog);
         assert!(
             !is_spatial_predicate_supported(&spatial_pred_geog, &geog_schema, &geog_schema)
-                .unwrap()
-        );
-    }
-
-    #[test]
-    fn raster_operand_is_not_supported_by_default_planner() {
-        // Raster operands are declined by the default planner (returns None), so
-        // raster predicates fall through to the raster extension planner.
-        let raster_schema = Arc::new(Schema::new(vec![RASTER
-            .to_storage_field("raster", false)
-            .unwrap()]));
-        let geom_schema = Arc::new(Schema::new(vec![WKB_GEOMETRY
-            .to_storage_field("geom", false)
-            .unwrap()]));
-        let raster_expr = Arc::new(Column::new("raster", 0)) as Arc<dyn PhysicalExpr>;
-        let geom_expr = Arc::new(Column::new("geom", 0)) as Arc<dyn PhysicalExpr>;
-
-        // raster + geometry
-        let raster_geom = SpatialPredicate::Relation(RelationPredicate::new(
-            raster_expr.clone(),
-            geom_expr.clone(),
-            SpatialRelationType::Intersects,
-        ));
-        assert!(
-            !is_spatial_predicate_supported(&raster_geom, &raster_schema, &geom_schema).unwrap()
-        );
-
-        // raster + raster
-        let raster_raster = SpatialPredicate::Relation(RelationPredicate::new(
-            raster_expr.clone(),
-            raster_expr.clone(),
-            SpatialRelationType::Intersects,
-        ));
-        assert!(
-            !is_spatial_predicate_supported(&raster_raster, &raster_schema, &raster_schema)
                 .unwrap()
         );
     }

--- a/rust/sedona/Cargo.toml
+++ b/rust/sedona/Cargo.toml
@@ -44,7 +44,7 @@ proj = ["sedona-proj/proj-sys"]
 gdal = ["sedona-gdal/gdal-sys"]
 # Enable bindgen for GDAL versions without pre-built bindings (e.g., GDAL 3.13+).
 bindgen = ["sedona-gdal/bindgen"]
-spatial-join = ["dep:sedona-spatial-join"]
+spatial-join = ["dep:sedona-spatial-join", "dep:sedona-spatial-join-raster"]
 gpu = ["dep:sedona-spatial-join-gpu", "sedona-spatial-join-gpu/gpu"]
 s2geography = ["dep:sedona-s2geography", "dep:sedona-spatial-join-geography"]
 
@@ -91,6 +91,7 @@ sedona-schema = { workspace = true }
 sedona-spatial-join = { workspace = true, optional = true }
 sedona-spatial-join-gpu = { workspace = true, optional = true }
 sedona-spatial-join-geography = { workspace = true, optional = true }
+sedona-spatial-join-raster = { workspace = true, optional = true }
 sedona-query-planner = { workspace = true }
 sedona-s2geography = { workspace = true, optional = true }
 sedona-testing = { workspace = true }

--- a/rust/sedona/src/context.rs
+++ b/rust/sedona/src/context.rs
@@ -157,6 +157,17 @@ impl SedonaContext {
                 DefaultSpatialJoinPhysicalPlanner::new(),
             ));
 
+            // Register the raster join after the default planner. It accelerates
+            // raster/geometry predicates; unsupported cases fall back to the
+            // default planner (and ultimately the nested-loop join).
+            {
+                use sedona_spatial_join_raster::physical_planner::RasterSpatialJoinPhysicalPlanner;
+
+                planner = planner.with_spatial_join_physical_planner(Arc::new(
+                    RasterSpatialJoinPhysicalPlanner::new(),
+                ));
+            }
+
             // Register the geography join after the default planner
             // If a query is not supported, it falls back to the default planner.
             #[cfg(feature = "s2geography")]

--- a/rust/sedona/src/context.rs
+++ b/rust/sedona/src/context.rs
@@ -157,17 +157,6 @@ impl SedonaContext {
                 DefaultSpatialJoinPhysicalPlanner::new(),
             ));
 
-            // Register the raster join after the default planner. It accelerates
-            // raster/geometry predicates; unsupported cases fall back to the
-            // default planner (and ultimately the nested-loop join).
-            {
-                use sedona_spatial_join_raster::physical_planner::RasterSpatialJoinPhysicalPlanner;
-
-                planner = planner.with_spatial_join_physical_planner(Arc::new(
-                    RasterSpatialJoinPhysicalPlanner::new(),
-                ));
-            }
-
             // Register the geography join after the default planner
             // If a query is not supported, it falls back to the default planner.
             #[cfg(feature = "s2geography")]
@@ -187,6 +176,21 @@ impl SedonaContext {
 
                 planner = planner.with_spatial_join_physical_planner(Arc::new(
                     GpuSpatialJoinPhysicalPlanner::new(),
+                ));
+            }
+
+            // Register the raster join last so it is consulted before the GPU
+            // planner (planners are tried in reverse registration order). It
+            // recognizes raster/geometry predicates and declines everything else
+            // with `None`, so a raster predicate is handled here rather than
+            // reaching the GPU planner — which would otherwise hard-error on a
+            // raster operand when `GpuOptions.fallback_to_cpu` is false. Anything
+            // it declines falls through to the GPU/geography/default planners.
+            {
+                use sedona_spatial_join_raster::physical_planner::RasterSpatialJoinPhysicalPlanner;
+
+                planner = planner.with_spatial_join_physical_planner(Arc::new(
+                    RasterSpatialJoinPhysicalPlanner::new(),
                 ));
             }
         }

--- a/rust/sedona/tests/raster_spatial_join.rs
+++ b/rust/sedona/tests/raster_spatial_join.rs
@@ -1,0 +1,201 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! End-to-end test for raster-geometry spatial-join recognition + fallback.
+//!
+//! A join predicated on `RS_Intersects(raster, geom)` is recognized as a spatial
+//! predicate (so it becomes a `SpatialJoin` extension node), but the optimized
+//! spatial join cannot yet evaluate raster operands. The join must therefore fall
+//! back to a `NestedLoopJoinExec` and still produce correct results.
+//!
+//! The row-correctness case is gated behind the `proj` feature because the
+//! `RS_Intersects` kernel always initializes the global PROJ engine (which needs
+//! `sedona-proj/proj-sys`); the recognition/fallback plan-shape case only plans and
+//! so runs without PROJ.
+
+// The spatial-join planner/optimizer are only wired in when this feature is enabled.
+#![cfg(feature = "spatial-join")]
+
+use std::sync::Arc;
+
+use arrow_array::{Int32Array, RecordBatch};
+use arrow_schema::{Field, Schema};
+use datafusion::catalog::MemTable;
+use datafusion::physical_plan::displayable;
+use sedona::context::SedonaContext;
+use sedona_geometry::types::Edges;
+use sedona_schema::crs::lnglat;
+use sedona_schema::datatypes::{SedonaType, RASTER};
+use sedona_testing::create::create_array;
+use sedona_testing::rasters::generate_test_rasters;
+
+/// Geometry type sharing the CRS that `generate_test_rasters` stamps on its rasters
+/// (lng/lat), so the predicate compares in a common CRS without reprojection.
+fn geom_type() -> SedonaType {
+    SedonaType::Wkb(Edges::Planar, lnglat())
+}
+
+/// Register a raster table `r(rid INT, raster RASTER)`.
+///
+/// `generate_test_rasters(3, Some(0))` yields: index 0 null, index 1 with a convex
+/// hull around x∈[2.0, 2.29] y∈[2.4, 3.08], index 2 around x∈[3.0, 3.84] y∈[2.4, 4.24].
+fn register_raster_table(ctx: &SedonaContext) {
+    let rasters = generate_test_rasters(3, Some(0)).unwrap();
+    let rid = Int32Array::from(vec![0, 1, 2]);
+
+    let raster_field = RASTER.to_storage_field("raster", true).unwrap();
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("rid", arrow_schema::DataType::Int32, false),
+        raster_field,
+    ]));
+    let batch =
+        RecordBatch::try_new(schema.clone(), vec![Arc::new(rid), Arc::new(rasters)]).unwrap();
+    let table = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+    ctx.ctx.register_table("r", Arc::new(table)).unwrap();
+}
+
+/// Register a geometry table `g(gid INT, geom GEOMETRY)`.
+fn register_geom_table(ctx: &SedonaContext) {
+    let geom_type = geom_type();
+    let gid = Int32Array::from(vec![10, 20, 30]);
+    let geom = create_array(
+        &[
+            Some("POINT (2.15 2.75)"),                       // inside raster 1 only
+            Some("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))"), // contains rasters 1 and 2
+            Some("POINT (0 0)"),                             // outside all rasters
+        ],
+        &geom_type,
+    );
+
+    let geom_field = geom_type.to_storage_field("geom", true).unwrap();
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("gid", arrow_schema::DataType::Int32, false),
+        geom_field,
+    ]));
+    let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(gid), geom]).unwrap();
+    let table = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+    ctx.ctx.register_table("g", Arc::new(table)).unwrap();
+}
+
+const RASTER_JOIN_SQL: &str = "SELECT r.rid, g.gid \
+     FROM r JOIN g ON RS_Intersects(r.raster, g.geom) \
+     ORDER BY r.rid, g.gid";
+
+/// The `RS_Intersects` join is recognized as a spatial predicate (so the optimized
+/// logical plan contains the `SpatialJoin` extension node), and — with no raster
+/// operand evaluator yet — falls back to a `NestedLoopJoinExec` rather than the
+/// optimized `SpatialJoinExec`. Planning only, so no PROJ required.
+#[tokio::test]
+async fn raster_join_recognized_and_falls_back_to_nested_loop() {
+    let ctx = SedonaContext::new_local_interactive().await.unwrap();
+    register_raster_table(&ctx);
+    register_geom_table(&ctx);
+
+    let df = ctx.sql(RASTER_JOIN_SQL).await.unwrap();
+
+    let optimized = df.clone().into_optimized_plan().unwrap();
+    let logical_str = format!("{}", optimized.display_indent());
+    assert!(
+        logical_str.contains("SpatialJoin"),
+        "expected a SpatialJoin extension node in the optimized logical plan, got:\n{logical_str}"
+    );
+
+    let physical = df.create_physical_plan().await.unwrap();
+    let physical_str = displayable(physical.as_ref()).indent(true).to_string();
+    assert!(
+        physical_str.contains("NestedLoopJoinExec"),
+        "expected NestedLoopJoinExec fallback, got:\n{physical_str}"
+    );
+    assert!(
+        !physical_str.contains("SpatialJoinExec"),
+        "raster join must not use the optimized SpatialJoinExec, got:\n{physical_str}"
+    );
+}
+
+/// The raster join executes correctly through the nested-loop fallback: only
+/// (raster 1, point-in-1), (raster 1, big-polygon), and (raster 2, big-polygon)
+/// intersect, and the null raster (rid 0) never matches.
+#[cfg(feature = "proj")]
+#[tokio::test]
+async fn raster_join_produces_correct_rows() {
+    let ctx = SedonaContext::new_local_interactive().await.unwrap();
+    register_raster_table(&ctx);
+    register_geom_table(&ctx);
+
+    let batches = ctx
+        .sql(RASTER_JOIN_SQL)
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    datafusion::assert_batches_eq!(
+        [
+            "+-----+-----+",
+            "| rid | gid |",
+            "+-----+-----+",
+            "| 1   | 10  |",
+            "| 1   | 20  |",
+            "| 2   | 20  |",
+            "+-----+-----+",
+        ],
+        &batches
+    );
+}
+
+/// A geometry-only join is unaffected by the raster changes: it still uses the
+/// optimized `SpatialJoinExec` (no regression to the existing ST_* path).
+#[tokio::test]
+async fn geometry_join_still_uses_optimized_spatial_join() {
+    let ctx = SedonaContext::new_local_interactive().await.unwrap();
+    register_geom_table(&ctx);
+
+    // Self-join two geometry tables on ST_Intersects.
+    let geom_type = geom_type();
+    let gid = Int32Array::from(vec![100, 200]);
+    let geom = create_array(
+        &[
+            Some("POLYGON ((0 0, 5 0, 5 5, 0 5, 0 0))"),
+            Some("POINT (100 100)"),
+        ],
+        &geom_type,
+    );
+    let geom_field = geom_type.to_storage_field("geom", true).unwrap();
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("gid2", arrow_schema::DataType::Int32, false),
+        geom_field,
+    ]));
+    let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(gid), geom]).unwrap();
+    let table = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+    ctx.ctx.register_table("g2", Arc::new(table)).unwrap();
+
+    let sql = "SELECT g.gid, g2.gid2 \
+               FROM g JOIN g2 ON ST_Intersects(g.geom, g2.geom)";
+    let df = ctx.sql(sql).await.unwrap();
+
+    let physical = df.clone().create_physical_plan().await.unwrap();
+    let physical_str = displayable(physical.as_ref()).indent(true).to_string();
+    assert!(
+        physical_str.contains("SpatialJoinExec"),
+        "geometry join should use the optimized SpatialJoinExec, got:\n{physical_str}"
+    );
+
+    // Sanity: the join still executes and produces at least the expected overlap row.
+    let batches = df.collect().await.unwrap();
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert!(total_rows >= 1, "expected at least one intersecting pair");
+}

--- a/rust/sedona/tests/raster_spatial_join.rs
+++ b/rust/sedona/tests/raster_spatial_join.rs
@@ -15,17 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! End-to-end test for raster-geometry spatial-join recognition + fallback.
+//! End-to-end test for raster-geometry optimized spatial joins.
 //!
 //! A join predicated on `RS_Intersects(raster, geom)` is recognized as a spatial
-//! predicate (so it becomes a `SpatialJoin` extension node), but the optimized
-//! spatial join cannot yet evaluate raster operands. The join must therefore fall
-//! back to a `NestedLoopJoinExec` and still produce correct results.
+//! predicate (so it becomes a `SpatialJoin` extension node) and is planned as the
+//! optimized `SpatialJoinExec` by the raster extension planner, which evaluates
+//! each raster into its footprint polygon rather than falling back to a
+//! `NestedLoopJoinExec`.
 //!
-//! The row-correctness case is gated behind the `proj` feature because the
-//! `RS_Intersects` kernel always initializes the global PROJ engine (which needs
-//! `sedona-proj/proj-sys`); the recognition/fallback plan-shape case only plans and
-//! so runs without PROJ.
+//! The row-correctness case is gated behind the `proj` feature because the raster
+//! footprint evaluator (like the `RS_Intersects` kernel) initializes the global
+//! PROJ engine (which needs `sedona-proj/proj-sys`); the plan-shape case only
+//! plans and so runs without PROJ.
 
 // The spatial-join planner/optimizer are only wired in when this feature is enabled.
 #![cfg(feature = "spatial-join")]
@@ -96,11 +97,11 @@ const RASTER_JOIN_SQL: &str = "SELECT r.rid, g.gid \
      ORDER BY r.rid, g.gid";
 
 /// The `RS_Intersects` join is recognized as a spatial predicate (so the optimized
-/// logical plan contains the `SpatialJoin` extension node), and — with no raster
-/// operand evaluator yet — falls back to a `NestedLoopJoinExec` rather than the
-/// optimized `SpatialJoinExec`. Planning only, so no PROJ required.
+/// logical plan contains the `SpatialJoin` extension node) and is planned as the
+/// optimized `SpatialJoinExec` by the raster extension planner, not the
+/// `NestedLoopJoinExec` fallback. Planning only, so no PROJ required.
 #[tokio::test]
-async fn raster_join_recognized_and_falls_back_to_nested_loop() {
+async fn raster_join_uses_optimized_spatial_join() {
     let ctx = SedonaContext::new_local_interactive().await.unwrap();
     register_raster_table(&ctx);
     register_geom_table(&ctx);
@@ -117,12 +118,12 @@ async fn raster_join_recognized_and_falls_back_to_nested_loop() {
     let physical = df.create_physical_plan().await.unwrap();
     let physical_str = displayable(physical.as_ref()).indent(true).to_string();
     assert!(
-        physical_str.contains("NestedLoopJoinExec"),
-        "expected NestedLoopJoinExec fallback, got:\n{physical_str}"
+        physical_str.contains("SpatialJoinExec"),
+        "raster join should use the optimized SpatialJoinExec, got:\n{physical_str}"
     );
     assert!(
-        !physical_str.contains("SpatialJoinExec"),
-        "raster join must not use the optimized SpatialJoinExec, got:\n{physical_str}"
+        !physical_str.contains("NestedLoopJoinExec"),
+        "raster join must not fall back to NestedLoopJoinExec, got:\n{physical_str}"
     );
 }
 

--- a/rust/sedona/tests/raster_spatial_join.rs
+++ b/rust/sedona/tests/raster_spatial_join.rs
@@ -158,58 +158,6 @@ async fn raster_join_produces_correct_rows() {
     );
 }
 
-/// An untagged (CRS-less) geometry joined against the WGS84 rasters no longer
-/// errors: the missing CRS is assumed to be WGS84 (matching the `RS_*` kernel and
-/// Sedona Spark), so the join returns exactly the rows of the CRS-tagged case
-/// (`raster_join_produces_correct_rows`).
-#[cfg(feature = "proj")]
-#[tokio::test]
-async fn untagged_geometry_join_assumes_wgs84() {
-    use sedona_schema::datatypes::WKB_GEOMETRY;
-
-    let ctx = SedonaContext::new_local_interactive().await.unwrap();
-    register_raster_table(&ctx);
-
-    // Same geometries as register_geom_table, but the column carries no CRS.
-    let gid = Int32Array::from(vec![10, 20, 30]);
-    let geom = create_array(
-        &[
-            Some("POINT (2.15 2.75)"),                       // inside raster 1 only
-            Some("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))"), // contains rasters 1 and 2
-            Some("POINT (0 0)"),                             // outside all rasters
-        ],
-        &WKB_GEOMETRY,
-    );
-    let geom_field = WKB_GEOMETRY.to_storage_field("geom", true).unwrap();
-    let schema = Arc::new(Schema::new(vec![
-        Field::new("gid", arrow_schema::DataType::Int32, false),
-        geom_field,
-    ]));
-    let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(gid), geom]).unwrap();
-    let table = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
-    ctx.ctx.register_table("g", Arc::new(table)).unwrap();
-
-    let batches = ctx
-        .sql(RASTER_JOIN_SQL)
-        .await
-        .unwrap()
-        .collect()
-        .await
-        .unwrap();
-    datafusion::assert_batches_eq!(
-        [
-            "+-----+-----+",
-            "| rid | gid |",
-            "+-----+-----+",
-            "| 1   | 10  |",
-            "| 1   | 20  |",
-            "| 2   | 20  |",
-            "+-----+-----+",
-        ],
-        &batches
-    );
-}
-
 /// A geometry-only join is unaffected by the raster changes: it still uses the
 /// optimized `SpatialJoinExec` (no regression to the existing ST_* path).
 #[tokio::test]

--- a/rust/sedona/tests/raster_spatial_join.rs
+++ b/rust/sedona/tests/raster_spatial_join.rs
@@ -158,6 +158,58 @@ async fn raster_join_produces_correct_rows() {
     );
 }
 
+/// An untagged (CRS-less) geometry joined against the WGS84 rasters no longer
+/// errors: the missing CRS is assumed to be WGS84 (matching the `RS_*` kernel and
+/// Sedona Spark), so the join returns exactly the rows of the CRS-tagged case
+/// (`raster_join_produces_correct_rows`).
+#[cfg(feature = "proj")]
+#[tokio::test]
+async fn untagged_geometry_join_assumes_wgs84() {
+    use sedona_schema::datatypes::WKB_GEOMETRY;
+
+    let ctx = SedonaContext::new_local_interactive().await.unwrap();
+    register_raster_table(&ctx);
+
+    // Same geometries as register_geom_table, but the column carries no CRS.
+    let gid = Int32Array::from(vec![10, 20, 30]);
+    let geom = create_array(
+        &[
+            Some("POINT (2.15 2.75)"),                       // inside raster 1 only
+            Some("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))"), // contains rasters 1 and 2
+            Some("POINT (0 0)"),                             // outside all rasters
+        ],
+        &WKB_GEOMETRY,
+    );
+    let geom_field = WKB_GEOMETRY.to_storage_field("geom", true).unwrap();
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("gid", arrow_schema::DataType::Int32, false),
+        geom_field,
+    ]));
+    let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(gid), geom]).unwrap();
+    let table = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+    ctx.ctx.register_table("g", Arc::new(table)).unwrap();
+
+    let batches = ctx
+        .sql(RASTER_JOIN_SQL)
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    datafusion::assert_batches_eq!(
+        [
+            "+-----+-----+",
+            "| rid | gid |",
+            "+-----+-----+",
+            "| 1   | 10  |",
+            "| 1   | 20  |",
+            "| 2   | 20  |",
+            "+-----+-----+",
+        ],
+        &batches
+    );
+}
+
 /// A geometry-only join is unaffected by the raster changes: it still uses the
 /// optimized `SpatialJoinExec` (no regression to the existing ST_* path).
 #[tokio::test]


### PR DESCRIPTION
Adds an index-optimized spatial join for `RS_Intersects`/`RS_Contains`/`RS_Within` between a raster and a geometry. A new `sedona-spatial-join-raster` crate plugs a raster-aware operand evaluator into the existing `SpatialJoinExec` — the raster is indexed and refined by the convex hull of its four world corners, so the R-tree and WKB refiner are unchanged.

CRS handling matches SedonaDB's `RS_` predicate kernels: same-CRS compares directly (exact); a one-sided/missing CRS is an error (not silently assumed to be WGS84); cross-CRS reprojects the raster footprint into the geometry operand's CRS, **densifying each edge (~10 points) before reprojection** so the footprint follows the projected curve rather than a straight chord. Reprojection routes through the `SedonaOptions`-injected `CrsEngine` (both the predicate kernels and the join use `with_crs_engine`, mirroring `RS_Clip`). A footprint with a non-finite reprojected point yields a null footprint (no match) instead of garbage.

Out of scope (tracked in #1076): antimeridian-crossing footprints, and geodesic / geography-tolerance matching.
