### PR TITLE
perf(rust/sedona-spatial-join-raster): pin raster operand to the probe side

### DIFF
--- a/rust/sedona-spatial-join-raster/src/physical_planner.rs
+++ b/rust/sedona-spatial-join-raster/src/physical_planner.rs
@@ -86,6 +86,16 @@ impl SpatialJoinPhysicalPlanner for RasterSpatialJoinPhysicalPlanner {
         // short-lived, and shared across the rows each raster fans out to. The
         // cardinality heuristic would put a low-cardinality raster input on the build
         // side, which is the worst case here, so it is bypassed for raster joins.
+        //
+        // The raster operand is pinned to the probe (streamed) side so its band
+        // buffers are not fully buffered on the build side (where ingest gc-compacts
+        // and copies view buffers) while passing through the join. Whether to pin
+        // unconditionally, or only when the vector side is not the vastly larger
+        // input (forcing a huge vector table onto the buffered build side can cost
+        // more than copying a few raster payloads) — and whether to instead make
+        // build-side ingest share view buffers so the statistics-based side
+        // heuristic can stay intact — is an open question. See
+        // https://github.com/apache/sedona-db/issues/1078.
         let raster_on_left =
             raster_operand_on_left(args.spatial_predicate, &args.physical_left.schema())?;
         let swap_raster_to_probe = raster_on_left && args.join_type.supports_swap();

--- a/rust/sedona-spatial-join-raster/src/physical_planner.rs
+++ b/rust/sedona-spatial-join-raster/src/physical_planner.rs
@@ -29,10 +29,7 @@ use sedona_query_planner::{
     spatial_predicate::{RelationPredicate, SpatialPredicate, SpatialRelationType},
 };
 use sedona_schema::{crs::Crs, datatypes::SedonaType, matchers::ArgMatcher};
-use sedona_spatial_join::{
-    physical_planner::{repartition_probe_side, should_swap_join_order},
-    SpatialJoinExec,
-};
+use sedona_spatial_join::{physical_planner::repartition_probe_side, SpatialJoinExec};
 
 use crate::join_provider::RasterJoinProvider;
 
@@ -40,9 +37,12 @@ use crate::join_provider::RasterJoinProvider;
 ///
 /// Handles `RS_Intersects`/`RS_Contains`/`RS_Within` predicates where exactly one
 /// operand is a raster and the other is a planar geometry, producing an optimized
-/// [`SpatialJoinExec`] backed by a [`RasterJoinProvider`]. All other predicates
-/// (including raster/raster, for which there is no fixed common CRS to compare in)
-/// are declined with `None` so they fall back to the nested-loop join.
+/// [`SpatialJoinExec`] backed by a [`RasterJoinProvider`]. The raster operand is
+/// always placed on the probe side (see [`plan_spatial_join`]). All other
+/// predicates (including raster/raster, for which there is no fixed common CRS to
+/// compare in) are declined with `None` so they fall back to the nested-loop join.
+///
+/// [`plan_spatial_join`]: SpatialJoinPhysicalPlanner::plan_spatial_join
 #[derive(Debug)]
 pub struct RasterSpatialJoinPhysicalPlanner;
 
@@ -73,20 +73,33 @@ impl SpatialJoinPhysicalPlanner for RasterSpatialJoinPhysicalPlanner {
             return Ok(None);
         };
 
-        let should_swap = args.join_type.supports_swap()
-            && should_swap_join_order(
-                args.join_options,
-                args.physical_left.as_ref(),
-                args.physical_right.as_ref(),
-            )?;
+        // Pin the raster operand to the probe (right) side, overriding the row-count
+        // reordering heuristic (`should_swap_join_order`, which is deliberately not
+        // consulted here).
+        //
+        // The build side is fully buffered and its ingest compacts view arrays
+        // (`gc_view_arrays`), copying raster `BinaryView` band payloads into fresh
+        // buffers and defeating the zero-copy design. The probe side streams one
+        // batch at a time and does not compact, and output columns are assembled
+        // with `arrow::compute::take`, which shares view-array data buffers. Placing
+        // the raster on the probe side therefore keeps raster band buffers uncopied,
+        // short-lived, and shared across the rows each raster fans out to. The
+        // cardinality heuristic would put a low-cardinality raster input on the build
+        // side, which is the worst case here, so it is bypassed for raster joins.
+        let raster_on_left =
+            raster_operand_on_left(args.spatial_predicate, &args.physical_left.schema())?;
+        let swap_raster_to_probe = raster_on_left && args.join_type.supports_swap();
 
         // Repartition the probe side when enabled, mirroring the default planner.
+        // The raster operand ends up on the probe side, so `swap_raster_to_probe`
+        // doubles as the swap decision `repartition_probe_side` uses to target the
+        // pre-swap input that becomes the probe.
         let (physical_left, physical_right) = if args.join_options.repartition_probe_side {
             repartition_probe_side(
                 args.physical_left.clone(),
                 args.physical_right.clone(),
                 args.spatial_predicate,
-                should_swap,
+                swap_raster_to_probe,
             )?
         } else {
             (args.physical_left.clone(), args.physical_right.clone())
@@ -114,7 +127,12 @@ impl SpatialJoinPhysicalPlanner for RasterSpatialJoinPhysicalPlanner {
         )?
         .with_spatial_join_provider(Arc::new(RasterJoinProvider::new(target_crs, engine)));
 
-        if should_swap {
+        if swap_raster_to_probe {
+            // Move the raster from the build side onto the probe side.
+            // `swap_inputs()` inverts the predicate (Contains<->Within), swaps the
+            // join type (Left<->Right), reorders the output columns, and carries the
+            // raster provider onto the rebuilt exec, so the raster-aware evaluator
+            // survives the swap and lands on the final plan.
             exec.swap_inputs().map(Some)
         } else {
             Ok(Some(Arc::new(exec) as Arc<dyn ExecutionPlan>))
@@ -172,6 +190,25 @@ fn raster_geometry_target_crs(
     Ok(target)
 }
 
+/// Return `true` when the raster operand of `spatial_predicate` is the left
+/// (build) input, resolving the left operand against `left_schema`.
+///
+/// This is only meaningful for a raster/geometry `Relation` predicate that
+/// [`raster_geometry_target_crs`] has already accepted (exactly one operand is a
+/// raster). Any other predicate shape reports `false`.
+fn raster_operand_on_left(
+    spatial_predicate: &SpatialPredicate,
+    left_schema: &Schema,
+) -> Result<bool> {
+    let SpatialPredicate::Relation(RelationPredicate { left, .. }) = spatial_predicate else {
+        return Ok(false);
+    };
+    Ok(matches!(
+        operand_sedona_type(left, left_schema)?,
+        SedonaType::Raster
+    ))
+}
+
 /// Resolve the [`SedonaType`] an operand expression evaluates to against `schema`.
 fn operand_sedona_type(expr: &Arc<dyn PhysicalExpr>, schema: &Schema) -> Result<SedonaType> {
     let return_field = expr.return_field(schema)?;
@@ -191,7 +228,7 @@ mod test {
     use sedona_schema::crs::{deserialize_crs, lnglat};
     use sedona_schema::datatypes::{SedonaType, RASTER, WKB_GEOMETRY};
 
-    use super::raster_geometry_target_crs;
+    use super::{raster_geometry_target_crs, raster_operand_on_left};
 
     fn schema_with(field_name: &str, sedona_type: &SedonaType) -> Arc<Schema> {
         Arc::new(Schema::new(vec![sedona_type
@@ -236,6 +273,22 @@ mod test {
             .as_deref()
             .unwrap()
             .crs_equals(lnglat().as_deref().unwrap()));
+    }
+
+    #[test]
+    fn raster_operand_side_is_detected() {
+        let geom_type = SedonaType::Wkb(Edges::Planar, lnglat());
+        let raster_schema = schema_with("raster", &RASTER);
+        let geom_schema = schema_with("geom", &geom_type);
+
+        // (raster, geometry): the left operand resolves against the left (raster)
+        // schema, so the raster is on the build side.
+        let pred = relation(col("raster"), col("geom"), SpatialRelationType::Intersects);
+        assert!(raster_operand_on_left(&pred, &raster_schema).unwrap());
+
+        // (geometry, raster): the raster is on the probe side already.
+        let pred = relation(col("geom"), col("raster"), SpatialRelationType::Intersects);
+        assert!(!raster_operand_on_left(&pred, &geom_schema).unwrap());
     }
 
     #[test]

--- a/rust/sedona-spatial-join-raster/src/physical_planner.rs
+++ b/rust/sedona-spatial-join-raster/src/physical_planner.rs
@@ -77,6 +77,14 @@ impl SpatialJoinPhysicalPlanner for RasterSpatialJoinPhysicalPlanner {
         // reordering heuristic (`should_swap_join_order`, which is deliberately not
         // consulted here).
         //
+        // This pin is load-bearing, not merely an optimization: the build (index)
+        // side must operate in a single common CRS — the geometry operand,
+        // reprojected to `target_crs` — to build and probe the spatial index in.
+        // Pinning the raster to the probe side is what keeps a raster (which carries
+        // its own, possibly differing CRS) off the index side, where it would break
+        // that single-common-CRS assumption. The buffer-copy win below is the
+        // second reason.
+        //
         // The build side is fully buffered and its ingest compacts view arrays
         // (`gc_view_arrays`), copying raster `BinaryView` band payloads into fresh
         // buffers and defeating the zero-copy design. The probe side streams one

--- a/rust/sedona-spatial-join-raster/tests/spatial_join_integration.rs
+++ b/rust/sedona-spatial-join-raster/tests/spatial_join_integration.rs
@@ -188,6 +188,32 @@ fn count_spatial_join_execs(plan: &Arc<dyn ExecutionPlan>) -> Result<usize> {
     Ok(count)
 }
 
+/// Whether `schema` contains a raster-typed field.
+fn schema_has_raster(schema: &Schema) -> bool {
+    schema
+        .fields()
+        .iter()
+        .any(|f| matches!(SedonaType::from_storage_field(f), Ok(SedonaType::Raster)))
+}
+
+/// Report `(build_side_has_raster, probe_side_has_raster)` for the single
+/// `SpatialJoinExec` in `plan`, inspecting each child input's schema. The build
+/// side is the left input and the probe side is the right input.
+fn spatial_join_raster_sides(plan: &Arc<dyn ExecutionPlan>) -> Result<(bool, bool)> {
+    let mut sides = None;
+    plan.apply(|node| {
+        if let Some(sj) = node.as_any().downcast_ref::<SpatialJoinExec>() {
+            sides = Some((
+                schema_has_raster(sj.left.schema().as_ref()),
+                schema_has_raster(sj.right.schema().as_ref()),
+            ));
+            return Ok(TreeNodeRecursion::Stop);
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })?;
+    sides.ok_or_else(|| datafusion_common::exec_datafusion_err!("plan has no SpatialJoinExec"))
+}
+
 async fn run_query(optimized: bool, sql: &str) -> Result<RecordBatch> {
     let ctx = setup_context(optimized)?;
     let df = ctx.sql(sql).await?;
@@ -222,6 +248,12 @@ async fn run_query(optimized: bool, sql: &str) -> Result<RecordBatch> {
 /// Assert the optimized `SpatialJoinExec` returns byte-identical rows to the
 /// nested-loop kernel for a same-CRS raster/geometry join. Covers all three
 /// `RS_*` predicates, both operand orderings, and inner/left/right joins.
+///
+/// Every case joins `FROM r ... g`, so the raster is the build-side (left) input
+/// and is pinned to the probe side by a forced swap. Parity here therefore also
+/// pins the swap: the inverted predicate (Contains<->Within), the swapped join
+/// type (Left<->Right), the reordered output columns, and the raster provider
+/// carried onto the rebuilt exec must all match the nested-loop kernel exactly.
 #[rstest]
 #[tokio::test]
 async fn same_crs_strict_parity(
@@ -239,6 +271,59 @@ async fn same_crs_strict_parity(
     assert_eq!(
         optimized, nested_loop,
         "optimized SpatialJoinExec must match the nested-loop kernel exactly for {sql}"
+    );
+    Ok(())
+}
+
+/// The raster operand is pinned to the probe (right) side of the
+/// `SpatialJoinExec` no matter which logical input it starts on. `FROM r JOIN g`
+/// starts the raster on the build (left) input, so the planner forces a swap onto
+/// the probe side; `FROM g JOIN r` starts it on the probe side already, so no swap
+/// is needed. Either way the raster lands on the probe side and never on the build
+/// side, and both orders return the same intersecting rows.
+///
+/// The `FROM r JOIN g` order additionally proves the raster provider survives the
+/// swap: were it lost, the swapped exec would try to read the raster column as WKB
+/// and fail with "Can't iterate over Raster as Wkb" rather than return rows.
+#[rstest]
+#[case::raster_starts_on_build(
+    "SELECT r.rid, g.gid FROM r JOIN g ON RS_Intersects(r.raster, g.geom) ORDER BY r.rid, g.gid"
+)]
+#[case::raster_starts_on_probe(
+    "SELECT r.rid, g.gid FROM g JOIN r ON RS_Intersects(g.geom, r.raster) ORDER BY r.rid, g.gid"
+)]
+#[tokio::test]
+async fn raster_pinned_to_probe_side(#[case] sql: &str) -> Result<()> {
+    let ctx = setup_context(true)?;
+    let df = ctx.sql(sql).await?;
+    let plan = df.clone().create_physical_plan().await?;
+
+    let (build_has_raster, probe_has_raster) = spatial_join_raster_sides(&plan)?;
+    let physical_str = displayable(plan.as_ref()).indent(true).to_string();
+    assert!(
+        probe_has_raster,
+        "raster must be pinned to the probe (right) side, got:\n{physical_str}"
+    );
+    assert!(
+        !build_has_raster,
+        "raster must not be on the build (left) side, got:\n{physical_str}"
+    );
+
+    let batches = df.collect().await?;
+    datafusion::assert_batches_eq!(
+        [
+            "+-----+-----+",
+            "| rid | gid |",
+            "+-----+-----+",
+            "| 1   | 10  |",
+            "| 1   | 30  |",
+            "| 1   | 50  |",
+            "| 1   | 60  |",
+            "| 2   | 20  |",
+            "| 2   | 50  |",
+            "+-----+-----+",
+        ],
+        &batches
     );
     Ok(())
 }


### PR DESCRIPTION
Stacked on #1073 — the diff shows both branches' commits until #1073 merges, then reduces to this branch's single commit.

Pins the raster operand of a raster–vector spatial join to the probe (streamed) side so its BinaryView band buffers stay uncopied, short-lived, and shared across the rows a raster fans out to — instead of being buffered and gc-compacted on the build side.