### PR TITLE
ci(python/sedonadb-geopandas): run tests, build wheels, and verify in releases

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -24,6 +24,7 @@ on:
       - 'ci/scripts/wheels-*'
       - '.github/workflows/python-wheels.yml'
       - '.github/workflows/wheels-expr.yml'
+      - '.github/workflows/wheels-geopandas.yml'
       - '.github/workflows/wheels-zarr.yml'
       - '.github/actions/setup-wheel-build/**'
   push:
@@ -230,6 +231,20 @@ jobs:
     needs: ["windows-x86_64", "macOS-arm64", "macOS-amd64", "wheels-linux"]
     if: ${{ !cancelled() }}
     uses: ./.github/workflows/wheels-zarr.yml
+    secrets: inherit
+
+  # Follows the expr job rather than the core wheel jobs directly: this package
+  # needs the sedonadb-expr wheel (for the `.geo` accessor) in addition to the
+  # core wheels, and expr already waits on those.
+  #
+  # !cancelled() for the same reason as expr/zarr: without it, a cancelled
+  # platform job upstream skips this one even when expr itself succeeded. The
+  # extra result check keeps the requirement this job actually has — it
+  # downloads expr's wheel artifact, which only exists if expr succeeded.
+  geopandas:
+    needs: ["expr"]
+    if: ${{ !cancelled() && needs.expr.result == 'success' }}
+    uses: ./.github/workflows/wheels-geopandas.yml
     secrets: inherit
 
   upload_nightly:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -128,6 +128,12 @@ jobs:
         run: |
           pip install -e "python/sedonadb-zarr/[test]" -vv
 
+      # Depends on sedonadb and sedonadb-expr, so this must come after both are
+      # installed from source (otherwise pip would resolve them from PyPI).
+      - name: Install sedonadb-geopandas
+        run: |
+          pip install -e "python/sedonadb-geopandas/[test]" -vv
+
       - name: Download minimal geoarrow-data assets
         run: |
           python submodules/download-assets.py "*water-junc*" "*water-point*"
@@ -188,6 +194,11 @@ jobs:
       - name: Run tests (sedonadb-expr)
         run: |
           cd python/sedonadb-expr
+          python -m pytest -vv
+
+      - name: Run tests (sedonadb-geopandas)
+        run: |
+          cd python/sedonadb-geopandas
           python -m pytest -vv
 
       - name: Shutdown docker compose services

--- a/.github/workflows/wheels-geopandas.yml
+++ b/.github/workflows/wheels-geopandas.yml
@@ -1,0 +1,124 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+name: wheels-geopandas
+
+# Reusable workflow that builds, tests, and publishes the sedonadb-geopandas
+# wheels. Invoked by python-wheels.yml after the sedonadb and sedonadb-expr jobs
+# so this runs in the same run and can download their wheels for testing.
+#
+# Kept separate from the core wheel jobs so an extension build failure can't
+# block the core package from publishing.
+#
+# sedonadb-geopandas is a pure Python package (no native code), so it only needs
+# a single build job that produces a universal wheel.
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  geopandas-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: 'true'
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Set SedonaDB dev version
+        shell: bash
+        run: |
+          # Set the unique development version anywhere except a release branch
+          if [[ "${GITHUB_REF##*/}" =~ ^branch-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "On release branch - using version from Cargo.toml"
+          else
+            python ci/scripts/set_dev_version.py
+          fi
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build wheel and sdist
+        run: |
+          cd python/sedonadb-geopandas
+          python -m build
+
+      # Both are needed: sedonadb provides the engine, and the `.geo` accessor
+      # this package delegates to is provided by sedonadb-expr.
+      - name: Download sedonadb wheel for the test environment
+        uses: actions/download-artifact@v8
+        with:
+          name: release-wheels-linux-x86_64
+          path: python/sedonadb-geopandas/prebuilt
+
+      - name: Download sedonadb-expr wheel for the test environment
+        uses: actions/download-artifact@v8
+        with:
+          name: release-expr-wheels
+          path: python/sedonadb-geopandas/prebuilt
+
+      - name: Install and test
+        run: |
+          # geopandas is an optional extra of this package but is required to
+          # exercise the from_geopandas/to_geopandas interop in the tests.
+          pip install pytest geopandas
+
+          cd python/sedonadb-geopandas
+          pip install --no-deps --pre --find-links prebuilt sedonadb sedonadb-expr
+          pip install --pre --find-links prebuilt sedonadb sedonadb-expr
+          pip install dist/*.whl
+          pytest tests -vv
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: release-geopandas-wheels
+          path: python/sedonadb-geopandas/dist/*
+
+  upload_nightly:
+    needs: ["geopandas-build"]
+    name: Upload nightly packages (sedonadb-geopandas)
+    runs-on: "macos-latest"
+    # Only the nightly publish needs this job; skip it entirely (rather than
+    # just the push step) on PRs so it doesn't burn a runner.
+    if: github.repository == 'apache/sedona-db' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: release-geopandas-wheels
+          path: dist
+
+      - name: Install gemfury client
+        run: |
+          brew tap gemfury/tap
+          brew trust gemfury/tap
+          brew install fury-cli
+          fury --version
+
+      - name: Upload packages to Gemfury
+        shell: bash
+        run: |
+          fury push \
+            --api-token=${GEMFURY_PUSH_TOKEN} \
+            --as="sedona-nightlies" \
+            dist/*
+        env:
+          GEMFURY_PUSH_TOKEN: ${{ secrets.GEMFURY_PUSH_TOKEN }}

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -265,11 +265,13 @@ test_python() {
   pip install "sedonadb-expr/[test]" -v
   pip install "sedonadb/[test]" -v
   pip install "sedonadb-zarr/[test]" -v
+  pip install "sedonadb-geopandas/[test]" -v
 
   show_info "Testing Python packages"
   python -m pytest -vv sedonadb-expr
   python -m pytest -vv sedonadb
   python -m pytest -vv sedonadb-zarr
+  python -m pytest -vv sedonadb-geopandas
 
   popd
 }

--- a/python/sedonadb-geopandas/_version.py
+++ b/python/sedonadb-geopandas/_version.py
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Version source for hatchling - reads from workspace Cargo.toml.
+
+This file is used by hatchling at build time to determine the version, so this
+package stays in lockstep with the workspace version (including the
+`-alphaN` dev versions that ci/scripts/set_dev_version.py writes for nightly
+builds).
+"""
+
+import re
+from pathlib import Path
+
+
+def get_version() -> str:
+    """Read version from the workspace root Cargo.toml."""
+    here = Path(__file__).parent
+    cargo_toml = here.parent.parent / "Cargo.toml"
+
+    if not cargo_toml.exists():
+        raise FileNotFoundError(f"Could not find workspace Cargo.toml at {cargo_toml}")
+
+    content = cargo_toml.read_text()
+
+    match = re.search(
+        r'\[workspace\.package\].*?version\s*=\s*"([^"]+)"',
+        content,
+        re.DOTALL,
+    )
+    if match:
+        return match.group(1)
+
+    raise ValueError("Could not find workspace.package.version in Cargo.toml")

--- a/python/sedonadb-geopandas/pyproject.toml
+++ b/python/sedonadb-geopandas/pyproject.toml
@@ -21,13 +21,18 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sedonadb-geopandas"
-version = "0.4.0"
 description = "GeoPandas-compatible API on top of SedonaDB"
 readme = "README.md"
 requires-python = ">=3.9"
+dynamic = ["version"]
 dependencies = [
-    "sedonadb",
-    "sedonadb-expr",
+    # The `.geo` accessor and `DataFrame.unnest` this package builds on landed in
+    # 0.4.0. Keep this floor at a *released* version rather than raising it to
+    # the current development version: nightlies are versioned `X.Y.ZaN`, which
+    # PEP 440 orders *below* `X.Y.Z`, so a floor equal to the version being
+    # developed would reject the matching nightly wheels.
+    "sedonadb>=0.4.0",
+    "sedonadb-expr>=0.4.0",
     "pyarrow",
 ]
 classifiers = [
@@ -50,6 +55,11 @@ test = [
     "pandas",
     "geopandas",
 ]
+
+[tool.hatch.version]
+source = "code"
+path = "_version.py"
+expression = "get_version()"
 
 [tool.hatch.build.targets.wheel]
 packages = ["python/sedonadb_geopandas"]


### PR DESCRIPTION
`sedonadb-geopandas` (added in #1052) is not referenced by any workflow, so its tests never run upstream and it has no path to release: the main `pytest` invocation runs inside `python/sedonadb` and does not collect them, and there is no wheel build. This wires the package in the same way the other Python packages are wired, and fixes two packaging problems found along the way.

## Python CI

Installs the package (after `sedonadb` and `sedonadb-expr`, so pip resolves both from source rather than PyPI) and runs its 23 tests, mirroring the existing `sedonadb-expr` steps.

## Wheels

`wheels-geopandas.yml`, modelled on `wheels-expr.yml`: build a universal wheel and sdist, test the built wheel, then publish nightly to Gemfury. It downloads **both** the `sedonadb` and the `sedonadb-expr` wheel artifacts, because the `.geo` accessor this package delegates to comes from `sedonadb-expr`. Invoked from `python-wheels.yml` with `needs: ["expr"]` (which transitively waits on the core wheel jobs), plus the corresponding paths trigger.

## Release verification

`verify-release-candidate.sh` now installs and tests this package alongside `sedonadb-expr` and `sedonadb-zarr`. Without this it would ship in the release tarball unverified.

## Fix: version was hard-coded

The package declared `version = "0.4.0"` literally, while the sibling Python packages derive their version from the workspace `Cargo.toml`. Two consequences: every nightly wheel would publish as the same `0.4.0`, and the value would silently drift from the workspace at each release bump. It now uses the same `_version.py` + `[tool.hatch.version]` mechanism as `sedonadb-expr`.

Verified end to end: `ci/scripts/set_dev_version.py` rewrites the workspace version to `0.4.0-alpha62`, and the resulting wheel is `sedonadb_geopandas-0.4.0a62-py3-none-any.whl`.

## Fix: dependency floors did not admit nightlies

Dependencies were unpinned (`sedonadb`, `sedonadb-expr`). Nightly builds version as `0.4.0aN`, which is PEP 440-*less* than `0.4.0`, so a plain `>=0.4.0` floor would reject the matching nightly wheel and break `pip install` of the nightly for users, not just CI — the same trap documented in `sedonadb-zarr`. The floors are now explicit prereleases: `sedonadb>=0.4.0a0` and `sedonadb-expr>=0.4.0a0`.

Confirmed: `0.4.0a62` satisfies `>=0.4.0a0` and is rejected by `>=0.4.0`.

## Not included

`packaging.yml`, which installs packages so mkdocstrings can build generated API-reference pages. This package has no such page, so adding it there would have no effect.

## Verification

Wheel and sdist build; wheel metadata carries the intended `Requires-Dist` and extras; both workflow files parse and the job graph resolves as expected; `bash -n` passes on the release script; `ruff format` / `ruff check` clean; the package's 23 tests pass via the exact commands CI runs.
