### PR TITLE
fix(python/sedonadb): skip RS_ReprojectMatch null-raster test without rasterio

### DIFF
--- a/python/sedonadb/tests/functions/test_rs_reprojectmatch.py
+++ b/python/sedonadb/tests/functions/test_rs_reprojectmatch.py
@@ -235,6 +235,7 @@ def test_reproject_match_int64_uint64_rejected(con, tmp_path, dtype):
 
 def test_reproject_match_null_raster_is_null(con, tmp_path):
     """A NULL input raster yields a NULL result rather than erroring."""
+    pytest.importorskip("rasterio")  # write_grid_geotiff needs rasterio
     ref = tmp_path / "refnull.tif"
     write_grid_geotiff(
         ref,


### PR DESCRIPTION
`test_reproject_match_null_raster_is_null` calls `write_grid_geotiff`, which imports `rasterio`, but is missing the `pytest.importorskip("rasterio")` guard that the other rasterio-dependent tests in the same file already have (see `test_reproject_match_int64_uint64_rejected` and `test_reproject_match_sql_smoke`). It therefore fails with `ModuleNotFoundError` in any environment without rasterio, rather than skipping like its neighbours.

This is currently breaking the wheel builds. `CIBW_TEST_REQUIRES` installs `pytest adbc_driver_manager geoarrow-pyarrow geopandas duckdb` — no rasterio — so `python-wheels` runs fail on this one test:

```
tests/functions/test_rs_reprojectmatch.py::test_reproject_match_null_raster_is_null FAILED
================ 1 failed, 3143 passed, 2495 skipped in 25.01s =================
```

```
>       import rasterio
E       ModuleNotFoundError: No module named 'rasterio'
```

Every `python-wheels` run on `main` has failed this way for several days, across `linux-arm64`, `linux-x86_64`, `macOS-arm64`, `macOS-amd64`, and `windows-x86_64`, which also skips the `expr`, `zarr`, and nightly-upload jobs.

## Change

One line, matching the convention used elsewhere in this file and in the other `test_rs_*.py` modules:

```python
pytest.importorskip("rasterio")  # write_grid_geotiff needs rasterio
```

## Verification

Reproduced locally in an environment without rasterio: the test failed before the change, and afterwards the module reports `13 skipped, 0 failed`. `ruff format` and `ruff check` are clean.

## Note

The alternative would be adding `rasterio` to `CIBW_TEST_REQUIRES` so these tests actually run during wheel builds. Worth considering separately: 12 of the 13 tests in this module already skip in that environment, so raster coverage there is currently minimal. That is a coverage decision rather than a fix for the broken build, so this PR only restores the skip behaviour the module already intends.
