### PR TITLE
ci(python-wheels): upload nightly wheels best-effort when a platform fails

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -204,6 +204,12 @@ jobs:
 
   upload_nightly:
     needs: ["wheels-linux", "macOS-arm64", "macOS-amd64", "windows-x86_64"]
+    # Publish whatever wheels built, even when some platform jobs fail. A job
+    # that fails to build or test never reaches its upload-artifact step, so the
+    # release-wheels-* artifacts hold only wheels that built and passed their
+    # tests -- one platform's failure no longer blocks the nightly for the rest.
+    # !cancelled() still skips a run superseded by a newer push to the branch.
+    if: ${{ !cancelled() }}
     name: Upload nightly packages
     runs-on: "macos-latest"
     steps:
@@ -224,6 +230,12 @@ jobs:
         if: github.repository == 'apache/sedona-db' && github.ref == 'refs/heads/main'
         shell: bash
         run: |
+          if [ -z "$(ls -A dist 2>/dev/null)" ]; then
+            echo "No wheels built successfully this run; nothing to upload."
+            exit 0
+          fi
+          echo "Uploading nightly wheels:"
+          ls -1 dist
           fury push \
             --api-token=${GEMFURY_PUSH_TOKEN} \
             --as="sedona-nightlies" \


### PR DESCRIPTION
Nightly wheels are gated all-or-nothing on all four platform build jobs, so one failing platform blocks the entire nightly — no set has published since 2026-07-10 (recently the Windows job has been red). This lets `upload_nightly` run best-effort and publish whatever `release-wheels-*` artifacts exist; a build/test job that fails never reaches its upload-artifact step, so only wheels that built and passed their tests are present. It does not fix the underlying Windows failure — that still needs root-causing separately.

I'm not sure if we should fail the workflow after uploading.