### PR TITLE
refactor(rust/sedona-raster): retire the pre-N-D metadata shim

### DIFF
--- a/rust/sedona-raster-functions/src/executor.rs
+++ b/rust/sedona-raster-functions/src/executor.rs
@@ -741,7 +741,7 @@ mod tests {
                 match raster_opt {
                     None => builder.append_null(),
                     Some(raster) => {
-                        let width = raster.metadata().width();
+                        let width = raster.width()?;
                         builder.append_value(width);
                     }
                 }
@@ -783,7 +783,7 @@ mod tests {
                 match raster_opt {
                     None => builder.append_null(),
                     Some(raster) => {
-                        let width = raster.metadata().width();
+                        let width = raster.width()?;
                         builder.append_value(width);
                     }
                 }
@@ -820,7 +820,7 @@ mod tests {
                 match raster_opt {
                     None => builder.append_null(),
                     Some(raster) => {
-                        let width = raster.metadata().width();
+                        let width = raster.width()?;
                         builder.append_value(width);
                     }
                 }

--- a/rust/sedona-raster-functions/src/footprint.rs
+++ b/rust/sedona-raster-functions/src/footprint.rs
@@ -44,8 +44,8 @@ pub const FOOTPRINT_POINTS_PER_EDGE: usize = 10;
 /// Returned in ring order: upper-left `(0, 0)`, upper-right `(width, 0)`,
 /// lower-right `(width, height)`, lower-left `(0, height)`.
 pub fn raster_footprint_corners(raster: &dyn RasterRef) -> [(f64, f64); 4] {
-    let width = raster.metadata().width();
-    let height = raster.metadata().height();
+    let width = raster.width().unwrap();
+    let height = raster.height().unwrap();
 
     [
         to_world_coordinate(raster, 0, 0),

--- a/rust/sedona-raster-functions/src/rs_band_accessors.rs
+++ b/rust/sedona-raster-functions/src/rs_band_accessors.rs
@@ -126,7 +126,7 @@ fn get_pixel_type(
                 return Ok(());
             }
             let band = raster.bands().band(band_index as usize)?;
-            let dt = band.metadata().data_type()?;
+            let dt = band.data_type();
             builder.append_value(dt.pixel_type_name());
             Ok(())
         }
@@ -230,8 +230,7 @@ fn get_nodata_value(
                 return Ok(());
             }
             let band = raster.bands().band(band_index as usize)?;
-            let band_meta = band.metadata();
-            match band_meta.nodata_value_as_f64()? {
+            match band.nodata_as_f64()? {
                 None => builder.append_null(),
                 Some(val) => builder.append_value(val),
             }

--- a/rust/sedona-raster-functions/src/rs_bandpath.rs
+++ b/rust/sedona-raster-functions/src/rs_bandpath.rs
@@ -24,7 +24,6 @@ use datafusion_common::error::Result;
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_raster::traits::RasterRef;
-use sedona_schema::raster::StorageType;
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
 
 /// RS_BandPath() scalar UDF implementation
@@ -130,11 +129,14 @@ fn get_band_path(
                 builder.append_null();
             } else {
                 let band = bands.band(band_index as usize)?;
-                let band_metadata = band.metadata();
 
-                if band_metadata.storage_type()? == StorageType::OutDbRef {
-                    match band_metadata.outdb_url() {
-                        Some(url) => builder.append_value(url),
+                if !band.is_indb() {
+                    match band.outdb_uri() {
+                        Some(uri) => {
+                            let (base_url, _band_id) =
+                                sedona_raster::traits::split_outdb_band_fragment(uri);
+                            builder.append_value(base_url)
+                        }
                         None => builder.append_null(),
                     }
                 } else {

--- a/rust/sedona-raster-functions/src/rs_envelope.rs
+++ b/rust/sedona-raster-functions/src/rs_envelope.rs
@@ -105,8 +105,8 @@ impl SedonaScalarKernel for RsEnvelope {
 /// derives the min/max X and Y to produce an axis-aligned bounding box.
 /// For skewed/rotated rasters, this differs from the convex hull.
 fn write_envelope_wkb(raster: &dyn RasterRef, out: &mut impl std::io::Write) -> Result<()> {
-    let width = raster.metadata().width();
-    let height = raster.metadata().height();
+    let width = raster.width()?;
+    let height = raster.height()?;
 
     // Compute the four corners in world coordinates
     let (ulx, uly) = to_world_coordinate(raster, 0, 0);

--- a/rust/sedona-raster-functions/src/rs_example.rs
+++ b/rust/sedona-raster-functions/src/rs_example.rs
@@ -21,13 +21,8 @@ use datafusion_common::error::Result;
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_raster::builder::RasterBuilder;
-use sedona_raster::traits::BandMetadata;
-use sedona_raster::traits::RasterMetadata;
 use sedona_schema::{
-    crs::lnglat,
-    datatypes::SedonaType,
-    matchers::ArgMatcher,
-    raster::{BandDataType, StorageType},
+    crs::lnglat, datatypes::SedonaType, matchers::ArgMatcher, raster::BandDataType,
 };
 
 /// RS_Example() scalar UDF implementation
@@ -60,30 +55,15 @@ impl SedonaScalarKernel for RsExample {
         let executor = RasterExecutor::new(arg_types, args);
         let mut builder = RasterBuilder::new(1);
 
-        let raster_metadata = RasterMetadata {
-            width: 64,
-            height: 32,
-            upperleft_x: 43.08,
-            upperleft_y: 79.07,
-            scale_x: 2.0,
-            scale_y: 2.0,
-            skew_x: 1.0,
-            skew_y: 1.0,
-        };
+        let width: i64 = 64;
+        let height: i64 = 32;
         let crs = lnglat().unwrap().to_crs_string();
-        builder.start_raster(&raster_metadata, Some(&crs))?;
+        builder.start_raster_2d(width, height, 43.08, 79.07, 2.0, 2.0, 1.0, 1.0, Some(&crs))?;
         let nodata_value = 127u8;
         for band_id in 1..=3 {
-            builder.start_band(BandMetadata {
-                datatype: BandDataType::UInt8,
-                nodata_value: Some(vec![nodata_value]),
-                storage_type: StorageType::InDb,
-                outdb_url: None,
-                outdb_band_id: None,
-            })?;
+            builder.start_band_2d(BandDataType::UInt8, Some(&[nodata_value]))?;
 
-            let mut band_data =
-                vec![band_id as u8; (raster_metadata.width * raster_metadata.height) as usize];
+            let mut band_data = vec![band_id as u8; (width * height) as usize];
             band_data[0] = nodata_value; // set the top corner to nodata
 
             builder.band_data_writer().append_value(&band_data);

--- a/rust/sedona-raster-functions/src/rs_georeference.rs
+++ b/rust/sedona-raster-functions/src/rs_georeference.rs
@@ -171,13 +171,12 @@ fn format_georeference(
     match raster_opt {
         None => builder.append_null(),
         Some(raster) => {
-            let metadata = raster.metadata();
-            let scale_x = metadata.scale_x();
-            let scale_y = metadata.scale_y();
-            let skew_x = metadata.skew_x();
-            let skew_y = metadata.skew_y();
-            let upper_left_x = metadata.upper_left_x();
-            let upper_left_y = metadata.upper_left_y();
+            let scale_x = raster.transform()[1];
+            let scale_y = raster.transform()[5];
+            let skew_x = raster.transform()[2];
+            let skew_y = raster.transform()[4];
+            let upper_left_x = raster.transform()[0];
+            let upper_left_y = raster.transform()[3];
 
             let georeference = match format {
                 GeoReferenceFormat::Gdal => {
@@ -189,7 +188,7 @@ fn format_georeference(
                 GeoReferenceFormat::Esri => {
                     // World coordinates of pixel-space (0.5, 0.5) — the full
                     // affine keeps the center shift exact under skew.
-                    let affine = AffineMatrix::from_metadata(&metadata);
+                    let affine = AffineMatrix::from_raster(raster);
                     let (esri_upper_left_x, esri_upper_left_y) = affine.transform(0.5, 0.5);
                     format!(
                         "{:.10}\n{:.10}\n{:.10}\n{:.10}\n{:.10}\n{:.10}",

--- a/rust/sedona-raster-functions/src/rs_geotransform.rs
+++ b/rust/sedona-raster-functions/src/rs_geotransform.rs
@@ -161,25 +161,18 @@ impl SedonaScalarKernel for RsGeoTransform {
         executor.execute_raster_void(|_i, raster_opt| {
             match raster_opt {
                 None => builder.append_null(),
-                Some(raster) => {
-                    let metadata = raster.metadata();
-                    match self.param {
-                        GeoTransformParam::Rotation => {
-                            let rotation = rotation(raster);
-                            builder.append_value(rotation);
-                        }
-                        GeoTransformParam::ScaleX => builder.append_value(metadata.scale_x()),
-                        GeoTransformParam::ScaleY => builder.append_value(metadata.scale_y()),
-                        GeoTransformParam::SkewX => builder.append_value(metadata.skew_x()),
-                        GeoTransformParam::SkewY => builder.append_value(metadata.skew_y()),
-                        GeoTransformParam::UpperLeftX => {
-                            builder.append_value(metadata.upper_left_x())
-                        }
-                        GeoTransformParam::UpperLeftY => {
-                            builder.append_value(metadata.upper_left_y())
-                        }
+                Some(raster) => match self.param {
+                    GeoTransformParam::Rotation => {
+                        let rotation = rotation(raster);
+                        builder.append_value(rotation);
                     }
-                }
+                    GeoTransformParam::ScaleX => builder.append_value(raster.transform()[1]),
+                    GeoTransformParam::ScaleY => builder.append_value(raster.transform()[5]),
+                    GeoTransformParam::SkewX => builder.append_value(raster.transform()[2]),
+                    GeoTransformParam::SkewY => builder.append_value(raster.transform()[4]),
+                    GeoTransformParam::UpperLeftX => builder.append_value(raster.transform()[0]),
+                    GeoTransformParam::UpperLeftY => builder.append_value(raster.transform()[3]),
+                },
             }
             Ok(())
         })?;

--- a/rust/sedona-raster-functions/src/rs_pixel_functions.rs
+++ b/rust/sedona-raster-functions/src/rs_pixel_functions.rs
@@ -191,7 +191,7 @@ impl SedonaScalarKernel for RsPixelAsCentroid {
                     let grid_x = (col_x - 1) as f64 + 0.5;
                     let grid_y = (row_y - 1) as f64 + 0.5;
 
-                    let affine = AffineMatrix::from_metadata(&raster.metadata());
+                    let affine = AffineMatrix::from_raster(raster);
                     let (wx, wy) = affine.transform(grid_x, grid_y);
 
                     write_wkb_point(&mut builder, (wx, wy))

--- a/rust/sedona-raster-functions/src/rs_setsrid.rs
+++ b/rust/sedona-raster-functions/src/rs_setsrid.rs
@@ -614,16 +614,10 @@ mod tests {
             let modified = result_array.get(i).unwrap();
 
             // Metadata preserved
-            assert_eq!(original.metadata().width(), modified.metadata().width());
-            assert_eq!(original.metadata().height(), modified.metadata().height());
-            assert_eq!(
-                original.metadata().upper_left_x(),
-                modified.metadata().upper_left_x()
-            );
-            assert_eq!(
-                original.metadata().upper_left_y(),
-                modified.metadata().upper_left_y()
-            );
+            assert_eq!(original.width().unwrap(), modified.width().unwrap());
+            assert_eq!(original.height().unwrap(), modified.height().unwrap());
+            assert_eq!(original.transform()[0], modified.transform()[0]);
+            assert_eq!(original.transform()[3], modified.transform()[3]);
 
             // Band data preserved
             let orig_bands = original.bands();
@@ -636,10 +630,7 @@ mod tests {
                     orig_band.nd_buffer().unwrap().as_contiguous().unwrap(),
                     mod_band.nd_buffer().unwrap().as_contiguous().unwrap()
                 );
-                assert_eq!(
-                    orig_band.metadata().data_type().unwrap(),
-                    mod_band.metadata().data_type().unwrap()
-                );
+                assert_eq!(orig_band.data_type(), mod_band.data_type());
             }
 
             // CRS changed

--- a/rust/sedona-raster-functions/src/rs_size.rs
+++ b/rust/sedona-raster-functions/src/rs_size.rs
@@ -85,11 +85,11 @@ impl SedonaScalarKernel for RsSize {
                 None => builder.append_null(),
                 Some(raster) => match self.size_type {
                     SizeType::Width => {
-                        let width = raster.metadata().width();
+                        let width = raster.width()?;
                         builder.append_value(width);
                     }
                     SizeType::Height => {
-                        let height = raster.metadata().height();
+                        let height = raster.height()?;
                         builder.append_value(height);
                     }
                 },

--- a/rust/sedona-raster-functions/src/rs_spatial_predicates.rs
+++ b/rust/sedona-raster-functions/src/rs_spatial_predicates.rs
@@ -418,12 +418,11 @@ mod tests {
     use sedona_geometry::types::Edges;
     use sedona_proj::transform::{with_global_proj_engine, LazyProjEngine};
     use sedona_raster::builder::RasterBuilder;
-    use sedona_raster::traits::{BandMetadata, RasterMetadata};
     use sedona_schema::crs::deserialize_crs;
     use sedona_schema::crs::OGC_CRS84_PROJJSON;
     use sedona_schema::datatypes::RASTER;
     use sedona_schema::datatypes::WKB_GEOMETRY;
-    use sedona_schema::raster::{BandDataType, StorageType};
+    use sedona_schema::raster::BandDataType;
     use sedona_testing::compare::assert_array_equal;
     use sedona_testing::create::create_array as create_geom_array;
     use sedona_testing::rasters::generate_test_rasters;
@@ -451,26 +450,10 @@ mod tests {
     /// If `crs` is `None`, the raster has no CRS.
     fn build_unit_raster(crs: Option<&str>) -> arrow_array::StructArray {
         let mut builder = RasterBuilder::new(1);
-        let metadata = RasterMetadata {
-            width: 1,
-            height: 1,
-            upperleft_x: 0.0,
-            upperleft_y: 1.0,
-            scale_x: 1.0,
-            scale_y: -1.0,
-            skew_x: 0.0,
-            skew_y: 0.0,
-        };
-        builder.start_raster(&metadata, crs).unwrap();
         builder
-            .start_band(BandMetadata {
-                datatype: BandDataType::UInt8,
-                nodata_value: None,
-                storage_type: StorageType::InDb,
-                outdb_url: None,
-                outdb_band_id: None,
-            })
+            .start_raster_2d(1, 1, 0.0, 1.0, 1.0, -1.0, 0.0, 0.0, crs)
             .unwrap();
+        builder.start_band_2d(BandDataType::UInt8, None).unwrap();
         builder.band_data_writer().append_value([0u8]);
         builder.finish_band().unwrap();
         builder.finish_raster().unwrap();

--- a/rust/sedona-raster-functions/src/rs_srid.rs
+++ b/rust/sedona-raster-functions/src/rs_srid.rs
@@ -126,9 +126,8 @@ mod tests {
     use datafusion_common::ScalarValue;
     use datafusion_expr::ScalarUDF;
     use sedona_raster::builder::RasterBuilder;
-    use sedona_raster::traits::{BandMetadata, RasterMetadata};
     use sedona_schema::datatypes::RASTER;
-    use sedona_schema::raster::{BandDataType, StorageType};
+    use sedona_schema::raster::BandDataType;
     use sedona_testing::compare::assert_array_equal;
     use sedona_testing::rasters::generate_test_rasters;
     use sedona_testing::testers::ScalarUdfTester;
@@ -224,26 +223,10 @@ mod tests {
     }
 
     fn append_1x1_raster_with_crs(builder: &mut RasterBuilder, crs: Option<&str>) {
-        let raster_metadata = RasterMetadata {
-            width: 1,
-            height: 1,
-            upperleft_x: 0.0,
-            upperleft_y: 0.0,
-            scale_x: 1.0,
-            scale_y: -1.0,
-            skew_x: 0.0,
-            skew_y: 0.0,
-        };
-        builder.start_raster(&raster_metadata, crs).unwrap();
         builder
-            .start_band(BandMetadata {
-                datatype: BandDataType::UInt8,
-                nodata_value: None,
-                storage_type: StorageType::InDb,
-                outdb_url: None,
-                outdb_band_id: None,
-            })
+            .start_raster_2d(1, 1, 0.0, 0.0, 1.0, -1.0, 0.0, 0.0, crs)
             .unwrap();
+        builder.start_band_2d(BandDataType::UInt8, None).unwrap();
         builder.band_data_writer().append_value([0u8]);
         builder.finish_band().unwrap();
         builder.finish_raster().unwrap();

--- a/rust/sedona-raster-functions/src/rs_value.rs
+++ b/rust/sedona-raster-functions/src/rs_value.rs
@@ -179,7 +179,7 @@ impl RsValuePoint {
                     return Ok(());
                 };
 
-                let affine = AffineMatrix::from_metadata(&raster.metadata());
+                let affine = AffineMatrix::from_raster(raster);
                 match xy_to_pixel("RS_Value", &affine, x, y)? {
                     Some((col, row)) => match sample_pixel(raster, col, row, band_num)? {
                         Some(value) => builder.append_value(value),
@@ -260,7 +260,7 @@ impl RsValuePoint {
             .transpose()?;
 
         // Affine transform and raster CRS, resolved once for all points.
-        let affine = AffineMatrix::from_metadata(&raster.metadata());
+        let affine = AffineMatrix::from_raster(&raster);
         let raster_crs = resolve_crs(raster.crs())?;
 
         let mut geom = executor.make_geom_wkb_crs_accessor(1)?;
@@ -825,7 +825,7 @@ mod tests {
             .bbox(0.0, 8.0, 2.0, 10.0)
             .build();
         let rasters = RasterStructArray::try_new(&raster).unwrap();
-        let affine = AffineMatrix::from_metadata(&rasters.get(0).unwrap().metadata());
+        let affine = AffineMatrix::from_raster(&rasters.get(0).unwrap());
 
         assert_eq!(
             xy_to_pixel("RS_Value", &affine, f64::NAN, 5.0).unwrap(),

--- a/rust/sedona-raster-functions/src/rs_values.rs
+++ b/rust/sedona-raster-functions/src/rs_values.rs
@@ -192,7 +192,7 @@ impl RsValues {
                 let nodata = band
                     .nodata_as_f64()
                     .map_err(|e| exec_datafusion_err!("RS_Values: {e}"))?;
-                let affine = AffineMatrix::from_metadata(&raster.metadata());
+                let affine = AffineMatrix::from_raster(raster);
 
                 // Sample each sub-point in one pass: the visitor transforms
                 // each coordinate into the raster CRS in place, so there is no
@@ -280,7 +280,7 @@ impl RsValues {
             .transpose()?;
 
         // Affine transform and raster CRS, resolved once for all rows.
-        let affine = AffineMatrix::from_metadata(&raster.metadata());
+        let affine = AffineMatrix::from_raster(&raster);
         let raster_crs = resolve_crs(raster.crs())?;
 
         let mut geom = executor.make_geom_wkb_crs_accessor(1)?;

--- a/rust/sedona-raster-gdal/src/gdal_common.rs
+++ b/rust/sedona-raster-gdal/src/gdal_common.rs
@@ -25,8 +25,8 @@ use sedona_gdal::raster::rasterband::RasterBand;
 use sedona_gdal::raster::types::DatasetOptions;
 use sedona_gdal::raster::types::GdalDataType;
 
-use sedona_raster::traits::{is_spatial_dim_pair, MetadataRef, RasterMetadata, RasterRef};
-use sedona_schema::raster::{BandDataType, StorageType};
+use sedona_raster::traits::{is_spatial_dim_pair, RasterRef};
+use sedona_schema::raster::BandDataType;
 
 use datafusion_common::{
     arrow_datafusion_err, exec_datafusion_err, exec_err, DataFusionError, Result,
@@ -44,27 +44,6 @@ where
     }
 }
 
-/// Convert raster metadata into GDAL's six-element geo-transform.
-///
-/// GDAL stores geo-transforms as
-/// `[origin_x, pixel_width, rotation_x, origin_y, rotation_y, pixel_height]`.
-pub(crate) trait ToGdalGeoTransform {
-    fn to_gdal_geotransform(&self) -> GeoTransform;
-}
-
-impl<T: MetadataRef + ?Sized> ToGdalGeoTransform for T {
-    fn to_gdal_geotransform(&self) -> GeoTransform {
-        [
-            self.upper_left_x(),
-            self.scale_x(),
-            self.skew_x(),
-            self.upper_left_y(),
-            self.skew_y(),
-            self.scale_y(),
-        ]
-    }
-}
-
 /// A raster's stored six-coefficient GDAL geo-transform as a fixed array,
 /// erroring when the transform is not exactly six elements.
 ///
@@ -73,26 +52,6 @@ impl<T: MetadataRef + ?Sized> ToGdalGeoTransform for T {
 pub fn raster_geo_transform<R: RasterRef + ?Sized>(raster: &R) -> Result<GeoTransform> {
     <[f64; 6]>::try_from(raster.transform())
         .map_err(|_| exec_datafusion_err!("expected a 6-element geotransform"))
-}
-
-/// Reconstruct raster metadata from a GDAL six-element geo-transform and raster dimensions.
-pub(crate) trait RasterMetadataFromGdalGeoTransform {
-    fn to_raster_metadata(&self, width: usize, height: usize) -> RasterMetadata;
-}
-
-impl RasterMetadataFromGdalGeoTransform for GeoTransform {
-    fn to_raster_metadata(&self, width: usize, height: usize) -> RasterMetadata {
-        RasterMetadata {
-            width: width as i64,
-            height: height as i64,
-            upperleft_x: self[0],
-            upperleft_y: self[3],
-            scale_x: self[1],
-            scale_y: self[5],
-            skew_x: self[2],
-            skew_y: self[4],
-        }
-    }
 }
 
 /// Converts a BandDataType to the corresponding GDAL data type.
@@ -214,11 +173,10 @@ pub unsafe fn raster_ref_to_gdal_mem<R: RasterRef + ?Sized>(
     raster: &R,
     band_indices: &[usize],
 ) -> Result<Dataset> {
-    let metadata = raster.metadata();
     let bands = raster.bands();
 
-    let width = metadata.width() as usize;
-    let height = metadata.height() as usize;
+    let width = raster.width().map_err(|e| arrow_datafusion_err!(e))? as usize;
+    let height = raster.height().map_err(|e| arrow_datafusion_err!(e))? as usize;
 
     // Create internal MEM dataset via sedona-gdal shim to avoid open dataset list contention.
     let mut mem_ds_builder = MemDatasetBuilder::new(width, height);
@@ -260,14 +218,13 @@ pub unsafe fn raster_ref_to_gdal_mem<R: RasterRef + ?Sized>(
             );
         }
 
-        if band.metadata().storage_type()? != StorageType::InDb {
+        if !band.is_indb() {
             return Err(DataFusionError::NotImplemented(
                 "OutDb bands are not supported by raster_ref_to_gdal_mem".to_string(),
             ));
         }
 
-        let band_metadata = band.metadata();
-        let band_type = band_metadata.data_type()?;
+        let band_type = band.data_type();
         let gdal_type = band_data_type_to_gdal(&band_type);
         // `as_contiguous()` borrows the bytes zero-copy (erroring on a strided
         // view); GDAL holds the pointer, so `raster` must outlive the dataset.
@@ -298,7 +255,7 @@ pub unsafe fn raster_ref_to_gdal_mem<R: RasterRef + ?Sized>(
             .map_err(|e| DataFusionError::External(Box::new(e)))?
     };
 
-    let geotransform = metadata.to_gdal_geotransform();
+    let geotransform = raster_geo_transform(raster)?;
 
     dataset
         .set_geo_transform(&geotransform)
@@ -316,12 +273,11 @@ pub unsafe fn raster_ref_to_gdal_mem<R: RasterRef + ?Sized>(
         let band = bands
             .band(src_band_index)
             .map_err(|e| arrow_datafusion_err!(e))?;
-        let band_metadata = band.metadata();
-        let band_type = band_metadata.data_type()?;
+        let band_type = band.data_type();
         let plane_bytes = width * height * band_type.byte_size();
         let band_bytes = band.nd_buffer().and_then(|ndb| ndb.as_contiguous())?;
         let plane_count = band_bytes.len() / plane_bytes;
-        let nodata = band_metadata.nodata_value();
+        let nodata = band.nodata();
         for _ in 0..plane_count {
             dst_band_index += 1;
             if let Some(nodata_bytes) = nodata {
@@ -581,10 +537,9 @@ fn strip_scheme_prefix<'a>(value: &'a str, scheme_prefix: &str) -> Option<&'a st
 mod tests {
     use super::*;
 
+    use crate::utils::Grid;
     use sedona_raster::array::RasterStructArray;
     use sedona_raster::builder::RasterBuilder;
-    use sedona_raster::traits::{BandMetadata, RasterMetadata};
-    use sedona_schema::raster::StorageType;
     use sedona_testing::rasters::{build_in_db_raster, InDbTestBand};
 
     fn single_raster<'a>(
@@ -615,37 +570,24 @@ mod tests {
     }
 
     #[test]
-    fn test_to_gdal_geotransform() {
-        let metadata = RasterMetadata {
-            width: 3,
-            height: 2,
-            upperleft_x: 10.0,
-            upperleft_y: 20.0,
-            scale_x: 0.5,
-            scale_y: -0.5,
-            skew_x: 0.1,
-            skew_y: -0.2,
-        };
-
+    fn test_raster_geo_transform() {
+        // A built raster's stored transform round-trips through the accessor.
+        let raster_array = build_in_db_raster(3, 2, [10.0, 0.5, 0.1, 20.0, -0.2, -0.5], None, &[]);
+        let raster = single_raster(&raster_array);
         assert_eq!(
-            metadata.to_gdal_geotransform(),
+            raster_geo_transform(&raster).unwrap(),
             [10.0, 0.5, 0.1, 20.0, -0.2, -0.5]
         );
     }
 
     #[test]
-    fn test_to_raster_metadata() {
+    fn test_grid_from_gdal() {
         let geotransform: GeoTransform = [12.5, 0.25, 0.75, -8.0, -0.5, -2.0];
-        let metadata = geotransform.to_raster_metadata(4, 3);
+        let grid = Grid::from_gdal(geotransform, 4, 3);
 
-        assert_eq!(metadata.width, 4);
-        assert_eq!(metadata.height, 3);
-        assert_eq!(metadata.upperleft_x, 12.5);
-        assert_eq!(metadata.upperleft_y, -8.0);
-        assert_eq!(metadata.scale_x, 0.25);
-        assert_eq!(metadata.scale_y, -2.0);
-        assert_eq!(metadata.skew_x, 0.75);
-        assert_eq!(metadata.skew_y, -0.5);
+        assert_eq!(grid.width, 4);
+        assert_eq!(grid.height, 3);
+        assert_eq!(grid.transform, [12.5, 0.25, 0.75, -8.0, -0.5, -2.0]);
     }
 
     #[test]
@@ -852,17 +794,13 @@ mod tests {
 
     #[test]
     fn test_raster_ref_to_gdal_empty_preserves_metadata_and_crs() {
-        let metadata = RasterMetadata {
-            width: 3,
-            height: 2,
-            upperleft_x: 10.0,
-            upperleft_y: 20.0,
-            scale_x: 0.5,
-            scale_y: -0.5,
-            skew_x: 0.1,
-            skew_y: -0.2,
-        };
-        let raster_array = build_in_db_raster(metadata, Some("EPSG:4326"), &[]);
+        let raster_array = build_in_db_raster(
+            3,
+            2,
+            [10.0, 0.5, 0.1, 20.0, -0.2, -0.5],
+            Some("EPSG:4326"),
+            &[],
+        );
         let raster = single_raster(&raster_array);
 
         with_gdal(|gdal| {
@@ -881,16 +819,6 @@ mod tests {
 
     #[test]
     fn test_raster_ref_to_gdal_mem_preserves_band_order_data_and_nodata() {
-        let metadata = RasterMetadata {
-            width: 2,
-            height: 2,
-            upperleft_x: 5.0,
-            upperleft_y: 8.0,
-            scale_x: 2.0,
-            scale_y: -2.0,
-            skew_x: 0.0,
-            skew_y: 0.0,
-        };
         let uint64_pixels = [1u64, 2, 3, 4]
             .into_iter()
             .flat_map(u64::to_le_bytes)
@@ -903,7 +831,9 @@ mod tests {
         let uint64_nodata = 9_007_199_254_740_992u64;
         let int64_nodata = -9_007_199_254_740_992i64;
         let raster_array = build_in_db_raster(
-            metadata,
+            2,
+            2,
+            [5.0, 2.0, 0.0, 8.0, 0.0, -2.0],
             Some("EPSG:4326"),
             &[
                 InDbTestBand {
@@ -950,25 +880,19 @@ mod tests {
     #[test]
     fn test_raster_ref_to_gdal_mem_rejects_outdb_bands() {
         let mut builder = RasterBuilder::new(1);
-        let metadata = RasterMetadata {
-            width: 1,
-            height: 1,
-            upperleft_x: 0.0,
-            upperleft_y: 1.0,
-            scale_x: 1.0,
-            scale_y: -1.0,
-            skew_x: 0.0,
-            skew_y: 0.0,
-        };
-        builder.start_raster(&metadata, None).unwrap();
         builder
-            .start_band(BandMetadata {
-                datatype: BandDataType::UInt8,
-                nodata_value: Some(vec![0u8]),
-                storage_type: StorageType::OutDbRef,
-                outdb_url: Some("/tmp/test.tif".to_string()),
-                outdb_band_id: Some(1),
-            })
+            .start_raster_2d(1, 1, 0.0, 1.0, 1.0, -1.0, 0.0, 0.0, None)
+            .unwrap();
+        builder
+            .start_band_nd(
+                None,
+                &["y", "x"],
+                &[1, 1],
+                BandDataType::UInt8,
+                Some(&[0u8]),
+                Some("/tmp/test.tif#band=1"),
+                None,
+            )
             .unwrap();
         builder.band_data_writer().append_value([]);
         builder.finish_band().unwrap();

--- a/rust/sedona-raster-gdal/src/gdal_dataset_provider.rs
+++ b/rust/sedona-raster-gdal/src/gdal_dataset_provider.rs
@@ -29,13 +29,13 @@ use sedona_gdal::geo_transform::{GeoTransform, GeoTransformEx};
 use sedona_gdal::raster::types::GdalDataType;
 
 use sedona_common::SedonaOptions;
-use sedona_raster::traits::RasterRef;
-use sedona_schema::raster::{BandDataType, StorageType};
+use sedona_raster::traits::{split_outdb_band_fragment, RasterRef};
+use sedona_schema::raster::BandDataType;
 
 use crate::gdal_common::{
     band_data_type_to_gdal, bytes_to_f64, convert_gdal_err, normalize_outdb_source_path,
-    open_gdal_dataset, raster_ref_to_gdal_empty, raster_ref_to_gdal_mem,
-    set_band_nodata_from_bytes, ToGdalGeoTransform,
+    open_gdal_dataset, raster_geo_transform, raster_ref_to_gdal_empty, raster_ref_to_gdal_mem,
+    set_band_nodata_from_bytes,
 };
 
 /// A GDAL dataset constructed from a `RasterRef`.
@@ -212,12 +212,11 @@ impl GDALDatasetCache {
         raster: &R,
         gdal_mem_source: Option<&Rc<Dataset>>,
     ) -> Result<(Rc<Dataset>, Vec<Rc<Dataset>>)> {
-        let metadata = raster.metadata();
         let bands = raster.bands();
         let num_bands = bands.len();
 
-        let metadata_width = metadata.width();
-        let metadata_height = metadata.height();
+        let metadata_width = raster.width().map_err(|e| arrow_datafusion_err!(e))?;
+        let metadata_height = raster.height().map_err(|e| arrow_datafusion_err!(e))?;
         let width: i32 = metadata_width.try_into().map_err(|_| {
             exec_datafusion_err!(
                 "Raster width {} exceeds supported GDAL/i32 limit {}",
@@ -248,7 +247,7 @@ impl GDALDatasetCache {
             .create_vrt(vrt_width, vrt_height)
             .map_err(convert_gdal_err)?;
 
-        let geotransform = metadata.to_gdal_geotransform();
+        let geotransform = raster_geo_transform(raster)?;
         vrt.set_geo_transform(&geotransform)
             .map_err(convert_gdal_err)?;
         if let Some(crs) = raster.crs() {
@@ -268,8 +267,7 @@ impl GDALDatasetCache {
                 );
             }
 
-            let band_metadata = band.metadata();
-            let band_type = band_metadata.data_type()?;
+            let band_type = band.data_type();
             let gdal_type = band_data_type_to_gdal(&band_type);
             if matches!(gdal_type, GdalDataType::Unknown) {
                 return Err(DataFusionError::NotImplemented(format!(
@@ -281,80 +279,72 @@ impl GDALDatasetCache {
             vrt.add_band(gdal_type, None).map_err(convert_gdal_err)?;
             let vrt_band = vrt.rasterband(i).map_err(convert_gdal_err)?;
 
-            if let Some(nodata_bytes) = band_metadata.nodata_value() {
+            if let Some(nodata_bytes) = band.nodata() {
                 set_band_nodata_from_bytes(&vrt_band, Some(nodata_bytes))?;
             }
 
-            match band_metadata.storage_type()? {
-                StorageType::OutDbRef => {
-                    let url = band_metadata.outdb_url().ok_or_else(|| {
-                        exec_datafusion_err!("Band {} is out-db but missing outdb_url", i)
-                    })?;
-                    let source_band_num: usize = band_metadata
-                        .outdb_band_id()
-                        .ok_or_else(|| {
-                            exec_datafusion_err!("Band {} is out-db but missing band_id", i)
-                        })?
-                        .try_into()
-                        .map_err(|_| {
-                            exec_datafusion_err!("Band {} out-db band_id is too large", i)
-                        })?;
+            if band.is_indb() {
+                let mem_dataset = gdal_mem_source
+                    .as_ref()
+                    .expect("in-db dataset should exist");
+                let source_band = mem_dataset
+                    .rasterband(mem_band_index)
+                    .map_err(convert_gdal_err)?;
+                mem_band_index += 1;
 
-                    let source_dataset = self.get_or_create_outdb_source(gdal, url, None)?;
+                vrt_band
+                    .add_simple_source(
+                        &source_band,
+                        (0, 0, width, height),
+                        (0, 0, width, height),
+                        None,
+                        None,
+                    )
+                    .map_err(convert_gdal_err)?;
+            } else {
+                let uri = band.outdb_uri().ok_or_else(|| {
+                    exec_datafusion_err!("Band {} is out-db but missing outdb_uri", i)
+                })?;
+                let (url, source_band_num_u32) = split_outdb_band_fragment(uri);
+                let source_band_num: usize = source_band_num_u32
+                    .try_into()
+                    .map_err(|_| exec_datafusion_err!("Band {} out-db band_id is too large", i))?;
 
-                    // If GDALGetGeoTransform(hdsSrc, ogt) fails, we fall back to (0, 1, 0, 0, 0, -1),
-                    // which is the identity transform.
-                    let src_geo_transform = source_dataset
-                        .geo_transform()
-                        .unwrap_or([0.0, 1.0, 0.0, 0.0, 0.0, -1.0]);
-                    let (src_w, src_h) = source_dataset.raster_size();
+                let source_dataset = self.get_or_create_outdb_source(gdal, &url, None)?;
 
-                    // Compute source and destination windows for the VRT simple source. The VRT usually only
-                    // clip a small portion of the source dataset.
-                    let Some((src_window, dst_window)) = compute_vrt_simple_source_windows(
-                        &geotransform,
-                        (width, height),
-                        &src_geo_transform,
-                        (src_w as i32, src_h as i32),
-                    )?
-                    else {
-                        // No spatial overlap between the target raster and the source dataset.
-                        // Leave the VRT band as nodata.
-                        continue;
-                    };
+                // If GDALGetGeoTransform(hdsSrc, ogt) fails, we fall back to (0, 1, 0, 0, 0, -1),
+                // which is the identity transform.
+                let src_geo_transform = source_dataset
+                    .geo_transform()
+                    .unwrap_or([0.0, 1.0, 0.0, 0.0, 0.0, -1.0]);
+                let (src_w, src_h) = source_dataset.raster_size();
 
-                    let source_band = source_dataset
-                        .rasterband(source_band_num)
-                        .map_err(convert_gdal_err)?;
+                // Compute source and destination windows for the VRT simple source. The VRT usually only
+                // clip a small portion of the source dataset.
+                let Some((src_window, dst_window)) = compute_vrt_simple_source_windows(
+                    &geotransform,
+                    (width, height),
+                    &src_geo_transform,
+                    (src_w as i32, src_h as i32),
+                )?
+                else {
+                    // No spatial overlap between the target raster and the source dataset.
+                    // Leave the VRT band as nodata.
+                    continue;
+                };
 
-                    vrt_band
-                        // Avoid passing per-source NODATA to VRT simple sources; some GDAL builds
-                        // warn that NODATA isn't supported for neighbour-sampled simple sources
-                        // on virtual datasources. We set band-level NODATA via set_no_data_value.
-                        .add_simple_source(&source_band, src_window, dst_window, None, None)
-                        .map_err(convert_gdal_err)?;
+                let source_band = source_dataset
+                    .rasterband(source_band_num)
+                    .map_err(convert_gdal_err)?;
 
-                    outdb_sources.push(source_dataset);
-                }
-                StorageType::InDb => {
-                    let mem_dataset = gdal_mem_source
-                        .as_ref()
-                        .expect("in-db dataset should exist");
-                    let source_band = mem_dataset
-                        .rasterband(mem_band_index)
-                        .map_err(convert_gdal_err)?;
-                    mem_band_index += 1;
+                vrt_band
+                    // Avoid passing per-source NODATA to VRT simple sources; some GDAL builds
+                    // warn that NODATA isn't supported for neighbour-sampled simple sources
+                    // on virtual datasources. We set band-level NODATA via set_no_data_value.
+                    .add_simple_source(&source_band, src_window, dst_window, None, None)
+                    .map_err(convert_gdal_err)?;
 
-                    vrt_band
-                        .add_simple_source(
-                            &source_band,
-                            (0, 0, width, height),
-                            (0, 0, width, height),
-                            None,
-                            None,
-                        )
-                        .map_err(convert_gdal_err)?;
-                }
+                outdb_sources.push(source_dataset);
             }
         }
 
@@ -394,9 +384,10 @@ impl<'a> GDALDatasetProvider<'a> {
         let mut has_outdb = false;
         for i in 1..=num_bands {
             let band = bands.band(i).map_err(|e| arrow_datafusion_err!(e))?;
-            match band.metadata().storage_type()? {
-                StorageType::InDb => indb_band_indices.push(i),
-                StorageType::OutDbRef => has_outdb = true,
+            if band.is_indb() {
+                indb_band_indices.push(i);
+            } else {
+                has_outdb = true;
             }
         }
 
@@ -463,7 +454,7 @@ impl<'a> GDALDatasetProvider<'a> {
 
 #[derive(Hash, Eq, PartialEq)]
 struct VrtBandKey {
-    storage_type: StorageType,
+    is_indb: bool,
     data_type: BandDataType,
     nodata_bits: Option<u64>,
     outdb_url: Option<String>,
@@ -481,19 +472,17 @@ struct VrtKey {
 
 impl VrtKey {
     fn from_raster<R: RasterRef + ?Sized>(raster: &R) -> Result<Self> {
-        let metadata = raster.metadata();
         let bands = raster.bands();
         let num_bands = bands.len();
 
-        let geotransform = metadata.to_gdal_geotransform();
+        let geotransform = raster_geo_transform(raster)?;
         let geotransform_bits = geotransform.map(f64::to_bits);
 
         let mut band_keys = Vec::with_capacity(num_bands);
         for i in 1..=num_bands {
             let band = bands.band(i).map_err(|e| arrow_datafusion_err!(e))?;
-            let band_metadata = band.metadata();
-            let band_type = band_metadata.data_type()?;
-            let nodata_bits = match (band_metadata.nodata_value(), band_type) {
+            let band_type = band.data_type();
+            let nodata_bits = match (band.nodata(), band_type) {
                 (Some(bytes), BandDataType::UInt64) => {
                     let bytes: [u8; 8] = bytes.try_into().map_err(|_| {
                         exec_datafusion_err!("Invalid nodata byte length for UInt64")
@@ -509,18 +498,27 @@ impl VrtKey {
                 (Some(bytes), _) => Some(bytes_to_f64(bytes, &band_type)?.to_bits()),
                 (None, _) => None,
             };
+            // Out-db bands recover their source path + band from the `#band=N`
+            // URI; in-db bands have no URI hint here.
+            let (outdb_url, outdb_band_id) = match band.outdb_uri() {
+                Some(uri) => {
+                    let (url, band_num) = split_outdb_band_fragment(uri);
+                    (Some(normalize_outdb_source_path(&url)), Some(band_num))
+                }
+                None => (None, None),
+            };
             band_keys.push(VrtBandKey {
-                storage_type: band_metadata.storage_type()?,
+                is_indb: band.is_indb(),
                 data_type: band_type,
                 nodata_bits,
-                outdb_url: band_metadata.outdb_url().map(normalize_outdb_source_path),
-                outdb_band_id: band_metadata.outdb_band_id(),
+                outdb_url,
+                outdb_band_id,
             });
         }
 
         Ok(Self {
-            width: metadata.width(),
-            height: metadata.height(),
+            width: raster.width()?,
+            height: raster.height()?,
             geotransform_bits,
             crs: raster.crs().map(|s| s.to_string()),
             bands: band_keys,
@@ -614,8 +612,7 @@ mod tests {
     use sedona_gdal::raster::types::Buffer;
     use sedona_raster::array::RasterStructArray;
     use sedona_raster::builder::RasterBuilder;
-    use sedona_raster::traits::{BandMetadata, RasterMetadata};
-    use sedona_schema::raster::{BandDataType, StorageType};
+    use sedona_schema::raster::BandDataType;
     use sedona_testing::rasters::{build_in_db_raster, InDbTestBand};
     use tempfile::TempDir;
 
@@ -672,26 +669,21 @@ mod tests {
 
     fn build_outdb_raster(path: &str) -> arrow_array::StructArray {
         let mut builder = RasterBuilder::new(1);
-        let metadata = RasterMetadata {
-            width: 8,
-            height: 8,
-            upperleft_x: 0.0,
-            upperleft_y: 8.0,
-            scale_x: 1.0,
-            scale_y: -1.0,
-            skew_x: 0.0,
-            skew_y: 0.0,
-        };
-        builder.start_raster(&metadata, None).unwrap();
+        builder
+            .start_raster_2d(8, 8, 0.0, 8.0, 1.0, -1.0, 0.0, 0.0, None)
+            .unwrap();
 
-        let band_metadata = BandMetadata {
-            nodata_value: Some(vec![0u8]),
-            storage_type: StorageType::OutDbRef,
-            datatype: BandDataType::UInt8,
-            outdb_url: Some(path.to_string()),
-            outdb_band_id: Some(1),
-        };
-        builder.start_band(band_metadata).unwrap();
+        builder
+            .start_band_nd(
+                None,
+                &["y", "x"],
+                &[8, 8],
+                BandDataType::UInt8,
+                Some(&[0u8]),
+                Some(&format!("{path}#band=1")),
+                None,
+            )
+            .unwrap();
         builder.band_data_writer().append_value([]);
         builder.finish_band().unwrap();
         builder.finish_raster().unwrap();
@@ -700,39 +692,27 @@ mod tests {
     }
 
     fn build_mixed_raster(path: &str) -> StructArray {
-        let metadata = RasterMetadata {
-            width: 8,
-            height: 8,
-            upperleft_x: 0.0,
-            upperleft_y: 8.0,
-            scale_x: 1.0,
-            scale_y: -1.0,
-            skew_x: 0.0,
-            skew_y: 0.0,
-        };
         let mut builder = RasterBuilder::new(1);
-        builder.start_raster(&metadata, Some("EPSG:4326")).unwrap();
+        builder
+            .start_raster_2d(8, 8, 0.0, 8.0, 1.0, -1.0, 0.0, 0.0, Some("EPSG:4326"))
+            .unwrap();
 
         builder
-            .start_band(BandMetadata {
-                datatype: BandDataType::UInt8,
-                nodata_value: Some(vec![255u8]),
-                storage_type: StorageType::InDb,
-                outdb_url: None,
-                outdb_band_id: None,
-            })
+            .start_band_2d(BandDataType::UInt8, Some(&[255u8]))
             .unwrap();
         builder.band_data_writer().append_value(vec![7u8; 8 * 8]);
         builder.finish_band().unwrap();
 
         builder
-            .start_band(BandMetadata {
-                datatype: BandDataType::UInt8,
-                nodata_value: Some(vec![0u8]),
-                storage_type: StorageType::OutDbRef,
-                outdb_url: Some(path.to_string()),
-                outdb_band_id: Some(1),
-            })
+            .start_band_nd(
+                None,
+                &["y", "x"],
+                &[8, 8],
+                BandDataType::UInt8,
+                Some(&[0u8]),
+                Some(&format!("{path}#band=1")),
+                None,
+            )
             .unwrap();
         builder.band_data_writer().append_value([]);
         builder.finish_band().unwrap();
@@ -841,17 +821,13 @@ mod tests {
 
     #[test]
     fn test_provider_returns_empty_dataset_for_zero_band_raster() {
-        let metadata = RasterMetadata {
-            width: 3,
-            height: 2,
-            upperleft_x: 1.0,
-            upperleft_y: 4.0,
-            scale_x: 1.0,
-            scale_y: -1.0,
-            skew_x: 0.0,
-            skew_y: 0.0,
-        };
-        let raster_struct = build_in_db_raster(metadata, Some("EPSG:4326"), &[]);
+        let raster_struct = build_in_db_raster(
+            3,
+            2,
+            [1.0, 1.0, 0.0, 4.0, 0.0, -1.0],
+            Some("EPSG:4326"),
+            &[],
+        );
         let raster_array = RasterStructArray::try_new(&raster_struct).unwrap();
         let raster = raster_array.get(0).unwrap();
         let cache = Rc::new(GDALDatasetCache::try_new(4, 4).unwrap());
@@ -869,20 +845,12 @@ mod tests {
 
     #[test]
     fn test_provider_returns_mem_dataset_for_indb_raster() {
-        let metadata = RasterMetadata {
-            width: 2,
-            height: 2,
-            upperleft_x: 0.0,
-            upperleft_y: 2.0,
-            scale_x: 1.0,
-            scale_y: -1.0,
-            skew_x: 0.0,
-            skew_y: 0.0,
-        };
         let band1 = vec![11u8, 12u8, 13u8, 14u8];
         let band2 = vec![21u8, 22u8, 23u8, 24u8];
         let raster_struct = build_in_db_raster(
-            metadata,
+            2,
+            2,
+            [0.0, 1.0, 0.0, 2.0, 0.0, -1.0],
             Some("EPSG:4326"),
             &[
                 InDbTestBand {
@@ -950,18 +918,11 @@ mod tests {
 
     #[test]
     fn test_vrt_key_distinguishes_lossless_uint64_nodata() {
-        let metadata = RasterMetadata {
-            width: 1,
-            height: 1,
-            upperleft_x: 0.0,
-            upperleft_y: 1.0,
-            scale_x: 1.0,
-            scale_y: -1.0,
-            skew_x: 0.0,
-            skew_y: 0.0,
-        };
+        let transform = [0.0, 1.0, 0.0, 1.0, 0.0, -1.0];
         let raster_a = build_in_db_raster(
-            metadata.clone(),
+            1,
+            1,
+            transform,
             None,
             &[InDbTestBand {
                 datatype: BandDataType::UInt64,
@@ -970,7 +931,9 @@ mod tests {
             }],
         );
         let raster_b = build_in_db_raster(
-            metadata,
+            1,
+            1,
+            transform,
             None,
             &[InDbTestBand {
                 datatype: BandDataType::UInt64,
@@ -1058,26 +1021,20 @@ mod tests {
         let path = create_two_band_source_tiff(&temp_dir, 7u8, 99u8);
 
         // Build a 1-band raster whose single band points at source band 2.
-        let metadata = RasterMetadata {
-            width: 8,
-            height: 8,
-            upperleft_x: 0.0,
-            upperleft_y: 8.0,
-            scale_x: 1.0,
-            scale_y: -1.0,
-            skew_x: 0.0,
-            skew_y: 0.0,
-        };
         let mut builder = RasterBuilder::new(1);
-        builder.start_raster(&metadata, None).unwrap();
         builder
-            .start_band(BandMetadata {
-                nodata_value: Some(vec![0u8]),
-                storage_type: StorageType::OutDbRef,
-                datatype: BandDataType::UInt8,
-                outdb_url: Some(path.clone()),
-                outdb_band_id: Some(2),
-            })
+            .start_raster_2d(8, 8, 0.0, 8.0, 1.0, -1.0, 0.0, 0.0, None)
+            .unwrap();
+        builder
+            .start_band_nd(
+                None,
+                &["y", "x"],
+                &[8, 8],
+                BandDataType::UInt8,
+                Some(&[0u8]),
+                Some(&format!("{path}#band=2")),
+                None,
+            )
             .unwrap();
         builder.band_data_writer().append_value([]);
         builder.finish_band().unwrap();

--- a/rust/sedona-raster-gdal/src/rs_as_geotiff.rs
+++ b/rust/sedona-raster-gdal/src/rs_as_geotiff.rs
@@ -301,10 +301,7 @@ fn predictor_for(raster: &RasterRefImpl) -> Result<i32> {
     let band = bands
         .band(1)
         .map_err(|e| exec_datafusion_err!("RS_AsGeoTiff: {e}"))?;
-    let data_type = band
-        .metadata()
-        .data_type()
-        .map_err(|e| exec_datafusion_err!("RS_AsGeoTiff: {e}"))?;
+    let data_type = band.data_type();
     Ok(match data_type {
         BandDataType::Float32 | BandDataType::Float64 => 3,
         _ => 2,
@@ -632,8 +629,8 @@ mod tests {
             let rt = RasterStructArray::try_new(&roundtrip).unwrap();
             let rt_raster = rt.get(0).unwrap();
 
-            assert_eq!(rt_raster.metadata().width(), raster.metadata().width());
-            assert_eq!(rt_raster.metadata().height(), raster.metadata().height());
+            assert_eq!(rt_raster.width()?, raster.width()?);
+            assert_eq!(rt_raster.height()?, raster.height()?);
             assert_eq!(rt_raster.bands().len(), raster.bands().len());
             // Pixel values must survive too — this would catch predictor or
             // compression corruption that dimension checks cannot.

--- a/rust/sedona-raster-gdal/src/rs_as_raster.rs
+++ b/rust/sedona-raster-gdal/src/rs_as_raster.rs
@@ -37,17 +37,18 @@ use sedona_gdal::mem::MemDatasetBuilder;
 use sedona_gdal::raster::{rasterband::RasterBand, types::Buffer};
 use sedona_raster::array::RasterRefImpl;
 use sedona_raster::builder::RasterBuilder;
-use sedona_raster::traits::{BandMetadata, RasterMetadata, RasterRef};
+use sedona_raster::traits::RasterRef;
 use sedona_raster_functions::{
     crs_utils::{align_wkb_to_crs, resolve_crs},
     RasterExecutor,
 };
 use sedona_schema::datatypes::{SedonaType, RASTER};
 use sedona_schema::matchers::ArgMatcher;
-use sedona_schema::raster::{BandDataType, StorageType};
+use sedona_schema::raster::BandDataType;
 
 use crate::gdal_common::{band_data_type_to_gdal, with_gdal};
 use crate::gdal_dataset_provider::{configure_thread_local_options, thread_local_provider};
+use crate::utils::Grid;
 
 pub fn rs_as_raster_udf() -> SedonaScalarUDF {
     SedonaScalarUDF::new(
@@ -231,7 +232,7 @@ impl SedonaScalarKernel for RsAsRaster {
                     engine.as_ref(),
                 )?;
 
-                let (out_metadata, out_band_metadata, out_band_bytes) = as_raster(
+                let rasterized = as_raster(
                     gdal,
                     &geom_wkb,
                     raster,
@@ -243,13 +244,16 @@ impl SedonaScalarKernel for RsAsRaster {
                 )
                 .map_err(|e| exec_datafusion_err!("RS_AsRaster failed: {}", e))?;
 
-                builder
-                    .start_raster(&out_metadata, raster.crs())
+                rasterized
+                    .grid
+                    .start_raster_into(&mut builder, raster.crs())
                     .map_err(|e| exec_datafusion_err!("Failed to start output raster: {}", e))?;
-                builder.start_band(out_band_metadata).map_err(|e| {
-                    exec_datafusion_err!("Failed to start output raster band: {}", e)
-                })?;
-                builder.band_data_writer().append_value(out_band_bytes);
+                builder
+                    .start_band_2d(rasterized.data_type, rasterized.nodata.as_deref())
+                    .map_err(|e| {
+                        exec_datafusion_err!("Failed to start output raster band: {}", e)
+                    })?;
+                builder.band_data_writer().append_value(rasterized.data);
                 builder.finish_band().map_err(|e| {
                     exec_datafusion_err!("Failed to finish output raster band: {}", e)
                 })?;
@@ -402,6 +406,15 @@ where
     })
 }
 
+/// The single in-db band produced by rasterizing a geometry: the output grid,
+/// the band's data type and optional nodata bytes, and the packed pixel bytes.
+struct RasterizedBand {
+    grid: Grid,
+    data_type: BandDataType,
+    nodata: Option<Vec<u8>>,
+    data: Vec<u8>,
+}
+
 #[allow(clippy::too_many_arguments)]
 fn as_raster(
     gdal: &Gdal,
@@ -412,10 +425,10 @@ fn as_raster(
     burn_value: f64,
     nodata_value: Option<f64>,
     use_geometry_extent: bool,
-) -> Result<(RasterMetadata, BandMetadata, Vec<u8>)> {
-    let ref_md = reference_raster.metadata();
+) -> Result<RasterizedBand> {
+    let ref_transform = reference_raster.transform();
 
-    if ref_md.skew_x() != 0.0 || ref_md.skew_y() != 0.0 {
+    if ref_transform[2] != 0.0 || ref_transform[4] != 0.0 {
         return exec_err!(
             "RS_AsRaster currently requires skew_x=0 and skew_y=0 in the reference raster"
         );
@@ -427,10 +440,10 @@ fn as_raster(
 
     let (out_width, out_height, out_ulx, out_uly) = if use_geometry_extent {
         let env = geometry.envelope();
-        let ulx = ref_md.upper_left_x();
-        let uly = ref_md.upper_left_y();
-        let scale_x = ref_md.scale_x();
-        let scale_y = ref_md.scale_y();
+        let ulx = ref_transform[0];
+        let uly = ref_transform[3];
+        let scale_x = ref_transform[1];
+        let scale_y = ref_transform[5];
 
         if scale_x == 0.0 || scale_y == 0.0 {
             return exec_err!("Reference raster has zero scale");
@@ -464,10 +477,10 @@ fn as_raster(
         )
     } else {
         (
-            ref_md.width() as usize,
-            ref_md.height() as usize,
-            ref_md.upper_left_x(),
-            ref_md.upper_left_y(),
+            reference_raster.width()? as usize,
+            reference_raster.height()? as usize,
+            ref_transform[0],
+            ref_transform[3],
         )
     };
 
@@ -480,15 +493,16 @@ fn as_raster(
     )
     .map_err(|e| exec_datafusion_err!("Failed to create dataset: {}", e))?;
 
+    let out_transform = [
+        out_ulx,
+        ref_transform[1],
+        ref_transform[2],
+        out_uly,
+        ref_transform[4],
+        ref_transform[5],
+    ];
     out_dataset
-        .set_geo_transform(&[
-            out_ulx,
-            ref_md.scale_x(),
-            ref_md.skew_x(),
-            out_uly,
-            ref_md.skew_y(),
-            ref_md.scale_y(),
-        ])
+        .set_geo_transform(&out_transform)
         .map_err(|e| exec_datafusion_err!("Failed to set geotransform: {}", e))?;
 
     let provider = thread_local_provider(gdal)
@@ -529,29 +543,21 @@ fn as_raster(
         )
         .map_err(|e| exec_datafusion_err!("Failed to read band data: {}", e))?;
 
-    Ok((
-        RasterMetadata {
-            width: out_width as i64,
-            height: out_height as i64,
-            upperleft_x: out_ulx,
-            upperleft_y: out_uly,
-            scale_x: ref_md.scale_x(),
-            scale_y: ref_md.scale_y(),
-            skew_x: ref_md.skew_x(),
-            skew_y: ref_md.skew_y(),
-        },
-        BandMetadata {
-            nodata_value: nodata_value
-                .map(|value| cast_f64_to_band_value(value, band_type, "nodata value"))
-                .transpose()?
-                .map(TypedBandValue::metadata_bytes),
-            storage_type: StorageType::InDb,
-            datatype: band_type,
-            outdb_url: None,
-            outdb_band_id: None,
-        },
-        band_bytes,
-    ))
+    let out_grid = Grid {
+        transform: out_transform,
+        width: out_width as i64,
+        height: out_height as i64,
+    };
+    let out_nodata = nodata_value
+        .map(|value| cast_f64_to_band_value(value, band_type, "nodata value"))
+        .transpose()?
+        .map(TypedBandValue::metadata_bytes);
+    Ok(RasterizedBand {
+        grid: out_grid,
+        data_type: band_type,
+        nodata: out_nodata,
+        data: band_bytes,
+    })
 }
 
 fn initialize_band(
@@ -653,10 +659,10 @@ mod tests {
             .nodata(0u8)
     }
 
-    fn load_reference_raster() -> RasterMetadata {
+    fn load_reference_raster() -> Grid {
         let raster_array = reference_raster_spec().build();
         let raster_struct = RasterStructArray::try_new(&raster_array).unwrap();
-        raster_struct.get(0).unwrap().metadata()
+        Grid::from_raster(&raster_struct.get(0).unwrap()).unwrap()
     }
 
     #[test]
@@ -707,18 +713,18 @@ mod tests {
         with_gdal(|gdal| {
             let raster_struct = RasterStructArray::try_new(&raster_array).unwrap();
             let raster = raster_struct.get(0).unwrap();
-            let md = raster.metadata();
+            let transform = raster.transform().to_vec();
 
             let wkt = format!(
                 "POLYGON(({x0} {y1}, {x0} {y0}, {x1} {y0}, {x1} {y1}, {x0} {y1}))",
-                x0 = md.upper_left_x(),
-                x1 = md.upper_left_x() + md.scale_x(),
-                y0 = md.upper_left_y(),
-                y1 = md.upper_left_y() + md.scale_y(),
+                x0 = transform[0],
+                x1 = transform[0] + transform[1],
+                y0 = transform[3],
+                y1 = transform[3] + transform[5],
             );
             let geom_wkb = make_wkb(&wkt);
 
-            let (out_md, _band_md, out_bytes) = as_raster(
+            let rasterized = as_raster(
                 gdal,
                 &geom_wkb,
                 &raster,
@@ -729,12 +735,12 @@ mod tests {
                 false,
             )?;
 
-            assert_eq!(out_md.width, md.width());
-            assert_eq!(out_md.height, md.height());
-            assert_eq!(out_md.upperleft_x, md.upper_left_x());
-            assert_eq!(out_md.upperleft_y, md.upper_left_y());
+            assert_eq!(rasterized.grid.width, raster.width()?);
+            assert_eq!(rasterized.grid.height, raster.height()?);
+            assert_eq!(rasterized.grid.transform[0], transform[0]);
+            assert_eq!(rasterized.grid.transform[3], transform[3]);
             assert_eq!(
-                bytes_to_f64(&out_bytes[..8], &BandDataType::Float64).unwrap(),
+                bytes_to_f64(&rasterized.data[..8], &BandDataType::Float64).unwrap(),
                 255.0
             );
             Ok::<_, datafusion_common::DataFusionError>(())
@@ -748,18 +754,18 @@ mod tests {
         with_gdal(|gdal| {
             let raster_struct = RasterStructArray::try_new(&raster_array).unwrap();
             let raster = raster_struct.get(0).unwrap();
-            let md = raster.metadata();
+            let transform = raster.transform().to_vec();
 
             let wkt = format!(
                 "POLYGON(({x0} {y1}, {x0} {y0}, {x1} {y0}, {x1} {y1}, {x0} {y1}))",
-                x0 = md.upper_left_x(),
-                x1 = md.upper_left_x() + md.scale_x(),
-                y0 = md.upper_left_y(),
-                y1 = md.upper_left_y() + md.scale_y(),
+                x0 = transform[0],
+                x1 = transform[0] + transform[1],
+                y0 = transform[3],
+                y1 = transform[3] + transform[5],
             );
             let geom_wkb = make_wkb(&wkt);
 
-            let (out_md, _band_md, out_bytes) = as_raster(
+            let rasterized = as_raster(
                 gdal,
                 &geom_wkb,
                 &raster,
@@ -770,12 +776,12 @@ mod tests {
                 true,
             )?;
 
-            assert_eq!(out_md.width, 1);
-            assert_eq!(out_md.height, 1);
-            assert_eq!(out_md.upperleft_x, md.upper_left_x());
-            assert_eq!(out_md.upperleft_y, md.upper_left_y());
+            assert_eq!(rasterized.grid.width, 1);
+            assert_eq!(rasterized.grid.height, 1);
+            assert_eq!(rasterized.grid.transform[0], transform[0]);
+            assert_eq!(rasterized.grid.transform[3], transform[3]);
             assert_eq!(
-                bytes_to_f64(&out_bytes, &BandDataType::Float64).unwrap(),
+                bytes_to_f64(&rasterized.data, &BandDataType::Float64).unwrap(),
                 255.0
             );
             Ok::<_, datafusion_common::DataFusionError>(())
@@ -794,10 +800,10 @@ mod tests {
         let geometry_type = SedonaType::Wkb(Edges::Planar, deserialize_crs("EPSG:4326").unwrap());
         let geom = format!(
             "POLYGON(({x0} {y1}, {x0} {y0}, {x1} {y0}, {x1} {y1}, {x0} {y1}))",
-            x0 = metadata.upper_left_x(),
-            x1 = metadata.upper_left_x() + metadata.scale_x(),
-            y0 = metadata.upper_left_y(),
-            y1 = metadata.upper_left_y() + metadata.scale_y(),
+            x0 = metadata.transform[0],
+            x1 = metadata.transform[0] + metadata.transform[1],
+            y0 = metadata.transform[3],
+            y1 = metadata.transform[3] + metadata.transform[5],
         );
 
         let udf: ScalarUDF = rs_as_raster_udf().into();
@@ -988,10 +994,10 @@ mod tests {
         let metadata = load_reference_raster();
         let geom = format!(
             "POLYGON(({x0} {y1}, {x0} {y0}, {x1} {y0}, {x1} {y1}, {x0} {y1}))",
-            x0 = metadata.upper_left_x(),
-            x1 = metadata.upper_left_x() + metadata.scale_x(),
-            y0 = metadata.upper_left_y(),
-            y1 = metadata.upper_left_y() + metadata.scale_y(),
+            x0 = metadata.transform[0],
+            x1 = metadata.transform[0] + metadata.transform[1],
+            y0 = metadata.transform[3],
+            y1 = metadata.transform[3] + metadata.transform[5],
         );
 
         let udf: ScalarUDF = rs_as_raster_udf().into();

--- a/rust/sedona-raster-gdal/src/rs_clip.rs
+++ b/rust/sedona-raster-gdal/src/rs_clip.rs
@@ -377,10 +377,9 @@ fn clip_raster(
     all_touched: bool,
     crop: bool,
 ) -> Result<Option<ClippedRasterData>> {
-    let metadata = raster.metadata();
     let bands = raster.bands();
-    let width = metadata.width() as usize;
-    let height = metadata.height() as usize;
+    let width = raster.width()? as usize;
+    let height = raster.height()? as usize;
 
     // Parse geometry from WKB
     let geometry = gdal
@@ -443,8 +442,7 @@ fn clip_raster(
         // `band_idx` is 1-based; the `band_name` accessor is 0-based.
         let band_name = raster.band_name(band_idx - 1).map(|s| s.to_string());
 
-        let band_metadata = band.metadata();
-        let data_type = band_metadata.data_type()?;
+        let data_type = band.data_type();
 
         // The trailing two axes are the spatial (y, x) plane; anything before
         // them is a stack of planes the 2-D clip is broadcast over.
@@ -503,7 +501,7 @@ fn clip_raster(
             Some(cn) => nodata_f64_to_bytes(cn, &data_type).map_err(|e| {
                 exec_datafusion_err!("RS_Clip: invalid no_data_value for band {band_idx}: {e}")
             })?,
-            None => match band_metadata.nodata_value() {
+            None => match band.nodata() {
                 Some(bytes) => bytes.to_vec(),
                 None => data_type.min_value_le_bytes(),
             },
@@ -837,7 +835,6 @@ mod tests {
         with_gdal(|gdal| {
             let rasters = RasterStructArray::try_new(&array).unwrap();
             let raster = rasters.get(0).unwrap();
-            let metadata = raster.metadata();
 
             // Top-left quadrant: x ∈ [0, 2], y ∈ [1, 2] — covers pixel centers
             // (0.5, 1.5) and (1.5, 1.5), i.e. a 2×1 window.
@@ -863,11 +860,11 @@ mod tests {
                 "cropped band should keep the source pixel values in the window"
             );
             assert!(
-                (cw.width as i64) < metadata.width(),
+                (cw.width as i64) < raster.width()?,
                 "Cropped width should be smaller"
             );
             assert!(
-                (cw.height as i64) < metadata.height(),
+                (cw.height as i64) < raster.height()?,
                 "Cropped height should be smaller"
             );
             Ok::<_, datafusion_common::DataFusionError>(())

--- a/rust/sedona-raster-gdal/src/rs_frompath.rs
+++ b/rust/sedona-raster-gdal/src/rs_frompath.rs
@@ -125,8 +125,8 @@ mod tests {
 
             for idx in 0..expected_len {
                 let raster = raster_array.get(idx).unwrap();
-                assert_eq!(raster.metadata().width(), width);
-                assert_eq!(raster.metadata().height(), height);
+                assert_eq!(raster.width().unwrap(), width);
+                assert_eq!(raster.height().unwrap(), height);
             }
         }
 
@@ -222,8 +222,8 @@ mod tests {
 
                 let raster_array = RasterStructArray::try_new(struct_arr).unwrap();
                 let raster = raster_array.get(0).unwrap();
-                assert_eq!(raster.metadata().width(), 10);
-                assert_eq!(raster.metadata().height(), 10);
+                assert_eq!(raster.width().unwrap(), 10);
+                assert_eq!(raster.height().unwrap(), 10);
             }
             other => panic!("Expected array result, got {other:?}"),
         }

--- a/rust/sedona-raster-gdal/src/rs_metadata.rs
+++ b/rust/sedona-raster-gdal/src/rs_metadata.rs
@@ -130,17 +130,17 @@ impl SedonaScalarKernel for RsMetaData {
                     }
                     Some(raster) => {
                         struct_validity.append(true);
-                        let metadata = raster.metadata();
+                        let transform = raster.transform();
                         let num_bands = raster.bands().len() as u32;
 
-                        upper_left_x_builder.append_value(metadata.upper_left_x());
-                        upper_left_y_builder.append_value(metadata.upper_left_y());
-                        grid_width_builder.append_value(metadata.width());
-                        grid_height_builder.append_value(metadata.height());
-                        scale_x_builder.append_value(metadata.scale_x());
-                        scale_y_builder.append_value(metadata.scale_y());
-                        skew_x_builder.append_value(metadata.skew_x());
-                        skew_y_builder.append_value(metadata.skew_y());
+                        upper_left_x_builder.append_value(transform[0]);
+                        upper_left_y_builder.append_value(transform[3]);
+                        grid_width_builder.append_value(raster.width()?);
+                        grid_height_builder.append_value(raster.height()?);
+                        scale_x_builder.append_value(transform[1]);
+                        scale_y_builder.append_value(transform[5]);
+                        skew_x_builder.append_value(transform[2]);
+                        skew_y_builder.append_value(transform[4]);
 
                         let srid = match raster.crs() {
                             None => 0i32,
@@ -213,7 +213,6 @@ mod tests {
     use datafusion_expr::ScalarUDF;
     use sedona_raster::array::RasterStructArray;
     use sedona_raster::builder::RasterBuilder;
-    use sedona_raster::traits::RasterMetadata;
     use sedona_schema::datatypes::RASTER;
     use sedona_schema::raster::BandDataType;
     use sedona_testing::{
@@ -268,34 +267,18 @@ mod tests {
 
     fn build_zero_band_raster() -> StructArray {
         let mut builder = RasterBuilder::new(1);
-        let metadata = RasterMetadata {
-            width: 4,
-            height: 3,
-            upperleft_x: 11.0,
-            upperleft_y: 22.0,
-            scale_x: 0.5,
-            scale_y: -0.5,
-            skew_x: 0.0,
-            skew_y: 0.0,
-        };
-        builder.start_raster(&metadata, Some("EPSG:4326")).unwrap();
+        builder
+            .start_raster_2d(4, 3, 11.0, 22.0, 0.5, -0.5, 0.0, 0.0, Some("EPSG:4326"))
+            .unwrap();
         builder.finish_raster().unwrap();
         builder.finish().unwrap()
     }
 
     fn build_no_crs_raster() -> StructArray {
-        let metadata = RasterMetadata {
-            width: 4,
-            height: 3,
-            upperleft_x: 7.0,
-            upperleft_y: 8.0,
-            scale_x: 1.0,
-            scale_y: -1.0,
-            skew_x: 0.0,
-            skew_y: 0.0,
-        };
         build_in_db_raster(
-            metadata,
+            4,
+            3,
+            [7.0, 1.0, 0.0, 8.0, 0.0, -1.0],
             None,
             &[InDbTestBand {
                 datatype: BandDataType::UInt8,

--- a/rust/sedona-raster-gdal/src/rs_reproject_match.rs
+++ b/rust/sedona-raster-gdal/src/rs_reproject_match.rs
@@ -387,16 +387,16 @@ mod tests {
         };
         let rasters = sedona_raster::array::RasterStructArray::try_new(struct_array).unwrap();
         let out = rasters.get(0).unwrap();
-        let m = out.metadata();
 
         assert_eq!(out.crs(), Some("EPSG:3857"));
-        assert_eq!(m.width(), 4);
-        assert_eq!(m.height(), 4);
+        assert_eq!(out.width().unwrap(), 4);
+        assert_eq!(out.height().unwrap(), 4);
         // The output grid is the reference's grid, verbatim.
-        assert_eq!(m.upper_left_x(), 1_113_194.9);
-        assert_eq!(m.upper_left_y(), 5_465_442.2);
-        assert_eq!(m.scale_x(), 111_319.5);
-        assert_eq!(m.scale_y(), -111_319.5);
+        let transform = out.transform();
+        assert_eq!(transform[0], 1_113_194.9);
+        assert_eq!(transform[3], 5_465_442.2);
+        assert_eq!(transform[1], 111_319.5);
+        assert_eq!(transform[5], -111_319.5);
     }
 
     #[test]

--- a/rust/sedona-raster-gdal/src/rs_resample.rs
+++ b/rust/sedona-raster-gdal/src/rs_resample.rs
@@ -448,14 +448,14 @@ fn plan_from_reference(
     use_scale: bool,
     algorithm: &str,
 ) -> Result<ResamplePlan> {
-    let m = reference.metadata();
+    let t = reference.transform();
     let (width_or_scale, height_or_scale) = if use_scale {
-        (m.scale_x(), m.scale_y())
+        (t[1], t[5])
     } else {
-        (m.width() as f64, m.height() as f64)
+        (reference.width()? as f64, reference.height()? as f64)
     };
     // The reference's upper-left corner is the grid the output origin snaps to.
-    let grid = Some((m.upper_left_x(), m.upper_left_y()));
+    let grid = Some((t[0], t[3]));
     plan_from_dims_or_scale(width_or_scale, height_or_scale, grid, use_scale, algorithm)
 }
 
@@ -502,8 +502,7 @@ fn resample_raster(
     plan: &ResamplePlan,
     builder: &mut RasterBuilder,
 ) -> Result<()> {
-    let metadata = raster.metadata();
-    let src = Grid::from_metadata(&metadata);
+    let src = Grid::from_raster(raster)?;
     if src.width <= 0 || src.height <= 0 {
         return exec_err!(
             "RS_Resample: source raster has non-positive dimensions {}x{}",
@@ -1337,8 +1336,7 @@ mod tests {
         let rasters = RasterStructArray::try_new(struct_array).unwrap();
         let raster = rasters.get(0).unwrap();
         assert_eq!(raster.crs(), Some("EPSG:4326"));
-        let m = raster.metadata();
-        assert_eq!(m.upper_left_x(), 10.0);
-        assert_eq!(m.upper_left_y(), 44.0);
+        assert_eq!(raster.transform()[0], 10.0);
+        assert_eq!(raster.transform()[3], 44.0);
     }
 }

--- a/rust/sedona-raster-gdal/src/rs_tile.rs
+++ b/rust/sedona-raster-gdal/src/rs_tile.rs
@@ -399,9 +399,8 @@ fn explode_raster_tiles(
         return exec_err!("RS_Tile: nodata is only meaningful with pad_with_nodata = true");
     }
 
-    let metadata = raster.metadata();
-    let width = metadata.width();
-    let height = metadata.height();
+    let width = raster.width()?;
+    let height = raster.height()?;
     if width < 0 || height < 0 {
         return sedona_internal_err!("RS_Tile: negative raster extent {width}x{height}");
     }
@@ -587,8 +586,7 @@ fn append_tile_band(
     // `band_idx` is 1-based; the `band_name` accessor is 0-based.
     let band_name = raster.band_name(band_idx - 1).map(|s| s.to_string());
 
-    let band_metadata = band.metadata();
-    let data_type = band_metadata.data_type()?;
+    let data_type = band.data_type();
     let byte_size = data_type.byte_size();
 
     // The trailing two axes are the spatial (y, x) plane; anything before them is
@@ -608,8 +606,8 @@ fn append_tile_band(
         );
     }
     let (plane_h, plane_w) = (shape[ndim - 2] as usize, shape[ndim - 1] as usize);
-    let width = raster.metadata().width() as usize;
-    let height = raster.metadata().height() as usize;
+    let width = raster.width()? as usize;
+    let height = raster.height()? as usize;
     if plane_w != width || plane_h != height {
         return exec_err!(
             "RS_Tile: band {band_idx} spatial extent {plane_w}x{plane_h} does not match the raster {width}x{height}"
@@ -644,7 +642,7 @@ fn append_tile_band(
             Some(value) => nodata_f64_to_bytes(value, &data_type).map_err(|e| {
                 exec_datafusion_err!("RS_Tile: invalid nodata for band {band_idx}: {e}")
             })?,
-            None => match band_metadata.nodata_value() {
+            None => match band.nodata() {
                 Some(bytes) => bytes.to_vec(),
                 None => data_type.min_value_le_bytes(),
             },
@@ -657,10 +655,7 @@ fn append_tile_band(
         }
         (Some(fill.clone()), Some(fill))
     } else {
-        (
-            None,
-            band_metadata.nodata_value().map(|bytes| bytes.to_vec()),
-        )
+        (None, band.nodata().map(|bytes| bytes.to_vec()))
     };
 
     // One output allocation serves the whole band: every plane appends into it,

--- a/rust/sedona-raster-gdal/src/rs_zonal_stats.rs
+++ b/rust/sedona-raster-gdal/src/rs_zonal_stats.rs
@@ -680,11 +680,10 @@ fn collect_zonal_values(
     let data_type = band.data_type();
     let byte_size = data_type.byte_size();
 
-    let metadata = raster.metadata();
     let transform = raster_geo_transform(raster)?;
-    let width = usize::try_from(metadata.width())
+    let width = usize::try_from(raster.width()?)
         .map_err(|_| exec_datafusion_err!("RS_ZonalStats: negative raster width"))?;
-    let height = usize::try_from(metadata.height())
+    let height = usize::try_from(raster.height()?)
         .map_err(|_| exec_datafusion_err!("RS_ZonalStats: negative raster height"))?;
 
     // No-intersection gate: a true geometry intersection between the roi and

--- a/rust/sedona-raster-gdal/src/utils.rs
+++ b/rust/sedona-raster-gdal/src/utils.rs
@@ -30,15 +30,15 @@ use sedona_gdal::raster::types::DatasetOptions;
 use sedona_gdal::raster::types::ResampleAlg;
 use sedona_gdal::spatial_ref::SpatialRef;
 
+use arrow_schema::ArrowError;
 use sedona_raster::array::RasterRefImpl;
 use sedona_raster::builder::RasterBuilder;
-use sedona_raster::traits::{BandMetadata, RasterMetadata, RasterRef};
-use sedona_schema::raster::{BandDataType, StorageType};
+use sedona_raster::traits::RasterRef;
+use sedona_schema::raster::BandDataType;
 
 use crate::gdal_common::{
     band_data_type_to_gdal, band_nodata_to_bytes, convert_gdal_err, gdal_to_band_data_type,
     normalize_outdb_source_path, set_band_nodata_from_bytes, GdalBandLayout,
-    RasterMetadataFromGdalGeoTransform,
 };
 
 /// Append a GDAL dataset as a single in-db raster to the provided [`RasterBuilder`].
@@ -49,15 +49,14 @@ pub fn append_as_indb_raster(dataset: &Dataset, builder: &mut RasterBuilder) -> 
         .geo_transform()
         .map_err(|e| exec_datafusion_err!("Failed to get geotransform: {}", e))?;
 
-    let metadata = geotransform.to_raster_metadata(width, height);
+    let grid = Grid::from_gdal(geotransform, width, height);
 
     let crs = dataset
         .spatial_ref()
         .ok()
         .and_then(|sr: SpatialRef| sr.to_projjson().ok());
 
-    builder
-        .start_raster(&metadata, crs.as_deref())
+    grid.start_raster_into(builder, crs.as_deref())
         .map_err(|e| exec_datafusion_err!("Failed to start raster: {}", e))?;
 
     let band_count = dataset.raster_count();
@@ -72,16 +71,8 @@ pub fn append_as_indb_raster(dataset: &Dataset, builder: &mut RasterBuilder) -> 
 
         let nodata_bytes = band_nodata_to_bytes(&band)?;
 
-        let band_metadata = BandMetadata {
-            nodata_value: nodata_bytes,
-            storage_type: StorageType::InDb,
-            datatype: band_data_type,
-            outdb_url: None,
-            outdb_band_id: None,
-        };
-
         builder
-            .start_band(band_metadata)
+            .start_band_2d(band_data_type, nodata_bytes.as_deref())
             .map_err(|e| exec_datafusion_err!("Failed to start band: {}", e))?;
 
         let band_data = band
@@ -132,14 +123,14 @@ pub fn append_as_outdb_raster(gdal: &Gdal, path: &str, builder: &mut RasterBuild
     let geotransform = dataset
         .geo_transform()
         .map_err(|e| exec_datafusion_err!("Failed to get geotransform: {}", e))?;
-    let metadata = geotransform.to_raster_metadata(width, height);
+    let grid = Grid::from_gdal(geotransform, width, height);
 
     let crs = dataset
         .spatial_ref()
         .ok()
         .and_then(|sr: SpatialRef| sr.to_projjson().ok());
 
-    builder.start_raster(&metadata, crs.as_deref())?;
+    grid.start_raster_into(builder, crs.as_deref())?;
 
     let band_count = dataset.raster_count();
     for band_idx in 1..=band_count {
@@ -153,15 +144,17 @@ pub fn append_as_outdb_raster(gdal: &Gdal, path: &str, builder: &mut RasterBuild
 
         let nodata_bytes = band_nodata_to_bytes(&band)?;
 
-        let band_metadata = BandMetadata {
-            nodata_value: nodata_bytes,
-            storage_type: StorageType::OutDbRef,
-            datatype: band_data_type,
-            outdb_url: Some(path.to_string()),
-            outdb_band_id: Some(band_idx as u32),
-        };
-
-        builder.start_band(band_metadata)?;
+        // Out-db band: location + band selector in the `#band=N` URI; empty data.
+        let outdb_uri = format!("{path}#band={band_idx}");
+        builder.start_band_nd(
+            None,
+            &["y", "x"],
+            &[height as i64, width as i64],
+            band_data_type,
+            nodata_bytes.as_deref(),
+            Some(&outdb_uri),
+            None,
+        )?;
         builder.band_data_writer().append_value([]);
         builder.finish_band()?;
     }
@@ -199,20 +192,20 @@ pub fn append_nd_from_dataset(
     let geotransform = dataset
         .geo_transform()
         .map_err(|e| exec_datafusion_err!("Failed to get geotransform: {}", e))?;
-    let metadata = geotransform.to_raster_metadata(width, height);
+    let grid = Grid::from_gdal(geotransform, width, height);
 
     let crs = dataset
         .spatial_ref()
         .ok()
         .and_then(|sr: SpatialRef| sr.to_projjson().ok());
 
-    append_nd_from_dataset_inner(dataset, layout, builder, &metadata, crs.as_deref(), None)
+    append_nd_from_dataset_inner(dataset, layout, builder, &grid, crs.as_deref(), None)
 }
 
 /// A raster's affine grid: its geotransform and pixel dimensions.
 ///
 /// This is the geometric core shared by a source raster's grid (via
-/// [`Grid::from_metadata`]) and every resample/warp output target, replacing the
+/// [`Grid::from_raster`]) and every resample/warp output target, replacing the
 /// several near-identical transform-plus-dimensions structs that had accumulated
 /// here.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -232,20 +225,47 @@ pub struct Envelope {
 }
 
 impl Grid {
-    /// The grid of an existing raster, read from its [`RasterMetadata`].
-    pub fn from_metadata(m: &RasterMetadata) -> Self {
+    /// Build a grid from a GDAL geotransform and pixel dimensions.
+    pub fn from_gdal(transform: GeoTransform, width: usize, height: usize) -> Self {
         Self {
-            transform: [
-                m.upper_left_x(),
-                m.scale_x(),
-                m.skew_x(),
-                m.upper_left_y(),
-                m.skew_y(),
-                m.scale_y(),
-            ],
-            width: m.width(),
-            height: m.height(),
+            transform,
+            width: width as i64,
+            height: height as i64,
         }
+    }
+
+    /// The grid of an existing raster, read from its transform and spatial
+    /// shape. Errors if the transform is not 6 elements or width/height are
+    /// missing (an invariant violation).
+    pub fn from_raster(raster: &dyn RasterRef) -> Result<Self, ArrowError> {
+        let transform = <[f64; 6]>::try_from(raster.transform()).map_err(|_| {
+            ArrowError::InvalidArgumentError("expected a 6-element geotransform".to_string())
+        })?;
+        Ok(Self {
+            transform,
+            width: raster.width()?,
+            height: raster.height()?,
+        })
+    }
+
+    /// Start `builder` on a 2-D raster covering this grid, stamping `crs`.
+    pub fn start_raster_into(
+        &self,
+        builder: &mut RasterBuilder,
+        crs: Option<&str>,
+    ) -> Result<(), ArrowError> {
+        let t = self.transform;
+        builder.start_raster_2d(
+            self.width,
+            self.height,
+            t[0],
+            t[3],
+            t[1],
+            t[5],
+            t[2],
+            t[4],
+            crs,
+        )
     }
 
     /// Bounding box of the four grid corners (handles skew; reduces to
@@ -386,15 +406,11 @@ pub fn append_resampled_nd_from_dataset(
     builder: &mut RasterBuilder,
     output: &OutputGrid<'_>,
 ) -> Result<()> {
-    let metadata = output
-        .grid
-        .transform
-        .to_raster_metadata(output.grid.width as usize, output.grid.height as usize);
     append_nd_from_dataset_inner(
         dataset,
         layout,
         builder,
-        &metadata,
+        &output.grid,
         output.crs,
         Some(output.alg),
     )
@@ -488,13 +504,16 @@ pub fn append_warped_nd_from_dataset(
     )
     .map_err(convert_gdal_err)?;
 
-    let metadata = output
-        .grid
-        .transform
-        .to_raster_metadata(out_width, out_height);
     // Read the warped buffers back out (native read, no further resampling),
     // regrouping the flat GDAL bands into N-D raster bands.
-    append_nd_from_dataset_inner(&dst_dataset, layout, builder, &metadata, output.crs, None)
+    append_nd_from_dataset_inner(
+        &dst_dataset,
+        layout,
+        builder,
+        &output.grid,
+        output.crs,
+        None,
+    )
 }
 
 /// Allocate a `total`-byte buffer pre-filled with the little-endian `nodata`
@@ -523,16 +542,15 @@ fn append_nd_from_dataset_inner(
     dataset: &Dataset,
     layout: &GdalBandLayout,
     builder: &mut RasterBuilder,
-    metadata: &RasterMetadata,
+    grid: &Grid,
     crs: Option<&str>,
     alg: Option<ResampleAlg>,
 ) -> Result<()> {
     let (src_width, src_height) = dataset.raster_size();
-    let out_width = metadata.width as usize;
-    let out_height = metadata.height as usize;
+    let out_width = grid.width as usize;
+    let out_height = grid.height as usize;
 
-    builder
-        .start_raster(metadata, crs)
+    grid.start_raster_into(builder, crs)
         .map_err(|e| exec_datafusion_err!("Failed to start raster: {}", e))?;
 
     let total_planes: usize = layout.bands.iter().map(|b| b.plane_count).sum();
@@ -638,7 +656,7 @@ mod tests {
     use sedona_raster::array::RasterStructArray;
     use sedona_raster::builder::RasterBuilder;
     use sedona_raster::traits::RasterRef;
-    use sedona_schema::raster::{BandDataType, StorageType};
+    use sedona_schema::raster::BandDataType;
     use sedona_testing::data::test_raster;
     use tempfile::TempDir;
 
@@ -774,14 +792,14 @@ mod tests {
         let raster = raster_struct.get(0).unwrap();
         let band = raster.bands().band(1).unwrap();
 
-        assert_eq!(raster.metadata().width(), 3);
-        assert_eq!(raster.metadata().height(), 2);
-        assert_eq!(raster.metadata().upper_left_x(), 1.5);
-        assert_eq!(raster.metadata().upper_left_y(), 4.5);
+        assert_eq!(raster.width().unwrap(), 3);
+        assert_eq!(raster.height().unwrap(), 2);
+        assert_eq!(raster.transform()[0], 1.5);
+        assert_eq!(raster.transform()[3], 4.5);
         assert!(raster.crs().is_some());
-        assert_eq!(band.metadata().storage_type().unwrap(), StorageType::InDb);
-        assert_eq!(band.metadata().data_type().unwrap(), BandDataType::UInt8);
-        assert_eq!(band.metadata().nodata_value().unwrap(), [255u8]);
+        assert!(band.is_indb());
+        assert_eq!(band.data_type(), BandDataType::UInt8);
+        assert_eq!(band.nodata().unwrap(), [255u8]);
         assert_eq!(
             band.nd_buffer().unwrap().as_contiguous().unwrap(),
             [1u8, 2, 3, 4, 5, 6]
@@ -797,16 +815,13 @@ mod tests {
         assert_eq!(raster_struct.len(), 1);
 
         let raster = raster_struct.get(0).unwrap();
-        assert_eq!(raster.metadata().width(), 10);
-        assert_eq!(raster.metadata().height(), 10);
+        assert_eq!(raster.width().unwrap(), 10);
+        assert_eq!(raster.height().unwrap(), 10);
         assert!(raster.crs().is_some());
 
         let band = raster.bands().band(1).unwrap();
-        assert_eq!(
-            band.metadata().storage_type().unwrap(),
-            StorageType::OutDbRef
-        );
-        assert!(band.metadata().outdb_url().unwrap().contains("test4.tiff"));
+        assert!(!band.is_indb());
+        assert!(band.outdb_uri().unwrap().contains("test4.tiff"));
     }
 
     #[test]
@@ -827,10 +842,7 @@ mod tests {
         let raster = raster_struct.get(0).unwrap();
         let band = raster.bands().band(1).unwrap();
 
-        assert_eq!(
-            band.metadata().nodata_value().unwrap(),
-            nodata.to_le_bytes()
-        );
+        assert_eq!(band.nodata().unwrap(), nodata.to_le_bytes());
     }
 
     #[test]
@@ -851,10 +863,7 @@ mod tests {
         let raster = raster_struct.get(0).unwrap();
         let band = raster.bands().band(1).unwrap();
 
-        assert_eq!(
-            band.metadata().nodata_value().unwrap(),
-            nodata.to_le_bytes()
-        );
+        assert_eq!(band.nodata().unwrap(), nodata.to_le_bytes());
     }
 
     #[test]
@@ -875,15 +884,12 @@ mod tests {
         let raster = raster_struct.get(0).unwrap();
         let band = raster.bands().band(1).unwrap();
 
-        assert_eq!(raster.metadata().width(), 2);
-        assert_eq!(raster.metadata().height(), 2);
-        assert_eq!(raster.metadata().upper_left_x(), 100.0);
-        assert_eq!(raster.metadata().upper_left_y(), 200.0);
-        assert_eq!(band.metadata().data_type().unwrap(), BandDataType::UInt64);
-        assert_eq!(
-            band.metadata().nodata_value().unwrap(),
-            &nodata.to_le_bytes()
-        );
+        assert_eq!(raster.width().unwrap(), 2);
+        assert_eq!(raster.height().unwrap(), 2);
+        assert_eq!(raster.transform()[0], 100.0);
+        assert_eq!(raster.transform()[3], 200.0);
+        assert_eq!(band.data_type(), BandDataType::UInt64);
+        assert_eq!(band.nodata().unwrap(), &nodata.to_le_bytes());
 
         let pixels: Vec<u64> = band
             .nd_buffer()
@@ -914,11 +920,8 @@ mod tests {
         let raster = raster_struct.get(0).unwrap();
         let band = raster.bands().band(1).unwrap();
 
-        assert_eq!(band.metadata().data_type().unwrap(), BandDataType::Int64);
-        assert_eq!(
-            band.metadata().nodata_value().unwrap(),
-            &nodata.to_le_bytes()
-        );
+        assert_eq!(band.data_type(), BandDataType::Int64);
+        assert_eq!(band.nodata().unwrap(), &nodata.to_le_bytes());
 
         let pixels: Vec<i64> = band
             .nd_buffer()
@@ -949,11 +952,8 @@ mod tests {
         let raster = raster_struct.get(0).unwrap();
         let band = raster.bands().band(1).unwrap();
 
-        assert_eq!(band.metadata().data_type().unwrap(), BandDataType::UInt16);
-        assert_eq!(
-            band.metadata().nodata_value().unwrap(),
-            &nodata.to_le_bytes()
-        );
+        assert_eq!(band.data_type(), BandDataType::UInt16);
+        assert_eq!(band.nodata().unwrap(), &nodata.to_le_bytes());
 
         let pixels: Vec<u16> = band
             .nd_buffer()
@@ -985,17 +985,17 @@ mod tests {
         let band2 = raster.bands().band(2).unwrap();
 
         assert_eq!(raster.bands().len(), 2);
-        assert_eq!(band1.metadata().storage_type().unwrap(), StorageType::InDb);
-        assert_eq!(band1.metadata().data_type().unwrap(), BandDataType::UInt8);
-        assert_eq!(band1.metadata().nodata_value().unwrap(), [255u8]);
+        assert!(band1.is_indb());
+        assert_eq!(band1.data_type(), BandDataType::UInt8);
+        assert_eq!(band1.nodata().unwrap(), [255u8]);
         assert_eq!(
             band1.nd_buffer().unwrap().as_contiguous().unwrap(),
             [10u8, 11, 12, 13]
         );
 
-        assert_eq!(band2.metadata().storage_type().unwrap(), StorageType::InDb);
-        assert_eq!(band2.metadata().data_type().unwrap(), BandDataType::UInt8);
-        assert_eq!(band2.metadata().nodata_value().unwrap(), [255u8]);
+        assert!(band2.is_indb());
+        assert_eq!(band2.data_type(), BandDataType::UInt8);
+        assert_eq!(band2.nodata().unwrap(), [255u8]);
         assert_eq!(
             band2.nd_buffer().unwrap().as_contiguous().unwrap(),
             [100u8, 0, 200, 0]
@@ -1016,17 +1016,17 @@ mod tests {
         let band2 = raster.bands().band(2).unwrap();
 
         assert_eq!(raster.bands().len(), 2);
-        assert_eq!(band1.metadata().storage_type().unwrap(), StorageType::InDb);
-        assert_eq!(band1.metadata().data_type().unwrap(), BandDataType::UInt8);
-        assert_eq!(band1.metadata().nodata_value().unwrap(), [0u8]);
+        assert!(band1.is_indb());
+        assert_eq!(band1.data_type(), BandDataType::UInt8);
+        assert_eq!(band1.nodata().unwrap(), [0u8]);
         assert_eq!(
             band1.nd_buffer().unwrap().as_contiguous().unwrap(),
             [10u8, 11, 12, 13]
         );
 
-        assert_eq!(band2.metadata().storage_type().unwrap(), StorageType::InDb);
-        assert_eq!(band2.metadata().data_type().unwrap(), BandDataType::UInt8);
-        assert_eq!(band2.metadata().nodata_value().unwrap(), [255u8]);
+        assert!(band2.is_indb());
+        assert_eq!(band2.data_type(), BandDataType::UInt8);
+        assert_eq!(band2.nodata().unwrap(), [255u8]);
         assert_eq!(
             band2.nd_buffer().unwrap().as_contiguous().unwrap(),
             [100u8, 0, 200, 0]
@@ -1067,13 +1067,13 @@ mod tests {
         assert_eq!(raster_struct.len(), 2);
 
         let first = raster_struct.get(0).unwrap();
-        assert_eq!(first.metadata().width(), 3);
-        assert_eq!(first.metadata().height(), 2);
+        assert_eq!(first.width().unwrap(), 3);
+        assert_eq!(first.height().unwrap(), 2);
         assert_eq!(first.bands().len(), 1);
 
         let second = raster_struct.get(1).unwrap();
-        assert_eq!(second.metadata().width(), 2);
-        assert_eq!(second.metadata().height(), 2);
+        assert_eq!(second.width().unwrap(), 2);
+        assert_eq!(second.height().unwrap(), 2);
         assert_eq!(second.bands().len(), 2);
     }
 }

--- a/rust/sedona-raster/src/affine_transformation.rs
+++ b/rust/sedona-raster/src/affine_transformation.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::traits::{MetadataRef, RasterRef};
+use crate::traits::RasterRef;
 use arrow_schema::ArrowError;
 
 /// Pre-computed affine transformation coefficients extracted from raster metadata.
@@ -34,16 +34,18 @@ pub struct AffineMatrix {
 }
 
 impl AffineMatrix {
-    /// Build an `AffineMatrix` from any `MetadataRef` implementer.
+    /// Build an `AffineMatrix` from a raster's 6-element GDAL geotransform
+    /// (`[origin_x, scale_x, skew_x, origin_y, skew_y, scale_y]`).
     #[inline]
-    pub fn from_metadata(m: &dyn MetadataRef) -> Self {
+    pub fn from_raster(raster: &dyn RasterRef) -> Self {
+        let t = raster.transform();
         Self {
-            offset_x: m.upper_left_x(),
-            offset_y: m.upper_left_y(),
-            scale_x: m.scale_x(),
-            scale_y: m.scale_y(),
-            skew_x: m.skew_x(),
-            skew_y: m.skew_y(),
+            offset_x: t[0],
+            scale_x: t[1],
+            skew_x: t[2],
+            offset_y: t[3],
+            skew_y: t[4],
+            scale_y: t[5],
         }
     }
 
@@ -192,8 +194,8 @@ impl AffineMatrix {
 /// Computes the rotation angle (in radians) of the raster based on its geotransform metadata.
 #[inline]
 pub fn rotation(raster: &dyn RasterRef) -> f64 {
-    let metadata = raster.metadata();
-    (-metadata.skew_x()).atan2(metadata.scale_x())
+    let t = raster.transform();
+    (-t[2]).atan2(t[1])
 }
 
 /// Performs an affine transformation on the provided x and y coordinates based on the geotransform
@@ -205,7 +207,7 @@ pub fn rotation(raster: &dyn RasterRef) -> f64 {
 /// * `y` - Y coordinate in pixel space (row)
 #[inline]
 pub fn to_world_coordinate(raster: &dyn RasterRef, x: i64, y: i64) -> (f64, f64) {
-    AffineMatrix::from_metadata(&raster.metadata()).transform(x as f64, y as f64)
+    AffineMatrix::from_raster(raster).transform(x as f64, y as f64)
 }
 
 /// Performs the inverse affine transformation to convert world coordinates back to raster pixel coordinates.
@@ -220,21 +222,24 @@ pub fn to_raster_coordinate(
     world_x: f64,
     world_y: f64,
 ) -> Result<(i64, i64), ArrowError> {
-    let (rx, ry) =
-        AffineMatrix::from_metadata(&raster.metadata()).inv_transform(world_x, world_y)?;
+    let (rx, ry) = AffineMatrix::from_raster(raster).inv_transform(world_x, world_y)?;
     Ok((rx as i64, ry as i64))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::traits::{BandRef, Bands, RasterMetadata};
+    use crate::traits::{BandRef, Bands};
     use approx::assert_relative_eq;
     use std::f64::consts::FRAC_1_SQRT_2;
     use std::f64::consts::PI;
 
+    /// Minimal `RasterRef` stub carrying only a geotransform and a spatial
+    /// shape — enough for the affine helpers, which read `transform()` and
+    /// (via `width()`/`height()`) `spatial_shape()`.
     struct TestRaster {
-        metadata: RasterMetadata,
+        transform: [f64; 6],
+        spatial_shape: [i64; 2],
     }
 
     impl RasterRef for TestRaster {
@@ -256,16 +261,13 @@ mod tests {
             None
         }
         fn transform(&self) -> &[f64] {
-            &[]
+            &self.transform
         }
         fn spatial_dims(&self) -> Vec<&str> {
-            vec![]
+            vec!["x", "y"]
         }
         fn spatial_shape(&self) -> &[i64] {
-            &[]
-        }
-        fn metadata(&self) -> RasterMetadata {
-            self.metadata.clone()
+            &self.spatial_shape
         }
     }
 
@@ -301,16 +303,8 @@ mod tests {
     fn test_to_world_coordinate() {
         // Test case with rotation/skew
         let raster = TestRaster {
-            metadata: RasterMetadata {
-                width: 10,
-                height: 20,
-                upperleft_x: 100.0,
-                upperleft_y: 200.0,
-                scale_x: 1.0,
-                scale_y: -2.0,
-                skew_x: 0.25,
-                skew_y: 0.5,
-            },
+            transform: [100.0, 1.0, 0.25, 200.0, 0.5, -2.0],
+            spatial_shape: [10, 20],
         };
 
         let (wx, wy) = to_world_coordinate(&raster, 0, 0);
@@ -333,16 +327,8 @@ mod tests {
     fn test_to_raster_coordinate() {
         // Test case with rotation/skew
         let raster = TestRaster {
-            metadata: RasterMetadata {
-                width: 10,
-                height: 20,
-                upperleft_x: 100.0,
-                upperleft_y: 200.0,
-                scale_x: 1.0,
-                scale_y: -2.0,
-                skew_x: 0.25,
-                skew_y: 0.5,
-            },
+            transform: [100.0, 1.0, 0.25, 200.0, 0.5, -2.0],
+            spatial_shape: [10, 20],
         };
 
         // Reverse of the to_world_coordinate tests
@@ -363,16 +349,8 @@ mod tests {
 
         // Check error handling for zero determinant
         let bad_raster = TestRaster {
-            metadata: RasterMetadata {
-                width: 10,
-                height: 20,
-                upperleft_x: 100.0,
-                upperleft_y: 200.0,
-                scale_x: 1.0,
-                scale_y: 0.0,
-                skew_x: 0.0,
-                skew_y: 0.0,
-            },
+            transform: [100.0, 1.0, 0.0, 200.0, 0.0, 0.0],
+            spatial_shape: [10, 20],
         };
         let result = to_raster_coordinate(&bad_raster, 100.0, 200.0);
         assert!(result.is_err());
@@ -385,16 +363,8 @@ mod tests {
 
     fn rotation_raster(scale_x: f64, scale_y: f64, skew_x: f64, skew_y: f64) -> TestRaster {
         TestRaster {
-            metadata: RasterMetadata {
-                width: 10,
-                height: 20,
-                upperleft_x: 0.0,
-                upperleft_y: 0.0,
-                scale_x,
-                scale_y,
-                skew_x,
-                skew_y,
-            },
+            transform: [0.0, scale_x, skew_x, 0.0, skew_y, scale_y],
+            spatial_shape: [10, 20],
         }
     }
 
@@ -462,18 +432,12 @@ mod tests {
     }
 
     #[test]
-    fn test_affine_from_metadata() {
-        let m = RasterMetadata {
-            width: 10,
-            height: 20,
-            upperleft_x: 100.0,
-            upperleft_y: 200.0,
-            scale_x: 1.0,
-            scale_y: -2.0,
-            skew_x: 0.25,
-            skew_y: 0.5,
+    fn test_affine_from_raster() {
+        let raster = TestRaster {
+            transform: [100.0, 1.0, 0.25, 200.0, 0.5, -2.0],
+            spatial_shape: [10, 20],
         };
-        let a = AffineMatrix::from_metadata(&m);
+        let a = AffineMatrix::from_raster(&raster);
         assert_eq!(a.offset_x, 100.0);
         assert_eq!(a.offset_y, 200.0);
         assert_eq!(a.scale_x, 1.0);

--- a/rust/sedona-raster/src/array.rs
+++ b/rust/sedona-raster/src/array.rs
@@ -558,13 +558,11 @@ impl<'a> RasterStructArray<'a> {
 mod tests {
     use super::*;
     use crate::builder::RasterBuilder;
-    use crate::traits::{BandMetadata, BandOverrides, RasterMetadata};
+    use crate::traits::BandOverrides;
     use arrow_array::{ArrayRef, ListArray, StructArray, UInt32Array};
     use arrow_buffer::{OffsetBuffer, ScalarBuffer};
     use arrow_schema::{DataType, Fields};
-    use sedona_schema::raster::{
-        band_indices, raster_indices, BandDataType, RasterSchema, StorageType,
-    };
+    use sedona_schema::raster::{band_indices, raster_indices, BandDataType, RasterSchema};
     use sedona_testing::rasters::generate_test_rasters;
     use std::sync::Arc;
 
@@ -689,31 +687,16 @@ mod tests {
         // Create a simple raster for testing using the correct API
         let mut builder = RasterBuilder::new(10); // capacity
 
-        let metadata = RasterMetadata {
-            width: 10,
-            height: 10,
-            upperleft_x: 0.0,
-            upperleft_y: 0.0,
-            scale_x: 1.0,
-            scale_y: -1.0,
-            skew_x: 0.0,
-            skew_y: 0.0,
-        };
-
         let epsg4326 = "EPSG:4326";
 
-        builder.start_raster(&metadata, Some(epsg4326)).unwrap();
-
-        let band_metadata = BandMetadata {
-            nodata_value: Some(vec![255u8]),
-            storage_type: StorageType::InDb,
-            datatype: BandDataType::UInt8,
-            outdb_url: None,
-            outdb_band_id: None,
-        };
+        builder
+            .start_raster_2d(10, 10, 0.0, 0.0, 1.0, -1.0, 0.0, 0.0, Some(epsg4326))
+            .unwrap();
 
         // Add a single band with some test data using the correct API
-        builder.start_band(band_metadata.clone()).unwrap();
+        builder
+            .start_band_2d(BandDataType::UInt8, Some(&[255u8]))
+            .unwrap();
         let test_data = vec![1u8; 100]; // 10x10 raster with value 1
         builder.band_data_writer().append_value(&test_data);
         builder.finish_band().unwrap();
@@ -729,12 +712,11 @@ mod tests {
         assert!(!rasters.is_empty());
 
         let raster = rasters.get(0).unwrap();
-        let metadata = raster.metadata();
 
-        assert_eq!(metadata.width(), 10);
-        assert_eq!(metadata.height(), 10);
-        assert_eq!(metadata.scale_x(), 1.0);
-        assert_eq!(metadata.scale_y(), -1.0);
+        assert_eq!(raster.width().unwrap(), 10);
+        assert_eq!(raster.height().unwrap(), 10);
+        assert_eq!(raster.transform()[1], 1.0);
+        assert_eq!(raster.transform()[5], -1.0);
 
         let bands = raster.bands();
         assert_eq!(bands.len(), 1);
@@ -748,9 +730,8 @@ mod tests {
         );
         assert_eq!(band.nd_buffer().unwrap().as_contiguous().unwrap()[0], 1u8);
 
-        let band_meta = band.metadata();
-        assert_eq!(band_meta.storage_type().unwrap(), StorageType::InDb);
-        assert_eq!(band_meta.data_type().unwrap(), BandDataType::UInt8);
+        assert!(band.is_indb());
+        assert_eq!(band.data_type(), BandDataType::UInt8);
 
         let crs = raster.crs().unwrap();
         assert_eq!(crs, epsg4326);
@@ -764,30 +745,15 @@ mod tests {
     fn test_multi_band_array() {
         let mut builder = RasterBuilder::new(3);
 
-        let metadata = RasterMetadata {
-            width: 5,
-            height: 5,
-            upperleft_x: 0.0,
-            upperleft_y: 0.0,
-            scale_x: 1.0,
-            scale_y: -1.0,
-            skew_x: 0.0,
-            skew_y: 0.0,
-        };
-
-        builder.start_raster(&metadata, None).unwrap();
+        builder
+            .start_raster_2d(5, 5, 0.0, 0.0, 1.0, -1.0, 0.0, 0.0, None)
+            .unwrap();
 
         // Add three bands using the correct API
         for band_idx in 0..3 {
-            let band_metadata = BandMetadata {
-                nodata_value: Some(vec![255u8]),
-                storage_type: StorageType::InDb,
-                datatype: BandDataType::UInt8,
-                outdb_url: None,
-                outdb_band_id: None,
-            };
-
-            builder.start_band(band_metadata).unwrap();
+            builder
+                .start_band_2d(BandDataType::UInt8, Some(&[255u8]))
+                .unwrap();
             let test_data = vec![band_idx as u8; 25]; // 5x5 raster
             builder.band_data_writer().append_value(&test_data);
             builder.finish_band().unwrap();
@@ -1040,24 +1006,14 @@ mod tests {
         let dyn_r: &dyn RasterRef = &r;
         assert_eq!(dyn_r.bands().len(), 2);
 
-        // metadata() shim: concrete RasterMetadata/BandMetadata values.
-        let m = r.metadata();
-        assert_eq!(m.width(), 3);
-        assert_eq!(m.height(), 2);
-        assert_eq!(m.upper_left_x(), 0.0);
-        assert_eq!(m.scale_x(), 1.0);
-        let b0 = r.band(0).unwrap();
-        let bm0 = b0.metadata();
-        assert_eq!(bm0.data_type().unwrap(), BandDataType::UInt16);
-        assert_eq!(
-            bm0.storage_type().unwrap(),
-            sedona_schema::raster::StorageType::InDb
-        );
-        assert_eq!(bm0.nodata_value(), Some(&[0xFFu8, 0xFE][..]));
-        // Band 0 is InDb (has bytes), so outdb_* are hidden via the shim
-        // even though the row carries an outdb_uri hint.
-        assert!(bm0.outdb_url().is_none());
-        assert!(bm0.outdb_band_id().is_none());
+        // Raster-level geometry via the direct accessors.
+        assert_eq!(r.width().unwrap(), 3);
+        assert_eq!(r.height().unwrap(), 2);
+        assert_eq!(r.transform()[0], 0.0);
+        assert_eq!(r.transform()[1], 1.0);
+        // Band 0 has bytes, so it reports InDb even though the row carries an
+        // outdb_uri hint.
+        assert!(r.band(0).unwrap().is_indb());
     }
 
     // multi-band, multi-raster identity
@@ -1259,6 +1215,5 @@ mod tests {
             band.is_indb(),
             "a 0-element band holds 0 bytes legitimately and must be InDb"
         );
-        assert_eq!(band.metadata().storage_type().unwrap(), StorageType::InDb);
     }
 }

--- a/rust/sedona-raster/src/builder.rs
+++ b/rust/sedona-raster/src/builder.rs
@@ -51,9 +51,9 @@ const MAX_INLINE_VIEW_LEN: u32 = 12;
 /// Required steps to build a raster:
 /// 1. Create a RasterBuilder with a specified capacity
 /// 2. For each raster to add:
-///    - Call `start_raster` with the appropriate metadata, CRS
+///    - Call `start_raster_2d` with the geotransform parameters and CRS
 ///    - For each band in the raster:
-///       - Call `start_band` with the band metadata
+///       - Call `start_band_2d` with the band data type and nodata
 ///       - Use `band_data_writer` to get a BinaryViewBuilder and write the band data
 ///       - Call `finish_band` to complete the band
 ///    - Call `finish_raster` to complete the raster
@@ -61,29 +61,17 @@ const MAX_INLINE_VIEW_LEN: u32 = 12;
 ///
 /// Example usage:
 /// ```
-/// use sedona_raster::traits::{RasterMetadata, BandMetadata};
-/// use sedona_schema::raster::{StorageType, BandDataType};
+/// use sedona_schema::raster::BandDataType;
 /// use sedona_raster::builder::RasterBuilder;
 ///
 /// let mut builder = RasterBuilder::new(1);
-/// let metadata = RasterMetadata {
-///     width: 100, height: 100,
-///     upperleft_x: 0.0, upperleft_y: 0.0,
-///     scale_x: 1.0, scale_y: -1.0,
-///     skew_x: 0.0, skew_y: 0.0,
-/// };
-/// // Start a raster from RasterMetadata struct
-/// builder.start_raster(&metadata, Some("EPSG:4326")).unwrap();
+/// // Start a 100x100 raster with a north-up geotransform.
+/// builder
+///     .start_raster_2d(100, 100, 0.0, 0.0, 1.0, -1.0, 0.0, 0.0, Some("EPSG:4326"))
+///     .unwrap();
 ///
 /// // Add a band:
-/// let band_metadata = BandMetadata {
-///     nodata_value: Some(vec![0u8]),
-///     storage_type: StorageType::InDb,
-///     datatype: BandDataType::UInt8,
-///     outdb_url: None,
-///     outdb_band_id: None,
-/// };
-/// builder.start_band(band_metadata).unwrap();
+/// builder.start_band_2d(BandDataType::UInt8, Some(&[0u8])).unwrap();
 /// let band_writer = builder.band_data_writer();
 /// band_writer.append_value(&vec![/* band data bytes */]);
 /// builder.finish_band().unwrap();
@@ -903,12 +891,11 @@ impl RasterBuilder {
 mod tests {
     use super::*;
     use crate::array::RasterStructArray;
-    use crate::traits::{RasterMetadata, RasterRef};
+    use crate::traits::RasterRef;
     use arrow_array::RecordBatch;
     use arrow_ipc::reader::StreamReader;
     use arrow_ipc::writer::StreamWriter;
     use arrow_schema::Schema;
-    use sedona_schema::raster::StorageType;
     use std::io::Cursor;
 
     #[test]
@@ -916,30 +903,15 @@ mod tests {
         // Create a simple raster for testing using the correct API
         let mut builder = RasterBuilder::new(10); // capacity
 
-        let metadata = RasterMetadata {
-            width: 10,
-            height: 10,
-            upperleft_x: 0.0,
-            upperleft_y: 0.0,
-            scale_x: 1.0,
-            scale_y: -1.0,
-            skew_x: 0.0,
-            skew_y: 0.0,
-        };
-
         let epsg4326 = "EPSG:4326";
-        builder.start_raster(&metadata, Some(epsg4326)).unwrap();
-
-        let band_metadata = BandMetadata {
-            nodata_value: Some(vec![255u8]),
-            storage_type: StorageType::InDb,
-            datatype: BandDataType::UInt8,
-            outdb_url: None,
-            outdb_band_id: None,
-        };
+        builder
+            .start_raster_2d(10, 10, 0.0, 0.0, 1.0, -1.0, 0.0, 0.0, Some(epsg4326))
+            .unwrap();
 
         // Add a single band with some test data using the correct API
-        builder.start_band(band_metadata.clone()).unwrap();
+        builder
+            .start_band_2d(BandDataType::UInt8, Some(&[255u8]))
+            .unwrap();
         let test_data = vec![1u8; 100]; // 10x10 raster with value 1
         builder.band_data_writer().append_value(&test_data);
         builder.finish_band().unwrap();
@@ -955,12 +927,11 @@ mod tests {
         assert!(!rasters.is_empty());
 
         let raster = rasters.get(0).unwrap();
-        let metadata = raster.metadata();
 
-        assert_eq!(metadata.width(), 10);
-        assert_eq!(metadata.height(), 10);
-        assert_eq!(metadata.scale_x(), 1.0);
-        assert_eq!(metadata.scale_y(), -1.0);
+        assert_eq!(raster.width().unwrap(), 10);
+        assert_eq!(raster.height().unwrap(), 10);
+        assert_eq!(raster.transform()[1], 1.0);
+        assert_eq!(raster.transform()[5], -1.0);
 
         let bands = raster.bands();
         assert_eq!(bands.len(), 1);
@@ -974,9 +945,8 @@ mod tests {
         );
         assert_eq!(band.nd_buffer().unwrap().as_contiguous().unwrap()[0], 1u8);
 
-        let band_meta = band.metadata();
-        assert_eq!(band_meta.storage_type().unwrap(), StorageType::InDb);
-        assert_eq!(band_meta.data_type().unwrap(), BandDataType::UInt8);
+        assert!(band.is_indb());
+        assert_eq!(band.data_type(), BandDataType::UInt8);
 
         let crs = raster.crs().unwrap();
         assert_eq!(crs, epsg4326);
@@ -990,30 +960,15 @@ mod tests {
     fn test_multi_band_iterator() {
         let mut builder = RasterBuilder::new(3);
 
-        let metadata = RasterMetadata {
-            width: 5,
-            height: 5,
-            upperleft_x: 0.0,
-            upperleft_y: 0.0,
-            scale_x: 1.0,
-            scale_y: -1.0,
-            skew_x: 0.0,
-            skew_y: 0.0,
-        };
-
-        builder.start_raster(&metadata, None).unwrap();
+        builder
+            .start_raster_2d(5, 5, 0.0, 0.0, 1.0, -1.0, 0.0, 0.0, None)
+            .unwrap();
 
         // Add three bands using the correct API
         for band_idx in 0..3 {
-            let band_metadata = BandMetadata {
-                nodata_value: Some(vec![255u8]),
-                storage_type: StorageType::InDb,
-                datatype: BandDataType::UInt8,
-                outdb_url: None,
-                outdb_band_id: None,
-            };
-
-            builder.start_band(band_metadata).unwrap();
+            builder
+                .start_band_2d(BandDataType::UInt8, Some(&[255u8]))
+                .unwrap();
             let test_data = vec![band_idx as u8; 25]; // 5x5 raster
             builder.band_data_writer().append_value(&test_data);
             builder.finish_band().unwrap();
@@ -1067,30 +1022,13 @@ mod tests {
         // Create an original raster
         let mut source_builder = RasterBuilder::new(10);
 
-        let original_metadata = RasterMetadata {
-            width: 42,
-            height: 24,
-            upperleft_x: -122.0,
-            upperleft_y: 37.8,
-            scale_x: 0.1,
-            scale_y: -0.1,
-            skew_x: 0.0,
-            skew_y: 0.0,
-        };
-
         source_builder
-            .start_raster(&original_metadata, None)
+            .start_raster_2d(42, 24, -122.0, 37.8, 0.1, -0.1, 0.0, 0.0, None)
             .unwrap();
 
-        let band_metadata = BandMetadata {
-            nodata_value: Some(vec![255u8]),
-            storage_type: StorageType::InDb,
-            datatype: BandDataType::UInt8,
-            outdb_url: None,
-            outdb_band_id: None,
-        };
-
-        source_builder.start_band(band_metadata).unwrap();
+        source_builder
+            .start_band_2d(BandDataType::UInt8, Some(&[255u8]))
+            .unwrap();
         let test_data = vec![42u8; 1008]; // 42x24 raster
         source_builder.band_data_writer().append_value(&test_data);
         source_builder.finish_band().unwrap();
@@ -1104,19 +1042,26 @@ mod tests {
         let source_raster = iterator.get(0).unwrap();
 
         target_builder
-            .start_raster(&source_raster.metadata(), source_raster.crs())
+            .start_raster_from(&source_raster, RasterOverrides::default())
             .unwrap();
 
-        // Add new band data while preserving original metadata
-        let new_band_metadata = BandMetadata {
-            nodata_value: None,
-            storage_type: StorageType::InDb,
-            datatype: BandDataType::UInt16,
-            outdb_url: None,
-            outdb_band_id: None,
-        };
-
-        target_builder.start_band(new_band_metadata).unwrap();
+        // Add new band data while preserving original metadata. `start_raster_from`
+        // copies the N-D spatial grid, so add the band with an explicit shape
+        // matching the source's [height, width].
+        target_builder
+            .start_band_nd(
+                None,
+                &["y", "x"],
+                &[
+                    source_raster.height().unwrap(),
+                    source_raster.width().unwrap(),
+                ],
+                BandDataType::UInt16,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
         let new_data = vec![100u16; 1008]; // Different data, same dimensions
         let new_data_bytes: Vec<u8> = new_data.iter().flat_map(|&x| x.to_le_bytes()).collect();
 
@@ -1131,21 +1076,19 @@ mod tests {
         // Verify the metadata was copied correctly
         let target_iterator = RasterStructArray::try_new(&target_array).unwrap();
         let target_raster = target_iterator.get(0).unwrap();
-        let target_metadata = target_raster.metadata();
 
         // All metadata should match the original
-        assert_eq!(target_metadata.width(), 42);
-        assert_eq!(target_metadata.height(), 24);
-        assert_eq!(target_metadata.upper_left_x(), -122.0);
-        assert_eq!(target_metadata.upper_left_y(), 37.8);
-        assert_eq!(target_metadata.scale_x(), 0.1);
-        assert_eq!(target_metadata.scale_y(), -0.1);
+        assert_eq!(target_raster.width().unwrap(), 42);
+        assert_eq!(target_raster.height().unwrap(), 24);
+        assert_eq!(target_raster.transform()[0], -122.0);
+        assert_eq!(target_raster.transform()[3], 37.8);
+        assert_eq!(target_raster.transform()[1], 0.1);
+        assert_eq!(target_raster.transform()[5], -0.1);
 
         // But band data and metadata should be different
         let target_band = target_raster.bands().band(1).unwrap();
-        let target_band_meta = target_band.metadata();
-        assert_eq!(target_band_meta.data_type().unwrap(), BandDataType::UInt16);
-        assert!(target_band_meta.nodata_value().is_none());
+        assert_eq!(target_band.data_type(), BandDataType::UInt16);
+        assert!(target_band.nodata().is_none());
         assert_eq!(
             target_band
                 .nd_buffer()
@@ -1200,18 +1143,9 @@ mod tests {
         // Create a test raster with bands of different data types
         let mut builder = RasterBuilder::new(1);
 
-        let metadata = RasterMetadata {
-            width: 2,
-            height: 2,
-            upperleft_x: 0.0,
-            upperleft_y: 0.0,
-            scale_x: 1.0,
-            scale_y: -1.0,
-            skew_x: 0.0,
-            skew_y: 0.0,
-        };
-
-        builder.start_raster(&metadata, None).unwrap();
+        builder
+            .start_raster_2d(2, 2, 0.0, 0.0, 1.0, -1.0, 0.0, 0.0, None)
+            .unwrap();
 
         // Test all BandDataType variants
         let test_cases = vec![
@@ -1271,15 +1205,7 @@ mod tests {
         ];
 
         for (expected_data_type, test_data) in test_cases {
-            let band_metadata = BandMetadata {
-                nodata_value: None,
-                storage_type: StorageType::InDb,
-                datatype: expected_data_type,
-                outdb_url: None,
-                outdb_band_id: None,
-            };
-
-            builder.start_band(band_metadata).unwrap();
+            builder.start_band_2d(expected_data_type, None).unwrap();
             builder.band_data_writer().append_value(&test_data);
             builder.finish_band().unwrap();
         }
@@ -1312,8 +1238,7 @@ mod tests {
         for (i, expected_type) in expected_types.iter().enumerate() {
             // Bands are 1-based band_number
             let band = bands.band(i + 1).unwrap();
-            let band_metadata = band.metadata();
-            let actual_type = band_metadata.data_type().unwrap();
+            let actual_type = band.data_type();
 
             assert_eq!(
                 actual_type, *expected_type,
@@ -1327,43 +1252,31 @@ mod tests {
         // Test creating raster with OutDb reference metadata
         let mut builder = RasterBuilder::new(10);
 
-        let metadata = RasterMetadata {
-            width: 1024,
-            height: 1024,
-            upperleft_x: 0.0,
-            upperleft_y: 0.0,
-            scale_x: 1.0,
-            scale_y: -1.0,
-            skew_x: 0.0,
-            skew_y: 0.0,
-        };
-
-        builder.start_raster(&metadata, None).unwrap();
+        builder
+            .start_raster_2d(1024, 1024, 0.0, 0.0, 1.0, -1.0, 0.0, 0.0, None)
+            .unwrap();
 
         // Test InDb band (should have null OutDb fields)
-        let indb_band_metadata = BandMetadata {
-            nodata_value: Some(vec![255u8]),
-            storage_type: StorageType::InDb,
-            datatype: BandDataType::UInt8,
-            outdb_url: None,
-            outdb_band_id: None,
-        };
-
-        builder.start_band(indb_band_metadata).unwrap();
+        builder
+            .start_band_2d(BandDataType::UInt8, Some(&[255u8]))
+            .unwrap();
         let test_data = vec![1u8; 100];
         builder.band_data_writer().append_value(&test_data);
         builder.finish_band().unwrap();
 
-        // Test OutDbRef band (should have OutDb fields populated)
-        let outdb_band_metadata = BandMetadata {
-            nodata_value: None,
-            storage_type: StorageType::OutDbRef,
-            datatype: BandDataType::Float32,
-            outdb_url: Some("s3://mybucket/satellite_image.tif".to_string()),
-            outdb_band_id: Some(2),
-        };
-
-        builder.start_band(outdb_band_metadata).unwrap();
+        // Test OutDbRef band: an out-db location is carried as an `outdb_uri`
+        // with the SedonaDB `#band=N` fragment; the band's own `data` is empty.
+        builder
+            .start_band_nd(
+                None,
+                &["y", "x"],
+                &[1024, 1024],
+                BandDataType::Float32,
+                None,
+                Some("s3://mybucket/satellite_image.tif#band=2"),
+                None,
+            )
+            .unwrap();
         // For OutDbRef, data field could be empty or contain metadata/thumbnail
         builder.band_data_writer().append_value([]);
         builder.finish_band().unwrap();
@@ -1380,27 +1293,18 @@ mod tests {
 
         // Test InDb band
         let indb_band = bands.band(1).unwrap();
-        let indb_metadata = indb_band.metadata();
-        assert_eq!(indb_metadata.storage_type().unwrap(), StorageType::InDb);
-        assert_eq!(indb_metadata.data_type().unwrap(), BandDataType::UInt8);
-        assert!(indb_metadata.outdb_url().is_none());
-        assert!(indb_metadata.outdb_band_id().is_none());
         assert!(indb_band.is_indb());
+        assert_eq!(indb_band.data_type(), BandDataType::UInt8);
+        assert!(indb_band.outdb_uri().is_none());
 
         // Test OutDbRef band
         let outdb_band = bands.band(2).unwrap();
-        let outdb_metadata = outdb_band.metadata();
-        assert_eq!(
-            outdb_metadata.storage_type().unwrap(),
-            StorageType::OutDbRef
-        );
-        assert_eq!(outdb_metadata.data_type().unwrap(), BandDataType::Float32);
-        assert_eq!(
-            outdb_metadata.outdb_url().unwrap(),
-            "s3://mybucket/satellite_image.tif"
-        );
-        assert_eq!(outdb_metadata.outdb_band_id().unwrap(), 2);
         assert!(!outdb_band.is_indb());
+        assert_eq!(outdb_band.data_type(), BandDataType::Float32);
+        assert_eq!(
+            outdb_band.outdb_uri().unwrap(),
+            "s3://mybucket/satellite_image.tif#band=2"
+        );
     }
 
     #[test]
@@ -1408,28 +1312,11 @@ mod tests {
         // Create a simple raster with one band
         let mut builder = RasterBuilder::new(1);
 
-        let metadata = RasterMetadata {
-            width: 10,
-            height: 10,
-            upperleft_x: 0.0,
-            upperleft_y: 0.0,
-            scale_x: 1.0,
-            scale_y: -1.0,
-            skew_x: 0.0,
-            skew_y: 0.0,
-        };
+        builder
+            .start_raster_2d(10, 10, 0.0, 0.0, 1.0, -1.0, 0.0, 0.0, None)
+            .unwrap();
 
-        builder.start_raster(&metadata, None).unwrap();
-
-        let band_metadata = BandMetadata {
-            nodata_value: None,
-            storage_type: StorageType::InDb,
-            datatype: BandDataType::UInt8,
-            outdb_url: None,
-            outdb_band_id: None,
-        };
-
-        builder.start_band(band_metadata).unwrap();
+        builder.start_band_2d(BandDataType::UInt8, None).unwrap();
         builder.band_data_writer().append_value([1u8; 100]);
         builder.finish_band().unwrap();
         builder.finish_raster().unwrap();

--- a/rust/sedona-raster/src/builder.rs
+++ b/rust/sedona-raster/src/builder.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 
 use sedona_schema::raster::{BandDataType, RasterSchema};
 
-use crate::traits::{BandMetadata, BandOverrides, MetadataRef, RasterRef};
+use crate::traits::{BandOverrides, RasterRef};
 use crate::view_entries::{ViewEntries, ViewEntry};
 
 /// Raster-level metadata overrides for [`RasterBuilder::start_raster_from`] and
@@ -336,27 +336,6 @@ impl RasterBuilder {
         Ok(())
     }
 
-    /// Start a 2-D raster from a `&dyn MetadataRef`. Matches the pre-N-D
-    /// signature so callers from before the refactor keep compiling without
-    /// changing argument lists.
-    pub fn start_raster(
-        &mut self,
-        metadata: &dyn MetadataRef,
-        crs: Option<&str>,
-    ) -> Result<(), ArrowError> {
-        self.start_raster_2d(
-            metadata.width(),
-            metadata.height(),
-            metadata.upper_left_x(),
-            metadata.upper_left_y(),
-            metadata.scale_x(),
-            metadata.scale_y(),
-            metadata.skew_x(),
-            metadata.skew_y(),
-            crs,
-        )
-    }
-
     /// Start a new band with explicit N-D parameters.
     ///
     /// `outdb_uri` is the *location* of the external resource (scheme is
@@ -530,33 +509,6 @@ impl RasterBuilder {
             data_type,
             nodata,
             None,
-            None,
-        )
-    }
-
-    /// Start a 2-D band from a concrete [`BandMetadata`] struct. Matches
-    /// the pre-N-D signature so callers from before the refactor keep
-    /// compiling. For OutDb bands the `outdb_url` + `outdb_band_id` are
-    /// recombined into the SedonaDB `<url>#band=N` URI convention.
-    pub fn start_band(&mut self, metadata: BandMetadata) -> Result<(), ArrowError> {
-        if self.current_width == 0 && self.current_height == 0 {
-            return Err(ArrowError::InvalidArgumentError(
-                "start_band requires prior start_raster / start_raster_2d (width and height are 0)"
-                    .into(),
-            ));
-        }
-        let outdb_uri = match (metadata.outdb_url.as_deref(), metadata.outdb_band_id) {
-            (Some(url), Some(band_id)) => Some(format!("{url}#band={band_id}")),
-            (Some(url), None) => Some(url.to_string()),
-            _ => None,
-        };
-        self.start_band_nd(
-            None,
-            &["y", "x"],
-            &[self.current_height, self.current_width],
-            metadata.datatype,
-            metadata.nodata_value.as_deref(),
-            outdb_uri.as_deref(),
             None,
         )
     }

--- a/rust/sedona-raster/src/display.rs
+++ b/rust/sedona-raster/src/display.rs
@@ -19,7 +19,6 @@ use std::fmt;
 
 use crate::affine_transformation::to_world_coordinate;
 use crate::traits::RasterRef;
-use sedona_schema::raster::StorageType;
 
 /// Wrapper for formatting a raster reference as a human-readable string.
 ///
@@ -57,11 +56,10 @@ pub struct RasterDisplay<'a>(pub &'a dyn RasterRef);
 impl fmt::Display for RasterDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let raster = self.0;
-        let metadata = raster.metadata();
         let bands = raster.bands();
 
-        let width = metadata.width();
-        let height = metadata.height();
+        let width = raster.width().unwrap();
+        let height = raster.height().unwrap();
         let nbands = bands.len();
 
         // Compute axis-aligned bounding box from 4 corners in world coordinates.
@@ -78,14 +76,15 @@ impl fmt::Display for RasterDisplay<'_> {
         let ymin = uly.min(ury).min(lry).min(lly);
         let ymax = uly.max(ury).max(lry).max(lly);
 
-        let skew_x = metadata.skew_x();
-        let skew_y = metadata.skew_y();
+        let transform = raster.transform();
+        let skew_x = transform[2];
+        let skew_y = transform[4];
         let has_skew = skew_x != 0.0 || skew_y != 0.0;
 
         let has_outdb = bands
             .iter()
             .filter_map(Result::ok)
-            .any(|band| matches!(band.metadata().storage_type(), Ok(StorageType::OutDbRef)));
+            .any(|band| !band.is_indb());
 
         // Write: [WxH/nbands] @ [xmin ymin xmax ymax]
         write!(

--- a/rust/sedona-raster/src/traits.rs
+++ b/rust/sedona-raster/src/traits.rs
@@ -121,156 +121,6 @@ impl<'a> NdBuffer<'a> {
     }
 }
 
-/// Concrete raster metadata returned by `RasterRef::metadata()`.
-///
-/// Restored from the pre-N-D schema to keep callers that pattern-match on
-/// `metadata.width`, `metadata.upperleft_x`, etc. compiling. Computed
-/// eagerly from `RasterRef::transform()` and `RasterRef::spatial_shape()`.
-///
-/// Panics on construction (`metadata()`) if the raster lacks width or
-/// height — corrupt schemas error through the `width()`/`height()` trait
-/// methods directly; the metadata accessor is the convenience surface.
-#[derive(Debug, Clone)]
-pub struct RasterMetadata {
-    pub width: i64,
-    pub height: i64,
-    pub upperleft_x: f64,
-    pub upperleft_y: f64,
-    pub scale_x: f64,
-    pub scale_y: f64,
-    pub skew_x: f64,
-    pub skew_y: f64,
-}
-
-/// Pre-N-D metadata-accessor trait. Restored so callers from before the
-/// N-D refactor that write `fn foo(metadata: &dyn MetadataRef)` keep
-/// compiling. `RasterMetadata` is the canonical implementer; new code
-/// should reach for `RasterRef::width()? / height()?` instead.
-pub trait MetadataRef {
-    /// Width of the raster in pixels
-    fn width(&self) -> i64;
-    /// Height of the raster in pixels
-    fn height(&self) -> i64;
-    /// X coordinate of the upper-left corner
-    fn upper_left_x(&self) -> f64;
-    /// Y coordinate of the upper-left corner
-    fn upper_left_y(&self) -> f64;
-    /// X-direction pixel size (scale)
-    fn scale_x(&self) -> f64;
-    /// Y-direction pixel size (scale)
-    fn scale_y(&self) -> f64;
-    /// X-direction skew/rotation
-    fn skew_x(&self) -> f64;
-    /// Y-direction skew/rotation
-    fn skew_y(&self) -> f64;
-}
-
-impl MetadataRef for RasterMetadata {
-    fn width(&self) -> i64 {
-        self.width
-    }
-    fn height(&self) -> i64 {
-        self.height
-    }
-    fn upper_left_x(&self) -> f64 {
-        self.upperleft_x
-    }
-    fn upper_left_y(&self) -> f64 {
-        self.upperleft_y
-    }
-    fn scale_x(&self) -> f64 {
-        self.scale_x
-    }
-    fn scale_y(&self) -> f64 {
-        self.scale_y
-    }
-    fn skew_x(&self) -> f64 {
-        self.skew_x
-    }
-    fn skew_y(&self) -> f64 {
-        self.skew_y
-    }
-}
-
-impl RasterMetadata {
-    pub fn width(&self) -> i64 {
-        self.width
-    }
-    pub fn height(&self) -> i64 {
-        self.height
-    }
-    pub fn upper_left_x(&self) -> f64 {
-        self.upperleft_x
-    }
-    pub fn upper_left_y(&self) -> f64 {
-        self.upperleft_y
-    }
-    pub fn scale_x(&self) -> f64 {
-        self.scale_x
-    }
-    pub fn scale_y(&self) -> f64 {
-        self.scale_y
-    }
-    pub fn skew_x(&self) -> f64 {
-        self.skew_x
-    }
-    pub fn skew_y(&self) -> f64 {
-        self.skew_y
-    }
-}
-
-/// Concrete band metadata returned by `BandRef::metadata()`.
-///
-/// Restored from the pre-N-D schema. The `outdb_url` and `outdb_band_id`
-/// fields are eagerly parsed from the N-D `outdb_uri` (which carries a
-/// `#band=N` fragment in the SedonaDB convention) so callers from the
-/// pre-N-D era keep compiling against the same field names.
-#[derive(Debug, Clone)]
-pub struct BandMetadata {
-    pub nodata_value: Option<Vec<u8>>,
-    pub storage_type: sedona_schema::raster::StorageType,
-    pub datatype: BandDataType,
-    pub outdb_url: Option<String>,
-    pub outdb_band_id: Option<u32>,
-}
-
-impl BandMetadata {
-    pub fn nodata_value(&self) -> Option<&[u8]> {
-        self.nodata_value.as_deref()
-    }
-    /// Returns the storage type. Wrapped in `Result` to match main's
-    /// `BandMetadataRef::storage_type()` signature — our shim
-    /// implementation never errors, but the signature is preserved so
-    /// existing `matches!(band.metadata().storage_type(), Ok(...))`
-    /// patterns from before the N-D refactor keep compiling.
-    pub fn storage_type(&self) -> Result<sedona_schema::raster::StorageType, ArrowError> {
-        Ok(self.storage_type)
-    }
-    /// Returns the band data type. Wrapped in `Result` to match main's
-    /// `BandMetadataRef::data_type()` signature — see `storage_type()`.
-    pub fn data_type(&self) -> Result<BandDataType, ArrowError> {
-        Ok(self.datatype)
-    }
-    pub fn outdb_url(&self) -> Option<&str> {
-        self.outdb_url.as_deref()
-    }
-    pub fn outdb_band_id(&self) -> Option<u32> {
-        self.outdb_band_id
-    }
-    /// Nodata value interpreted as f64. Mirrors the pre-N-D
-    /// `BandMetadataRef::nodata_value_as_f64()`. Uses the lossless
-    /// conversion (errors on i64/u64 magnitudes > 2^53) so the shim
-    /// surface picks up the same correctness fix as
-    /// `BandRef::nodata_as_f64()`.
-    pub fn nodata_value_as_f64(&self) -> Result<Option<f64>, ArrowError> {
-        let bytes = match self.nodata_value.as_deref() {
-            Some(b) => b,
-            None => return Ok(None),
-        };
-        nodata_bytes_to_f64_lossless(bytes, &self.datatype).map(Some)
-    }
-}
-
 /// Parse the SedonaDB `#band=N` fragment out of an out-DB URI.
 /// Returns `(base_url, band_id)`; band_id defaults to 1 if the fragment is
 /// absent or malformed (e.g. a non-positive-integer band value), in which
@@ -341,8 +191,9 @@ impl<'a> Bands<'a> {
 
 /// Trait for accessing an N-dimensional raster (top level).
 ///
-/// Replaces the legacy `RasterRef` + `MetadataRef` + `BandsRef` hierarchy with
-/// a single flat interface. Bands are 0-indexed.
+/// A single flat interface: raster-level geometry (`width`/`height`/
+/// `transform`) and band access live directly on this trait. Bands are
+/// 0-indexed.
 pub trait RasterRef {
     /// Number of bands/variables
     fn num_bands(&self) -> usize;
@@ -409,37 +260,6 @@ pub trait RasterRef {
     /// 6-element affine transform in GDAL GeoTransform order:
     /// `[origin_x, scale_x, skew_x, origin_y, skew_y, scale_y]`
     fn transform(&self) -> &[f64];
-
-    /// Eagerly-computed concrete metadata view (width, height, geotransform
-    /// scalars). Mirrors the pre-N-D `RasterRef::metadata()` accessor.
-    ///
-    /// Panics if `spatial_shape` lacks width/height or `transform` is the
-    /// wrong length — those are corrupt-schema cases that error cleanly
-    /// through the `width()`/`height()` trait methods, but the metadata
-    /// accessor predates that contract and is kept infallible for caller
-    /// ergonomics.
-    fn metadata(&self) -> RasterMetadata {
-        let width = self
-            .width()
-            .expect("raster has no width (spatial_shape missing); use width()? for error handling");
-        let height = self
-            .height()
-            .expect("raster has no height; use height()? for error handling");
-        let t = self.transform();
-        if t.len() != 6 {
-            panic!("transform must be 6 elements, got {}", t.len());
-        }
-        RasterMetadata {
-            width,
-            height,
-            upperleft_x: t[0],
-            scale_x: t[1],
-            skew_x: t[2],
-            upperleft_y: t[3],
-            skew_y: t[4],
-            scale_y: t[5],
-        }
-    }
 
     /// Spatial dimension names, in order (today `["x","y"]`; a future Z phase
     /// would extend to `["x","y","z"]`). Every band must contain each of these
@@ -627,41 +447,6 @@ pub trait BandRef {
     /// impl answers directly. `nd_buffer()` depends on `is_indb()`, so any
     /// `nd_buffer`-based default would recurse.
     fn is_indb(&self) -> bool;
-
-    /// Eagerly-computed concrete band metadata. Mirrors the pre-N-D
-    /// `BandRef::metadata()` accessor.
-    ///
-    /// `outdb_url` and `outdb_band_id` are parsed from `outdb_uri()`'s
-    /// SedonaDB `#band=N` fragment convention so callers that pattern-match
-    /// on those fields keep compiling.
-    fn metadata(&self) -> BandMetadata {
-        let is_indb = self.is_indb();
-        // Match the pre-N-D contract: outdb_url / outdb_band_id are only
-        // populated when storage_type is OutDbRef. The current schema lets
-        // the URI hint coexist with InDb data; this surface hides that.
-        let (outdb_url, outdb_band_id) = if !is_indb {
-            match self.outdb_uri() {
-                Some(uri) => {
-                    let (base, band) = split_outdb_band_fragment(uri);
-                    (Some(base), Some(band))
-                }
-                None => (None, None),
-            }
-        } else {
-            (None, None)
-        };
-        BandMetadata {
-            nodata_value: self.nodata().map(|b| b.to_vec()),
-            storage_type: if is_indb {
-                sedona_schema::raster::StorageType::InDb
-            } else {
-                sedona_schema::raster::StorageType::OutDbRef
-            },
-            datatype: self.data_type(),
-            outdb_url,
-            outdb_band_id,
-        }
-    }
 
     // -- Data access --
 

--- a/rust/sedona-raster/src/traits.rs
+++ b/rust/sedona-raster/src/traits.rs
@@ -272,11 +272,12 @@ impl BandMetadata {
 }
 
 /// Parse the SedonaDB `#band=N` fragment out of an out-DB URI.
-/// Returns `(base_url, band_id)`; band_id defaults to 1 if absent.
-/// Duplicated (intentionally — and minimally) from
-/// `sedona-raster-gdal::source_uri` because the shim lives in
-/// `sedona-raster` and can't reach across the crate boundary.
-fn split_outdb_band_fragment(uri: &str) -> (String, u32) {
+/// Returns `(base_url, band_id)`; band_id defaults to 1 if the fragment is
+/// absent or malformed (e.g. a non-positive-integer band value), in which
+/// case the whole string is treated as the base URL. This lenient parsing
+/// is the shared convention consumers use to recover the source path and
+/// band from a band's `outdb_uri()`.
+pub fn split_outdb_band_fragment(uri: &str) -> (String, u32) {
     if let Some(hash_pos) = uri.rfind('#') {
         let (base, fragment) = uri.split_at(hash_pos);
         let fragment = &fragment[1..]; // skip the '#'

--- a/rust/sedona-schema/src/raster.rs
+++ b/rust/sedona-schema/src/raster.rs
@@ -225,21 +225,6 @@ impl BandDataType {
     }
 }
 
-/// Where a band's pixel data lives.
-///
-/// Restored from the pre-N-D schema to keep downstream code that pattern-
-/// matches on `StorageType::InDb` / `StorageType::OutDbRef` compiling.
-/// The current N-D schema discriminates via `BandRef::is_indb()` (true ↔
-/// `InDb`, false ↔ `OutDbRef`); this enum is the shim over that.
-#[repr(u16)]
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Copy)]
-pub enum StorageType {
-    /// Band data is materialized into the raster row's `data` Arrow column.
-    InDb = 0,
-    /// Band data lives outside the row and is referenced by `outdb_uri`.
-    OutDbRef = 1,
-}
-
 /// Hard-coded column indices for performant access to nested struct fields.
 /// These indices must match the exact order defined in the RasterSchema methods.
 ///

--- a/rust/sedona-spatial-join-raster/src/join_provider.rs
+++ b/rust/sedona-spatial-join-raster/src/join_provider.rs
@@ -371,36 +371,19 @@ mod test {
     use sedona_geometry::error::SedonaGeometryError;
     use sedona_geometry::transform::CrsTransform;
     use sedona_raster::builder::RasterBuilder;
-    use sedona_raster::traits::{BandMetadata, RasterMetadata};
     use sedona_raster_functions::footprint::write_convexhull_wkb;
     use sedona_schema::crs::lnglat;
     use sedona_schema::datatypes::RASTER;
-    use sedona_schema::raster::{BandDataType, StorageType};
+    use sedona_schema::raster::BandDataType;
     use sedona_testing::rasters::generate_test_rasters;
 
     /// A 1x1 raster over world coords (0,0)-(1,1), with `crs` (or none).
     fn build_unit_raster(crs: Option<&str>) -> arrow_array::StructArray {
         let mut builder = RasterBuilder::new(1);
-        let metadata = RasterMetadata {
-            width: 1,
-            height: 1,
-            upperleft_x: 0.0,
-            upperleft_y: 1.0,
-            scale_x: 1.0,
-            scale_y: -1.0,
-            skew_x: 0.0,
-            skew_y: 0.0,
-        };
-        builder.start_raster(&metadata, crs).unwrap();
         builder
-            .start_band(BandMetadata {
-                datatype: BandDataType::UInt8,
-                nodata_value: None,
-                storage_type: StorageType::InDb,
-                outdb_url: None,
-                outdb_band_id: None,
-            })
+            .start_raster_2d(1, 1, 0.0, 1.0, 1.0, -1.0, 0.0, 0.0, crs)
             .unwrap();
+        builder.start_band_2d(BandDataType::UInt8, None).unwrap();
         builder.band_data_writer().append_value([0u8]);
         builder.finish_band().unwrap();
         builder.finish_raster().unwrap();

--- a/rust/sedona-spatial-join-raster/tests/spatial_join_integration.rs
+++ b/rust/sedona-spatial-join-raster/tests/spatial_join_integration.rs
@@ -434,8 +434,8 @@ fn build_skewed_raster_3857() -> StructArray {
 fn skewed_raster_native_corners(raster: &StructArray) -> [(f64, f64); 4] {
     let rasters = RasterStructArray::try_new(raster).unwrap();
     let r = rasters.get(0).unwrap();
-    let w = r.metadata().width();
-    let h = r.metadata().height();
+    let w = r.width().unwrap();
+    let h = r.height().unwrap();
     [
         to_world_coordinate(&r, 0, 0),
         to_world_coordinate(&r, w, 0),

--- a/rust/sedona-testing/src/benchmark_util.rs
+++ b/rust/sedona-testing/src/benchmark_util.rs
@@ -986,8 +986,7 @@ mod test {
         let rasters = RasterStructArray::try_new(raster_array).unwrap();
         assert_eq!(rasters.len(), ROWS_PER_BATCH);
         let raster = rasters.get(0).unwrap();
-        let metadata = raster.metadata();
-        assert_eq!(metadata.width(), 10);
-        assert_eq!(metadata.height(), 5);
+        assert_eq!(raster.width().unwrap(), 10);
+        assert_eq!(raster.height().unwrap(), 5);
     }
 }

--- a/rust/sedona-testing/src/raster_spec.rs
+++ b/rust/sedona-testing/src/raster_spec.rs
@@ -539,11 +539,10 @@ mod tests {
         let array = RasterStructArray::try_new(&raster).unwrap();
         assert_eq!(array.len(), 1);
         let raster_ref = array.get(0).unwrap();
-        let metadata = raster_ref.metadata();
-        assert_eq!(metadata.width(), 4);
-        assert_eq!(metadata.height(), 5);
-        assert_eq!(metadata.scale_x(), 1.0);
-        assert_eq!(metadata.scale_y(), -1.0);
+        assert_eq!(raster_ref.width().unwrap(), 4);
+        assert_eq!(raster_ref.height().unwrap(), 5);
+        assert_eq!(raster_ref.transform()[1], 1.0);
+        assert_eq!(raster_ref.transform()[5], -1.0);
 
         let bands = raster_ref.bands();
         assert_eq!(bands.len(), 1);
@@ -567,13 +566,14 @@ mod tests {
             .band(BandDataType::UInt8)
             .build();
         let array = RasterStructArray::try_new(&raster).unwrap();
-        let metadata = array.get(0).unwrap().metadata();
-        assert_eq!(metadata.upper_left_x(), 100.0);
-        assert_eq!(metadata.upper_left_y(), 500.0);
-        assert_eq!(metadata.scale_x(), 2.0);
-        assert_eq!(metadata.scale_y(), -3.0);
-        assert_eq!(metadata.skew_x(), 0.0);
-        assert_eq!(metadata.skew_y(), 0.0);
+        let raster_ref = array.get(0).unwrap();
+        let transform = raster_ref.transform();
+        assert_eq!(transform[0], 100.0);
+        assert_eq!(transform[3], 500.0);
+        assert_eq!(transform[1], 2.0);
+        assert_eq!(transform[5], -3.0);
+        assert_eq!(transform[2], 0.0);
+        assert_eq!(transform[4], 0.0);
     }
 
     #[test]
@@ -585,8 +585,8 @@ mod tests {
         let raster_ref = array.get(0).unwrap();
 
         // Raster-level spatial metadata is X-first, like the readers emit.
-        assert_eq!(raster_ref.metadata().width(), 5);
-        assert_eq!(raster_ref.metadata().height(), 4);
+        assert_eq!(raster_ref.width().unwrap(), 5);
+        assert_eq!(raster_ref.height().unwrap(), 4);
 
         let bands = raster_ref.bands();
         let band = bands.band(1).unwrap();
@@ -656,9 +656,7 @@ mod tests {
         let bands = raster_ref.bands();
         let band = bands.band(1).unwrap();
         assert!(!band.is_indb());
-        let metadata = band.metadata();
-        assert_eq!(metadata.outdb_url(), Some("s3://bucket/raster.tif"));
-        assert_eq!(metadata.outdb_band_id(), Some(2));
+        assert_eq!(band.outdb_uri(), Some("s3://bucket/raster.tif#band=2"));
     }
 
     #[test]

--- a/rust/sedona-testing/src/rasters.rs
+++ b/rust/sedona-testing/src/rasters.rs
@@ -19,9 +19,9 @@ use datafusion_common::Result;
 use fastrand::Rng;
 use sedona_raster::array::RasterStructArray;
 use sedona_raster::builder::RasterBuilder;
-use sedona_raster::traits::{BandMetadata, RasterMetadata, RasterRef};
+use sedona_raster::traits::RasterRef;
 use sedona_schema::crs::lnglat;
-use sedona_schema::raster::{BandDataType, StorageType};
+use sedona_schema::raster::BandDataType;
 
 use crate::raster_spec::RasterSpec;
 
@@ -48,24 +48,18 @@ pub fn generate_test_rasters(
             continue;
         }
 
-        let raster_metadata = RasterMetadata {
-            width: i as i64 + 1,
-            height: i as i64 + 2,
-            upperleft_x: i as f64 + 1.0,
-            upperleft_y: i as f64 + 2.0,
-            scale_x: i.max(1) as f64 * 0.1,
-            scale_y: i.max(1) as f64 * -0.2,
-            skew_x: i as f64 * 0.03,
-            skew_y: i as f64 * 0.04,
-        };
-        builder.start_raster(&raster_metadata, Some(&crs))?;
-        builder.start_band(BandMetadata {
-            datatype: BandDataType::UInt16,
-            nodata_value: Some(vec![0u8; 2]),
-            storage_type: StorageType::InDb,
-            outdb_url: None,
-            outdb_band_id: None,
-        })?;
+        builder.start_raster_2d(
+            i as i64 + 1,
+            i as i64 + 2,
+            i as f64 + 1.0,
+            i as f64 + 2.0,
+            i.max(1) as f64 * 0.1,
+            i.max(1) as f64 * -0.2,
+            i as f64 * 0.03,
+            i as f64 * 0.04,
+            Some(&crs),
+        )?;
+        builder.start_band_2d(BandDataType::UInt16, Some(&[0u8, 0u8]))?;
 
         let pixel_count = (i + 1) * (i + 2); // width * height
         let mut band_data = Vec::with_capacity(pixel_count * 2); // 2 bytes per u16
@@ -130,18 +124,17 @@ pub fn generate_tiled_rasters(
             let origin_x = (tile_x * tile_width) as f64;
             let origin_y = (tile_y * tile_height) as f64;
 
-            let raster_metadata = RasterMetadata {
-                width: tile_width as i64,
-                height: tile_height as i64,
-                upperleft_x: origin_x,
-                upperleft_y: origin_y,
-                scale_x: 1.0,
-                scale_y: 1.0,
-                skew_x: 0.0,
-                skew_y: 0.0,
-            };
-
-            raster_builder.start_raster(&raster_metadata, Some(&crs))?;
+            raster_builder.start_raster_2d(
+                tile_width as i64,
+                tile_height as i64,
+                origin_x,
+                origin_y,
+                1.0,
+                1.0,
+                0.0,
+                0.0,
+                Some(&crs),
+            )?;
 
             for _ in 0..band_count {
                 // Set a nodata value appropriate for the data type
@@ -149,15 +142,7 @@ pub fn generate_tiled_rasters(
 
                 let nodata_value_bytes = nodata_value.clone();
 
-                let band_metadata = BandMetadata {
-                    nodata_value,
-                    storage_type: StorageType::InDb,
-                    datatype: data_type,
-                    outdb_url: None,
-                    outdb_band_id: None,
-                };
-
-                raster_builder.start_band(band_metadata)?;
+                raster_builder.start_band_2d(data_type, nodata_value.as_deref())?;
 
                 let pixel_count = tile_width * tile_height;
 
@@ -187,28 +172,12 @@ pub fn generate_tiled_rasters(
 /// Useful for testing error handling of inverse affine transforms.
 pub fn build_noninvertible_raster() -> StructArray {
     let mut builder = RasterBuilder::new(1);
-    let metadata = RasterMetadata {
-        width: 1,
-        height: 1,
-        upperleft_x: 0.0,
-        upperleft_y: 0.0,
-        scale_x: 0.0,
-        scale_y: 0.0,
-        skew_x: 0.0,
-        skew_y: 0.0,
-    };
     let crs = lnglat().unwrap().to_crs_string();
     builder
-        .start_raster(&metadata, Some(&crs))
+        .start_raster_2d(1, 1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, Some(&crs))
         .expect("start raster");
     builder
-        .start_band(BandMetadata {
-            datatype: BandDataType::UInt8,
-            nodata_value: None,
-            storage_type: StorageType::InDb,
-            outdb_url: None,
-            outdb_band_id: None,
-        })
+        .start_band_2d(BandDataType::UInt8, None)
         .expect("start band");
     builder.band_data_writer().append_value([0u8]);
     builder.finish_band().expect("finish band");
@@ -216,23 +185,33 @@ pub fn build_noninvertible_raster() -> StructArray {
     builder.finish().expect("finish")
 }
 
-/// Builds a single raster with in-db bands from explicit metadata and raw band bytes.
+/// Builds a single raster with in-db bands from an explicit width/height,
+/// 6-element GDAL geotransform (`[origin_x, scale_x, skew_x, origin_y,
+/// skew_y, scale_y]`), CRS, and raw band bytes.
 pub fn build_in_db_raster(
-    metadata: RasterMetadata,
+    width: i64,
+    height: i64,
+    transform: [f64; 6],
     crs: Option<&str>,
     bands: &[InDbTestBand],
 ) -> StructArray {
     let mut builder = RasterBuilder::new(1);
-    builder.start_raster(&metadata, crs).expect("start raster");
+    builder
+        .start_raster_2d(
+            width,
+            height,
+            transform[0],
+            transform[3],
+            transform[1],
+            transform[5],
+            transform[2],
+            transform[4],
+            crs,
+        )
+        .expect("start raster");
     for band in bands {
         builder
-            .start_band(BandMetadata {
-                datatype: band.datatype,
-                nodata_value: band.nodata_value.clone(),
-                storage_type: StorageType::InDb,
-                outdb_url: None,
-                outdb_band_id: None,
-            })
+            .start_band_2d(band.datatype, band.nodata_value.as_deref())
             .expect("start band");
         builder.band_data_writer().append_value(&band.data);
         builder.finish_band().expect("finish band");
@@ -249,19 +228,10 @@ pub fn raster_from_single_band(
     band_bytes: &[u8],
     crs: Option<&str>,
 ) -> StructArray {
-    let metadata = RasterMetadata {
-        width: width as i64,
-        height: height as i64,
-        upperleft_x: 0.0,
-        upperleft_y: 0.0,
-        scale_x: 1.0,
-        scale_y: -1.0,
-        skew_x: 0.0,
-        skew_y: 0.0,
-    };
-
     build_in_db_raster(
-        metadata,
+        width as i64,
+        height as i64,
+        [0.0, 1.0, 0.0, 0.0, 0.0, -1.0],
         crs,
         &[InDbTestBand {
             datatype: data_type,
@@ -276,16 +246,6 @@ pub fn raster_from_single_band(
 /// Each band is 2x2 pixels.
 pub fn generate_multi_band_raster() -> StructArray {
     let crs = lnglat().unwrap().to_crs_string();
-    let metadata = RasterMetadata {
-        width: 2,
-        height: 2,
-        upperleft_x: 10.0,
-        upperleft_y: 20.0,
-        scale_x: 0.5,
-        scale_y: -0.5,
-        skew_x: 0.0,
-        skew_y: 0.0,
-    };
 
     let band2_data: Vec<u8> = [100u16, 200u16, 300u16, 400u16]
         .iter()
@@ -297,7 +257,9 @@ pub fn generate_multi_band_raster() -> StructArray {
         .collect();
 
     build_in_db_raster(
-        metadata,
+        2,
+        2,
+        [10.0, 0.5, 0.0, 20.0, 0.0, -0.5],
         Some(&crs),
         &[
             InDbTestBand {
@@ -435,44 +397,21 @@ pub fn assert_raster_arrays_equal(
 
 /// Compare two rasters for equality
 pub fn assert_raster_equal(raster1: &impl RasterRef, raster2: &impl RasterRef) {
-    // Compare metadata
-    let meta1 = raster1.metadata();
-    let meta2 = raster2.metadata();
-    assert_eq!(meta1.width(), meta2.width(), "Raster widths do not match");
+    // Compare width/height and the 6-element GDAL geotransform.
     assert_eq!(
-        meta1.height(),
-        meta2.height(),
+        raster1.width().unwrap(),
+        raster2.width().unwrap(),
+        "Raster widths do not match"
+    );
+    assert_eq!(
+        raster1.height().unwrap(),
+        raster2.height().unwrap(),
         "Raster heights do not match"
     );
     assert_eq!(
-        meta1.upper_left_x(),
-        meta2.upper_left_x(),
-        "Raster upper left x does not match"
-    );
-    assert_eq!(
-        meta1.upper_left_y(),
-        meta2.upper_left_y(),
-        "Raster upper left y does not match"
-    );
-    assert_eq!(
-        meta1.scale_x(),
-        meta2.scale_x(),
-        "Raster scale x does not match"
-    );
-    assert_eq!(
-        meta1.scale_y(),
-        meta2.scale_y(),
-        "Raster scale y does not match"
-    );
-    assert_eq!(
-        meta1.skew_x(),
-        meta2.skew_x(),
-        "Raster skew x does not match"
-    );
-    assert_eq!(
-        meta1.skew_y(),
-        meta2.skew_y(),
-        "Raster skew y does not match"
+        raster1.transform(),
+        raster2.transform(),
+        "Raster geotransforms do not match"
     );
 
     // Compare CRS and N-D spatial layout. The `metadata()` view above only
@@ -506,32 +445,20 @@ pub fn assert_raster_equal(raster1: &impl RasterRef, raster2: &impl RasterRef) {
         );
         assert_eq!(band1.shape(), band2.shape(), "Band shape does not match");
 
-        let band_meta1 = band1.metadata();
-        let band_meta2 = band2.metadata();
         assert_eq!(
-            band_meta1.data_type().unwrap(),
-            band_meta2.data_type().unwrap(),
+            band1.data_type(),
+            band2.data_type(),
             "Band data types do not match"
         );
         assert_eq!(
-            band_meta1.nodata_value(),
-            band_meta2.nodata_value(),
+            band1.nodata(),
+            band2.nodata(),
             "Band nodata values do not match"
         );
         assert_eq!(
-            band_meta1.storage_type().unwrap(),
-            band_meta2.storage_type().unwrap(),
-            "Band storage types do not match"
-        );
-        assert_eq!(
-            band_meta1.outdb_url(),
-            band_meta2.outdb_url(),
-            "Band outdb URLs do not match"
-        );
-        assert_eq!(
-            band_meta1.outdb_band_id(),
-            band_meta2.outdb_band_id(),
-            "Band outdb band IDs do not match"
+            band1.outdb_uri(),
+            band2.outdb_uri(),
+            "Band outdb URIs do not match"
         );
 
         assert_eq!(
@@ -586,24 +513,22 @@ mod tests {
 
         for i in 0..count {
             let raster = raster_array.get(i).unwrap();
-            let metadata = raster.metadata();
-            assert_eq!(metadata.width(), i as i64 + 1);
-            assert_eq!(metadata.height(), i as i64 + 2);
-            assert_eq!(metadata.upper_left_x(), i as f64 + 1.0);
-            assert_eq!(metadata.upper_left_y(), i as f64 + 2.0);
-            assert_eq!(metadata.scale_x(), (i.max(1) as f64) * 0.1);
-            assert_eq!(metadata.scale_y(), (i.max(1) as f64) * -0.2);
-            assert_eq!(metadata.skew_x(), (i as f64) * 0.03);
-            assert_eq!(metadata.skew_y(), (i as f64) * 0.04);
+            assert_eq!(raster.width().unwrap(), i as i64 + 1);
+            assert_eq!(raster.height().unwrap(), i as i64 + 2);
+            let transform = raster.transform();
+            assert_eq!(transform[0], i as f64 + 1.0);
+            assert_eq!(transform[3], i as f64 + 2.0);
+            assert_eq!(transform[1], (i.max(1) as f64) * 0.1);
+            assert_eq!(transform[5], (i.max(1) as f64) * -0.2);
+            assert_eq!(transform[2], (i as f64) * 0.03);
+            assert_eq!(transform[4], (i as f64) * 0.04);
 
             let bands = raster.bands();
             let band = bands.band(1).unwrap();
-            let band_metadata = band.metadata();
-            assert_eq!(band_metadata.data_type().unwrap(), BandDataType::UInt16);
-            assert_eq!(band_metadata.nodata_value(), Some(&[0u8, 0u8][..]));
-            assert_eq!(band_metadata.storage_type().unwrap(), StorageType::InDb);
-            assert_eq!(band_metadata.outdb_url(), None);
-            assert_eq!(band_metadata.outdb_band_id(), None);
+            assert_eq!(band.data_type(), BandDataType::UInt16);
+            assert_eq!(band.nodata(), Some(&[0u8, 0u8][..]));
+            assert!(band.is_indb());
+            assert_eq!(band.outdb_uri(), None);
 
             let band_data = band.nd_buffer().unwrap().as_contiguous().unwrap();
             let expected_pixel_count = (i + 1) * (i + 2); // width * height
@@ -630,18 +555,17 @@ mod tests {
         assert_eq!(raster_array.len(), 16); // 4x4 tiles
         for i in 0..16 {
             let raster = raster_array.get(i).unwrap();
-            let metadata = raster.metadata();
-            assert_eq!(metadata.width(), 64);
-            assert_eq!(metadata.height(), 64);
-            assert_eq!(metadata.upper_left_x(), ((i % 4) * 64) as f64);
-            assert_eq!(metadata.upper_left_y(), ((i / 4) * 64) as f64);
+            assert_eq!(raster.width().unwrap(), 64);
+            assert_eq!(raster.height().unwrap(), 64);
+            let transform = raster.transform();
+            assert_eq!(transform[0], ((i % 4) * 64) as f64);
+            assert_eq!(transform[3], ((i / 4) * 64) as f64);
             let bands = raster.bands();
             assert_eq!(bands.len(), 3);
             for band_index in 0..3 {
                 let band = bands.band(band_index + 1).unwrap();
-                let band_metadata = band.metadata();
-                assert_eq!(band_metadata.data_type().unwrap(), BandDataType::UInt8);
-                assert_eq!(band_metadata.storage_type().unwrap(), StorageType::InDb);
+                assert_eq!(band.data_type(), BandDataType::UInt8);
+                assert!(band.is_indb());
                 let band_data = band.nd_buffer().unwrap().as_contiguous().unwrap();
                 assert_eq!(band_data.len(), 64 * 64); // 4096 pixels
             }
@@ -723,19 +647,18 @@ mod tests {
         assert_eq!(raster_array.len(), 1);
 
         let raster = raster_array.get(0).unwrap();
-        let metadata = raster.metadata();
-        assert_eq!(metadata.width(), 2);
-        assert_eq!(metadata.height(), 2);
-        assert_eq!(metadata.upper_left_x(), 10.0);
-        assert_eq!(metadata.upper_left_y(), 20.0);
+        assert_eq!(raster.width().unwrap(), 2);
+        assert_eq!(raster.height().unwrap(), 2);
+        assert_eq!(raster.transform()[0], 10.0);
+        assert_eq!(raster.transform()[3], 20.0);
 
         let bands = raster.bands();
         assert_eq!(bands.len(), 3);
 
         // Band 1: UInt8, nodata=255
         let b1 = bands.band(1).unwrap();
-        assert_eq!(b1.metadata().data_type().unwrap(), BandDataType::UInt8);
-        assert_eq!(b1.metadata().nodata_value(), Some(&[255u8][..]));
+        assert_eq!(b1.data_type(), BandDataType::UInt8);
+        assert_eq!(b1.nodata(), Some(&[255u8][..]));
         assert_eq!(
             b1.nd_buffer().unwrap().as_contiguous().unwrap(),
             &[1u8, 2, 3, 4]
@@ -743,17 +666,17 @@ mod tests {
 
         // Band 2: UInt16, nodata=0
         let b2 = bands.band(2).unwrap();
-        assert_eq!(b2.metadata().data_type().unwrap(), BandDataType::UInt16);
-        assert_eq!(b2.metadata().nodata_value(), Some(&[0u8, 0][..]));
+        assert_eq!(b2.data_type(), BandDataType::UInt16);
+        assert_eq!(b2.nodata(), Some(&[0u8, 0][..]));
 
         // Band 3: Float32, no nodata
         let b3 = bands.band(3).unwrap();
-        assert_eq!(b3.metadata().data_type().unwrap(), BandDataType::Float32);
-        assert_eq!(b3.metadata().nodata_value(), None);
+        assert_eq!(b3.data_type(), BandDataType::Float32);
+        assert_eq!(b3.nodata(), None);
     }
 
     #[test]
-    #[should_panic = "Raster upper left x does not match"]
+    #[should_panic = "Raster geotransforms do not match"]
     fn test_raster_different_metadata() {
         let raster_array =
             generate_tiled_rasters((128, 128), (2, 1), BandDataType::UInt8, Some(43)).unwrap();


### PR DESCRIPTION
Migrates every raster caller off the pre-N-D metadata shim (`RasterMetadata` / `BandMetadata` / `MetadataRef` / `StorageType` + the `start_raster`/`start_band` builder shims) onto the direct N-D trait accessors (`width()?`/`height()?`/`transform()`, `data_type()`/`nodata()`/`is_indb()`/`outdb_uri()`, `start_raster_2d`/`start_band_2d`/`start_band_nd`), then deletes the shim. Behavior-preserving. Two commits — migrate, then delete — so the deletion reviews as a self-contained "the shim is dead" diff.