### PR TITLE
fix: SRID extraction returns NULL for a valid authority-less CRS

### DIFF
--- a/python/sedonadb/tests/functions/test_raster_functions.py
+++ b/python/sedonadb/tests/functions/test_raster_functions.py
@@ -83,12 +83,13 @@ def test_rs_srid_from_wkt():
     )
 
 
-def test_rs_srid_from_authorityless_wkt_errors(con):
-    """A WKT with no authority code anywhere has no SRID to extract."""
-    with pytest.raises(Exception, match="SRID"):
-        con.sql(
-            f"SELECT RS_SRID(RS_SetCRS(RS_Example(), '{WKT_LCC_NO_AUTHORITY}'))"
-        ).to_arrow_table()
+def test_rs_srid_from_authorityless_wkt_is_null(con):
+    """A WKT with no authority code anywhere is a valid, usable CRS but has no
+    SRID to extract, so RS_SRID yields NULL rather than erroring."""
+    result = con.sql(
+        f"SELECT RS_SRID(RS_SetCRS(RS_Example(), '{WKT_LCC_NO_AUTHORITY}')) AS srid"
+    ).to_arrow_table()
+    assert result["srid"][0].as_py() is None
 
 
 def test_rs_ensureloaded(con, sedona_testing):

--- a/python/sedonadb/tests/functions/test_transforms.py
+++ b/python/sedonadb/tests/functions/test_transforms.py
@@ -242,13 +242,14 @@ def test_st_srid_from_wkt(con):
     assert result["srid"][0].as_py() == 3857
 
 
-def test_st_srid_from_authorityless_wkt_errors(con):
-    """A WKT with no authority code anywhere has no SRID to extract."""
-    with pytest.raises(Exception, match="SRID"):
-        con.sql(
-            "SELECT ST_SRID(ST_SetCrs(ST_GeomFromText('POINT (0 1)'), $1))",
-            params=(WKT_LCC_NO_AUTHORITY,),
-        ).to_arrow_table()
+def test_st_srid_from_authorityless_wkt_is_null(con):
+    """A WKT with no authority code anywhere is a valid, usable CRS but has no
+    SRID to extract, so ST_SRID yields NULL rather than erroring."""
+    result = con.sql(
+        "SELECT ST_SRID(ST_SetCrs(ST_GeomFromText('POINT (0 1)'), $1)) AS srid",
+        params=(WKT_LCC_NO_AUTHORITY,),
+    ).to_arrow_table()
+    assert result["srid"][0].as_py() is None
 
 
 def test_st_transform_from_wkt_crs(con):

--- a/rust/sedona-functions/src/st_srid.rs
+++ b/rust/sedona-functions/src/st_srid.rs
@@ -23,7 +23,7 @@ use arrow_array::{
 use arrow_schema::DataType;
 use datafusion_common::{
     cast::{as_string_view_array, as_struct_array},
-    DataFusionError, Result, ScalarValue,
+    Result, ScalarValue,
 };
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_common::sedona_internal_err;
@@ -75,13 +75,11 @@ impl SedonaScalarKernel for StSrid {
     ) -> Result<ColumnarValue> {
         let executor = WkbExecutor::new(arg_types, args);
         let mut builder = UInt32Builder::with_capacity(executor.num_iterations());
+        // A CRS with an authority code yields its integer SRID; a valid CRS with
+        // no authority code (e.g. a custom WKT) yields None, surfaced as NULL. A
+        // missing CRS is SRID 0, the "unknown SRID" sentinel.
         let srid_opt = match &arg_types[0] {
-            SedonaType::Wkb(_, Some(crs)) | SedonaType::WkbView(_, Some(crs)) => {
-                match crs.srid()? {
-                    Some(srid) => Some(srid),
-                    None => return Err(DataFusionError::Execution("CRS has no SRID".to_string())),
-                }
-            }
+            SedonaType::Wkb(_, Some(crs)) | SedonaType::WkbView(_, Some(crs)) => crs.srid()?,
             _ => Some(0),
         };
 
@@ -141,13 +139,14 @@ impl SedonaScalarKernel for StSridItemCrs {
                     continue;
                 }
 
+                // None (a valid CRS with no authority SRID) is appended as NULL.
                 let srid = crs_to_srid_mapping.get_srid(maybe_crs)?;
-                builder.append_value(srid);
+                builder.append_option(srid);
             }
         } else {
             for maybe_crs in crs_string_array {
                 let srid = crs_to_srid_mapping.get_srid(maybe_crs)?;
-                builder.append_value(srid);
+                builder.append_option(srid);
             }
         }
 
@@ -327,13 +326,19 @@ mod test {
             &expected.as_ref()
         );
 
-        // Call with a CRS with no SRID (should error)
-        let crs = deserialize_crs("{}").unwrap();
+        // Call with a valid CRS that carries no authority code (a custom LCC
+        // WKT with no top-level AUTHORITY): the CRS is usable but has no SRID to
+        // extract, so ST_SRID returns NULL rather than erroring.
+        let wkt_no_authority = r#"PROJCS["Custom LCC",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563]]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["standard_parallel_1",33],PARAMETER["standard_parallel_2",45],UNIT["metre",1]]"#;
+        let crs = deserialize_crs(wkt_no_authority).unwrap();
+        assert!(
+            crs.is_some(),
+            "custom WKT should deserialize to a valid CRS"
+        );
         let sedona_type = SedonaType::Wkb(Edges::Planar, crs.clone());
         let tester = ScalarUdfTester::new(udf.clone(), vec![sedona_type]);
-        let result = tester.invoke_scalar("POINT (0 1)");
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("CRS has no SRID"));
+        let result = tester.invoke_scalar("POINT (0 1)").unwrap();
+        tester.assert_scalar_result_equals(result, ScalarValue::UInt32(None));
     }
 
     #[test]
@@ -360,25 +365,33 @@ mod test {
             .unwrap();
         tester.assert_scalar_result_equals(result, 3857);
 
+        // A valid CRS with no top-level authority code (a custom LCC WKT) has no
+        // SRID to extract, so its row is NULL — distinct from the no-CRS row,
+        // which is SRID 0.
+        const WKT_NO_AUTHORITY: &str = r#"PROJCS["Custom LCC",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563]]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["standard_parallel_1",33],PARAMETER["standard_parallel_2",45],UNIT["metre",1]]"#;
         let item_crs_array = create_array_item_crs(
             &[
                 Some("POINT (0 1)"),
                 Some("POINT (2 3)"),
                 Some("POINT (4 5)"),
                 Some("POINT (6 7)"),
+                Some("POINT (8 9)"),
                 None,
             ],
             [
                 Some("OGC:CRS84"),
                 Some("EPSG:3857"),
                 Some("EPSG:3857"),
+                Some(WKT_NO_AUTHORITY),
                 None,
                 None,
             ],
             &WKB_GEOMETRY,
         );
-        let expected_srid =
-            create_array!(UInt32, [Some(4326), Some(3857), Some(3857), Some(0), None]) as ArrayRef;
+        let expected_srid = create_array!(
+            UInt32,
+            [Some(4326), Some(3857), Some(3857), None, Some(0), None]
+        ) as ArrayRef;
 
         let result = tester.invoke_array(item_crs_array).unwrap();
         assert_eq!(&result, &expected_srid);

--- a/rust/sedona-raster-functions/src/rs_srid.rs
+++ b/rust/sedona-raster-functions/src/rs_srid.rs
@@ -71,8 +71,9 @@ impl SedonaScalarKernel for RsSrid {
             };
 
             let maybe_crs = raster.crs_str_ref();
+            // None (a valid CRS with no authority SRID) is appended as NULL.
             let srid = crs_to_srid_mapping.get_srid(maybe_crs)?;
-            builder.append_value(srid);
+            builder.append_option(srid);
             Ok(())
         })?;
 
@@ -168,25 +169,33 @@ mod tests {
         let result = tester.invoke_array(Arc::new(rasters)).unwrap();
         let expected: Arc<dyn arrow_array::Array> = Arc::new(UInt32Array::from(vec![Some(0)]));
         assert_array_equal(&result, &expected);
+
+        // A raster with an authority-coded CRS resolves to its integer SRID.
+        let mut builder = RasterBuilder::new(1);
+        append_1x1_raster_with_crs(&mut builder, Some("EPSG:3031"));
+        let rasters = builder.finish().unwrap();
+
+        let result = tester.invoke_array(Arc::new(rasters)).unwrap();
+        let expected: Arc<dyn arrow_array::Array> = Arc::new(UInt32Array::from(vec![Some(3031)]));
+        assert_array_equal(&result, &expected);
     }
 
     #[test]
-    fn udf_srid_missing_srid_returns_error() {
+    fn udf_srid_authorityless_crs_is_null() {
         let udf: ScalarUDF = rs_srid_udf().into();
         let tester = ScalarUdfTester::new(udf, vec![RASTER]);
 
-        // A PROJJSON CRS without an authority identifier should error.
+        // A valid CRS with no authority identifier (here a PROJJSON GeographicCRS
+        // with no `id`, the shape CF/rioxarray emit) is usable but has no SRID to
+        // extract, so RS_SRID yields NULL rather than erroring.
         let projjson_crs = "{\"type\":\"GeographicCRS\",\"name\":\"No authority id\"}";
         let mut builder = RasterBuilder::new(1);
         append_1x1_raster_with_crs(&mut builder, Some(projjson_crs));
         let rasters = builder.finish().unwrap();
 
-        let err = tester.invoke_array(Arc::new(rasters)).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("Can't extract SRID from item-level CRS"),
-            "unexpected error: {err}"
-        );
+        let result = tester.invoke_array(Arc::new(rasters)).unwrap();
+        let expected: Arc<dyn arrow_array::Array> = Arc::new(UInt32Array::from(vec![None]));
+        assert_array_equal(&result, &expected);
     }
 
     #[test]

--- a/rust/sedona-schema/src/crs.rs
+++ b/rust/sedona-schema/src/crs.rs
@@ -132,25 +132,32 @@ impl CachedCrsToSRIDMapping {
         }
     }
 
-    /// Get the SRID for a given CRS string, using the cache to avoid expensive deserialization where possible.
-    /// Returns 0 for missing CRS or CRS that don't have an SRID. Errors if the CRS string is invalid or if the
-    /// CRS can't be deserialized.
-    pub fn get_srid(&mut self, maybe_crs: Option<&str>) -> Result<u32> {
+    /// Get the SRID for a given CRS string, using the cache to avoid expensive
+    /// deserialization where possible.
+    ///
+    /// Returns `Some(0)` for a missing CRS (`None`, `""`, or `"0"`) and
+    /// `Some(srid)` for a CRS that resolves to an authority SRID. A valid CRS
+    /// that carries no authority code — e.g. a custom polar-stereographic WKT
+    /// from CF/rioxarray with no top-level `AUTHORITY`/`ID` — is still fully
+    /// usable but has no SRID to extract, so it returns `None`; the SRID UDFs
+    /// surface that as a NULL rather than an error. Only a genuinely malformed /
+    /// undeserializable CRS string errors, propagated from [`deserialize_crs`].
+    pub fn get_srid(&mut self, maybe_crs: Option<&str>) -> Result<Option<u32>> {
         if let Some(crs_str) = maybe_crs {
             if let Some(srid) = self.cache.get(crs_str) {
-                Ok(*srid)
+                Ok(Some(*srid))
             } else if let Some(crs) = deserialize_crs(crs_str)? {
                 if let Some(srid) = crs.srid()? {
                     self.cache.insert(crs_str.to_string(), srid);
-                    Ok(srid)
+                    Ok(Some(srid))
                 } else {
-                    exec_err!("Can't extract SRID from item-level CRS '{crs_str}'")
+                    Ok(None)
                 }
             } else {
-                Ok(0)
+                Ok(Some(0))
             }
         } else {
-            Ok(0)
+            Ok(Some(0))
         }
     }
 }
@@ -1316,6 +1323,43 @@ mod test {
         let crs3857 = deserialize_crs("EPSG:3857").unwrap().unwrap();
         assert_eq!(crs3857.to_crs_string(), "EPSG:3857");
         assert_eq!(crs3857.to_json(), r#""EPSG:3857""#);
+    }
+
+    #[test]
+    fn cached_crs_to_srid_mapping() {
+        // A custom Lambert Conformal WKT with no top-level AUTHORITY/ID: a valid,
+        // usable CRS that simply has no SRID (the shape CF/rioxarray emit for
+        // polar-stereographic and other custom grids).
+        const WKT_LCC_NO_AUTHORITY: &str = r#"PROJCS["Custom LCC",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563]]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["standard_parallel_1",33],PARAMETER["standard_parallel_2",45],UNIT["metre",1]]"#;
+
+        let mut mapping = CachedCrsToSRIDMapping::new();
+
+        // A missing CRS resolves to SRID 0 (the "unknown SRID" sentinel),
+        // matching PostGIS's ST_SRID of an unset geometry.
+        assert_eq!(mapping.get_srid(None).unwrap(), Some(0));
+        assert_eq!(mapping.get_srid(Some("")).unwrap(), Some(0));
+        assert_eq!(mapping.get_srid(Some("0")).unwrap(), Some(0));
+
+        // An authority-coded CRS resolves to its integer SRID (served from the
+        // cache on the second call).
+        assert_eq!(mapping.get_srid(Some("EPSG:3857")).unwrap(), Some(3857));
+        assert_eq!(mapping.get_srid(Some("EPSG:3857")).unwrap(), Some(3857));
+        assert_eq!(mapping.get_srid(Some("OGC:CRS84")).unwrap(), Some(4326));
+
+        // A valid CRS with no authority code (WKT or PROJJSON lacking a
+        // top-level AUTHORITY/id) is usable but has no SRID: None, not an error.
+        assert_eq!(mapping.get_srid(Some(WKT_LCC_NO_AUTHORITY)).unwrap(), None);
+        assert_eq!(
+            mapping
+                .get_srid(Some(r#"{"type":"GeographicCRS","name":"No authority id"}"#))
+                .unwrap(),
+            None
+        );
+
+        // A genuinely malformed CRS string (valid JSON, but not a PROJJSON
+        // object) can't be deserialized at all, so it still errors — that is
+        // distinct from a valid CRS that merely lacks an authority SRID.
+        assert!(mapping.get_srid(Some("[1,2,3]")).is_err());
     }
 }
 


### PR DESCRIPTION
A valid CRS with no top-level authority code (e.g. a custom polar-stereographic WKT from CF/rioxarray) is fully usable but has no EPSG/SRID. `RS_SRID`/`ST_SRID` on such a CRS now return NULL instead of erroring; a genuinely malformed CRS string still errors, and an authority-coded CRS still returns its integer SRID.