### PR TITLE
chore(ci): Lazily fail tests so that nightlies are still uploaded (even if some tests fail)

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -180,6 +180,7 @@ jobs:
     runs-on: ${{ matrix.config.os }}
     timeout-minutes: 150
     strategy:
+      fail-fast: false
       matrix:
         config:
           - {os: "ubuntu-latest", label: "linux-x86_64", arch: "x86_64"}

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -79,8 +79,9 @@ jobs:
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas
           # Test command exits 0 even on failure so CIBW continues building all wheels;
           # failures are recorded in .test_failed and checked after upload.
+          # We use Python here to be absolutely sure there are no shell escaping issues.
           CIBW_TEST_COMMAND: >-
-            python -c "import subprocess,sys,pathlib; r=subprocess.run([sys.executable,'-m','pytest',str(pathlib.Path(r'{package}')/'tests'),'-vv','-o','faulthandler_timeout=600']); r.returncode and (pathlib.Path(r'{project}')/'.test_failed').touch(); sys.exit(0)"
+            python -c "import subprocess,sys,pathlib; r=subprocess.run([sys.executable,'-m','pytest',str(pathlib.Path(r'{package}')/'tests'),'-vv','-o','faulthandler_timeout=600']); r.returncode and (print(f'Tests failed (exit {r.returncode}), creating .test_failed marker at {pathlib.Path(r\"{project}\").absolute()}') or (pathlib.Path(r'{project}')/'.test_failed').touch() or True); sys.exit(0)"
 
       - uses: actions/upload-artifact@v7
         with:
@@ -88,7 +89,7 @@ jobs:
           path: python/sedonadb/dist/*.whl
 
       - name: Fail if tests failed
-        run: if (Test-Path .test_failed) { exit 1 }
+        run: python -c "import sys,pathlib; f=pathlib.Path('.test_failed'); print(f'Checking for {f.absolute()}, exists={f.exists()}'); sys.exit(1 if f.exists() else 0)"
 
   macOS-arm64:
     runs-on: macOS-latest

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -80,7 +80,7 @@ jobs:
           # Test command exits 0 even on failure so CIBW continues building all wheels;
           # failures are recorded in .test_failed and checked after upload.
           CIBW_TEST_COMMAND: >-
-            python -c "import subprocess,sys,pathlib; r=subprocess.run([sys.executable,'-m','pytest','{package}/tests','-vv','-o','faulthandler_timeout=600']); r.returncode and pathlib.Path('{project}/.test_failed').touch(); sys.exit(0)"
+            python -c "import subprocess,sys,pathlib; r=subprocess.run([sys.executable,'-m','pytest',str(pathlib.Path('{package}')/'tests'),'-vv','-o','faulthandler_timeout=600']); r.returncode and pathlib.Path('{project}/.test_failed').touch(); sys.exit(0)"
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -76,12 +76,18 @@ jobs:
           CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
           CIBW_BUILD: "*-win_amd64"
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas
-          CIBW_TEST_COMMAND: pytest {package}/tests -vv -o faulthandler_timeout=600
+          # Test command exits 0 even on failure so CIBW continues building all wheels;
+          # failures are recorded in .test_failed and checked after upload.
+          CIBW_TEST_COMMAND: >-
+            cmd /c "pytest {package}/tests -vv -o faulthandler_timeout=600 || (echo.> {project}\.test_failed & exit /b 0)"
 
       - uses: actions/upload-artifact@v7
         with:
           name: release-wheels-windows-x86_64
           path: python/sedonadb/dist/*.whl
+
+      - name: Fail if tests failed
+        run: if (Test-Path .test_failed) { exit 1 }
 
   macOS-arm64:
     runs-on: macOS-latest
@@ -107,17 +113,23 @@ jobs:
 
       - name: Build and test wheels (sedonadb)
         run: |
+          rm -f .test_failed
           cd ci/scripts
           ./wheels-build-macos.sh sedonadb
         env:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas duckdb
-          CIBW_TEST_COMMAND: pytest {package}/tests -vv -o faulthandler_timeout=600
+          # Test command exits 0 even on failure so CIBW continues building all wheels;
+          # failures are recorded in .test_failed and checked after upload.
+          CIBW_TEST_COMMAND: "pytest {package}/tests -vv -o faulthandler_timeout=600 || touch {project}/.test_failed"
 
       - uses: actions/upload-artifact@v7
         with:
           name: release-wheels-macOS-arm64
           path: python/sedonadb/dist/*.whl
+
+      - name: Fail if tests failed
+        run: test ! -f .test_failed
 
   macOS-amd64:
     runs-on: macos-15-intel
@@ -143,18 +155,24 @@ jobs:
 
       - name: Build and test wheels (sedonadb)
         run: |
+          rm -f .test_failed
           cd ci/scripts
           ./wheels-build-macos.sh sedonadb
         env:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas duckdb
-          CIBW_TEST_COMMAND: pytest {package}/tests -vv -o faulthandler_timeout=600
+          # Test command exits 0 even on failure so CIBW continues building all wheels;
+          # failures are recorded in .test_failed and checked after upload.
+          CIBW_TEST_COMMAND: "pytest {package}/tests -vv -o faulthandler_timeout=600 || touch {project}/.test_failed"
           SEDONADB_MACOS_ARCH: x86_64
 
       - uses: actions/upload-artifact@v7
         with:
           name: release-wheels-macOS-amd64
           path: python/sedonadb/dist/*.whl
+
+      - name: Fail if tests failed
+        run: test ! -f .test_failed
 
   wheels-linux:
     name: ${{ matrix.config.label }}
@@ -176,17 +194,23 @@ jobs:
 
       - name: Build and test wheels (sedonadb)
         run: |
+          rm -f .test_failed
           cd ci/scripts
           ./wheels-build-linux.sh ${{ matrix.config.arch }} sedonadb
         env:
           CIBW_SKIP: "*musllinux*"
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas duckdb
-          CIBW_TEST_COMMAND: pytest {package}/tests -vv -o faulthandler_timeout=600
+          # Test command exits 0 even on failure so CIBW continues building all wheels;
+          # failures are recorded in .test_failed and checked after upload.
+          CIBW_TEST_COMMAND: "pytest {package}/tests -vv -o faulthandler_timeout=600 || touch {project}/.test_failed"
 
       - uses: actions/upload-artifact@v7
         with:
           name: release-wheels-${{ matrix.config.label }}
           path: python/sedonadb/dist/*.whl
+
+      - name: Fail if tests failed
+        run: test ! -f .test_failed
 
   # Extension wheels build in their own reusable workflow, gated on the
   # sedonadb jobs (so they run in the same run and can download those wheels

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -68,6 +68,7 @@ jobs:
 
       - name: Build and test wheels (sedonadb)
         run: |
+          Remove-Item -Force .test_failed -ErrorAction SilentlyContinue
           cd ci/scripts
           .\wheels-build-windows.ps1
         env:
@@ -79,7 +80,7 @@ jobs:
           # Test command exits 0 even on failure so CIBW continues building all wheels;
           # failures are recorded in .test_failed and checked after upload.
           CIBW_TEST_COMMAND: >-
-            cmd /c "pytest {package}/tests -vv -o faulthandler_timeout=600 || (echo.> {project}\.test_failed & exit /b 0)"
+            powershell -Command "pytest {package}/tests -vv -o faulthandler_timeout=600; if ($LASTEXITCODE -ne 0) { New-Item -Path '{project}/.test_failed' -ItemType File -Force | Out-Null }"
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -80,7 +80,7 @@ jobs:
           # Test command exits 0 even on failure so CIBW continues building all wheels;
           # failures are recorded in .test_failed and checked after upload.
           CIBW_TEST_COMMAND: >-
-            python -c "import subprocess,sys,pathlib; r=subprocess.run([sys.executable,'-m','pytest',str(pathlib.Path('{package}')/'tests'),'-vv','-o','faulthandler_timeout=600']); r.returncode and pathlib.Path('{project}/.test_failed').touch(); sys.exit(0)"
+            python -c "import subprocess,sys,pathlib; r=subprocess.run([sys.executable,'-m','pytest',str(pathlib.Path(r'{package}')/'tests'),'-vv','-o','faulthandler_timeout=600']); r.returncode and (pathlib.Path(r'{project}')/'.test_failed').touch(); sys.exit(0)"
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -216,13 +216,16 @@ jobs:
   # sedonadb jobs (so they run in the same run and can download those wheels
   # to test against) but isolated so an extension failure can't block the
   # core package's nightly. Future extensions follow the same shape.
+  # !cancelled() ensures extensions build even if sedonadb tests failed.
   expr:
     needs: ["windows-x86_64", "macOS-arm64", "macOS-amd64", "wheels-linux"]
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/wheels-expr.yml
     secrets: inherit
 
   zarr:
     needs: ["windows-x86_64", "macOS-arm64", "macOS-amd64", "wheels-linux"]
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/wheels-zarr.yml
     secrets: inherit
 

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -81,7 +81,7 @@ jobs:
           # failures are recorded in .test_failed and checked after upload.
           # We use Python here to be absolutely sure there are no shell escaping issues.
           CIBW_TEST_COMMAND: >-
-            python -c "import subprocess,sys,pathlib; r=subprocess.run([sys.executable,'-m','pytest',str(pathlib.Path(r'{package}')/'tests'),'-vv','-o','faulthandler_timeout=600']); r.returncode and (print(f'Tests failed (exit {r.returncode}), creating .test_failed marker at {pathlib.Path(r\"{project}\").absolute()}') or (pathlib.Path(r'{project}')/'.test_failed').touch() or True); sys.exit(0)"
+            python -c "import subprocess,sys,pathlib; proj=pathlib.Path(r'{project}'); r=subprocess.run([sys.executable,'-m','pytest',str(pathlib.Path(r'{package}')/'tests'),'-vv','-o','faulthandler_timeout=600']); r.returncode and (print(f'Tests failed (exit {r.returncode}), creating .test_failed marker at {proj.absolute()}') or (proj/'.test_failed').touch() or True); sys.exit(0)"
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -80,7 +80,7 @@ jobs:
           # Test command exits 0 even on failure so CIBW continues building all wheels;
           # failures are recorded in .test_failed and checked after upload.
           CIBW_TEST_COMMAND: >-
-            powershell -Command "pytest {package}/tests -vv -o faulthandler_timeout=600; if ($LASTEXITCODE -ne 0) { New-Item -Path '{project}/.test_failed' -ItemType File -Force | Out-Null }"
+            python -c "import subprocess,sys,pathlib; r=subprocess.run([sys.executable,'-m','pytest','{package}/tests','-vv','-o','faulthandler_timeout=600']); r.returncode and pathlib.Path('{project}/.test_failed').touch(); sys.exit(0)"
 
       - uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
This PR delays failure so we still upload nightly wheels. There are a few features we're working on which depend on extension functionality only present in the current sedonadb, and using nightly wheels is an easy way to go about setting up that CI until we release a version that includes the full FFI extension functionality.

We also have some long standing wheel test failures which we should fix, but at least this doesn't block nightly installs (which also help debug the fixes!).