### PR TITLE
refactor(rust/sedona-raster): lift GeoTransform/GeoTransformEx into sedona-raster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5943,6 +5943,7 @@ version = "0.4.0"
 dependencies = [
  "gdal-sys",
  "libloading 0.9.0",
+ "sedona-raster",
  "sedona-testing",
  "thiserror 2.0.17",
 ]

--- a/c/sedona-gdal/Cargo.toml
+++ b/c/sedona-gdal/Cargo.toml
@@ -32,6 +32,7 @@ rust-version.workspace = true
 [dependencies]
 gdal-sys = { version = "0.12.0", optional = true }
 libloading = { workspace = true }
+sedona-raster = { workspace = true }
 thiserror = { workspace = true }
 
 [features]

--- a/c/sedona-gdal/src/gdal.rs
+++ b/c/sedona-gdal/src/gdal.rs
@@ -28,7 +28,6 @@ use crate::driver::{Driver, DriverManager};
 use crate::errors::Result;
 use crate::gdal_api::GdalApi;
 use crate::gdal_dyn_bindgen::{GDALOpenFlags, OGRFieldType};
-use crate::geo_transform::GeoTransform;
 use crate::mem::create_mem_dataset;
 use crate::raster::polygonize::{fpolygonize, polygonize, PolygonizeOptions};
 use crate::raster::rasterband::RasterBand;
@@ -44,6 +43,7 @@ use crate::vector::layer::Layer;
 use crate::vrt::VrtDataset;
 use crate::vsi;
 use crate::warp;
+use sedona_raster::geo_transform::GeoTransform;
 
 /// High-level convenience wrapper around [`GdalApi`].
 ///

--- a/c/sedona-gdal/src/lib.rs
+++ b/c/sedona-gdal/src/lib.rs
@@ -32,7 +32,6 @@ pub mod config;
 pub mod cpl;
 pub mod dataset;
 pub mod driver;
-pub mod geo_transform;
 pub mod mem;
 pub mod raster;
 pub mod spatial_ref;

--- a/c/sedona-gdal/src/raster/rasterize_affine.rs
+++ b/c/sedona-gdal/src/raster/rasterize_affine.rs
@@ -31,8 +31,8 @@ use crate::dataset::Dataset;
 use crate::errors::{GdalError, Result};
 use crate::gdal_api::{call_gdal_api, GdalApi};
 use crate::gdal_dyn_bindgen::CE_None;
-use crate::geo_transform::{GeoTransform, GeoTransformEx};
 use crate::vector::geometry::Geometry;
+use sedona_raster::geo_transform::{GeoTransform, GeoTransformEx};
 
 #[repr(C)]
 struct AffineTransformArg {

--- a/c/sedona-gdal/src/warp.rs
+++ b/c/sedona-gdal/src/warp.rs
@@ -30,9 +30,9 @@ use crate::dataset::Dataset;
 use crate::errors::{GdalError, Result};
 use crate::gdal_api::{call_gdal_api, GdalApi};
 use crate::gdal_dyn_bindgen::{CE_Failure, CE_None};
-use crate::geo_transform::GeoTransform;
 use crate::raster::types::ResampleAlg;
 use crate::spatial_ref::SpatialRef;
+use sedona_raster::geo_transform::GeoTransform;
 
 /// Reproject/warp `src` into the already-created `dst` dataset.
 ///

--- a/rust/sedona-raster-functions/src/rs_georeference.rs
+++ b/rust/sedona-raster-functions/src/rs_georeference.rs
@@ -26,7 +26,6 @@ use datafusion_common::DataFusionError;
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_raster::affine_transformation::AffineMatrix;
-use sedona_raster::traits::RasterRef;
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
 
 /// RS_GeoReference() scalar UDF implementation
@@ -171,12 +170,15 @@ fn format_georeference(
     match raster_opt {
         None => builder.append_null(),
         Some(raster) => {
-            let scale_x = raster.transform()[1];
-            let scale_y = raster.transform()[5];
-            let skew_x = raster.transform()[2];
-            let skew_y = raster.transform()[4];
-            let upper_left_x = raster.transform()[0];
-            let upper_left_y = raster.transform()[3];
+            let affine = AffineMatrix::from_raster(raster);
+            let AffineMatrix {
+                offset_x: upper_left_x,
+                offset_y: upper_left_y,
+                scale_x,
+                scale_y,
+                skew_x,
+                skew_y,
+            } = affine;
 
             let georeference = match format {
                 GeoReferenceFormat::Gdal => {
@@ -188,7 +190,6 @@ fn format_georeference(
                 GeoReferenceFormat::Esri => {
                     // World coordinates of pixel-space (0.5, 0.5) — the full
                     // affine keeps the center shift exact under skew.
-                    let affine = AffineMatrix::from_raster(raster);
                     let (esri_upper_left_x, esri_upper_left_y) = affine.transform(0.5, 0.5);
                     format!(
                         "{:.10}\n{:.10}\n{:.10}\n{:.10}\n{:.10}\n{:.10}",

--- a/rust/sedona-raster-functions/src/rs_georeference.rs
+++ b/rust/sedona-raster-functions/src/rs_georeference.rs
@@ -25,7 +25,8 @@ use datafusion_common::error::Result;
 use datafusion_common::DataFusionError;
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
-use sedona_raster::affine_transformation::AffineMatrix;
+use sedona_raster::geo_transform::GeoTransformEx;
+use sedona_raster::traits::RasterRef;
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
 
 /// RS_GeoReference() scalar UDF implementation
@@ -170,15 +171,15 @@ fn format_georeference(
     match raster_opt {
         None => builder.append_null(),
         Some(raster) => {
-            let affine = AffineMatrix::from_raster(raster);
-            let AffineMatrix {
-                offset_x: upper_left_x,
-                offset_y: upper_left_y,
-                scale_x,
-                scale_y,
-                skew_x,
-                skew_y,
-            } = affine;
+            let gt = raster.transform();
+            let (scale_x, scale_y, skew_x, skew_y, upper_left_x, upper_left_y) = (
+                gt.scale_x(),
+                gt.scale_y(),
+                gt.skew_x(),
+                gt.skew_y(),
+                gt.origin_x(),
+                gt.origin_y(),
+            );
 
             let georeference = match format {
                 GeoReferenceFormat::Gdal => {
@@ -190,7 +191,7 @@ fn format_georeference(
                 GeoReferenceFormat::Esri => {
                     // World coordinates of pixel-space (0.5, 0.5) — the full
                     // affine keeps the center shift exact under skew.
-                    let (esri_upper_left_x, esri_upper_left_y) = affine.transform(0.5, 0.5);
+                    let (esri_upper_left_x, esri_upper_left_y) = gt.apply(0.5, 0.5);
                     format!(
                         "{:.10}\n{:.10}\n{:.10}\n{:.10}\n{:.10}\n{:.10}",
                         scale_x, skew_y, skew_x, scale_y, esri_upper_left_x, esri_upper_left_y

--- a/rust/sedona-raster-functions/src/rs_pixel_functions.rs
+++ b/rust/sedona-raster-functions/src/rs_pixel_functions.rs
@@ -28,7 +28,8 @@ use sedona_expr::item_crs::make_item_crs;
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_geometry::types::Edges;
 use sedona_geometry::wkb_factory::{write_wkb_point, write_wkb_polygon, WKB_MIN_PROBABLE_BYTES};
-use sedona_raster::affine_transformation::{to_world_coordinate, AffineMatrix};
+use sedona_raster::affine_transformation::to_world_coordinate;
+use sedona_raster::geo_transform::GeoTransformEx;
 use sedona_raster::traits::RasterRef;
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
 
@@ -191,8 +192,7 @@ impl SedonaScalarKernel for RsPixelAsCentroid {
                     let grid_x = (col_x - 1) as f64 + 0.5;
                     let grid_y = (row_y - 1) as f64 + 0.5;
 
-                    let affine = AffineMatrix::from_raster(raster);
-                    let (wx, wy) = affine.transform(grid_x, grid_y);
+                    let (wx, wy) = raster.transform().apply(grid_x, grid_y);
 
                     write_wkb_point(&mut builder, (wx, wy))
                         .map_err(|e| DataFusionError::External(e.into()))?;

--- a/rust/sedona-raster-functions/src/rs_set_georeference.rs
+++ b/rust/sedona-raster-functions/src/rs_set_georeference.rs
@@ -160,7 +160,7 @@ impl SedonaScalarKernel for RsSetGeoReference {
 /// coordinates are pixel-center and shifted back to the corner.
 ///
 /// The stringly-typed six-value format is a bit unwieldy; a future dedicated
-/// affine-matrix type (cf. `sedona_raster::affine_transformation::AffineMatrix`,
+/// affine-matrix input type (cf. `sedona_raster::geo_transform::GeoTransform`,
 /// which could also back `ST_Affine`) would be a cleaner input.
 fn parse_georeference(georef: &str, format: GeoReferenceFormat) -> Result<[f64; 6]> {
     let values: Vec<f64> = georef

--- a/rust/sedona-raster-functions/src/rs_value.rs
+++ b/rust/sedona-raster-functions/src/rs_value.rs
@@ -43,7 +43,6 @@ use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_geometry::transform::CrsTransform;
 use sedona_geometry::wkb_header::read_point_xy;
-use sedona_raster::affine_transformation::AffineMatrix;
 use sedona_raster::array::RasterStructArray;
 use sedona_raster::traits::RasterRef;
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
@@ -179,8 +178,8 @@ impl RsValuePoint {
                     return Ok(());
                 };
 
-                let affine = AffineMatrix::from_raster(raster);
-                match xy_to_pixel("RS_Value", &affine, x, y)? {
+                let transform = raster.transform();
+                match xy_to_pixel("RS_Value", transform, x, y)? {
                     Some((col, row)) => match sample_pixel(raster, col, row, band_num)? {
                         Some(value) => builder.append_value(value),
                         None => builder.append_null(),
@@ -260,7 +259,7 @@ impl RsValuePoint {
             .transpose()?;
 
         // Affine transform and raster CRS, resolved once for all points.
-        let affine = AffineMatrix::from_raster(&raster);
+        let transform = raster.transform();
         let raster_crs = resolve_crs(raster.crs())?;
 
         let mut geom = executor.make_geom_wkb_crs_accessor(1)?;
@@ -343,14 +342,14 @@ impl RsValuePoint {
                     .nodata_as_f64()
                     .map_err(|e| exec_datafusion_err!("RS_Value: {e}"))?;
                 for (i, x, y, _band) in selection {
-                    if let Some((col, row)) = xy_to_pixel("RS_Value", &affine, x, y)? {
+                    if let Some((col, row)) = xy_to_pixel("RS_Value", transform, x, y)? {
                         out[i] = read_pixel("RS_Value", &buffer, nodata, col, row)?;
                     }
                 }
             }
             None => {
                 for (i, x, y, band_num) in selection {
-                    if let Some((col, row)) = xy_to_pixel("RS_Value", &affine, x, y)? {
+                    if let Some((col, row)) = xy_to_pixel("RS_Value", transform, x, y)? {
                         out[i] = sample_pixel(&raster, col, row, band_num)?;
                     }
                 }
@@ -818,30 +817,31 @@ mod tests {
     #[test]
     fn non_finite_point_ordinate_is_none() {
         // A point with a NaN/Inf ordinate (e.g. POINT(NaN 5)) has no location to
-        // sample. Without the finite guard a NaN survives `inv_transform` and the
+        // sample. Without the finite guard a NaN survives the inverse transform and the
         // saturating cast turns it into pixel column 0, silently sampling a value.
         let raster = RasterSpec::d2(2, 2)
             .band_values(&[1u8, 2, 3, 4])
             .bbox(0.0, 8.0, 2.0, 10.0)
             .build();
         let rasters = RasterStructArray::try_new(&raster).unwrap();
-        let affine = AffineMatrix::from_raster(&rasters.get(0).unwrap());
+        let raster0 = rasters.get(0).unwrap();
+        let transform = raster0.transform();
 
         assert_eq!(
-            xy_to_pixel("RS_Value", &affine, f64::NAN, 5.0).unwrap(),
+            xy_to_pixel("RS_Value", transform, f64::NAN, 5.0).unwrap(),
             None
         );
         assert_eq!(
-            xy_to_pixel("RS_Value", &affine, 5.0, f64::NAN).unwrap(),
+            xy_to_pixel("RS_Value", transform, 5.0, f64::NAN).unwrap(),
             None
         );
         assert_eq!(
-            xy_to_pixel("RS_Value", &affine, f64::INFINITY, 5.0).unwrap(),
+            xy_to_pixel("RS_Value", transform, f64::INFINITY, 5.0).unwrap(),
             None
         );
         // A finite in-bounds point still maps to a real pixel.
         assert_eq!(
-            xy_to_pixel("RS_Value", &affine, 0.5, 9.5).unwrap(),
+            xy_to_pixel("RS_Value", transform, 0.5, 9.5).unwrap(),
             Some((0, 0))
         );
     }

--- a/rust/sedona-raster-functions/src/rs_values.rs
+++ b/rust/sedona-raster-functions/src/rs_values.rs
@@ -47,7 +47,6 @@ use datafusion_common::config::ConfigOptions;
 use datafusion_common::{exec_datafusion_err, exec_err, Result, ScalarValue};
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
-use sedona_raster::affine_transformation::AffineMatrix;
 use sedona_raster::array::RasterStructArray;
 use sedona_raster::traits::{BandRef, NdBuffer, RasterRef};
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
@@ -192,7 +191,7 @@ impl RsValues {
                 let nodata = band
                     .nodata_as_f64()
                     .map_err(|e| exec_datafusion_err!("RS_Values: {e}"))?;
-                let affine = AffineMatrix::from_raster(raster);
+                let transform = raster.transform();
 
                 // Sample each sub-point in one pass: the visitor transforms
                 // each coordinate into the raster CRS in place, so there is no
@@ -200,7 +199,7 @@ impl RsValues {
                 let trans =
                     point_crs_transform("RS_Values", geom_crs, raster_crs.as_deref(), engine)?;
                 visit_points("RS_Values", geom_wkb, trans.as_deref(), |xy| {
-                    append_sample(xy, &affine, &buffer, nodata, &mut list_builder)
+                    append_sample(xy, transform, &buffer, nodata, &mut list_builder)
                 })?;
                 list_builder.append(true);
                 Ok(())
@@ -280,7 +279,7 @@ impl RsValues {
             .transpose()?;
 
         // Affine transform and raster CRS, resolved once for all rows.
-        let affine = AffineMatrix::from_raster(&raster);
+        let transform = raster.transform();
         let raster_crs = resolve_crs(raster.crs())?;
 
         let mut geom = executor.make_geom_wkb_crs_accessor(1)?;
@@ -366,7 +365,7 @@ impl RsValues {
                         continue;
                     };
                     for xy in &coords[*start..*start + *len] {
-                        append_sample(*xy, &affine, &buffer, nodata, &mut list_builder)?;
+                        append_sample(*xy, transform, &buffer, nodata, &mut list_builder)?;
                     }
                     list_builder.append(true);
                 }
@@ -385,7 +384,7 @@ impl RsValues {
                         .nodata_as_f64()
                         .map_err(|e| exec_datafusion_err!("RS_Values: {e}"))?;
                     for xy in &coords[*start..*start + *len] {
-                        append_sample(*xy, &affine, &buffer, nodata, &mut list_builder)?;
+                        append_sample(*xy, transform, &buffer, nodata, &mut list_builder)?;
                     }
                     list_builder.append(true);
                 }
@@ -417,13 +416,13 @@ fn resolve_band_2d<'a>(
 /// out-of-bounds/nodata pixels both append a NULL element.
 fn append_sample(
     xy: Option<(f64, f64)>,
-    affine: &AffineMatrix,
+    transform: &[f64],
     buffer: &NdBuffer,
     nodata: Option<f64>,
     list_builder: &mut ListBuilder<Float64Builder>,
 ) -> Result<()> {
     let sample = match xy {
-        Some((x, y)) => match xy_to_pixel("RS_Values", affine, x, y)? {
+        Some((x, y)) => match xy_to_pixel("RS_Values", transform, x, y)? {
             Some((col, row)) => read_pixel("RS_Values", buffer, nodata, col, row)?,
             None => None,
         },

--- a/rust/sedona-raster-functions/src/sampling.rs
+++ b/rust/sedona-raster-functions/src/sampling.rs
@@ -33,7 +33,7 @@ use datafusion_common::{exec_datafusion_err, exec_err, DataFusionError, Result};
 use datafusion_expr::ColumnarValue;
 use sedona_geometry::error::SedonaGeometryError;
 use sedona_geometry::transform::{visit_point_coords, CrsEngine, CrsTransform};
-use sedona_raster::affine_transformation::AffineMatrix;
+use sedona_raster::geo_transform::GeoTransformEx;
 use sedona_raster::traits::{nodata_bytes_to_f64_lossless, NdBuffer};
 use sedona_schema::crs::CrsRef;
 use sedona_schema::datatypes::SedonaType;
@@ -179,22 +179,23 @@ pub(crate) fn visit_points(
 /// or `None` when the coordinate has no location to sample.
 ///
 /// A non-finite coordinate (e.g. `POINT(NaN 5)`) returns `None`: without this
-/// guard a NaN would survive `inv_transform` and the saturating `f64 -> i64`
-/// cast would turn it into 0 (in bounds), silently sampling pixel column 0
-/// rather than yielding NULL. `func` names the calling UDF for the error
-/// message.
+/// guard a NaN would survive the inverse transform and the saturating
+/// `f64 -> i64` cast would turn it into 0 (in bounds), silently sampling pixel
+/// column 0 rather than yielding NULL. `func` names the calling UDF for the
+/// error message.
 pub(crate) fn xy_to_pixel(
     func: &str,
-    affine: &AffineMatrix,
+    transform: &[f64],
     x: f64,
     y: f64,
 ) -> Result<Option<(i64, i64)>> {
     if !x.is_finite() || !y.is_finite() {
         return Ok(None);
     }
-    let (raster_x, raster_y) = affine
-        .inv_transform(x, y)
-        .map_err(|e| exec_datafusion_err!("{func}: {e}"))?;
+    let inverse = transform.invert().map_err(|_| {
+        exec_datafusion_err!("{func}: Cannot compute coordinate: determinant is zero.")
+    })?;
+    let (raster_x, raster_y) = inverse.apply(x, y);
     // Floor (not truncate toward zero) so a point just outside the top/left edge
     // maps to a negative index and is rejected as out of bounds, rather than
     // truncating to 0 and sampling an edge pixel. The `f64 -> i64` cast saturates

--- a/rust/sedona-raster-gdal/src/gdal_common.rs
+++ b/rust/sedona-raster-gdal/src/gdal_common.rs
@@ -19,11 +19,11 @@ use sedona_gdal::dataset::Dataset;
 use sedona_gdal::errors::GdalError;
 use sedona_gdal::gdal::Gdal;
 use sedona_gdal::gdal_dyn_bindgen::{GDAL_OF_RASTER, GDAL_OF_READONLY, GDAL_OF_VERBOSE_ERROR};
-use sedona_gdal::geo_transform::GeoTransform;
 use sedona_gdal::mem::MemDatasetBuilder;
 use sedona_gdal::raster::rasterband::RasterBand;
 use sedona_gdal::raster::types::DatasetOptions;
 use sedona_gdal::raster::types::GdalDataType;
+use sedona_raster::geo_transform::GeoTransform;
 
 use sedona_raster::traits::{is_spatial_dim_pair, RasterRef};
 use sedona_schema::raster::BandDataType;

--- a/rust/sedona-raster-gdal/src/gdal_dataset_provider.rs
+++ b/rust/sedona-raster-gdal/src/gdal_dataset_provider.rs
@@ -25,8 +25,8 @@ use datafusion_common::{
 
 use sedona_gdal::dataset::Dataset;
 use sedona_gdal::gdal::Gdal;
-use sedona_gdal::geo_transform::{GeoTransform, GeoTransformEx};
 use sedona_gdal::raster::types::GdalDataType;
+use sedona_raster::geo_transform::{GeoTransform, GeoTransformEx};
 
 use sedona_common::SedonaOptions;
 use sedona_raster::traits::{split_outdb_band_fragment, RasterRef};

--- a/rust/sedona-raster-gdal/src/mask.rs
+++ b/rust/sedona-raster-gdal/src/mask.rs
@@ -28,10 +28,10 @@
 
 use datafusion_common::{exec_datafusion_err, Result};
 use sedona_gdal::gdal::Gdal;
-use sedona_gdal::geo_transform::{GeoTransform, GeoTransformEx};
 use sedona_gdal::mem::MemDatasetBuilder;
 use sedona_gdal::raster::types::GdalDataType;
 use sedona_gdal::vector::geometry::Geometry;
+use sedona_raster::geo_transform::{GeoTransform, GeoTransformEx};
 
 /// A rectangular pixel window (offset + size) into a raster grid.
 #[derive(Debug, Clone, Copy)]

--- a/rust/sedona-raster-gdal/src/rs_reproject_match.rs
+++ b/rust/sedona-raster-gdal/src/rs_reproject_match.rs
@@ -44,10 +44,10 @@ use datafusion_expr::{ColumnarValue, Volatility};
 
 use sedona_common::{sedona_internal_err, SedonaOptions};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
-use sedona_gdal::geo_transform::GeoTransform;
 use sedona_gdal::raster::types::ResampleAlg;
 use sedona_raster::array::RasterRefImpl;
 use sedona_raster::builder::RasterBuilder;
+use sedona_raster::geo_transform::GeoTransform;
 use sedona_raster::traits::RasterRef;
 use sedona_raster_functions::rs_ensure_loaded::{
     NEEDS_PIXELS_METADATA_KEY, RETURNS_BYTES_METADATA_KEY,

--- a/rust/sedona-raster-gdal/src/rs_resample.rs
+++ b/rust/sedona-raster-gdal/src/rs_resample.rs
@@ -52,10 +52,10 @@ use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_common::sedona_internal_err;
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_gdal::gdal::Gdal;
-use sedona_gdal::geo_transform::{GeoTransform, GeoTransformEx};
 use sedona_gdal::raster::types::ResampleAlg;
 use sedona_raster::array::RasterRefImpl;
 use sedona_raster::builder::RasterBuilder;
+use sedona_raster::geo_transform::{GeoTransform, GeoTransformEx};
 use sedona_raster::traits::RasterRef;
 use sedona_raster_functions::crs_utils::{crs_transform_required, resolve_crs};
 use sedona_raster_functions::rs_ensure_loaded::{

--- a/rust/sedona-raster-gdal/src/rs_tile.rs
+++ b/rust/sedona-raster-gdal/src/rs_tile.rs
@@ -42,9 +42,9 @@ use datafusion_expr::{ColumnarValue, Volatility};
 
 use sedona_common::sedona_internal_err;
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
-use sedona_gdal::geo_transform::{GeoTransform, GeoTransformEx};
 use sedona_raster::array::RasterRefImpl;
 use sedona_raster::builder::RasterBuilder;
+use sedona_raster::geo_transform::{GeoTransform, GeoTransformEx};
 use sedona_raster::traits::{is_spatial_dim_pair, nodata_f64_to_bytes, Bands, RasterRef};
 use sedona_raster_functions::rs_ensure_loaded::NEEDS_PIXELS_METADATA_KEY;
 use sedona_raster_functions::RasterExecutor;

--- a/rust/sedona-raster-gdal/src/utils.rs
+++ b/rust/sedona-raster-gdal/src/utils.rs
@@ -24,11 +24,11 @@ use datafusion_common::{exec_datafusion_err, exec_err};
 use sedona_gdal::dataset::Dataset;
 use sedona_gdal::gdal::Gdal;
 use sedona_gdal::gdal_dyn_bindgen::{GDAL_OF_RASTER, GDAL_OF_READONLY};
-use sedona_gdal::geo_transform::{GeoTransform, GeoTransformEx};
 use sedona_gdal::mem::MemDatasetBuilder;
 use sedona_gdal::raster::types::DatasetOptions;
 use sedona_gdal::raster::types::ResampleAlg;
 use sedona_gdal::spatial_ref::SpatialRef;
+use sedona_raster::geo_transform::{GeoTransform, GeoTransformEx};
 
 use arrow_schema::ArrowError;
 use sedona_raster::array::RasterRefImpl;

--- a/rust/sedona-raster-zarr/src/geozarr.rs
+++ b/rust/sedona-raster-zarr/src/geozarr.rs
@@ -54,7 +54,7 @@ pub struct GroupGeoMetadata {
     /// to derive a transform when no explicit `spatial:transform` is present.
     /// The grid shape is read from the array itself (not a separate
     /// `spatial:shape` attribute, which could drift from the real shape), so the
-    /// loader supplies it to `AffineMatrix::from_bbox_and_spatial_shape`.
+    /// loader supplies it to `geotransform_from_bbox_and_spatial_shape`.
     pub bbox: Option<[f64; 4]>,
     /// `spatial:registration` — `"pixel"` or `"node"`; `None` defaults to
     /// `"pixel"`. Governs how `bbox` maps to the grid (outer edge vs. cell
@@ -231,7 +231,7 @@ fn parse_transform(
 
 /// Parse the optional `spatial:bbox` attribute into `[xmin, ymin, xmax, ymax]`.
 /// `None` when absent. The grid shape is *not* read from `spatial:shape`; the
-/// loader supplies the array's own shape to `AffineMatrix::from_bbox_and_spatial_shape`.
+/// loader supplies the array's own shape to `geotransform_from_bbox_and_spatial_shape`.
 ///
 /// A malformed `spatial:bbox` (not a 4-element numeric array) is treated as
 /// absent — it warns and returns `None` rather than failing the load, so the
@@ -255,7 +255,7 @@ fn parse_bbox(attrs: &serde_json::Map<String, serde_json::Value>) -> Option<[f64
 }
 
 /// Parse the optional `spatial:registration` attribute (a string). `Ok(None)`
-/// when absent; `AffineMatrix::from_bbox_and_spatial_shape` then defaults to `"pixel"`.
+/// when absent; `geotransform_from_bbox_and_spatial_shape` then defaults to `"pixel"`.
 fn parse_registration(
     attrs: &serde_json::Map<String, serde_json::Value>,
 ) -> Result<Option<String>, ArrowError> {

--- a/rust/sedona-raster-zarr/src/loader.rs
+++ b/rust/sedona-raster-zarr/src/loader.rs
@@ -29,8 +29,8 @@ use std::sync::Arc;
 use arrow_array::{RecordBatch, RecordBatchReader};
 use arrow_schema::{ArrowError, Schema, SchemaRef};
 use sedona_common::sedona_internal_datafusion_err;
-use sedona_raster::affine_transformation::AffineMatrix;
 use sedona_raster::builder::RasterBuilder;
+use sedona_raster::geo_transform::geotransform_from_bbox_and_spatial_shape;
 use sedona_raster::traits::is_spatial_dim_pair;
 use sedona_schema::datatypes::SedonaType;
 use sedona_schema::raster::BandDataType;
@@ -457,13 +457,9 @@ fn transform_from_bbox(
     let bbox = geo.bbox?;
     let height = array_infos[0].shape[y_axis];
     let width = array_infos[0].shape[x_axis];
-    match AffineMatrix::from_bbox_and_spatial_shape(
-        bbox,
-        height,
-        width,
-        geo.registration.as_deref(),
-    ) {
-        Ok(matrix) => {
+    match geotransform_from_bbox_and_spatial_shape(bbox, height, width, geo.registration.as_deref())
+    {
+        Ok(gt) => {
             // Mirror the coordinate-array path: when the group declares no CRS,
             // infer a geographic one from the spatial dim names (lat/lon).
             // Generic y/x stay CRS-less (attach via RS_SetCRS).
@@ -479,7 +475,7 @@ fn transform_from_bbox(
                 "Zarr group at {group_uri} has no `spatial:transform`; derived a \
                  geotransform from `spatial:bbox` and the {height}x{width} array shape"
             );
-            Some(matrix.to_gdal_geotransform())
+            Some(gt)
         }
         Err(e) => {
             log::warn!(

--- a/rust/sedona-raster/src/affine_transformation.rs
+++ b/rust/sedona-raster/src/affine_transformation.rs
@@ -15,174 +15,23 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::geo_transform::{GeoTransform, GeoTransformEx};
+//! Raster ↔ world coordinate helpers built on [`GeoTransformEx`].
+//!
+//! These convenience wrappers read a raster's [`GeoTransform`] once (via
+//! [`RasterRef::transform`]) and apply/invert it. The affine math itself lives
+//! in [`crate::geo_transform`]; there is exactly one `apply`/`invert`
+//! implementation.
+//!
+//! [`GeoTransform`]: crate::geo_transform::GeoTransform
+
+use crate::geo_transform::GeoTransformEx;
 use crate::traits::RasterRef;
 use arrow_schema::ArrowError;
-
-/// Pre-computed affine transformation coefficients extracted from raster metadata.
-///
-/// Constructing this struct pays the cost of reading metadata once (which may involve
-/// vtable dispatch for Arrow-backed rasters). Subsequent `transform` / `inv_transform`
-/// calls are pure arithmetic with no virtual calls.
-#[derive(Debug, Clone)]
-pub struct AffineMatrix {
-    pub offset_x: f64,
-    pub offset_y: f64,
-    pub scale_x: f64,
-    pub scale_y: f64,
-    pub skew_x: f64,
-    pub skew_y: f64,
-}
-
-impl AffineMatrix {
-    /// Build an `AffineMatrix` from a raster's 6-element GDAL geotransform
-    /// (`[origin_x, scale_x, skew_x, origin_y, skew_y, scale_y]`).
-    #[inline]
-    pub fn from_raster(raster: &dyn RasterRef) -> Self {
-        let t = raster.transform();
-        Self {
-            offset_x: t[0],
-            scale_x: t[1],
-            skew_x: t[2],
-            offset_y: t[3],
-            skew_y: t[4],
-            scale_y: t[5],
-        }
-    }
-
-    /// Derive a north-up `AffineMatrix` from a spatial bounding box and the
-    /// grid's spatial shape.
-    ///
-    /// `bbox` is `[xmin, ymin, xmax, ymax]`; `height` and `width` are the number
-    /// of cells along the y and x axes. `registration` controls how the bbox
-    /// maps to the grid and defaults to `"pixel"` when `None`:
-    /// - `"pixel"` (cell-area): the bbox is the grid's outer edge, spanning all
-    ///   N cells, so the top-left corner is the bbox edge. Matches
-    ///   `rasterio.transform.from_bounds`.
-    /// - `"node"` (cell-center): the bbox endpoints are the centers of the
-    ///   border cells, so N centers span N-1 intervals and the footprint extends
-    ///   half a cell beyond the bbox.
-    ///
-    /// The result is axis-aligned (zero skews) with a negative `scale_y` (rows
-    /// increase downward). Errors on a degenerate/inverted bbox, a zero
-    /// dimension, a node-registered grid smaller than 2 cells, or an unknown
-    /// registration.
-    pub fn from_bbox_and_spatial_shape(
-        bbox: [f64; 4],
-        height: u64,
-        width: u64,
-        registration: Option<&str>,
-    ) -> Result<Self, ArrowError> {
-        let [xmin, ymin, xmax, ymax] = bbox;
-        // Reject a degenerate or inverted bbox: a zero span gives a
-        // non-invertible (zero-scale) transform and a negative span isn't
-        // north-up.
-        if !(xmax > xmin && ymax > ymin) {
-            return Err(ArrowError::InvalidArgumentError(format!(
-                "bbox must have xmin < xmax and ymin < ymax; got [{xmin}, {ymin}, {xmax}, {ymax}]"
-            )));
-        }
-        // A real raster axis is at least 1 cell.
-        if height == 0 || width == 0 {
-            return Err(ArrowError::InvalidArgumentError(
-                "raster spatial dimensions must be non-zero to derive a transform from a bbox"
-                    .into(),
-            ));
-        }
-        let (height, width) = (height as f64, width as f64);
-
-        // cell-area registration is the conventional default.
-        let registration = registration.unwrap_or("pixel");
-        // scale_y is negative throughout: rows increase downward.
-        let (scale_x, scale_y, offset_x, offset_y) = match registration {
-            // Pixel-registered: the bbox is the grid's outer edge, spanning all
-            // N cells, so the top-left corner is the bbox edge.
-            "pixel" => {
-                let scale_x = (xmax - xmin) / width;
-                let scale_y = (ymin - ymax) / height;
-                (scale_x, scale_y, xmin, ymax)
-            }
-            // Node-registered: the bbox endpoints are the *centers* of the border
-            // cells, so N centers span N-1 intervals and the footprint extends
-            // half a cell beyond — the corner sits half a cell outside the bbox.
-            "node" => {
-                if width < 2.0 || height < 2.0 {
-                    return Err(ArrowError::InvalidArgumentError(
-                        "node-registered grid must be at least 2 cells in each spatial dimension"
-                            .into(),
-                    ));
-                }
-                let scale_x = (xmax - xmin) / (width - 1.0);
-                let scale_y = (ymin - ymax) / (height - 1.0);
-                (scale_x, scale_y, xmin - scale_x / 2.0, ymax - scale_y / 2.0)
-            }
-            other => {
-                return Err(ArrowError::InvalidArgumentError(format!(
-                    "registration must be \"pixel\" or \"node\"; got {other:?}"
-                )))
-            }
-        };
-
-        Ok(Self {
-            offset_x,
-            offset_y,
-            scale_x,
-            scale_y,
-            skew_x: 0.0,
-            skew_y: 0.0,
-        })
-    }
-
-    /// The coefficients in GDAL [`GeoTransform`] order:
-    /// `[origin_x, scale_x, skew_x, origin_y, skew_y, scale_y]`.
-    #[inline]
-    pub fn to_gdal_geotransform(&self) -> GeoTransform {
-        [
-            self.offset_x,
-            self.scale_x,
-            self.skew_x,
-            self.offset_y,
-            self.skew_y,
-            self.scale_y,
-        ]
-    }
-
-    /// Forward affine transform: pixel (x, y) → world (wx, wy).
-    ///
-    /// Accepts `f64` coordinates so callers can pass fractional offsets
-    /// (e.g. +0.5 for pixel centroids) without duplicating the math. Delegates
-    /// to the single [`GeoTransformEx::apply`] implementation.
-    #[inline]
-    pub fn transform(&self, x: f64, y: f64) -> (f64, f64) {
-        self.to_gdal_geotransform().apply(x, y)
-    }
-
-    /// Inverse affine transform: world (wx, wy) → pixel (x, y).
-    ///
-    /// Inverts the geo-transform via the single [`GeoTransformEx::invert`]
-    /// implementation, then applies the inverse. Returns an error if the
-    /// determinant is zero (singular matrix).
-    #[inline]
-    pub fn inv_transform(&self, world_x: f64, world_y: f64) -> Result<(f64, f64), ArrowError> {
-        let inverse = self.to_gdal_geotransform().invert().map_err(|_| {
-            ArrowError::InvalidArgumentError(
-                "Cannot compute coordinate: determinant is zero.".to_string(),
-            )
-        })?;
-        Ok(inverse.apply(world_x, world_y))
-    }
-
-    /// Rotation angle (radians) implied by the affine coefficients.
-    #[inline]
-    pub fn rotation(&self) -> f64 {
-        (-self.skew_x).atan2(self.scale_x)
-    }
-}
 
 /// Computes the rotation angle (in radians) of the raster based on its geotransform metadata.
 #[inline]
 pub fn rotation(raster: &dyn RasterRef) -> f64 {
-    AffineMatrix::from_raster(raster).rotation()
+    raster.transform().rotation()
 }
 
 /// Performs an affine transformation on the provided x and y coordinates based on the geotransform
@@ -194,7 +43,7 @@ pub fn rotation(raster: &dyn RasterRef) -> f64 {
 /// * `y` - Y coordinate in pixel space (row)
 #[inline]
 pub fn to_world_coordinate(raster: &dyn RasterRef, x: i64, y: i64) -> (f64, f64) {
-    AffineMatrix::from_raster(raster).transform(x as f64, y as f64)
+    raster.transform().apply(x as f64, y as f64)
 }
 
 /// Performs the inverse affine transformation to convert world coordinates back to raster pixel coordinates.
@@ -209,7 +58,12 @@ pub fn to_raster_coordinate(
     world_x: f64,
     world_y: f64,
 ) -> Result<(i64, i64), ArrowError> {
-    let (rx, ry) = AffineMatrix::from_raster(raster).inv_transform(world_x, world_y)?;
+    let inverse = raster.transform().invert().map_err(|_| {
+        ArrowError::InvalidArgumentError(
+            "Cannot compute coordinate: determinant is zero.".to_string(),
+        )
+    })?;
+    let (rx, ry) = inverse.apply(world_x, world_y);
     Ok((rx as i64, ry as i64))
 }
 
@@ -353,191 +207,5 @@ mod tests {
             transform: [0.0, scale_x, skew_x, 0.0, skew_y, scale_y],
             spatial_shape: [10, 20],
         }
-    }
-
-    fn test_affine() -> AffineMatrix {
-        AffineMatrix {
-            offset_x: 100.0,
-            offset_y: 200.0,
-            scale_x: 1.0,
-            scale_y: -2.0,
-            skew_x: 0.25,
-            skew_y: 0.5,
-        }
-    }
-
-    #[test]
-    fn test_affine_transform() {
-        let a = test_affine();
-        let (wx, wy) = a.transform(0.5, 0.5);
-        assert_relative_eq!(wx, 100.625, epsilon = 1e-10);
-        assert_relative_eq!(wy, 199.25, epsilon = 1e-10);
-    }
-
-    #[test]
-    fn test_affine_round_trip() {
-        let a = test_affine();
-        let coords = [(0.0, 0.0), (5.0, 10.0), (9.0, 19.0), (0.5, 0.5)];
-        for (x, y) in coords {
-            let (wx, wy) = a.transform(x, y);
-            let (rx, ry) = a.inv_transform(wx, wy).unwrap();
-            assert_relative_eq!(rx, x, epsilon = 1e-10);
-            assert_relative_eq!(ry, y, epsilon = 1e-10);
-        }
-    }
-
-    #[test]
-    fn test_affine_inv_transform_singular() {
-        let a = AffineMatrix {
-            offset_x: 0.0,
-            offset_y: 0.0,
-            scale_x: 1.0,
-            scale_y: 0.0,
-            skew_x: 0.0,
-            skew_y: 0.0,
-        };
-        let result = a.inv_transform(0.0, 0.0);
-        assert!(result.is_err());
-        assert!(result
-            .err()
-            .unwrap()
-            .to_string()
-            .contains("determinant is zero."));
-    }
-
-    #[test]
-    fn test_affine_rotation() {
-        let a = AffineMatrix {
-            offset_x: 0.0,
-            offset_y: 0.0,
-            scale_x: FRAC_1_SQRT_2,
-            scale_y: FRAC_1_SQRT_2,
-            skew_x: -FRAC_1_SQRT_2,
-            skew_y: FRAC_1_SQRT_2,
-        };
-        assert_relative_eq!(a.rotation(), PI / 4.0, epsilon = 1e-6);
-    }
-
-    #[test]
-    fn test_affine_from_raster() {
-        let raster = TestRaster {
-            transform: [100.0, 1.0, 0.25, 200.0, 0.5, -2.0],
-            spatial_shape: [10, 20],
-        };
-        let a = AffineMatrix::from_raster(&raster);
-        assert_eq!(a.offset_x, 100.0);
-        assert_eq!(a.offset_y, 200.0);
-        assert_eq!(a.scale_x, 1.0);
-        assert_eq!(a.scale_y, -2.0);
-        assert_eq!(a.skew_x, 0.25);
-        assert_eq!(a.skew_y, 0.5);
-    }
-
-    #[test]
-    fn bbox_pixel_registration_derives_transform() {
-        // A bbox over a 1000x1000 grid with "pixel" registration. Height/width
-        // are the array's own dims.
-        let gt = AffineMatrix::from_bbox_and_spatial_shape(
-            [600000.0, 5690000.0, 610000.0, 5700000.0],
-            1000,
-            1000,
-            Some("pixel"),
-        )
-        .unwrap()
-        .to_gdal_geotransform();
-        assert_eq!(gt, [600000.0, 10.0, 0.0, 5700000.0, 0.0, -10.0]);
-    }
-
-    #[test]
-    fn bbox_pixel_registration_matches_rasterio_from_bounds() {
-        // Cross-check against rasterio: for the same bounds and raster size,
-        // `rasterio.transform.from_bounds(west, south, east, north, width, height)`
-        // returns Affine(a, b, c, d, e, f) with a = (east-west)/width = 0.25,
-        // e = (south-north)/height = -0.5, c = west = -100, f = north = 40, and
-        // b = d = 0. In GDAL order that is [c, a, b, f, d, e].
-        let gt =
-            AffineMatrix::from_bbox_and_spatial_shape([-100.0, -10.0, 0.0, 40.0], 100, 400, None)
-                .unwrap()
-                .to_gdal_geotransform();
-        assert_eq!(gt, [-100.0, 0.25, 0.0, 40.0, 0.0, -0.5]);
-    }
-
-    #[test]
-    fn bbox_registration_defaults_to_pixel() {
-        // `None` registration behaves as cell-area ("pixel").
-        let gt = AffineMatrix::from_bbox_and_spatial_shape(
-            [600000.0, 5690000.0, 610000.0, 5700000.0],
-            1000,
-            1000,
-            None,
-        )
-        .unwrap()
-        .to_gdal_geotransform();
-        assert_eq!(gt, [600000.0, 10.0, 0.0, 5700000.0, 0.0, -10.0]);
-    }
-
-    #[test]
-    fn bbox_node_registration_uses_n_minus_1_intervals() {
-        // "node": the bbox endpoints are cell centers, so 11 centers span 10
-        // intervals -> scale = 100 / 10 = 10, and the corner sits half a cell
-        // (5) outside the bbox: origin (-5, 105).
-        let gt = AffineMatrix::from_bbox_and_spatial_shape(
-            [0.0, 0.0, 100.0, 100.0],
-            11,
-            11,
-            Some("node"),
-        )
-        .unwrap()
-        .to_gdal_geotransform();
-        assert_eq!(gt, [-5.0, 10.0, 0.0, 105.0, 0.0, -10.0]);
-    }
-
-    #[test]
-    fn bbox_node_registration_requires_at_least_two_cells() {
-        // A single-cell node grid can't define a spacing from its bbox alone.
-        let err =
-            AffineMatrix::from_bbox_and_spatial_shape([0.0, 0.0, 100.0, 100.0], 1, 1, Some("node"))
-                .unwrap_err()
-                .to_string();
-        assert!(err.contains("at least 2"), "{err}");
-    }
-
-    #[test]
-    fn bbox_unknown_registration_errors() {
-        let err = AffineMatrix::from_bbox_and_spatial_shape(
-            [0.0, 0.0, 100.0, 100.0],
-            10,
-            10,
-            Some("corner"),
-        )
-        .unwrap_err()
-        .to_string();
-        assert!(err.contains("pixel") && err.contains("node"), "{err}");
-    }
-
-    #[test]
-    fn degenerate_or_inverted_bbox_errors() {
-        // Zero x-span (non-invertible) and inverted y (not north-up) are both
-        // rejected.
-        for bbox in [
-            [10.0, 0.0, 10.0, 5.0], // xmin == xmax
-            [0.0, 5.0, 5.0, 0.0],   // ymax < ymin
-        ] {
-            let err = AffineMatrix::from_bbox_and_spatial_shape(bbox, 10, 10, None)
-                .unwrap_err()
-                .to_string();
-            assert!(
-                err.contains("xmin < xmax") || err.contains("ymin < ymax"),
-                "{err}"
-            );
-        }
-    }
-
-    #[test]
-    fn zero_dimension_bbox_errors() {
-        let err = AffineMatrix::from_bbox_and_spatial_shape([0.0, 0.0, 10.0, 10.0], 0, 10, None)
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains("non-zero"), "{err}");
     }
 }

--- a/rust/sedona-raster/src/affine_transformation.rs
+++ b/rust/sedona-raster/src/affine_transformation.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::geo_transform::{GeoTransform, GeoTransformEx};
 use crate::traits::RasterRef;
 use arrow_schema::ArrowError;
 
@@ -132,10 +133,10 @@ impl AffineMatrix {
         })
     }
 
-    /// The coefficients in GDAL `GeoTransform` order:
+    /// The coefficients in GDAL [`GeoTransform`] order:
     /// `[origin_x, scale_x, skew_x, origin_y, skew_y, scale_y]`.
     #[inline]
-    pub fn to_gdal_geotransform(&self) -> [f64; 6] {
+    pub fn to_gdal_geotransform(&self) -> GeoTransform {
         [
             self.offset_x,
             self.scale_x,
@@ -149,39 +150,26 @@ impl AffineMatrix {
     /// Forward affine transform: pixel (x, y) → world (wx, wy).
     ///
     /// Accepts `f64` coordinates so callers can pass fractional offsets
-    /// (e.g. +0.5 for pixel centroids) without duplicating the math.
+    /// (e.g. +0.5 for pixel centroids) without duplicating the math. Delegates
+    /// to the single [`GeoTransformEx::apply`] implementation.
     #[inline]
     pub fn transform(&self, x: f64, y: f64) -> (f64, f64) {
-        let wx = self.offset_x + x * self.scale_x + y * self.skew_x;
-        let wy = self.offset_y + x * self.skew_y + y * self.scale_y;
-        (wx, wy)
+        self.to_gdal_geotransform().apply(x, y)
     }
 
     /// Inverse affine transform: world (wx, wy) → pixel (x, y).
     ///
-    /// Returns an error if the determinant is zero (singular matrix).
+    /// Inverts the geo-transform via the single [`GeoTransformEx::invert`]
+    /// implementation, then applies the inverse. Returns an error if the
+    /// determinant is zero (singular matrix).
     #[inline]
     pub fn inv_transform(&self, world_x: f64, world_y: f64) -> Result<(f64, f64), ArrowError> {
-        let det = self.scale_x * self.scale_y - self.skew_x * self.skew_y;
-
-        if det.abs() < f64::EPSILON {
-            return Err(ArrowError::InvalidArgumentError(
+        let inverse = self.to_gdal_geotransform().invert().map_err(|_| {
+            ArrowError::InvalidArgumentError(
                 "Cannot compute coordinate: determinant is zero.".to_string(),
-            ));
-        }
-
-        let inv_scale_x = self.scale_y / det;
-        let inv_scale_y = self.scale_x / det;
-        let inv_skew_x = -self.skew_x / det;
-        let inv_skew_y = -self.skew_y / det;
-
-        let dx = world_x - self.offset_x;
-        let dy = world_y - self.offset_y;
-
-        let rx = inv_scale_x * dx + inv_skew_x * dy;
-        let ry = inv_skew_y * dx + inv_scale_y * dy;
-
-        Ok((rx, ry))
+            )
+        })?;
+        Ok(inverse.apply(world_x, world_y))
     }
 
     /// Rotation angle (radians) implied by the affine coefficients.
@@ -194,8 +182,7 @@ impl AffineMatrix {
 /// Computes the rotation angle (in radians) of the raster based on its geotransform metadata.
 #[inline]
 pub fn rotation(raster: &dyn RasterRef) -> f64 {
-    let t = raster.transform();
-    (-t[2]).atan2(t[1])
+    AffineMatrix::from_raster(raster).rotation()
 }
 
 /// Performs an affine transformation on the provided x and y coordinates based on the geotransform

--- a/rust/sedona-raster/src/geo_transform.rs
+++ b/rust/sedona-raster/src/geo_transform.rs
@@ -27,9 +27,12 @@
 //! thread-local state is needed.
 //!
 //! This is the single home for the six-coefficient affine geo-transform used
-//! across the raster stack (GDAL, Zarr, and the `RS_` functions). The richer
-//! [`AffineMatrix`](crate::affine_transformation::AffineMatrix) is built on top
-//! of this trait so there is exactly one `apply`/`invert` implementation.
+//! across the raster stack (GDAL, Zarr, and the `RS_` functions). Callers work
+//! directly on the `[f64; 6]` a raster stores — [`RasterRef::transform`] returns
+//! a `&[f64]`, so [`GeoTransformEx`] is implemented on `[f64]` and its named
+//! accessors ([`scale_x`](GeoTransformEx::scale_x), ...) replace magic indices.
+//!
+//! [`RasterRef::transform`]: crate::traits::RasterRef::transform
 
 use arrow_schema::ArrowError;
 
@@ -43,7 +46,13 @@ use arrow_schema::ArrowError;
 /// - `[5]`: N-S pixel resolution (pixel height, negative for North-up).
 pub type GeoTransform = [f64; 6];
 
-/// Extension methods on [`GeoTransform`].
+/// Extension methods on a six-coefficient GDAL geo-transform.
+///
+/// Implemented on `[f64]` so it applies both to an owned [`GeoTransform`]
+/// (`[f64; 6]`) and to the `&[f64]` returned by
+/// [`RasterRef::transform`](crate::traits::RasterRef::transform). The accessors
+/// panic on a slice shorter than six elements, matching the "rasters carry a
+/// 6-element geo-transform" invariant.
 pub trait GeoTransformEx {
     /// Apply the geo-transform to a pixel/line coordinate, returning (geo_x, geo_y).
     fn apply(&self, x: f64, y: f64) -> (f64, f64);
@@ -51,9 +60,25 @@ pub trait GeoTransformEx {
     /// Invert this geo-transform, returning the inverse coefficients for
     /// computing (geo_x, geo_y) -> (x, y) transformations.
     fn invert(&self) -> Result<GeoTransform, ArrowError>;
+
+    /// Rotation angle (radians) implied by the coefficients.
+    fn rotation(&self) -> f64;
+
+    /// x-coordinate of the upper-left corner of the upper-left pixel (`[0]`).
+    fn origin_x(&self) -> f64;
+    /// W-E pixel resolution / pixel width (`[1]`).
+    fn scale_x(&self) -> f64;
+    /// Row rotation term, typically zero (`[2]`).
+    fn skew_x(&self) -> f64;
+    /// y-coordinate of the upper-left corner of the upper-left pixel (`[3]`).
+    fn origin_y(&self) -> f64;
+    /// Column rotation term, typically zero (`[4]`).
+    fn skew_y(&self) -> f64;
+    /// N-S pixel resolution / pixel height, negative for North-up (`[5]`).
+    fn scale_y(&self) -> f64;
 }
 
-impl GeoTransformEx for GeoTransform {
+impl GeoTransformEx for [f64] {
     /// Pure-Rust equivalent of GDAL's `GDALApplyGeoTransform`.
     #[inline]
     fn apply(&self, x: f64, y: f64) -> (f64, f64) {
@@ -102,11 +127,116 @@ impl GeoTransformEx for GeoTransform {
             gt[1] * inv_det,
         ])
     }
+
+    #[inline]
+    fn rotation(&self) -> f64 {
+        (-self.skew_x()).atan2(self.scale_x())
+    }
+
+    #[inline]
+    fn origin_x(&self) -> f64 {
+        self[0]
+    }
+    #[inline]
+    fn scale_x(&self) -> f64 {
+        self[1]
+    }
+    #[inline]
+    fn skew_x(&self) -> f64 {
+        self[2]
+    }
+    #[inline]
+    fn origin_y(&self) -> f64 {
+        self[3]
+    }
+    #[inline]
+    fn skew_y(&self) -> f64 {
+        self[4]
+    }
+    #[inline]
+    fn scale_y(&self) -> f64 {
+        self[5]
+    }
+}
+
+/// Derive a north-up [`GeoTransform`] from a spatial bounding box and the grid's
+/// spatial shape.
+///
+/// `bbox` is `[xmin, ymin, xmax, ymax]`; `height` and `width` are the number of
+/// cells along the y and x axes. `registration` controls how the bbox maps to
+/// the grid and defaults to `"pixel"` when `None`:
+/// - `"pixel"` (cell-area): the bbox is the grid's outer edge, spanning all N
+///   cells, so the top-left corner is the bbox edge. Matches
+///   `rasterio.transform.from_bounds`.
+/// - `"node"` (cell-center): the bbox endpoints are the centers of the border
+///   cells, so N centers span N-1 intervals and the footprint extends half a
+///   cell beyond the bbox.
+///
+/// The result is axis-aligned (zero skews) with a negative `scale_y` (rows
+/// increase downward). Errors on a degenerate/inverted bbox, a zero dimension, a
+/// node-registered grid smaller than 2 cells, or an unknown registration.
+pub fn geotransform_from_bbox_and_spatial_shape(
+    bbox: [f64; 4],
+    height: u64,
+    width: u64,
+    registration: Option<&str>,
+) -> Result<GeoTransform, ArrowError> {
+    let [xmin, ymin, xmax, ymax] = bbox;
+    // Reject a degenerate or inverted bbox: a zero span gives a non-invertible
+    // (zero-scale) transform and a negative span isn't north-up.
+    if !(xmax > xmin && ymax > ymin) {
+        return Err(ArrowError::InvalidArgumentError(format!(
+            "bbox must have xmin < xmax and ymin < ymax; got [{xmin}, {ymin}, {xmax}, {ymax}]"
+        )));
+    }
+    // A real raster axis is at least 1 cell.
+    if height == 0 || width == 0 {
+        return Err(ArrowError::InvalidArgumentError(
+            "raster spatial dimensions must be non-zero to derive a transform from a bbox".into(),
+        ));
+    }
+    let (height, width) = (height as f64, width as f64);
+
+    // cell-area registration is the conventional default.
+    let registration = registration.unwrap_or("pixel");
+    // scale_y is negative throughout: rows increase downward.
+    let (scale_x, scale_y, offset_x, offset_y) = match registration {
+        // Pixel-registered: the bbox is the grid's outer edge, spanning all N
+        // cells, so the top-left corner is the bbox edge.
+        "pixel" => {
+            let scale_x = (xmax - xmin) / width;
+            let scale_y = (ymin - ymax) / height;
+            (scale_x, scale_y, xmin, ymax)
+        }
+        // Node-registered: the bbox endpoints are the *centers* of the border
+        // cells, so N centers span N-1 intervals and the footprint extends half
+        // a cell beyond — the corner sits half a cell outside the bbox.
+        "node" => {
+            if width < 2.0 || height < 2.0 {
+                return Err(ArrowError::InvalidArgumentError(
+                    "node-registered grid must be at least 2 cells in each spatial dimension"
+                        .into(),
+                ));
+            }
+            let scale_x = (xmax - xmin) / (width - 1.0);
+            let scale_y = (ymin - ymax) / (height - 1.0);
+            (scale_x, scale_y, xmin - scale_x / 2.0, ymax - scale_y / 2.0)
+        }
+        other => {
+            return Err(ArrowError::InvalidArgumentError(format!(
+                "registration must be \"pixel\" or \"node\"; got {other:?}"
+            )))
+        }
+    };
+
+    Ok([offset_x, scale_x, 0.0, offset_y, 0.0, scale_y])
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
+    use std::f64::consts::{FRAC_1_SQRT_2, PI};
 
     #[test]
     fn test_apply_no_rotation() {
@@ -125,6 +255,16 @@ mod tests {
         assert!((x - 156.0).abs() < 1e-12);
         // 200 + 5*3 + 3*(-10) = 185
         assert!((y - 185.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_apply_fractional_offset() {
+        // Pixel-centroid (+0.5) sampling under skew: matches the closed form
+        // 100 + 0.5*1 + 0.5*0.25 = 100.625; 200 + 0.5*0.5 + 0.5*(-2) = 199.25.
+        let gt: GeoTransform = [100.0, 1.0, 0.25, 200.0, 0.5, -2.0];
+        let (wx, wy) = gt.apply(0.5, 0.5);
+        assert_relative_eq!(wx, 100.625, epsilon = 1e-10);
+        assert_relative_eq!(wy, 199.25, epsilon = 1e-10);
     }
 
     #[test]
@@ -149,9 +289,169 @@ mod tests {
     }
 
     #[test]
+    fn test_invert_round_trip_skewed() {
+        // A skewed transform round-trips at several pixel offsets, including a
+        // fractional one.
+        let gt: GeoTransform = [100.0, 1.0, 0.25, 200.0, 0.5, -2.0];
+        let inv = gt.invert().unwrap();
+        for (x, y) in [(0.0, 0.0), (5.0, 10.0), (9.0, 19.0), (0.5, 0.5)] {
+            let (wx, wy) = gt.apply(x, y);
+            let (rx, ry) = inv.apply(wx, wy);
+            assert_relative_eq!(rx, x, epsilon = 1e-10);
+            assert_relative_eq!(ry, y, epsilon = 1e-10);
+        }
+    }
+
+    #[test]
     fn test_invert_singular() {
         // Determinant is zero: both rows are proportional.
         let gt: GeoTransform = [0.0, 1.0, 2.0, 0.0, 2.0, 4.0];
         assert!(gt.invert().is_err());
+    }
+
+    #[test]
+    fn test_accessors() {
+        // Named accessors read the GDAL-order coefficients.
+        let gt: GeoTransform = [100.0, 1.0, 0.25, 200.0, 0.5, -2.0];
+        assert_eq!(gt.origin_x(), 100.0);
+        assert_eq!(gt.scale_x(), 1.0);
+        assert_eq!(gt.skew_x(), 0.25);
+        assert_eq!(gt.origin_y(), 200.0);
+        assert_eq!(gt.skew_y(), 0.5);
+        assert_eq!(gt.scale_y(), -2.0);
+    }
+
+    #[test]
+    fn test_rotation() {
+        // 0 degrees.
+        let gt: GeoTransform = [0.0, 1.0, 0.0, 0.0, 0.0, -1.0];
+        assert_eq!(gt.rotation(), 0.0);
+
+        // pi/2.
+        let gt: GeoTransform = [0.0, 0.0, -1.0, 0.0, 1.0, 0.0];
+        assert_relative_eq!(gt.rotation(), PI / 2.0, epsilon = 1e-6);
+
+        // pi/4.
+        let gt: GeoTransform = [
+            0.0,
+            FRAC_1_SQRT_2,
+            -FRAC_1_SQRT_2,
+            0.0,
+            FRAC_1_SQRT_2,
+            FRAC_1_SQRT_2,
+        ];
+        assert_relative_eq!(gt.rotation(), PI / 4.0, epsilon = 1e-6);
+
+        // pi/3.
+        let gt: GeoTransform = [0.0, 0.5, -0.866025, 0.0, 0.866025, 0.5];
+        assert_relative_eq!(gt.rotation(), PI / 3.0, epsilon = 1e-6);
+
+        // pi.
+        let gt: GeoTransform = [0.0, -1.0, 0.0, 0.0, 0.0, -1.0];
+        assert_relative_eq!(gt.rotation(), -PI, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn bbox_pixel_registration_derives_transform() {
+        // A bbox over a 1000x1000 grid with "pixel" registration. Height/width
+        // are the array's own dims.
+        let gt = geotransform_from_bbox_and_spatial_shape(
+            [600000.0, 5690000.0, 610000.0, 5700000.0],
+            1000,
+            1000,
+            Some("pixel"),
+        )
+        .unwrap();
+        assert_eq!(gt, [600000.0, 10.0, 0.0, 5700000.0, 0.0, -10.0]);
+    }
+
+    #[test]
+    fn bbox_pixel_registration_matches_rasterio_from_bounds() {
+        // Cross-check against rasterio: for the same bounds and raster size,
+        // `rasterio.transform.from_bounds(west, south, east, north, width, height)`
+        // returns Affine(a, b, c, d, e, f) with a = (east-west)/width = 0.25,
+        // e = (south-north)/height = -0.5, c = west = -100, f = north = 40, and
+        // b = d = 0. In GDAL order that is [c, a, b, f, d, e].
+        let gt =
+            geotransform_from_bbox_and_spatial_shape([-100.0, -10.0, 0.0, 40.0], 100, 400, None)
+                .unwrap();
+        assert_eq!(gt, [-100.0, 0.25, 0.0, 40.0, 0.0, -0.5]);
+    }
+
+    #[test]
+    fn bbox_registration_defaults_to_pixel() {
+        // `None` registration behaves as cell-area ("pixel").
+        let gt = geotransform_from_bbox_and_spatial_shape(
+            [600000.0, 5690000.0, 610000.0, 5700000.0],
+            1000,
+            1000,
+            None,
+        )
+        .unwrap();
+        assert_eq!(gt, [600000.0, 10.0, 0.0, 5700000.0, 0.0, -10.0]);
+    }
+
+    #[test]
+    fn bbox_node_registration_uses_n_minus_1_intervals() {
+        // "node": the bbox endpoints are cell centers, so 11 centers span 10
+        // intervals -> scale = 100 / 10 = 10, and the corner sits half a cell
+        // (5) outside the bbox: origin (-5, 105).
+        let gt = geotransform_from_bbox_and_spatial_shape(
+            [0.0, 0.0, 100.0, 100.0],
+            11,
+            11,
+            Some("node"),
+        )
+        .unwrap();
+        assert_eq!(gt, [-5.0, 10.0, 0.0, 105.0, 0.0, -10.0]);
+    }
+
+    #[test]
+    fn bbox_node_registration_requires_at_least_two_cells() {
+        // A single-cell node grid can't define a spacing from its bbox alone.
+        let err =
+            geotransform_from_bbox_and_spatial_shape([0.0, 0.0, 100.0, 100.0], 1, 1, Some("node"))
+                .unwrap_err()
+                .to_string();
+        assert!(err.contains("at least 2"), "{err}");
+    }
+
+    #[test]
+    fn bbox_unknown_registration_errors() {
+        let err = geotransform_from_bbox_and_spatial_shape(
+            [0.0, 0.0, 100.0, 100.0],
+            10,
+            10,
+            Some("corner"),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("pixel") && err.contains("node"), "{err}");
+    }
+
+    #[test]
+    fn degenerate_or_inverted_bbox_errors() {
+        // Zero x-span (non-invertible) and inverted y (not north-up) are both
+        // rejected.
+        for bbox in [
+            [10.0, 0.0, 10.0, 5.0], // xmin == xmax
+            [0.0, 5.0, 5.0, 0.0],   // ymax < ymin
+        ] {
+            let err = geotransform_from_bbox_and_spatial_shape(bbox, 10, 10, None)
+                .unwrap_err()
+                .to_string();
+            assert!(
+                err.contains("xmin < xmax") || err.contains("ymin < ymax"),
+                "{err}"
+            );
+        }
+    }
+
+    #[test]
+    fn zero_dimension_bbox_errors() {
+        let err = geotransform_from_bbox_and_spatial_shape([0.0, 0.0, 10.0, 10.0], 0, 10, None)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("non-zero"), "{err}");
     }
 }

--- a/rust/sedona-raster/src/geo_transform.rs
+++ b/rust/sedona-raster/src/geo_transform.rs
@@ -25,9 +25,13 @@
 //! methods are pure-Rust reimplementations of GDAL's `GDALApplyGeoTransform`
 //! and `GDALInvGeoTransform` (from `alg/gdaltransformer.cpp`). No FFI call or
 //! thread-local state is needed.
+//!
+//! This is the single home for the six-coefficient affine geo-transform used
+//! across the raster stack (GDAL, Zarr, and the `RS_` functions). The richer
+//! [`AffineMatrix`](crate::affine_transformation::AffineMatrix) is built on top
+//! of this trait so there is exactly one `apply`/`invert` implementation.
 
-use crate::errors;
-use crate::errors::GdalError;
+use arrow_schema::ArrowError;
 
 /// An affine geo-transform: six coefficients mapping pixel/line to projection coordinates.
 ///
@@ -46,11 +50,12 @@ pub trait GeoTransformEx {
 
     /// Invert this geo-transform, returning the inverse coefficients for
     /// computing (geo_x, geo_y) -> (x, y) transformations.
-    fn invert(&self) -> errors::Result<GeoTransform>;
+    fn invert(&self) -> Result<GeoTransform, ArrowError>;
 }
 
 impl GeoTransformEx for GeoTransform {
     /// Pure-Rust equivalent of GDAL's `GDALApplyGeoTransform`.
+    #[inline]
     fn apply(&self, x: f64, y: f64) -> (f64, f64) {
         let geo_x = self[0] + x * self[1] + y * self[2];
         let geo_y = self[3] + x * self[4] + y * self[5];
@@ -58,7 +63,7 @@ impl GeoTransformEx for GeoTransform {
     }
 
     /// Pure-Rust equivalent of GDAL's `GDALInvGeoTransform`.
-    fn invert(&self) -> errors::Result<GeoTransform> {
+    fn invert(&self) -> Result<GeoTransform, ArrowError> {
         let gt = self;
 
         // Fast path: no rotation/skew — avoid determinant and precision issues.
@@ -81,7 +86,7 @@ impl GeoTransformEx for GeoTransform {
             .max(gt[4].abs().max(gt[5].abs()));
 
         if det.abs() <= 1e-10 * magnitude * magnitude {
-            return Err(GdalError::BadArgument(
+            return Err(ArrowError::InvalidArgumentError(
                 "Geo transform is uninvertible".to_string(),
             ));
         }

--- a/rust/sedona-raster/src/lib.rs
+++ b/rust/sedona-raster/src/lib.rs
@@ -19,6 +19,7 @@ pub mod affine_transformation;
 pub mod array;
 pub mod builder;
 pub mod display;
+pub mod geo_transform;
 pub mod raster_loader;
 pub mod traits;
 pub mod view_entries;


### PR DESCRIPTION
Lifts the six-coefficient `GeoTransform` type and `GeoTransformEx` trait (apply/invert) out of `c/sedona-gdal` into a new `sedona-raster::geo_transform` module so GDAL, Zarr, and the RS_ functions share one geo-transform home.

`AffineMatrix` delegates `transform`/`inv_transform` to the single `GeoTransformEx` implementation, so there is exactly one apply/invert. The free `rotation()` helper now builds on `AffineMatrix::rotation`, and `rs_georeference` reads `AffineMatrix` named fields instead of raw geotransform indices.