### PR TITLE
refactor(rust/sedona-raster-gdal): share the N-D plane bridge helpers

### DIFF
--- a/rust/sedona-raster-gdal/src/gdal_common.rs
+++ b/rust/sedona-raster-gdal/src/gdal_common.rs
@@ -176,37 +176,31 @@ pub unsafe fn raster_ref_to_gdal_mem<R: RasterRef + ?Sized>(
     let width = raster.width().map_err(|e| arrow_datafusion_err!(e))? as usize;
     let height = raster.height().map_err(|e| arrow_datafusion_err!(e))? as usize;
 
-    // Create internal MEM dataset via sedona-gdal shim to avoid open dataset list contention.
-    let mut mem_ds_builder = MemDatasetBuilder::new(width, height);
+    // The N-D → flat-GDAL plane layout (band-major, plane-major). Deriving it
+    // performs the trailing-(y, x)-pair check and records each band's plane
+    // count / dtype / nodata, so the add and nodata loops below share one source
+    // of truth for band order and plane counts.
+    let layout = GdalBandLayout::from_raster(raster, band_indices)?;
 
-    // Add bands with DATAPOINTER option (zero-copy)
-    //
-    // Note: GDALAddBand always appends a new band, so the destination band index
-    // is sequential (1..=band_indices.len()), even if the source band indices are
-    // sparse (e.g. [1, 3]).
-    for &src_band_index in band_indices.iter() {
+    // One base pointer per source band: the start of its zero-copy contiguous
+    // bytes. `as_contiguous()` borrows the bytes (erroring on a strided view);
+    // GDAL holds the pointer, so `raster` must outlive the dataset. Because
+    // (y, x) are innermost, each plane is a contiguous sub-range, so the
+    // per-plane DATAPOINTER math holds.
+    let mut base_ptrs: Vec<*mut u8> = Vec::with_capacity(layout.bands.len());
+    for (&src_band_index, plan) in band_indices.iter().zip(&layout.bands) {
         // `band_indices` are 1-based; the `band` accessor is 0-based.
         let band = raster
             .band(src_band_index - 1)
             .map_err(|e| arrow_datafusion_err!(e))?;
 
-        // An N-D band's trailing two axes must be the spatial (y, x) pair; the
-        // non-spatial axes become a stack of 2-D planes, one GDAL band each. A
-        // plain 2-D band is just the single-plane case.
-        let dims = band.dim_names();
-        let ndim = dims.len();
-        if ndim < 2 || !is_spatial_dim_pair(dims[ndim - 2], dims[ndim - 1]) {
-            return exec_err!(
-                "GDAL backend requires a band whose trailing two dims are a \
-                 spatial (y, x) pair; got dim_names={dims:?}"
-            );
-        }
-
         // The plane's 2-D extent must equal the MEM dataset's (and the raster's
-        // spatial grid); otherwise the per-plane byte slicing below would
-        // disagree with the GDAL band size and silently mis-stack the planes.
+        // spatial grid); otherwise the per-plane byte slicing would disagree
+        // with the GDAL band size and silently mis-stack the planes.
         // `finish_raster` already enforces this for builder-made rasters, but
         // re-check so the public bridge stays sound for any `RasterRef`.
+        let dims = band.dim_names();
+        let ndim = dims.len();
         let shape = band.shape();
         if shape[ndim - 2] as usize != height || shape[ndim - 1] as usize != width {
             return exec_err!(
@@ -223,30 +217,29 @@ pub unsafe fn raster_ref_to_gdal_mem<R: RasterRef + ?Sized>(
             ));
         }
 
-        let band_type = band.data_type();
-        let gdal_type = band_data_type_to_gdal(&band_type);
-        // `as_contiguous()` borrows the bytes zero-copy (erroring on a strided
-        // view); GDAL holds the pointer, so `raster` must outlive the dataset.
-        // Because (y, x) are innermost, each plane is a contiguous sub-range, so
-        // the zero-copy DATAPOINTER holds per plane.
         let band_bytes = band.nd_buffer().and_then(|ndb| ndb.as_contiguous())?;
-        let plane_bytes = width * height * band_type.byte_size();
-        if plane_bytes == 0 || band_bytes.len() % plane_bytes != 0 {
+        let plane_bytes = width * height * plan.data_type.byte_size();
+        if plane_bytes == 0 || band_bytes.len() != plan.plane_count * plane_bytes {
             return exec_err!(
-                "band byte length {} is not a multiple of the {width}x{height} \
-                 plane size (dim_names={dims:?})",
-                band_bytes.len()
+                "band byte length {} does not match {} planes of the \
+                 {width}x{height} plane size (dim_names={dims:?})",
+                band_bytes.len(),
+                plan.plane_count
             );
         }
-        let plane_count = band_bytes.len() / plane_bytes;
-        for plane in 0..plane_count {
-            let off = plane * plane_bytes;
-            let data_ptr: *const u8 = band_bytes[off..off + plane_bytes].as_ptr();
-            unsafe {
-                mem_ds_builder = mem_ds_builder.add_band(gdal_type, data_ptr as *mut u8);
-            }
-        }
+        base_ptrs.push(band_bytes.as_ptr() as *mut u8);
     }
+
+    // Create internal MEM dataset via sedona-gdal shim to avoid open dataset list
+    // contention, then attach the band×plane DATAPOINTER bands (zero-copy).
+    //
+    // SAFETY: each base pointer starts `plan.plane_count` contiguous planes of
+    // `width*height*byte_size` bytes inside `raster`'s buffers, which outlive the
+    // returned dataset; the helper only adds bands.
+    let mut mem_ds_builder = MemDatasetBuilder::new(width, height);
+    mem_ds_builder = unsafe {
+        add_layout_datapointer_bands(mem_ds_builder, &layout, &base_ptrs, width * height)
+    };
 
     let dataset = unsafe {
         mem_ds_builder
@@ -268,19 +261,10 @@ pub unsafe fn raster_ref_to_gdal_mem<R: RasterRef + ?Sized>(
     // Nodata is per source band, shared across all its planes. Walk the dst
     // bands in the same band-major / plane order as the add loop above.
     let mut dst_band_index = 0usize;
-    for &src_band_index in band_indices.iter() {
-        // `band_indices` are 1-based; the `band` accessor is 0-based.
-        let band = raster
-            .band(src_band_index - 1)
-            .map_err(|e| arrow_datafusion_err!(e))?;
-        let band_type = band.data_type();
-        let plane_bytes = width * height * band_type.byte_size();
-        let band_bytes = band.nd_buffer().and_then(|ndb| ndb.as_contiguous())?;
-        let plane_count = band_bytes.len() / plane_bytes;
-        let nodata = band.nodata();
-        for _ in 0..plane_count {
+    for plan in &layout.bands {
+        for _ in 0..plan.plane_count {
             dst_band_index += 1;
-            if let Some(nodata_bytes) = nodata {
+            if let Some(nodata_bytes) = plan.nodata.as_deref() {
                 let raster_band = dataset
                     .rasterband(dst_band_index)
                     .map_err(convert_gdal_err)?;
@@ -365,6 +349,44 @@ impl GdalBandLayout {
         }
         Ok(Self { bands: plans })
     }
+}
+
+/// Attach the DATAPOINTER bands for an N-D raster's flattened plane list to
+/// `builder`: one GDAL band per 2-D plane, band-major then plane-major (the
+/// order [`GdalBandLayout`] records and `append_nd_from_dataset` regroups).
+/// `GDALAddBand` appends, so the destination band indices run
+/// `1..=Σ plane_count` even when the source band indices are sparse.
+///
+/// `base_ptrs[i]` is the start of band `i`'s contiguous bytes — its
+/// `plane_count` planes laid out plane-major — so plane `p` of that band lives
+/// at `base_ptrs[i] + p * plane_pixel_count * data_type.byte_size()`. The helper
+/// only adds bands; the caller owns the pointed-to buffers and their lifetime.
+///
+/// # Safety
+/// `base_ptrs.len()` must equal `layout.bands.len()`, and for each band `i`
+/// `base_ptrs[i]` must point to at least
+/// `plan.plane_count * plane_pixel_count * plan.data_type.byte_size()` bytes that
+/// are valid, aligned for the band's data type, and outlive the built
+/// [`Dataset`] — GDAL reads them, and for a writable destination writes them,
+/// through the DATAPOINTER.
+pub(crate) unsafe fn add_layout_datapointer_bands(
+    mut builder: MemDatasetBuilder,
+    layout: &GdalBandLayout,
+    base_ptrs: &[*mut u8],
+    plane_pixel_count: usize,
+) -> MemDatasetBuilder {
+    for (plan, &base) in layout.bands.iter().zip(base_ptrs) {
+        let gdal_type = band_data_type_to_gdal(&plan.data_type);
+        let plane_byte_size = plane_pixel_count * plan.data_type.byte_size();
+        for plane in 0..plan.plane_count {
+            // SAFETY: by the contract above, `base + plane * plane_byte_size`
+            // begins a full `plane_byte_size`-byte plane inside band `i`'s
+            // buffer, aligned for the band type, that outlives the dataset.
+            let plane_ptr = unsafe { base.add(plane * plane_byte_size) };
+            builder = unsafe { builder.add_band(gdal_type, plane_ptr) };
+        }
+    }
+    builder
 }
 
 /// Interpret optional nodata bytes according to the band data type and return an Option<f64>.

--- a/rust/sedona-raster-gdal/src/gdal_common.rs
+++ b/rust/sedona-raster-gdal/src/gdal_common.rs
@@ -218,8 +218,20 @@ pub unsafe fn raster_ref_to_gdal_mem<R: RasterRef + ?Sized>(
         }
 
         let band_bytes = band.nd_buffer().and_then(|ndb| ndb.as_contiguous())?;
-        let plane_bytes = width * height * plan.data_type.byte_size();
-        if plane_bytes == 0 || band_bytes.len() != plan.plane_count * plane_bytes {
+        let plane_bytes = width
+            .checked_mul(height)
+            .and_then(|px| px.checked_mul(plan.data_type.byte_size()))
+            .ok_or_else(|| exec_datafusion_err!("band plane extent {width}x{height} overflows"))?;
+        // The per-plane DATAPOINTER math in `add_layout_datapointer_bands` walks
+        // `plane_count` planes of `plane_bytes`; keep the product checked so the
+        // guard protecting that pointer arithmetic can't itself wrap.
+        let expected_len = plane_bytes.checked_mul(plan.plane_count).ok_or_else(|| {
+            exec_datafusion_err!(
+                "band size of {} planes at {width}x{height} overflows",
+                plan.plane_count
+            )
+        })?;
+        if plane_bytes == 0 || band_bytes.len() != expected_len {
             return exec_err!(
                 "band byte length {} does not match {} planes of the \
                  {width}x{height} plane size (dim_names={dims:?})",
@@ -227,15 +239,23 @@ pub unsafe fn raster_ref_to_gdal_mem<R: RasterRef + ?Sized>(
                 plan.plane_count
             );
         }
+        // SAFETY precondition for `add_layout_datapointer_bands`: band i's buffer
+        // holds exactly `plan.plane_count` planes of `plane_bytes`, so its
+        // per-plane `base + plane * plane_byte_size` pointer math stays in bounds.
+        debug_assert_eq!(
+            band_bytes.len(),
+            expected_len,
+            "band buffer length must equal plane_count * plane_bytes for the DATAPOINTER plane math"
+        );
         base_ptrs.push(band_bytes.as_ptr() as *mut u8);
     }
 
     // Create internal MEM dataset via sedona-gdal shim to avoid open dataset list
     // contention, then attach the band×plane DATAPOINTER bands (zero-copy).
     //
-    // SAFETY: each base pointer starts `plan.plane_count` contiguous planes of
-    // `width*height*byte_size` bytes inside `raster`'s buffers, which outlive the
-    // returned dataset; the helper only adds bands.
+    // SAFETY: satisfies `add_layout_datapointer_bands`' # Safety contract — the
+    // loop above validated each band's buffer length and left `base_ptrs` 1:1
+    // with `layout.bands`, and `raster`'s buffers outlive the returned dataset.
     let mut mem_ds_builder = MemDatasetBuilder::new(width, height);
     mem_ds_builder = unsafe {
         add_layout_datapointer_bands(mem_ds_builder, &layout, &base_ptrs, width * height)
@@ -375,13 +395,18 @@ pub(crate) unsafe fn add_layout_datapointer_bands(
     base_ptrs: &[*mut u8],
     plane_pixel_count: usize,
 ) -> MemDatasetBuilder {
+    // The # Safety contract requires one base pointer per source band; `zip`
+    // would silently truncate on drift, so pin the 1:1 pairing here.
+    debug_assert_eq!(
+        base_ptrs.len(),
+        layout.bands.len(),
+        "base_ptrs must be 1:1 with layout.bands (# Safety contract)"
+    );
     for (plan, &base) in layout.bands.iter().zip(base_ptrs) {
         let gdal_type = band_data_type_to_gdal(&plan.data_type);
         let plane_byte_size = plane_pixel_count * plan.data_type.byte_size();
         for plane in 0..plan.plane_count {
-            // SAFETY: by the contract above, `base + plane * plane_byte_size`
-            // begins a full `plane_byte_size`-byte plane inside band `i`'s
-            // buffer, aligned for the band type, that outlives the dataset.
+            // SAFETY: per the # Safety contract, base + plane*plane_byte_size stays within band i's buffer.
             let plane_ptr = unsafe { base.add(plane * plane_byte_size) };
             builder = unsafe { builder.add_band(gdal_type, plane_ptr) };
         }

--- a/rust/sedona-raster-gdal/src/rs_clip.rs
+++ b/rust/sedona-raster-gdal/src/rs_clip.rs
@@ -25,7 +25,6 @@
 use std::sync::Arc;
 
 use arrow_array::ArrayRef;
-use arrow_buffer::Buffer;
 use datafusion_common::cast::{as_boolean_array, as_float64_array, as_int32_array};
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::error::Result;
@@ -52,6 +51,7 @@ use sedona_schema::raster::BandDataType;
 use crate::gdal_common::{raster_geo_transform, with_gdal};
 use crate::gdal_dataset_provider::configure_thread_local_options;
 use crate::mask::{envelope_window, rasterize_geometry_mask, PixelWindow};
+use crate::utils::{append_band_from_buffer, BandHeader};
 use sedona_raster::traits::nodata_f64_to_bytes;
 
 /// RS_Clip() scalar UDF implementation
@@ -726,32 +726,17 @@ fn build_clipped_raster(
 
     for band in clipped_data.bands {
         let dim_names: Vec<&str> = band.dim_names.iter().map(String::as_str).collect();
-        builder
-            .start_band_nd(
-                band.name.as_deref(),
-                &dim_names,
-                &band.shape,
-                band.data_type,
-                Some(&band.nodata),
-                None,
-                None,
-            )
-            .map_err(|e| exec_datafusion_err!("Failed to start band: {}", e))?;
-        // Move the band bytes into an Arrow buffer and append them as a view
-        // (a refcount bump), instead of copying them through the builder.
-        let len = u32::try_from(band.data.len()).map_err(|_| {
-            exec_datafusion_err!(
-                "RS_Clip: band data of {} bytes exceeds the binary-view limit",
-                band.data.len()
-            )
-        })?;
-        let buffer = Buffer::from(band.data);
-        builder
-            .append_band_data_buffer(&buffer, 0, len)
-            .map_err(|e| exec_datafusion_err!("Failed to append band data: {}", e))?;
-        builder
-            .finish_band()
-            .map_err(|e| exec_datafusion_err!("Failed to finish band: {}", e))?;
+        append_band_from_buffer(
+            builder,
+            &BandHeader {
+                name: band.name.as_deref(),
+                dim_names: &dim_names,
+                shape: &band.shape,
+                data_type: band.data_type,
+                nodata: Some(&band.nodata),
+            },
+            band.data,
+        )?;
     }
 
     builder

--- a/rust/sedona-raster-gdal/src/rs_tile.rs
+++ b/rust/sedona-raster-gdal/src/rs_tile.rs
@@ -32,7 +32,6 @@ use std::sync::Arc;
 
 use arrow_array::builder::{Int32Builder, NullBufferBuilder, OffsetBufferBuilder};
 use arrow_array::{Array, ArrayRef, ListArray, StructArray};
-use arrow_buffer::Buffer;
 use arrow_schema::{DataType, Field, Fields};
 use datafusion_common::cast::{as_boolean_array, as_float64_array, as_int64_array, as_list_array};
 use datafusion_common::config::ConfigOptions;
@@ -48,6 +47,8 @@ use sedona_raster::geo_transform::{GeoTransform, GeoTransformEx};
 use sedona_raster::traits::{is_spatial_dim_pair, nodata_f64_to_bytes, RasterRef};
 use sedona_raster_functions::rs_ensure_loaded::NEEDS_PIXELS_METADATA_KEY;
 use sedona_raster_functions::RasterExecutor;
+
+use crate::utils::{append_stacked_band, BandHeader};
 use sedona_schema::datatypes::{SedonaType, RASTER};
 use sedona_schema::matchers::{ArgMatcher, TypeMatcher};
 
@@ -655,69 +656,40 @@ fn append_tile_band(
         (None, band.nodata().map(|bytes| bytes.to_vec()))
     };
 
-    // One output allocation serves the whole band: every plane appends into it,
-    // and the finished Vec moves into the Arrow array as a zero-copy view block
-    // rather than being copied through the builder. The band data is appended as
-    // one binary view (u32-limited), so size the buffer with checked arithmetic
-    // and reject an oversize (e.g. huge padded) tile before allocating rather
-    // than after filling the whole thing.
-    let total_bytes = window
-        .out_w
-        .checked_mul(window.out_h)
-        .and_then(|plane| plane.checked_mul(byte_size))
-        .and_then(|plane_bytes| plane_bytes.checked_mul(n_planes))
-        .ok_or_else(|| {
-            exec_datafusion_err!(
-                "RS_Tile: tile band extent {}x{} of {n_planes} planes overflows",
-                window.out_w,
-                window.out_h
-            )
-        })?;
-    let band_data_len = u32::try_from(total_bytes).map_err(|_| {
-        exec_datafusion_err!(
-            "RS_Tile: tile band data of {total_bytes} bytes exceeds the binary-view limit"
-        )
-    })?;
-    let mut tile_data = Vec::with_capacity(total_bytes);
-    for plane in 0..n_planes {
-        let plane_bytes = &source[plane * in_plane_bytes..(plane + 1) * in_plane_bytes];
-        copy_tile_window(
-            plane_bytes,
-            width,
-            window,
-            byte_size,
-            pad_fill.as_deref(),
-            &mut tile_data,
-        )?;
-    }
-
     let mut out_shape = shape[..ndim - 2].to_vec();
     out_shape.push(window.out_h as i64);
     out_shape.push(window.out_w as i64);
-
     let dim_names_ref: Vec<&str> = dim_names.iter().map(String::as_str).collect();
-    rast_builder
-        .start_band_nd(
-            band_name.as_deref(),
-            &dim_names_ref,
-            &out_shape,
-            data_type,
-            tile_nodata.as_deref(),
-            None,
-            None,
-        )
-        .map_err(|e| exec_datafusion_err!("RS_Tile: failed to start band: {e}"))?;
 
-    // Move the band bytes into an Arrow buffer and append them as a view (a
-    // refcount bump) instead of copying them through the builder.
-    let buffer = Buffer::from(tile_data);
-    rast_builder
-        .append_band_data_buffer(&buffer, 0, band_data_len)
-        .map_err(|e| exec_datafusion_err!("RS_Tile: failed to append band data: {e}"))?;
-    rast_builder
-        .finish_band()
-        .map_err(|e| exec_datafusion_err!("RS_Tile: failed to finish band: {e}"))?;
-    Ok(())
+    // Copy each source plane's tile window and stack the planes into the N-D tile
+    // band. `in_plane_bytes` is the full source plane; the tile window may be
+    // smaller (a crop) or larger (padded past the source edge). The shared helper
+    // sizes the output buffer with checked arithmetic, rejects an oversize (e.g.
+    // huge padded) tile before allocating, and appends the finished bytes as a
+    // zero-copy view block.
+    append_stacked_band(
+        rast_builder,
+        &BandHeader {
+            name: band_name.as_deref(),
+            dim_names: &dim_names_ref,
+            shape: &out_shape,
+            data_type,
+            nodata: tile_nodata.as_deref(),
+        },
+        window.out_w * window.out_h * byte_size,
+        n_planes,
+        |plane, out| {
+            let src_plane = &source[plane * in_plane_bytes..(plane + 1) * in_plane_bytes];
+            copy_tile_window(
+                src_plane,
+                width,
+                window,
+                byte_size,
+                pad_fill.as_deref(),
+                out,
+            )
+        },
+    )
 }
 
 /// Copy one source plane's tile window into `out`, padding out-of-bounds pixels

--- a/rust/sedona-raster-gdal/src/rs_tile.rs
+++ b/rust/sedona-raster-gdal/src/rs_tile.rs
@@ -663,10 +663,7 @@ fn append_tile_band(
 
     // Copy each source plane's tile window and stack the planes into the N-D tile
     // band. `in_plane_bytes` is the full source plane; the tile window may be
-    // smaller (a crop) or larger (padded past the source edge). The shared helper
-    // sizes the output buffer with checked arithmetic, rejects an oversize (e.g.
-    // huge padded) tile before allocating, and appends the finished bytes as a
-    // zero-copy view block.
+    // smaller (a crop) or larger (padded past the source edge).
     append_stacked_band(
         rast_builder,
         &BandHeader {
@@ -676,8 +673,6 @@ fn append_tile_band(
             data_type,
             nodata: tile_nodata.as_deref(),
         },
-        window.out_w * window.out_h * byte_size,
-        n_planes,
         |plane, out| {
             let src_plane = &source[plane * in_plane_bytes..(plane + 1) * in_plane_bytes];
             copy_tile_window(

--- a/rust/sedona-raster-gdal/src/utils.rs
+++ b/rust/sedona-raster-gdal/src/utils.rs
@@ -467,7 +467,6 @@ pub fn append_warped_nd_from_dataset(
     dst_builder = unsafe {
         add_layout_datapointer_bands(dst_builder, layout, &base_ptrs, out_width * out_height)
     };
-    // SAFETY: the DATAPOINTER buffers in `band_buffers` outlive `dst_dataset`.
     let dst_dataset = unsafe { dst_builder.build(gdal).map_err(convert_gdal_err)? };
     dst_dataset
         .set_geo_transform(&output.grid.transform)
@@ -543,10 +542,14 @@ pub(crate) struct BandHeader<'a> {
     pub nodata: Option<&'a [u8]>,
 }
 
-/// Assemble one N-D raster band from `n_planes` per-plane outputs and append it
-/// to `builder`. For each plane in `0..n_planes`, `fill_plane(plane, &mut buf)`
-/// appends exactly that plane's `plane_bytes` (= out_w × out_h ×
-/// `header.data_type.byte_size()`) to `buf`, band-major planes concatenated
+/// Assemble one N-D raster band and append it to `builder`. The per-plane byte
+/// size and plane count are derived from `header.shape`
+/// (`[non-spatial..., height, width]`) with a fully checked multiply chain, so a
+/// pathological extent overflows into a descriptive error rather than wrapping,
+/// and an oversize (> u32 view limit) band is rejected before allocating rather
+/// than after filling. For each plane in `0..n_planes`, `fill_plane(plane, &mut
+/// buf)` appends exactly that plane's `height × width ×
+/// header.data_type.byte_size()` bytes to `buf`, band-major planes concatenated
 /// plane-major; the accumulated buffer is then moved into the Arrow array as a
 /// zero-copy view block (a refcount bump) rather than copied through the builder.
 ///
@@ -554,21 +557,45 @@ pub(crate) struct BandHeader<'a> {
 /// ([`add_layout_datapointer_bands`]): the per-plane op — a GDAL band read, a
 /// mask/crop, a tile-window copy — is the caller's `fill_plane` closure; the
 /// plane iteration, checked buffer sizing, and band packaging are shared here.
-/// An oversize (> u32 view limit) band is rejected before allocating rather than
-/// after filling.
 pub(crate) fn append_stacked_band<F>(
     builder: &mut RasterBuilder,
     header: &BandHeader<'_>,
-    plane_bytes: usize,
-    n_planes: usize,
     mut fill_plane: F,
 ) -> Result<()>
 where
     F: FnMut(usize, &mut Vec<u8>) -> Result<()>,
 {
-    let capacity = plane_bytes
-        .checked_mul(n_planes)
-        .ok_or_else(|| exec_datafusion_err!("band size overflow ({plane_bytes} x {n_planes})"))?;
+    // Derive the plane byte size and plane count from the output band shape with
+    // a fully checked multiply chain: the total is the capacity of the buffer the
+    // DATAPOINTER-free read-back path fills, and every factor comes from
+    // untrusted band dimensions, so an overflow must error rather than wrap.
+    let shape = header.shape;
+    let ndim = shape.len();
+    if ndim < 2 {
+        return sedona_internal_err!(
+            "append_stacked_band requires a trailing (height, width) pair, got shape {shape:?}"
+        );
+    }
+    let byte_size = header.data_type.byte_size();
+    let out_h = usize::try_from(shape[ndim - 2])
+        .map_err(|_| exec_datafusion_err!("negative band height in shape {shape:?}"))?;
+    let out_w = usize::try_from(shape[ndim - 1])
+        .map_err(|_| exec_datafusion_err!("negative band width in shape {shape:?}"))?;
+    let plane_bytes = out_w
+        .checked_mul(out_h)
+        .and_then(|px| px.checked_mul(byte_size))
+        .ok_or_else(|| exec_datafusion_err!("band plane extent {out_w}x{out_h} overflows"))?;
+    let mut n_planes: usize = 1;
+    for &dim in &shape[..ndim - 2] {
+        let dim = usize::try_from(dim)
+            .map_err(|_| exec_datafusion_err!("negative band dimension in shape {shape:?}"))?;
+        n_planes = n_planes.checked_mul(dim).ok_or_else(|| {
+            exec_datafusion_err!("band plane count overflows for shape {shape:?}")
+        })?;
+    }
+    let capacity = plane_bytes.checked_mul(n_planes).ok_or_else(|| {
+        exec_datafusion_err!("band extent {out_w}x{out_h} of {n_planes} planes overflows")
+    })?;
     let band_data_len = u32::try_from(capacity).map_err(|_| {
         exec_datafusion_err!("band data of {capacity} bytes exceeds the binary-view limit")
     })?;
@@ -595,8 +622,6 @@ where
             None,
         )
         .map_err(|e| exec_datafusion_err!("Failed to start band: {e}"))?;
-    // Move the finished band bytes into an Arrow buffer and append them as a view
-    // (a refcount bump) instead of copying them through the builder.
     builder
         .append_band_data_buffer(&Buffer::from(band_data), 0, band_data_len)
         .map_err(|e| exec_datafusion_err!("Failed to append band data: {e}"))?;
@@ -656,8 +681,6 @@ fn append_nd_from_dataset_inner(
                 data_type: plan.data_type,
                 nodata: plan.nodata.as_deref(),
             },
-            out_width * out_height * plan.data_type.byte_size(),
-            plan.plane_count,
             |plane, out| {
                 let gdal_band = gdal_band_base + plane;
                 let band = dataset
@@ -702,7 +725,10 @@ pub fn gdal_dataset_to_nd_raster(
 
 #[cfg(test)]
 mod tests {
-    use super::{append_as_indb_raster, append_as_outdb_raster, dataset_to_indb_raster};
+    use super::{
+        append_as_indb_raster, append_as_outdb_raster, append_stacked_band, dataset_to_indb_raster,
+        BandHeader,
+    };
 
     use arrow_array::StructArray;
     use datafusion_common::exec_datafusion_err;
@@ -739,6 +765,33 @@ mod tests {
         let mut builder = RasterBuilder::new(1);
         append_as_outdb_raster(gdal, path, &mut builder)?;
         builder.finish().map_err(Into::into)
+    }
+
+    #[test]
+    fn test_append_stacked_band_rejects_oversize_extent() {
+        // A pathological plane extent whose byte product overflows `usize` must
+        // return the descriptive overflow error rather than panic (debug) or wrap
+        // (release). This guards the shared band-stacking path that both RS_Tile
+        // and the warp/resample read-back funnel through. `fill_plane` never runs
+        // because the size check fails before the buffer is allocated.
+        let huge = 1i64 << 40; // (1<<40)^2 = 2^80, overflows usize
+        let mut builder = RasterBuilder::new(1);
+        let err = append_stacked_band(
+            &mut builder,
+            &BandHeader {
+                name: None,
+                dim_names: &["y", "x"],
+                shape: &[huge, huge],
+                data_type: BandDataType::UInt8,
+                nodata: None,
+            },
+            |_plane, _out| panic!("fill_plane must not run when the extent overflows"),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("overflows"),
+            "expected an overflow error, got: {err}"
+        );
     }
 
     fn write_uint64_tiff(gdal: &Gdal, path: &str, nodata: u64, data: Vec<u64>) {

--- a/rust/sedona-raster-gdal/src/utils.rs
+++ b/rust/sedona-raster-gdal/src/utils.rs
@@ -31,13 +31,14 @@ use sedona_gdal::spatial_ref::SpatialRef;
 use sedona_raster::geo_transform::{GeoTransform, GeoTransformEx};
 
 use arrow_schema::ArrowError;
+use sedona_common::sedona_internal_err;
 use sedona_raster::array::RasterRefImpl;
 use sedona_raster::builder::RasterBuilder;
 use sedona_raster::traits::RasterRef;
 use sedona_schema::raster::BandDataType;
 
 use crate::gdal_common::{
-    band_data_type_to_gdal, band_nodata_to_bytes, convert_gdal_err, gdal_to_band_data_type,
+    add_layout_datapointer_bands, band_nodata_to_bytes, convert_gdal_err, gdal_to_band_data_type,
     normalize_outdb_source_path, set_band_nodata_from_bytes, GdalBandLayout,
 };
 
@@ -454,20 +455,18 @@ pub fn append_warped_nd_from_dataset(
         band_buffers.push(filled_with_nodata(total, plan.nodata.as_deref()));
     }
 
+    // Base pointer per band: the start of its nodata-pre-filled buffer. The
+    // destination DATAPOINTER bands point into plane-major sub-ranges of these,
+    // which GDAL warps into.
+    //
+    // SAFETY: each buffer holds exactly `plan.plane_count` writable planes of
+    // `out_width*out_height*byte_size` bytes and, declared before `dst_dataset`,
+    // outlives it; the helper only adds bands.
+    let base_ptrs: Vec<*mut u8> = band_buffers.iter_mut().map(|b| b.as_mut_ptr()).collect();
     let mut dst_builder = MemDatasetBuilder::new(out_width, out_height);
-    for (plan, buffer) in layout.bands.iter().zip(band_buffers.iter_mut()) {
-        let gdal_type = band_data_type_to_gdal(&plan.data_type);
-        let plane_bytes = out_width * out_height * plan.data_type.byte_size();
-        for plane in 0..plan.plane_count {
-            let ptr = buffer[plane * plane_bytes..].as_mut_ptr();
-            // SAFETY: each plane sub-range holds exactly `plane_bytes` valid,
-            // writable bytes aligned for the band type, and `band_buffers`
-            // outlives `dst_dataset`.
-            unsafe {
-                dst_builder = dst_builder.add_band(gdal_type, ptr);
-            }
-        }
-    }
+    dst_builder = unsafe {
+        add_layout_datapointer_bands(dst_builder, layout, &base_ptrs, out_width * out_height)
+    };
     // SAFETY: the DATAPOINTER buffers in `band_buffers` outlive `dst_dataset`.
     let dst_dataset = unsafe { dst_builder.build(gdal).map_err(convert_gdal_err)? };
     dst_dataset
@@ -532,6 +531,81 @@ fn filled_with_nodata(total: usize, nodata: Option<&[u8]>) -> Vec<u8> {
     }
 }
 
+/// The descriptive header for one output raster band — everything
+/// [`RasterBuilder::start_band_nd`] needs except the pixel bytes. Bundled so
+/// [`append_stacked_band`] takes named fields rather than a long positional list.
+pub(crate) struct BandHeader<'a> {
+    pub name: Option<&'a str>,
+    pub dim_names: &'a [&'a str],
+    /// Full band shape `[non-spatial..., height, width]`.
+    pub shape: &'a [i64],
+    pub data_type: BandDataType,
+    pub nodata: Option<&'a [u8]>,
+}
+
+/// Assemble one N-D raster band from `n_planes` per-plane outputs and append it
+/// to `builder`. For each plane in `0..n_planes`, `fill_plane(plane, &mut buf)`
+/// appends exactly that plane's `plane_bytes` (= out_w × out_h ×
+/// `header.data_type.byte_size()`) to `buf`, band-major planes concatenated
+/// plane-major; the accumulated buffer is then moved into the Arrow array as a
+/// zero-copy view block (a refcount bump) rather than copied through the builder.
+///
+/// This is the read-back / output-assembly inverse of the plane *input* bridge
+/// ([`add_layout_datapointer_bands`]): the per-plane op — a GDAL band read, a
+/// mask/crop, a tile-window copy — is the caller's `fill_plane` closure; the
+/// plane iteration, checked buffer sizing, and band packaging are shared here.
+/// An oversize (> u32 view limit) band is rejected before allocating rather than
+/// after filling.
+pub(crate) fn append_stacked_band<F>(
+    builder: &mut RasterBuilder,
+    header: &BandHeader<'_>,
+    plane_bytes: usize,
+    n_planes: usize,
+    mut fill_plane: F,
+) -> Result<()>
+where
+    F: FnMut(usize, &mut Vec<u8>) -> Result<()>,
+{
+    let capacity = plane_bytes
+        .checked_mul(n_planes)
+        .ok_or_else(|| exec_datafusion_err!("band size overflow ({plane_bytes} x {n_planes})"))?;
+    let band_data_len = u32::try_from(capacity).map_err(|_| {
+        exec_datafusion_err!("band data of {capacity} bytes exceeds the binary-view limit")
+    })?;
+
+    let mut band_data: Vec<u8> = Vec::with_capacity(capacity);
+    for plane in 0..n_planes {
+        fill_plane(plane, &mut band_data)?;
+    }
+    if band_data.len() != capacity {
+        return sedona_internal_err!(
+            "stacked band produced {} bytes, expected {capacity}",
+            band_data.len()
+        );
+    }
+
+    builder
+        .start_band_nd(
+            header.name,
+            header.dim_names,
+            header.shape,
+            header.data_type,
+            header.nodata,
+            None,
+            None,
+        )
+        .map_err(|e| exec_datafusion_err!("Failed to start band: {e}"))?;
+    // Move the finished band bytes into an Arrow buffer and append them as a view
+    // (a refcount bump) instead of copying them through the builder.
+    builder
+        .append_band_data_buffer(&Buffer::from(band_data), 0, band_data_len)
+        .map_err(|e| exec_datafusion_err!("Failed to append band data: {e}"))?;
+    builder
+        .finish_band()
+        .map_err(|e| exec_datafusion_err!("Failed to finish band: {e}"))?;
+    Ok(())
+}
+
 /// Regroup a GDAL dataset's flat band list into N-D raster bands per `layout`,
 /// reading each plane at the `metadata` grid size. With `alg = None` the read is
 /// native (`out` == source size, an identity materialization); with `alg =
@@ -569,57 +643,41 @@ fn append_nd_from_dataset_inner(
         shape.push(out_height as i64);
         shape.push(out_width as i64);
 
-        builder
-            .start_band_nd(
-                plan.name.as_deref(),
-                &dim_names,
-                &shape,
-                plan.data_type,
-                plan.nodata.as_deref(),
-                None,
-                None,
-            )
-            .map_err(|e| exec_datafusion_err!("Failed to start band: {}", e))?;
-
-        let capacity = out_width
-            .checked_mul(out_height)
-            .and_then(|a| a.checked_mul(plan.data_type.byte_size()))
-            .and_then(|a| a.checked_mul(plan.plane_count))
-            .ok_or_else(|| {
-                exec_datafusion_err!("resampled band size overflow ({out_width}x{out_height})")
-            })?;
-        let mut band_data: Vec<u8> = Vec::with_capacity(capacity);
-        for _ in 0..plan.plane_count {
-            let band = dataset
-                .rasterband(gdal_band)
-                .map_err(|e| exec_datafusion_err!("Failed to get band {}: {}", gdal_band, e))?;
-            let plane = band
-                .read_as_bytes(
-                    (0, 0),
-                    (src_width, src_height),
-                    (out_width, out_height),
-                    alg,
-                )
-                .map_err(|e| {
-                    exec_datafusion_err!("Failed to read band {} data: {}", gdal_band, e)
-                })?;
-            band_data.extend_from_slice(&plane);
-            gdal_band += 1;
-        }
-
-        let band_data_len = u32::try_from(band_data.len())
-            .map_err(|_| exec_datafusion_err!("Band data too large for Arrow view"))?;
-        let block = builder
-            .band_data_writer()
-            .append_block(Buffer::from_vec(band_data));
-        builder
-            .band_data_writer()
-            .try_append_view(block, 0, band_data_len)
-            .map_err(|e| exec_datafusion_err!("Failed to append band data: {}", e))?;
-
-        builder
-            .finish_band()
-            .map_err(|e| exec_datafusion_err!("Failed to finish band: {}", e))?;
+        // This band's planes are `plan.plane_count` consecutive GDAL bands
+        // starting at `gdal_band`; read each at the output grid size (native when
+        // `alg` is `None`, resampled otherwise) and stack them into the N-D band.
+        let gdal_band_base = gdal_band;
+        append_stacked_band(
+            builder,
+            &BandHeader {
+                name: plan.name.as_deref(),
+                dim_names: &dim_names,
+                shape: &shape,
+                data_type: plan.data_type,
+                nodata: plan.nodata.as_deref(),
+            },
+            out_width * out_height * plan.data_type.byte_size(),
+            plan.plane_count,
+            |plane, out| {
+                let gdal_band = gdal_band_base + plane;
+                let band = dataset
+                    .rasterband(gdal_band)
+                    .map_err(|e| exec_datafusion_err!("Failed to get band {gdal_band}: {e}"))?;
+                let plane = band
+                    .read_as_bytes(
+                        (0, 0),
+                        (src_width, src_height),
+                        (out_width, out_height),
+                        alg,
+                    )
+                    .map_err(|e| {
+                        exec_datafusion_err!("Failed to read band {gdal_band} data: {e}")
+                    })?;
+                out.extend_from_slice(&plane);
+                Ok(())
+            },
+        )?;
+        gdal_band += plan.plane_count;
     }
 
     builder

--- a/rust/sedona-raster-gdal/src/utils.rs
+++ b/rust/sedona-raster-gdal/src/utils.rs
@@ -72,25 +72,22 @@ pub fn append_as_indb_raster(dataset: &Dataset, builder: &mut RasterBuilder) -> 
 
         let nodata_bytes = band_nodata_to_bytes(&band)?;
 
-        builder
-            .start_band_2d(band_data_type, nodata_bytes.as_deref())
-            .map_err(|e| exec_datafusion_err!("Failed to start band: {}", e))?;
-
         let band_data = band
             .read_as_bytes((0, 0), (width, height), (width, height), None)
             .map_err(|e| exec_datafusion_err!("Failed to read band {} data: {}", band_idx, e))?;
-        let band_data_len = u32::try_from(band_data.len())
-            .map_err(|_| exec_datafusion_err!("Band {} data too large for Arrow view", band_idx))?;
-        // Hand the freshly-read allocation to Arrow as a shared data block (a
-        // refcount bump, never a copy). `append_band_data_buffer` also stores
-        // sub-inline-threshold bands inline, keeping the view canonical.
-        builder
-            .append_band_data_buffer(&Buffer::from_vec(band_data), 0, band_data_len)
-            .map_err(|e| exec_datafusion_err!("Failed to append band {} data: {}", band_idx, e))?;
-
-        builder
-            .finish_band()
-            .map_err(|e| exec_datafusion_err!("Failed to finish band: {}", e))?;
+        // Single-band native read: the 2-D `["y", "x"]` band `start_band_2d`
+        // would build, shape `[height, width]`.
+        append_band_from_buffer(
+            builder,
+            &BandHeader {
+                name: None,
+                dim_names: &["y", "x"],
+                shape: &[height as i64, width as i64],
+                data_type: band_data_type,
+                nodata: nodata_bytes.as_deref(),
+            },
+            band_data,
+        )?;
     }
 
     builder
@@ -542,6 +539,52 @@ pub(crate) struct BandHeader<'a> {
     pub nodata: Option<&'a [u8]>,
 }
 
+/// Move an already-assembled per-band `Vec<u8>` of in-db pixel bytes into
+/// `builder` as one band: start the band from `header`, hand the owned buffer to
+/// Arrow as a shared data block (a refcount bump, never a copy), and finish the
+/// band. This is the shared packaging tail of every path that builds one band's
+/// bytes in an owned buffer — the read-back stacker ([`append_stacked_band`]),
+/// the single-band GDAL reader ([`append_as_indb_raster`]), and RS_Clip's
+/// masked-crop output.
+///
+/// The band is in-db (its `data` buffer is authoritative), so `outdb_uri` /
+/// `outdb_format` are `None`; out-db bands carry no pixel buffer and do not use
+/// this path. An oversize (> u32 view limit) band is rejected with a descriptive
+/// error rather than a panic.
+pub(crate) fn append_band_from_buffer(
+    builder: &mut RasterBuilder,
+    header: &BandHeader<'_>,
+    band_data: Vec<u8>,
+) -> Result<()> {
+    let band_data_len = u32::try_from(band_data.len()).map_err(|_| {
+        exec_datafusion_err!(
+            "band data of {} bytes exceeds the binary-view limit",
+            band_data.len()
+        )
+    })?;
+    builder
+        .start_band_nd(
+            header.name,
+            header.dim_names,
+            header.shape,
+            header.data_type,
+            header.nodata,
+            None,
+            None,
+        )
+        .map_err(|e| exec_datafusion_err!("Failed to start band: {e}"))?;
+    // Hand the owned buffer to Arrow as a shared data block (a refcount bump,
+    // never a copy). `append_band_data_buffer` also stores sub-inline-threshold
+    // bands inline, keeping the view canonical.
+    builder
+        .append_band_data_buffer(&Buffer::from(band_data), 0, band_data_len)
+        .map_err(|e| exec_datafusion_err!("Failed to append band data: {e}"))?;
+    builder
+        .finish_band()
+        .map_err(|e| exec_datafusion_err!("Failed to finish band: {e}"))?;
+    Ok(())
+}
+
 /// Assemble one N-D raster band and append it to `builder`. The per-plane byte
 /// size and plane count are derived from `header.shape`
 /// (`[non-spatial..., height, width]`) with a fully checked multiply chain, so a
@@ -596,7 +639,10 @@ where
     let capacity = plane_bytes.checked_mul(n_planes).ok_or_else(|| {
         exec_datafusion_err!("band extent {out_w}x{out_h} of {n_planes} planes overflows")
     })?;
-    let band_data_len = u32::try_from(capacity).map_err(|_| {
+    // Reject an oversize (> u32 view limit) band before allocating and filling
+    // the buffer rather than after. `append_band_from_buffer` re-checks the
+    // realized length below; this is the pre-allocation guard.
+    u32::try_from(capacity).map_err(|_| {
         exec_datafusion_err!("band data of {capacity} bytes exceeds the binary-view limit")
     })?;
 
@@ -611,24 +657,7 @@ where
         );
     }
 
-    builder
-        .start_band_nd(
-            header.name,
-            header.dim_names,
-            header.shape,
-            header.data_type,
-            header.nodata,
-            None,
-            None,
-        )
-        .map_err(|e| exec_datafusion_err!("Failed to start band: {e}"))?;
-    builder
-        .append_band_data_buffer(&Buffer::from(band_data), 0, band_data_len)
-        .map_err(|e| exec_datafusion_err!("Failed to append band data: {e}"))?;
-    builder
-        .finish_band()
-        .map_err(|e| exec_datafusion_err!("Failed to finish band: {e}"))?;
-    Ok(())
+    append_band_from_buffer(builder, header, band_data)
 }
 
 /// Regroup a GDAL dataset's flat band list into N-D raster bands per `layout`,


### PR DESCRIPTION
DRY the N-D↔2-D-plane GDAL bridge in `sedona-raster-gdal`:

- `add_layout_datapointer_bands` — the shared per-plane DATAPOINTER band construction (input side), used by `raster_ref_to_gdal_mem` and `append_warped_nd_from_dataset`.
- `append_stacked_band` — the shared plane read-back / band-stacking (output side), used by `append_nd_from_dataset_inner` and RS_Tile's `append_tile_band`.

RS_Clip keeps its two-phase `ClippedRasterData` structure (its plane stacking is decoupled from packaging for the lenient no-intersection return, and that struct is part of its tested surface).