### PR TITLE
ci: trigger the zarr wheel build on sedona-raster-zarr / sedonadb-zarr changes

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -25,6 +25,12 @@ on:
       - '.github/workflows/python-wheels.yml'
       - '.github/workflows/wheels-expr.yml'
       - '.github/workflows/wheels-zarr.yml'
+      # The zarr extension wheel — including the Windows/MSVC build that links
+      # blosc — only builds when this workflow runs. Trigger it on changes to
+      # the zarr crate/package too, so a change there can't skip wheel
+      # validation (blosc on Windows in particular) until the next main push.
+      - 'rust/sedona-raster-zarr/**'
+      - 'python/sedonadb-zarr/**'
       - '.github/actions/setup-wheel-build/**'
   push:
     branches:


### PR DESCRIPTION
The python-wheels PR path filter listed `wheels-zarr.yml` but not the zarr crate/package, so a change to `sedona-raster-zarr`/`sedonadb-zarr` skipped the zarr wheel build (and its Windows/MSVC + blosc link) on the PR that changed it. Add those paths so blosc-on-Windows stays validated pre-merge.