### PR TITLE
feat(python/sedonadb): Raster.from_numpy(bbox=, registration=)

### DIFF
--- a/python/sedonadb/python/sedonadb/raster.py
+++ b/python/sedonadb/python/sedonadb/raster.py
@@ -22,7 +22,7 @@ from typing import List, Optional, TYPE_CHECKING, Tuple, Any, Iterable
 import geoarrow.types as gat
 import pyarrow as pa
 
-from sedonadb._lib import raster_type
+from sedonadb._lib import geotransform_from_bbox, raster_type
 
 if TYPE_CHECKING:
     import numpy as np
@@ -97,6 +97,8 @@ class Raster:
         crs: Any = None,
         nodata: Any = None,
         transform: Optional[Iterable[float]] = None,
+        bbox: Optional[Iterable[float]] = None,
+        registration: Optional[str] = None,
     ) -> "Raster":
         """Create an in-database raster from a NumPy array, holding pixels inline.
 
@@ -116,7 +118,14 @@ class Raster:
             nodata: Optional nodata sentinel, packed in the array's dtype.
             transform: Optional GDAL-order geotransform
                 `[origin_x, scale_x, skew_x, origin_y, skew_y, scale_y]`;
-                defaults to a north-up identity.
+                defaults to a north-up identity. Mutually exclusive with `bbox`.
+            bbox: Optional spatial bounding box `[xmin, ymin, xmax, ymax]` to
+                derive a north-up geotransform from, using the array's trailing
+                `(y, x)` shape. Mutually exclusive with `transform`.
+            registration: How `bbox` maps to the grid, either `"pixel"` (the
+                default: the bbox is the grid's outer edge) or `"node"` (the bbox
+                endpoints are the centers of the border cells). Only meaningful
+                together with `bbox`.
 
         Returns:
             A new Raster instance with a single in-database band.
@@ -138,6 +147,14 @@ class Raster:
         dtype = str(array.dtype)
         if dtype not in BAND_DATA_TYPE_IDS:
             raise ValueError(f"Unsupported raster dtype: {dtype}")
+
+        if bbox is not None:
+            if transform is not None:
+                raise ValueError("bbox and transform are mutually exclusive")
+            # The trailing (y, x) axes are the spatial pair; the bbox->transform
+            # math lives in Rust (geotransform_from_bbox_and_spatial_shape).
+            height, width = shape[-2], shape[-1]
+            transform = geotransform_from_bbox(list(bbox), height, width, registration)
 
         return _build_raster(
             dim_names,

--- a/python/sedonadb/src/lib.rs
+++ b/python/sedonadb/src/lib.rs
@@ -20,10 +20,11 @@ use crate::{
     raster_loader::py_raster_loader,
     udf::{sedona_aggregate_udf, sedona_scalar_udf},
 };
-use pyo3::{ffi::Py_uintptr_t, prelude::*};
+use pyo3::{exceptions::PyValueError, ffi::Py_uintptr_t, prelude::*};
 use sedona_adbc::AdbcSedonadbDriverInit;
 use sedona_gdal::global::{configure_global_gdal_api, with_global_gdal, GdalApiBuilder};
 use sedona_proj::register::{configure_global_proj_engine, ProjCrsEngineBuilder};
+use sedona_raster::geo_transform::geotransform_from_bbox_and_spatial_shape;
 use std::ffi::c_void;
 
 mod context;
@@ -111,6 +112,26 @@ fn configure_gdal_shared(shared_library_path: String) -> Result<(), PySedonaErro
     Ok(())
 }
 
+/// Derive a north-up, GDAL-order geotransform from a spatial bounding box and
+/// grid shape. Thin wrapper over `geotransform_from_bbox_and_spatial_shape` so
+/// the bbox-to-transform math stays a single Rust source of truth.
+///
+/// `bbox` is `[xmin, ymin, xmax, ymax]`; `registration` is `"pixel"` (the
+/// default when `None`) or `"node"`. Returns the six coefficients
+/// `[origin_x, scale_x, skew_x, origin_y, skew_y, scale_y]`.
+#[pyfunction]
+#[pyo3(signature = (bbox, height, width, registration=None))]
+fn geotransform_from_bbox(
+    bbox: [f64; 4],
+    height: u64,
+    width: u64,
+    registration: Option<String>,
+) -> PyResult<Vec<f64>> {
+    geotransform_from_bbox_and_spatial_shape(bbox, height, width, registration.as_deref())
+        .map(|gt| gt.to_vec())
+        .map_err(|e| PyValueError::new_err(e.to_string()))
+}
+
 #[pyfunction]
 fn gdal_version() -> Result<Option<String>, PySedonaError> {
     match with_global_gdal(|gdal| gdal.version_info("RELEASE_NAME")) {
@@ -132,6 +153,7 @@ fn _lib(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(expr::expr_not, m)?)?;
     m.add_function(wrap_pyfunction!(expr::expr_sort_expr, m)?)?;
     m.add_function(wrap_pyfunction!(gdal_version, m)?)?;
+    m.add_function(wrap_pyfunction!(geotransform_from_bbox, m)?)?;
     m.add_function(wrap_pyfunction!(py_raster_loader, m)?)?;
     m.add_function(wrap_pyfunction!(schema::raster_type, m)?)?;
     m.add_function(wrap_pyfunction!(sedona_adbc_driver_init, m)?)?;

--- a/python/sedonadb/tests/test_raster.py
+++ b/python/sedonadb/tests/test_raster.py
@@ -301,6 +301,48 @@ def test_raster_from_numpy_invalid_shape():
         Raster.from_numpy(np.zeros((2, 2, 3), dtype="uint8"))
 
 
+def test_raster_from_numpy_bbox_matches_rasterio():
+    # bbox (pixel/default) must produce rasterio.transform.from_bounds, in GDAL order.
+    rasterio = pytest.importorskip("rasterio")
+
+    xmin, ymin, xmax, ymax = -100.0, 20.0, -40.0, 50.0
+    arr = np.arange(4 * 5, dtype="uint8").reshape(4, 5)  # (height, width) = (4, 5)
+    r = Raster.from_numpy(arr, bbox=[xmin, ymin, xmax, ymax])
+
+    # rasterio reference: from_bounds(west, south, east, north, width, height)
+    # returns an Affine (a, b, c, d, e, f); GDAL order is [c, a, b, f, d, e].
+    a, b, c, d, e, f = rasterio.transform.from_bounds(xmin, ymin, xmax, ymax, 5, 4)[:6]
+    expected = [c, a, b, f, d, e]
+
+    assert list(r.transform) == pytest.approx(expected, abs=1e-12)
+
+
+def test_raster_from_numpy_bbox_and_transform_mutually_exclusive():
+    arr = np.zeros((4, 5), dtype="uint8")
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        Raster.from_numpy(
+            arr,
+            bbox=[-100.0, 20.0, -40.0, 50.0],
+            transform=[0.0, 1.0, 0.0, 0.0, 0.0, -1.0],
+        )
+
+
+def test_raster_from_numpy_bbox_registration_node():
+    # A node-registered grid maps the bbox to cell centers, so its transform
+    # differs from the default pixel registration (exact values are pinned by the
+    # Rust unit test); this is the Python end-to-end smoke.
+    arr = np.zeros((4, 5), dtype="uint8")
+    bbox = [-100.0, 20.0, -40.0, 50.0]
+
+    pixel = Raster.from_numpy(arr, bbox=bbox).transform
+    node = Raster.from_numpy(arr, bbox=bbox, registration="node").transform
+
+    assert list(node) != list(pixel)
+    # node: scale_x = 60/(5-1) = 15, scale_y = -30/(4-1) = -10, corner is half a
+    # cell outside the bbox: origin_x = -100 - 15/2, origin_y = 50 - (-10)/2.
+    assert list(node) == pytest.approx([-107.5, 15.0, 0.0, 55.0, 0.0, -10.0], abs=1e-12)
+
+
 def test_raster_lazy_zero_size():
     """Test that a raster with zero-size shape returns an empty memoryview."""
     r = Raster.lazy(


### PR DESCRIPTION
Wires `Raster.from_numpy` to accept `bbox=[xmin,ymin,xmax,ymax]` + `registration="pixel"|"node"`, building the geotransform via the Rust `geotransform_from_bbox_and_spatial_shape` (exposed through pyo3) — mutually exclusive with an explicit `transform`. Python test cross-checks the pixel case against `rasterio.transform.from_bounds`.