### PR TITLE
refactor(rust/sedona-raster): consolidate start_band into a named-args constructor

### DIFF
--- a/rust/sedona-raster-functions/src/rs_dim_band.rs
+++ b/rust/sedona-raster-functions/src/rs_dim_band.rs
@@ -24,7 +24,7 @@ use datafusion_common::{arrow_datafusion_err, exec_err};
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_common::sedona_internal_datafusion_err;
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
-use sedona_raster::builder::RasterBuilder;
+use sedona_raster::builder::{RasterBuilder, StartBandArgs};
 use sedona_raster::traits::RasterRef;
 use sedona_schema::datatypes::SedonaType;
 use sedona_schema::matchers::ArgMatcher;
@@ -112,15 +112,16 @@ impl SedonaScalarKernel for RsDimToBand {
                                 // Band doesn't have this dimension -- pass through
                                 let dim_names = band.dim_names();
                                 let band_name = raster.band_name(band_idx);
-                                new_builder.start_band_nd(
-                                    band_name,
-                                    &dim_names,
-                                    band.shape(),
-                                    band.data_type(),
-                                    band.nodata(),
-                                    None,
-                                    None,
-                                )?;
+                                new_builder.start_band(StartBandArgs {
+                                    name: band_name,
+                                    dim_names: &dim_names,
+                                    source_shape: band.shape(),
+                                    view: None,
+                                    data_type: band.data_type(),
+                                    nodata: band.nodata(),
+                                    outdb_uri: None,
+                                    outdb_format: None,
+                                })?;
                                 let ndb = band.nd_buffer()?;
                                 let data = ndb.as_contiguous()?;
                                 new_builder.band_data_writer().append_value(data);
@@ -151,15 +152,16 @@ impl SedonaScalarKernel for RsDimToBand {
 
                                     let new_band_name =
                                         orig_band_name.map(|n| format!("{n}_{name}_{idx}"));
-                                    new_builder.start_band_nd(
-                                        new_band_name.as_deref(),
-                                        &new_dim_names,
-                                        &new_shape,
-                                        band.data_type(),
-                                        band.nodata(),
-                                        None,
-                                        None,
-                                    )?;
+                                    new_builder.start_band(StartBandArgs {
+                                        name: new_band_name.as_deref(),
+                                        dim_names: &new_dim_names,
+                                        source_shape: &new_shape,
+                                        view: None,
+                                        data_type: band.data_type(),
+                                        nodata: band.nodata(),
+                                        outdb_uri: None,
+                                        outdb_format: None,
+                                    })?;
                                     new_builder.band_data_writer().append_value(&sliced_data);
                                     new_builder.finish_band()?;
                                 }
@@ -306,15 +308,16 @@ impl SedonaScalarKernel for RsBandToDim {
                         raster.spatial_shape(),
                         raster.crs(),
                     )?;
-                    new_builder.start_band_nd(
-                        None,
-                        &new_dim_names,
-                        &new_shape,
-                        ref_data_type,
+                    new_builder.start_band(StartBandArgs {
+                        name: None,
+                        dim_names: &new_dim_names,
+                        source_shape: &new_shape,
+                        view: None,
+                        data_type: ref_data_type,
                         nodata,
-                        None,
-                        None,
-                    )?;
+                        outdb_uri: None,
+                        outdb_format: None,
+                    })?;
                     new_builder.band_data_writer().append_value(&concat_data);
                     new_builder.finish_band()?;
                     new_builder.finish_raster()?;
@@ -335,7 +338,7 @@ mod tests {
     use arrow_schema::DataType;
     use datafusion_expr::ScalarUDF;
     use sedona_raster::array::RasterStructArray;
-    use sedona_raster::builder::RasterBuilder;
+    use sedona_raster::builder::{RasterBuilder, StartBandArgs};
     use sedona_raster::traits::RasterRef;
     use sedona_schema::datatypes::RASTER;
     use sedona_schema::raster::BandDataType;
@@ -435,29 +438,31 @@ mod tests {
             .unwrap();
 
         builder
-            .start_band_nd(
-                None,
-                &["time", "y", "x"],
-                &[3, 2, 2],
-                BandDataType::UInt8,
-                None,
-                None,
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["time", "y", "x"],
+                source_shape: &[3, 2, 2],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder.band_data_writer().append_value([0u8; 12]);
         builder.finish_band().unwrap();
 
         builder
-            .start_band_nd(
-                None,
-                &["time", "y", "x"],
-                &[4, 2, 2],
-                BandDataType::UInt8,
-                None,
-                None,
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["time", "y", "x"],
+                source_shape: &[4, 2, 2],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder.band_data_writer().append_value([0u8; 16]);
         builder.finish_band().unwrap();
@@ -492,28 +497,30 @@ mod tests {
             .start_raster_nd(&transform, &["x", "y"], &[2, 2], None)
             .unwrap();
         builder
-            .start_band_nd(
-                None,
-                &["y", "x"],
-                &[2, 2],
-                BandDataType::UInt8,
-                Some(&[0u8]),
-                None,
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["y", "x"],
+                source_shape: &[2, 2],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: Some(&[0u8]),
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder.band_data_writer().append_value([0u8; 4]);
         builder.finish_band().unwrap();
         builder
-            .start_band_nd(
-                None,
-                &["y", "x"],
-                &[2, 2],
-                BandDataType::UInt8,
-                Some(&[255u8]),
-                None,
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["y", "x"],
+                source_shape: &[2, 2],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: Some(&[255u8]),
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder.band_data_writer().append_value([0u8; 4]);
         builder.finish_band().unwrap();
@@ -539,15 +546,16 @@ mod tests {
             .unwrap();
         for _ in 0..2 {
             builder
-                .start_band_nd(
-                    None,
-                    &["y", "x"],
-                    &[2, 2],
-                    BandDataType::UInt8,
-                    None,
-                    None,
-                    None,
-                )
+                .start_band(StartBandArgs {
+                    name: None,
+                    dim_names: &["y", "x"],
+                    source_shape: &[2, 2],
+                    view: None,
+                    data_type: BandDataType::UInt8,
+                    nodata: None,
+                    outdb_uri: None,
+                    outdb_format: None,
+                })
                 .unwrap();
             builder.band_data_writer().append_value([0u8; 4]);
             builder.finish_band().unwrap();

--- a/rust/sedona-raster-functions/src/rs_dim_band.rs
+++ b/rust/sedona-raster-functions/src/rs_dim_band.rs
@@ -114,13 +114,8 @@ impl SedonaScalarKernel for RsDimToBand {
                                 let band_name = raster.band_name(band_idx);
                                 new_builder.start_band(StartBandArgs {
                                     name: band_name,
-                                    dim_names: &dim_names,
-                                    source_shape: band.shape(),
-                                    view: None,
-                                    data_type: band.data_type(),
                                     nodata: band.nodata(),
-                                    outdb_uri: None,
-                                    outdb_format: None,
+                                    ..StartBandArgs::new(&dim_names, band.shape(), band.data_type())
                                 })?;
                                 let ndb = band.nd_buffer()?;
                                 let data = ndb.as_contiguous()?;
@@ -154,13 +149,12 @@ impl SedonaScalarKernel for RsDimToBand {
                                         orig_band_name.map(|n| format!("{n}_{name}_{idx}"));
                                     new_builder.start_band(StartBandArgs {
                                         name: new_band_name.as_deref(),
-                                        dim_names: &new_dim_names,
-                                        source_shape: &new_shape,
-                                        view: None,
-                                        data_type: band.data_type(),
                                         nodata: band.nodata(),
-                                        outdb_uri: None,
-                                        outdb_format: None,
+                                        ..StartBandArgs::new(
+                                            &new_dim_names,
+                                            &new_shape,
+                                            band.data_type(),
+                                        )
                                     })?;
                                     new_builder.band_data_writer().append_value(&sliced_data);
                                     new_builder.finish_band()?;
@@ -309,14 +303,8 @@ impl SedonaScalarKernel for RsBandToDim {
                         raster.crs(),
                     )?;
                     new_builder.start_band(StartBandArgs {
-                        name: None,
-                        dim_names: &new_dim_names,
-                        source_shape: &new_shape,
-                        view: None,
-                        data_type: ref_data_type,
                         nodata,
-                        outdb_uri: None,
-                        outdb_format: None,
+                        ..StartBandArgs::new(&new_dim_names, &new_shape, ref_data_type)
                     })?;
                     new_builder.band_data_writer().append_value(&concat_data);
                     new_builder.finish_band()?;
@@ -438,31 +426,21 @@ mod tests {
             .unwrap();
 
         builder
-            .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["time", "y", "x"],
-                source_shape: &[3, 2, 2],
-                view: None,
-                data_type: BandDataType::UInt8,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
-            })
+            .start_band(StartBandArgs::new(
+                &["time", "y", "x"],
+                &[3, 2, 2],
+                BandDataType::UInt8,
+            ))
             .unwrap();
         builder.band_data_writer().append_value([0u8; 12]);
         builder.finish_band().unwrap();
 
         builder
-            .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["time", "y", "x"],
-                source_shape: &[4, 2, 2],
-                view: None,
-                data_type: BandDataType::UInt8,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
-            })
+            .start_band(StartBandArgs::new(
+                &["time", "y", "x"],
+                &[4, 2, 2],
+                BandDataType::UInt8,
+            ))
             .unwrap();
         builder.band_data_writer().append_value([0u8; 16]);
         builder.finish_band().unwrap();
@@ -498,28 +476,16 @@ mod tests {
             .unwrap();
         builder
             .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["y", "x"],
-                source_shape: &[2, 2],
-                view: None,
-                data_type: BandDataType::UInt8,
                 nodata: Some(&[0u8]),
-                outdb_uri: None,
-                outdb_format: None,
+                ..StartBandArgs::new(&["y", "x"], &[2, 2], BandDataType::UInt8)
             })
             .unwrap();
         builder.band_data_writer().append_value([0u8; 4]);
         builder.finish_band().unwrap();
         builder
             .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["y", "x"],
-                source_shape: &[2, 2],
-                view: None,
-                data_type: BandDataType::UInt8,
                 nodata: Some(&[255u8]),
-                outdb_uri: None,
-                outdb_format: None,
+                ..StartBandArgs::new(&["y", "x"], &[2, 2], BandDataType::UInt8)
             })
             .unwrap();
         builder.band_data_writer().append_value([0u8; 4]);
@@ -546,16 +512,11 @@ mod tests {
             .unwrap();
         for _ in 0..2 {
             builder
-                .start_band(StartBandArgs {
-                    name: None,
-                    dim_names: &["y", "x"],
-                    source_shape: &[2, 2],
-                    view: None,
-                    data_type: BandDataType::UInt8,
-                    nodata: None,
-                    outdb_uri: None,
-                    outdb_format: None,
-                })
+                .start_band(StartBandArgs::new(
+                    &["y", "x"],
+                    &[2, 2],
+                    BandDataType::UInt8,
+                ))
                 .unwrap();
             builder.band_data_writer().append_value([0u8; 4]);
             builder.finish_band().unwrap();

--- a/rust/sedona-raster-functions/src/rs_ensure_loaded.rs
+++ b/rust/sedona-raster-functions/src/rs_ensure_loaded.rs
@@ -40,7 +40,7 @@ use datafusion_expr::{
 };
 use sedona_common::{sedona_internal_datafusion_err, sedona_internal_err};
 use sedona_raster::array::RasterStructArray;
-use sedona_raster::builder::RasterBuilder;
+use sedona_raster::builder::{RasterBuilder, StartBandArgs};
 use sedona_raster::raster_loader::{
     AsyncRasterLoader, RasterLoadRequest, RasterLoaderConfig, RasterLoaderRegistry,
 };
@@ -350,7 +350,7 @@ where
                 let outdb_format: Option<String> = band.outdb_format().map(|s| s.to_string());
                 let is_indb = band.is_indb();
                 // A non-identity view can't be passed through yet: the rebuild
-                // via `start_band_nd` below emits an identity band, so the view
+                // via `start_band` below emits an identity band, so the view
                 // would be silently dropped — the zero-copy passthrough shares
                 // the source bytes but does not carry the view. Unreachable
                 // today (the read boundary rejects non-identity views), but
@@ -379,18 +379,19 @@ where
 
             let dim_names: Vec<&str> = dim_names_owned.iter().map(String::as_str).collect();
             builder
-                .start_band_nd(
-                    band_name.as_deref(),
-                    &dim_names,
-                    &source_shape,
+                .start_band(StartBandArgs {
+                    name: band_name.as_deref(),
+                    dim_names: &dim_names,
+                    source_shape: &source_shape,
+                    view: None,
                     data_type,
-                    nodata.as_deref(),
-                    outdb_uri.as_deref(),
-                    outdb_format.as_deref(),
-                )
+                    nodata: nodata.as_deref(),
+                    outdb_uri: outdb_uri.as_deref(),
+                    outdb_format: outdb_format.as_deref(),
+                })
                 .map_err(|e| {
                     sedona_internal_datafusion_err!(
-                        "RS_EnsureLoaded: start_band_nd failed at ({raster_idx},{band_idx}): {e}"
+                        "RS_EnsureLoaded: start_band failed at ({raster_idx},{band_idx}): {e}"
                     )
                 })?;
 
@@ -449,9 +450,10 @@ where
                 }
 
                 // We can only build identity-view output bands today
-                // (`start_band_nd`). A loader that resolved/cropped the view —
-                // returning a different `source_shape` or a non-identity
-                // `view` — needs `start_band_with_view`. Reserved for
+                // (`start_band` with `view: None`). A loader that
+                // resolved/cropped the view — returning a different
+                // `source_shape` or a non-identity `view` — needs `start_band`
+                // with a `Some` view. Reserved for
                 // https://github.com/apache/sedona-db/issues/897.
                 let result = &result[0];
                 if result.source_shape != source_shape
@@ -518,7 +520,7 @@ mod tests {
     use arrow_array::Array;
     use arrow_buffer::Buffer;
     use sedona_raster::array::RasterStructArray;
-    use sedona_raster::builder::RasterBuilder;
+    use sedona_raster::builder::{RasterBuilder, StartBandArgs};
     use sedona_raster::raster_loader::{RasterLoadResult, RasterLoaderRegistry};
     use sedona_raster::traits::RasterRef;
     use sedona_schema::raster::BandDataType;
@@ -569,15 +571,16 @@ mod tests {
             None,
         )
         .unwrap();
-        b.start_band_nd(
-            Some("band0"),
-            &["y", "x"],
+        b.start_band(StartBandArgs {
+            name: Some("band0"),
+            dim_names: &["y", "x"],
             source_shape,
-            BandDataType::UInt8,
-            None,
-            Some(uri),
-            Some(format),
-        )
+            view: None,
+            data_type: BandDataType::UInt8,
+            nodata: None,
+            outdb_uri: Some(uri),
+            outdb_format: Some(format),
+        })
         .unwrap();
         // OutDb bands write empty data.
         b.band_data_writer().append_value([0u8; 0]);
@@ -597,15 +600,16 @@ mod tests {
             None,
         )
         .unwrap();
-        b.start_band_nd(
-            Some("band0"),
-            &["y", "x"],
+        b.start_band(StartBandArgs {
+            name: Some("band0"),
+            dim_names: &["y", "x"],
             source_shape,
-            BandDataType::UInt8,
-            None,
-            None,
-            None,
-        )
+            view: None,
+            data_type: BandDataType::UInt8,
+            nodata: None,
+            outdb_uri: None,
+            outdb_format: None,
+        })
         .unwrap();
         b.band_data_writer().append_value(data);
         b.finish_band().unwrap();
@@ -949,15 +953,16 @@ mod tests {
         let mut b = RasterBuilder::new(2);
         b.start_raster_nd(&[0.0, 1.0, 0.0, 0.0, 0.0, -1.0], &["y", "x"], &[2, 3], None)
             .unwrap();
-        b.start_band_nd(
-            Some("band0"),
-            &["y", "x"],
-            &[2, 3],
-            BandDataType::UInt8,
-            None,
-            Some("file:///tmp/foo.tif"),
-            Some("mock"),
-        )
+        b.start_band(StartBandArgs {
+            name: Some("band0"),
+            dim_names: &["y", "x"],
+            source_shape: &[2, 3],
+            view: None,
+            data_type: BandDataType::UInt8,
+            nodata: None,
+            outdb_uri: Some("file:///tmp/foo.tif"),
+            outdb_format: Some("mock"),
+        })
         .unwrap();
         b.band_data_writer().append_value([0u8; 0]);
         b.finish_band().unwrap();

--- a/rust/sedona-raster-functions/src/rs_ensure_loaded.rs
+++ b/rust/sedona-raster-functions/src/rs_ensure_loaded.rs
@@ -381,13 +381,10 @@ where
             builder
                 .start_band(StartBandArgs {
                     name: band_name.as_deref(),
-                    dim_names: &dim_names,
-                    source_shape: &source_shape,
-                    view: None,
-                    data_type,
                     nodata: nodata.as_deref(),
                     outdb_uri: outdb_uri.as_deref(),
                     outdb_format: outdb_format.as_deref(),
+                    ..StartBandArgs::new(&dim_names, &source_shape, data_type)
                 })
                 .map_err(|e| {
                     sedona_internal_datafusion_err!(
@@ -573,13 +570,9 @@ mod tests {
         .unwrap();
         b.start_band(StartBandArgs {
             name: Some("band0"),
-            dim_names: &["y", "x"],
-            source_shape,
-            view: None,
-            data_type: BandDataType::UInt8,
-            nodata: None,
             outdb_uri: Some(uri),
             outdb_format: Some(format),
+            ..StartBandArgs::new(&["y", "x"], source_shape, BandDataType::UInt8)
         })
         .unwrap();
         // OutDb bands write empty data.
@@ -602,13 +595,7 @@ mod tests {
         .unwrap();
         b.start_band(StartBandArgs {
             name: Some("band0"),
-            dim_names: &["y", "x"],
-            source_shape,
-            view: None,
-            data_type: BandDataType::UInt8,
-            nodata: None,
-            outdb_uri: None,
-            outdb_format: None,
+            ..StartBandArgs::new(&["y", "x"], source_shape, BandDataType::UInt8)
         })
         .unwrap();
         b.band_data_writer().append_value(data);
@@ -955,13 +942,9 @@ mod tests {
             .unwrap();
         b.start_band(StartBandArgs {
             name: Some("band0"),
-            dim_names: &["y", "x"],
-            source_shape: &[2, 3],
-            view: None,
-            data_type: BandDataType::UInt8,
-            nodata: None,
             outdb_uri: Some("file:///tmp/foo.tif"),
             outdb_format: Some("mock"),
+            ..StartBandArgs::new(&["y", "x"], &[2, 3], BandDataType::UInt8)
         })
         .unwrap();
         b.band_data_writer().append_value([0u8; 0]);

--- a/rust/sedona-raster-functions/src/rs_slice.rs
+++ b/rust/sedona-raster-functions/src/rs_slice.rs
@@ -24,7 +24,7 @@ use datafusion_common::{arrow_datafusion_err, exec_err};
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_common::sedona_internal_datafusion_err;
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
-use sedona_raster::builder::RasterBuilder;
+use sedona_raster::builder::{RasterBuilder, StartBandArgs};
 use sedona_raster::traits::{BandRef, RasterRef};
 use sedona_schema::datatypes::SedonaType;
 use sedona_schema::matchers::ArgMatcher;
@@ -118,15 +118,16 @@ impl SedonaScalarKernel for RsSlice {
                         let Some(dim_idx) = band.dim_index(name) else {
                             let dim_names = band.dim_names();
                             let band_name = raster.band_name(band_idx);
-                            new_builder.start_band_nd(
-                                band_name,
-                                &dim_names,
-                                band.shape(),
-                                band.data_type(),
-                                band.nodata(),
-                                None,
-                                None,
-                            )?;
+                            new_builder.start_band(StartBandArgs {
+name: band_name,
+dim_names: &dim_names,
+source_shape: band.shape(),
+view: None,
+data_type: band.data_type(),
+nodata: band.nodata(),
+outdb_uri: None,
+outdb_format: None,
+})?;
                             let ndb = band.nd_buffer()?;
                             let data = ndb.as_contiguous()?;
                             new_builder.band_data_writer().append_value(data);
@@ -160,15 +161,16 @@ impl SedonaScalarKernel for RsSlice {
                             extract_slice(band.as_ref(), dim_idx, idx, 1)?;
 
                         let band_name = raster.band_name(band_idx);
-                        new_builder.start_band_nd(
-                            band_name,
-                            &new_dim_names,
-                            &new_shape,
-                            band.data_type(),
-                            band.nodata(),
-                            None,
-                            None,
-                        )?;
+                        new_builder.start_band(StartBandArgs {
+name: band_name,
+dim_names: &new_dim_names,
+source_shape: &new_shape,
+view: None,
+data_type: band.data_type(),
+nodata: band.nodata(),
+outdb_uri: None,
+outdb_format: None,
+})?;
                         new_builder.band_data_writer().append_value(&sliced_data);
                         new_builder.finish_band()?;
                     }
@@ -286,15 +288,16 @@ impl SedonaScalarKernel for RsSliceRange {
                         let Some(dim_idx) = band.dim_index(name) else {
                             let dim_names = band.dim_names();
                             let band_name = raster.band_name(band_idx);
-                            new_builder.start_band_nd(
-                                band_name,
-                                &dim_names,
-                                band.shape(),
-                                band.data_type(),
-                                band.nodata(),
-                                None,
-                                None,
-                            )?;
+                            new_builder.start_band(StartBandArgs {
+name: band_name,
+dim_names: &dim_names,
+source_shape: band.shape(),
+view: None,
+data_type: band.data_type(),
+nodata: band.nodata(),
+outdb_uri: None,
+outdb_format: None,
+})?;
                             let ndb = band.nd_buffer()?;
                             let data = ndb.as_contiguous()?;
                             new_builder.band_data_writer().append_value(data);
@@ -319,15 +322,16 @@ impl SedonaScalarKernel for RsSliceRange {
                             extract_slice(band.as_ref(), dim_idx, start_val, range_len)?;
 
                         let band_name = raster.band_name(band_idx);
-                        new_builder.start_band_nd(
-                            band_name,
-                            &dim_names,
-                            &new_shape,
-                            band.data_type(),
-                            band.nodata(),
-                            None,
-                            None,
-                        )?;
+                        new_builder.start_band(StartBandArgs {
+name: band_name,
+dim_names: &dim_names,
+source_shape: &new_shape,
+view: None,
+data_type: band.data_type(),
+nodata: band.nodata(),
+outdb_uri: None,
+outdb_format: None,
+})?;
                         new_builder.band_data_writer().append_value(&sliced_data);
                         new_builder.finish_band()?;
                     }

--- a/rust/sedona-raster-functions/src/rs_slice.rs
+++ b/rust/sedona-raster-functions/src/rs_slice.rs
@@ -119,15 +119,10 @@ impl SedonaScalarKernel for RsSlice {
                             let dim_names = band.dim_names();
                             let band_name = raster.band_name(band_idx);
                             new_builder.start_band(StartBandArgs {
-name: band_name,
-dim_names: &dim_names,
-source_shape: band.shape(),
-view: None,
-data_type: band.data_type(),
-nodata: band.nodata(),
-outdb_uri: None,
-outdb_format: None,
-})?;
+                                name: band_name,
+                                nodata: band.nodata(),
+                                ..StartBandArgs::new(&dim_names, band.shape(), band.data_type())
+                            })?;
                             let ndb = band.nd_buffer()?;
                             let data = ndb.as_contiguous()?;
                             new_builder.band_data_writer().append_value(data);
@@ -162,15 +157,10 @@ outdb_format: None,
 
                         let band_name = raster.band_name(band_idx);
                         new_builder.start_band(StartBandArgs {
-name: band_name,
-dim_names: &new_dim_names,
-source_shape: &new_shape,
-view: None,
-data_type: band.data_type(),
-nodata: band.nodata(),
-outdb_uri: None,
-outdb_format: None,
-})?;
+                            name: band_name,
+                            nodata: band.nodata(),
+                            ..StartBandArgs::new(&new_dim_names, &new_shape, band.data_type())
+                        })?;
                         new_builder.band_data_writer().append_value(&sliced_data);
                         new_builder.finish_band()?;
                     }
@@ -289,15 +279,10 @@ impl SedonaScalarKernel for RsSliceRange {
                             let dim_names = band.dim_names();
                             let band_name = raster.band_name(band_idx);
                             new_builder.start_band(StartBandArgs {
-name: band_name,
-dim_names: &dim_names,
-source_shape: band.shape(),
-view: None,
-data_type: band.data_type(),
-nodata: band.nodata(),
-outdb_uri: None,
-outdb_format: None,
-})?;
+                                name: band_name,
+                                nodata: band.nodata(),
+                                ..StartBandArgs::new(&dim_names, band.shape(), band.data_type())
+                            })?;
                             let ndb = band.nd_buffer()?;
                             let data = ndb.as_contiguous()?;
                             new_builder.band_data_writer().append_value(data);
@@ -323,15 +308,10 @@ outdb_format: None,
 
                         let band_name = raster.band_name(band_idx);
                         new_builder.start_band(StartBandArgs {
-name: band_name,
-dim_names: &dim_names,
-source_shape: &new_shape,
-view: None,
-data_type: band.data_type(),
-nodata: band.nodata(),
-outdb_uri: None,
-outdb_format: None,
-})?;
+                            name: band_name,
+                            nodata: band.nodata(),
+                            ..StartBandArgs::new(&dim_names, &new_shape, band.data_type())
+                        })?;
                         new_builder.band_data_writer().append_value(&sliced_data);
                         new_builder.finish_band()?;
                     }

--- a/rust/sedona-raster-gdal/src/gdal_common.rs
+++ b/rust/sedona-raster-gdal/src/gdal_common.rs
@@ -586,7 +586,7 @@ mod tests {
 
     use crate::utils::Grid;
     use sedona_raster::array::RasterStructArray;
-    use sedona_raster::builder::RasterBuilder;
+    use sedona_raster::builder::{RasterBuilder, StartBandArgs};
     use sedona_testing::rasters::{build_in_db_raster, InDbTestBand};
 
     fn single_raster<'a>(
@@ -931,15 +931,16 @@ mod tests {
             .start_raster_2d(1, 1, 0.0, 1.0, 1.0, -1.0, 0.0, 0.0, None)
             .unwrap();
         builder
-            .start_band_nd(
-                None,
-                &["y", "x"],
-                &[1, 1],
-                BandDataType::UInt8,
-                Some(&[0u8]),
-                Some("/tmp/test.tif#band=1"),
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["y", "x"],
+                source_shape: &[1, 1],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: Some(&[0u8]),
+                outdb_uri: Some("/tmp/test.tif#band=1"),
+                outdb_format: None,
+            })
             .unwrap();
         builder.band_data_writer().append_value([]);
         builder.finish_band().unwrap();
@@ -964,15 +965,16 @@ mod tests {
             .start_raster_2d(2, 2, 0.0, 2.0, 1.0, -1.0, 0.0, 0.0, None)
             .unwrap();
         builder
-            .start_band_nd(
-                Some("cube"),
-                &["time", "y", "x"],
-                &[3, 2, 2],
-                BandDataType::UInt8,
-                None,
-                None,
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: Some("cube"),
+                dim_names: &["time", "y", "x"],
+                source_shape: &[3, 2, 2],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder.band_data_writer().append_value(&data);
         builder.finish_band().unwrap();
@@ -1015,28 +1017,30 @@ mod tests {
             .start_raster_2d(2, 2, 0.0, 2.0, 1.0, -1.0, 0.0, 0.0, None)
             .unwrap();
         builder
-            .start_band_nd(
-                Some("flat"),
-                &["y", "x"],
-                &[2, 2],
-                BandDataType::UInt8,
-                None,
-                None,
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: Some("flat"),
+                dim_names: &["y", "x"],
+                source_shape: &[2, 2],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder.band_data_writer().append_value(&band0);
         builder.finish_band().unwrap();
         builder
-            .start_band_nd(
-                Some("cube"),
-                &["time", "y", "x"],
-                &[3, 2, 2],
-                BandDataType::UInt8,
-                Some(&[7u8]),
-                None,
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: Some("cube"),
+                dim_names: &["time", "y", "x"],
+                source_shape: &[3, 2, 2],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: Some(&[7u8]),
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder.band_data_writer().append_value(&band1);
         builder.finish_band().unwrap();
@@ -1097,15 +1101,16 @@ mod tests {
             .start_raster_2d(2, 2, 0.0, 2.0, 1.0, -1.0, 0.0, 0.0, None)
             .unwrap();
         builder
-            .start_band_nd(
-                Some("hypercube"),
-                &["time", "level", "y", "x"],
-                &[2, 2, 2, 2],
-                BandDataType::UInt8,
-                None,
-                None,
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: Some("hypercube"),
+                dim_names: &["time", "level", "y", "x"],
+                source_shape: &[2, 2, 2, 2],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder.band_data_writer().append_value(&data);
         builder.finish_band().unwrap();
@@ -1144,15 +1149,16 @@ mod tests {
             .start_raster_2d(2, 2, 0.0, 2.0, 1.0, -1.0, 0.0, 0.0, None)
             .unwrap();
         builder
-            .start_band_nd(
-                None,
-                &["y", "x", "time"],
-                &[2, 2, 3],
-                BandDataType::UInt8,
-                None,
-                None,
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["y", "x", "time"],
+                source_shape: &[2, 2, 3],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder
             .band_data_writer()

--- a/rust/sedona-raster-gdal/src/gdal_common.rs
+++ b/rust/sedona-raster-gdal/src/gdal_common.rs
@@ -932,14 +932,9 @@ mod tests {
             .unwrap();
         builder
             .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["y", "x"],
-                source_shape: &[1, 1],
-                view: None,
-                data_type: BandDataType::UInt8,
                 nodata: Some(&[0u8]),
                 outdb_uri: Some("/tmp/test.tif#band=1"),
-                outdb_format: None,
+                ..StartBandArgs::new(&["y", "x"], &[1, 1], BandDataType::UInt8)
             })
             .unwrap();
         builder.band_data_writer().append_value([]);
@@ -967,13 +962,7 @@ mod tests {
         builder
             .start_band(StartBandArgs {
                 name: Some("cube"),
-                dim_names: &["time", "y", "x"],
-                source_shape: &[3, 2, 2],
-                view: None,
-                data_type: BandDataType::UInt8,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
+                ..StartBandArgs::new(&["time", "y", "x"], &[3, 2, 2], BandDataType::UInt8)
             })
             .unwrap();
         builder.band_data_writer().append_value(&data);
@@ -1019,13 +1008,7 @@ mod tests {
         builder
             .start_band(StartBandArgs {
                 name: Some("flat"),
-                dim_names: &["y", "x"],
-                source_shape: &[2, 2],
-                view: None,
-                data_type: BandDataType::UInt8,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
+                ..StartBandArgs::new(&["y", "x"], &[2, 2], BandDataType::UInt8)
             })
             .unwrap();
         builder.band_data_writer().append_value(&band0);
@@ -1033,13 +1016,8 @@ mod tests {
         builder
             .start_band(StartBandArgs {
                 name: Some("cube"),
-                dim_names: &["time", "y", "x"],
-                source_shape: &[3, 2, 2],
-                view: None,
-                data_type: BandDataType::UInt8,
                 nodata: Some(&[7u8]),
-                outdb_uri: None,
-                outdb_format: None,
+                ..StartBandArgs::new(&["time", "y", "x"], &[3, 2, 2], BandDataType::UInt8)
             })
             .unwrap();
         builder.band_data_writer().append_value(&band1);
@@ -1103,13 +1081,11 @@ mod tests {
         builder
             .start_band(StartBandArgs {
                 name: Some("hypercube"),
-                dim_names: &["time", "level", "y", "x"],
-                source_shape: &[2, 2, 2, 2],
-                view: None,
-                data_type: BandDataType::UInt8,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
+                ..StartBandArgs::new(
+                    &["time", "level", "y", "x"],
+                    &[2, 2, 2, 2],
+                    BandDataType::UInt8,
+                )
             })
             .unwrap();
         builder.band_data_writer().append_value(&data);
@@ -1149,16 +1125,11 @@ mod tests {
             .start_raster_2d(2, 2, 0.0, 2.0, 1.0, -1.0, 0.0, 0.0, None)
             .unwrap();
         builder
-            .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["y", "x", "time"],
-                source_shape: &[2, 2, 3],
-                view: None,
-                data_type: BandDataType::UInt8,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
-            })
+            .start_band(StartBandArgs::new(
+                &["y", "x", "time"],
+                &[2, 2, 3],
+                BandDataType::UInt8,
+            ))
             .unwrap();
         builder
             .band_data_writer()

--- a/rust/sedona-raster-gdal/src/gdal_dataset_provider.rs
+++ b/rust/sedona-raster-gdal/src/gdal_dataset_provider.rs
@@ -614,7 +614,7 @@ mod tests {
     use arrow_array::StructArray;
     use sedona_gdal::raster::types::Buffer;
     use sedona_raster::array::RasterStructArray;
-    use sedona_raster::builder::RasterBuilder;
+    use sedona_raster::builder::{RasterBuilder, StartBandArgs};
     use sedona_schema::raster::BandDataType;
     use sedona_testing::rasters::{build_in_db_raster, InDbTestBand};
     use tempfile::TempDir;
@@ -677,15 +677,16 @@ mod tests {
             .unwrap();
 
         builder
-            .start_band_nd(
-                None,
-                &["y", "x"],
-                &[8, 8],
-                BandDataType::UInt8,
-                Some(&[0u8]),
-                Some(&format!("{path}#band=1")),
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["y", "x"],
+                source_shape: &[8, 8],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: Some(&[0u8]),
+                outdb_uri: Some(&format!("{path}#band=1")),
+                outdb_format: None,
+            })
             .unwrap();
         builder.band_data_writer().append_value([]);
         builder.finish_band().unwrap();
@@ -707,15 +708,16 @@ mod tests {
         builder.finish_band().unwrap();
 
         builder
-            .start_band_nd(
-                None,
-                &["y", "x"],
-                &[8, 8],
-                BandDataType::UInt8,
-                Some(&[0u8]),
-                Some(&format!("{path}#band=1")),
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["y", "x"],
+                source_shape: &[8, 8],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: Some(&[0u8]),
+                outdb_uri: Some(&format!("{path}#band=1")),
+                outdb_format: None,
+            })
             .unwrap();
         builder.band_data_writer().append_value([]);
         builder.finish_band().unwrap();
@@ -975,30 +977,32 @@ mod tests {
             .start_raster_2d(8, 8, 0.0, 8.0, 1.0, -1.0, 0.0, 0.0, None)
             .unwrap();
         builder
-            .start_band_nd(
-                None,
-                &["time", "y", "x"],
-                &[2, 8, 8],
-                BandDataType::UInt8,
-                None,
-                None,
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["time", "y", "x"],
+                source_shape: &[2, 8, 8],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder
             .band_data_writer()
             .append_value(vec![0u8; 2 * 8 * 8]);
         builder.finish_band().unwrap();
         builder
-            .start_band_nd(
-                None,
-                &["y", "x"],
-                &[8, 8],
-                BandDataType::UInt8,
-                Some(&[0u8]),
-                Some(&path),
-                Some("geotiff"),
-            )
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["y", "x"],
+                source_shape: &[8, 8],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: Some(&[0u8]),
+                outdb_uri: Some(&path),
+                outdb_format: Some("geotiff"),
+            })
             .unwrap();
         builder.band_data_writer().append_value([]);
         builder.finish_band().unwrap();
@@ -1029,15 +1033,16 @@ mod tests {
             .start_raster_2d(8, 8, 0.0, 8.0, 1.0, -1.0, 0.0, 0.0, None)
             .unwrap();
         builder
-            .start_band_nd(
-                None,
-                &["y", "x"],
-                &[8, 8],
-                BandDataType::UInt8,
-                Some(&[0u8]),
-                Some(&format!("{path}#band=2")),
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["y", "x"],
+                source_shape: &[8, 8],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: Some(&[0u8]),
+                outdb_uri: Some(&format!("{path}#band=2")),
+                outdb_format: None,
+            })
             .unwrap();
         builder.band_data_writer().append_value([]);
         builder.finish_band().unwrap();

--- a/rust/sedona-raster-gdal/src/gdal_dataset_provider.rs
+++ b/rust/sedona-raster-gdal/src/gdal_dataset_provider.rs
@@ -678,14 +678,9 @@ mod tests {
 
         builder
             .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["y", "x"],
-                source_shape: &[8, 8],
-                view: None,
-                data_type: BandDataType::UInt8,
                 nodata: Some(&[0u8]),
                 outdb_uri: Some(&format!("{path}#band=1")),
-                outdb_format: None,
+                ..StartBandArgs::new(&["y", "x"], &[8, 8], BandDataType::UInt8)
             })
             .unwrap();
         builder.band_data_writer().append_value([]);
@@ -709,14 +704,9 @@ mod tests {
 
         builder
             .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["y", "x"],
-                source_shape: &[8, 8],
-                view: None,
-                data_type: BandDataType::UInt8,
                 nodata: Some(&[0u8]),
                 outdb_uri: Some(&format!("{path}#band=1")),
-                outdb_format: None,
+                ..StartBandArgs::new(&["y", "x"], &[8, 8], BandDataType::UInt8)
             })
             .unwrap();
         builder.band_data_writer().append_value([]);
@@ -977,16 +967,11 @@ mod tests {
             .start_raster_2d(8, 8, 0.0, 8.0, 1.0, -1.0, 0.0, 0.0, None)
             .unwrap();
         builder
-            .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["time", "y", "x"],
-                source_shape: &[2, 8, 8],
-                view: None,
-                data_type: BandDataType::UInt8,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
-            })
+            .start_band(StartBandArgs::new(
+                &["time", "y", "x"],
+                &[2, 8, 8],
+                BandDataType::UInt8,
+            ))
             .unwrap();
         builder
             .band_data_writer()
@@ -994,14 +979,10 @@ mod tests {
         builder.finish_band().unwrap();
         builder
             .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["y", "x"],
-                source_shape: &[8, 8],
-                view: None,
-                data_type: BandDataType::UInt8,
                 nodata: Some(&[0u8]),
                 outdb_uri: Some(&path),
                 outdb_format: Some("geotiff"),
+                ..StartBandArgs::new(&["y", "x"], &[8, 8], BandDataType::UInt8)
             })
             .unwrap();
         builder.band_data_writer().append_value([]);
@@ -1034,14 +1015,9 @@ mod tests {
             .unwrap();
         builder
             .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["y", "x"],
-                source_shape: &[8, 8],
-                view: None,
-                data_type: BandDataType::UInt8,
                 nodata: Some(&[0u8]),
                 outdb_uri: Some(&format!("{path}#band=2")),
-                outdb_format: None,
+                ..StartBandArgs::new(&["y", "x"], &[8, 8], BandDataType::UInt8)
             })
             .unwrap();
         builder.band_data_writer().append_value([]);

--- a/rust/sedona-raster-gdal/src/utils.rs
+++ b/rust/sedona-raster-gdal/src/utils.rs
@@ -33,7 +33,7 @@ use sedona_raster::geo_transform::{GeoTransform, GeoTransformEx};
 use arrow_schema::ArrowError;
 use sedona_common::sedona_internal_err;
 use sedona_raster::array::RasterRefImpl;
-use sedona_raster::builder::RasterBuilder;
+use sedona_raster::builder::{RasterBuilder, StartBandArgs};
 use sedona_raster::traits::RasterRef;
 use sedona_schema::raster::BandDataType;
 
@@ -144,15 +144,16 @@ pub fn append_as_outdb_raster(gdal: &Gdal, path: &str, builder: &mut RasterBuild
 
         // Out-db band: location + band selector in the `#band=N` URI; empty data.
         let outdb_uri = format!("{path}#band={band_idx}");
-        builder.start_band_nd(
-            None,
-            &["y", "x"],
-            &[height as i64, width as i64],
-            band_data_type,
-            nodata_bytes.as_deref(),
-            Some(&outdb_uri),
-            None,
-        )?;
+        builder.start_band(StartBandArgs {
+            name: None,
+            dim_names: &["y", "x"],
+            source_shape: &[height as i64, width as i64],
+            view: None,
+            data_type: band_data_type,
+            nodata: nodata_bytes.as_deref(),
+            outdb_uri: Some(&outdb_uri),
+            outdb_format: None,
+        })?;
         builder.band_data_writer().append_value([]);
         builder.finish_band()?;
     }
@@ -528,7 +529,7 @@ fn filled_with_nodata(total: usize, nodata: Option<&[u8]>) -> Vec<u8> {
 }
 
 /// The descriptive header for one output raster band — everything
-/// [`RasterBuilder::start_band_nd`] needs except the pixel bytes. Bundled so
+/// [`RasterBuilder::start_band`] needs except the pixel bytes. Bundled so
 /// [`append_stacked_band`] takes named fields rather than a long positional list.
 pub(crate) struct BandHeader<'a> {
     pub name: Option<&'a str>,
@@ -563,15 +564,16 @@ pub(crate) fn append_band_from_buffer(
         )
     })?;
     builder
-        .start_band_nd(
-            header.name,
-            header.dim_names,
-            header.shape,
-            header.data_type,
-            header.nodata,
-            None,
-            None,
-        )
+        .start_band(StartBandArgs {
+            name: header.name,
+            dim_names: header.dim_names,
+            source_shape: header.shape,
+            view: None,
+            data_type: header.data_type,
+            nodata: header.nodata,
+            outdb_uri: None,
+            outdb_format: None,
+        })
         .map_err(|e| exec_datafusion_err!("Failed to start band: {e}"))?;
     // Hand the owned buffer to Arrow as a shared data block (a refcount bump,
     // never a copy). `append_band_data_buffer` also stores sub-inline-threshold

--- a/rust/sedona-raster-gdal/src/utils.rs
+++ b/rust/sedona-raster-gdal/src/utils.rs
@@ -145,14 +145,9 @@ pub fn append_as_outdb_raster(gdal: &Gdal, path: &str, builder: &mut RasterBuild
         // Out-db band: location + band selector in the `#band=N` URI; empty data.
         let outdb_uri = format!("{path}#band={band_idx}");
         builder.start_band(StartBandArgs {
-            name: None,
-            dim_names: &["y", "x"],
-            source_shape: &[height as i64, width as i64],
-            view: None,
-            data_type: band_data_type,
             nodata: nodata_bytes.as_deref(),
             outdb_uri: Some(&outdb_uri),
-            outdb_format: None,
+            ..StartBandArgs::new(&["y", "x"], &[height as i64, width as i64], band_data_type)
         })?;
         builder.band_data_writer().append_value([]);
         builder.finish_band()?;
@@ -566,13 +561,8 @@ pub(crate) fn append_band_from_buffer(
     builder
         .start_band(StartBandArgs {
             name: header.name,
-            dim_names: header.dim_names,
-            source_shape: header.shape,
-            view: None,
-            data_type: header.data_type,
             nodata: header.nodata,
-            outdb_uri: None,
-            outdb_format: None,
+            ..StartBandArgs::new(header.dim_names, header.shape, header.data_type)
         })
         .map_err(|e| exec_datafusion_err!("Failed to start band: {e}"))?;
     // Hand the owned buffer to Arrow as a shared data block (a refcount bump,

--- a/rust/sedona-raster-zarr/src/loader.rs
+++ b/rust/sedona-raster-zarr/src/loader.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 use arrow_array::{RecordBatch, RecordBatchReader};
 use arrow_schema::{ArrowError, Schema, SchemaRef};
 use sedona_common::sedona_internal_datafusion_err;
-use sedona_raster::builder::RasterBuilder;
+use sedona_raster::builder::{RasterBuilder, StartBandArgs};
 use sedona_raster::geo_transform::geotransform_from_bbox_and_spatial_shape;
 use sedona_raster::traits::is_spatial_dim_pair;
 use sedona_schema::datatypes::SedonaType;
@@ -176,15 +176,16 @@ impl ZarrChunkReader {
             // defers pixel-byte resolution to the raster byte loader.
             let anchor = build_chunk_anchor(&self.group_uri, &info.path, &self.chunk_indices);
             let source_shape: Vec<i64> = info.chunk_shape.iter().map(|&n| n as i64).collect();
-            builder.start_band_nd(
-                Some(info.path.as_str()),
-                &dim_names_ref,
-                &source_shape,
-                info.data_type,
-                nodata_ref,
-                Some(anchor.as_str()),
-                Some("zarr"),
-            )?;
+            builder.start_band(StartBandArgs {
+                name: Some(info.path.as_str()),
+                dim_names: &dim_names_ref,
+                source_shape: &source_shape,
+                view: None,
+                data_type: info.data_type,
+                nodata: nodata_ref,
+                outdb_uri: Some(anchor.as_str()),
+                outdb_format: Some("zarr"),
+            })?;
             builder.band_data_writer().append_value([0u8; 0]);
             builder.finish_band()?;
         }

--- a/rust/sedona-raster-zarr/src/loader.rs
+++ b/rust/sedona-raster-zarr/src/loader.rs
@@ -178,13 +178,10 @@ impl ZarrChunkReader {
             let source_shape: Vec<i64> = info.chunk_shape.iter().map(|&n| n as i64).collect();
             builder.start_band(StartBandArgs {
                 name: Some(info.path.as_str()),
-                dim_names: &dim_names_ref,
-                source_shape: &source_shape,
-                view: None,
-                data_type: info.data_type,
                 nodata: nodata_ref,
                 outdb_uri: Some(anchor.as_str()),
                 outdb_format: Some("zarr"),
+                ..StartBandArgs::new(&dim_names_ref, &source_shape, info.data_type)
             })?;
             builder.band_data_writer().append_value([0u8; 0]);
             builder.finish_band()?;

--- a/rust/sedona-raster/src/array.rs
+++ b/rust/sedona-raster/src/array.rs
@@ -553,7 +553,7 @@ impl<'a> RasterStructArray<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::builder::RasterBuilder;
+    use crate::builder::{RasterBuilder, StartBandArgs};
     use crate::traits::BandOverrides;
     use arrow_array::{ArrayRef, ListArray, StructArray, UInt32Array};
     use arrow_buffer::{OffsetBuffer, ScalarBuffer};
@@ -568,15 +568,16 @@ mod tests {
         let transform = [0.0, 1.0, 0.0, 0.0, 0.0, -1.0];
         let mut ib = RasterBuilder::new(1);
         ib.start_raster_nd(&transform, &["x"], &[16], None).unwrap();
-        ib.start_band_nd(
-            Some("orig"),
-            &["x"],
-            &[16],
-            BandDataType::UInt8,
-            None,
-            None,
-            None,
-        )
+        ib.start_band(StartBandArgs {
+            name: Some("orig"),
+            dim_names: &["x"],
+            source_shape: &[16],
+            view: None,
+            data_type: BandDataType::UInt8,
+            nodata: None,
+            outdb_uri: None,
+            outdb_format: None,
+        })
         .unwrap();
         ib.band_data_writer()
             .append_value((0u8..16).collect::<Vec<u8>>());
@@ -631,15 +632,16 @@ mod tests {
         let transform = [0.0, 1.0, 0.0, 0.0, 0.0, -1.0];
         let mut ib = RasterBuilder::new(1);
         ib.start_raster_nd(&transform, &["x"], &[4], None).unwrap();
-        ib.start_band_nd(
-            Some("orig"),
-            &["x"],
-            &[4],
-            BandDataType::UInt8,
-            None,
-            None,
-            None,
-        )
+        ib.start_band(StartBandArgs {
+            name: Some("orig"),
+            dim_names: &["x"],
+            source_shape: &[4],
+            view: None,
+            data_type: BandDataType::UInt8,
+            nodata: None,
+            outdb_uri: None,
+            outdb_format: None,
+        })
         .unwrap();
         ib.band_data_writer().append_value(vec![1u8, 2, 3, 4]);
         ib.finish_band().unwrap();
@@ -814,7 +816,16 @@ mod tests {
             .start_raster_nd(&transform, &["x"], &[3], None)
             .unwrap();
         builder
-            .start_band_nd(None, &["x"], &[3], BandDataType::UInt8, None, None, None)
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["x"],
+                source_shape: &[3],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder.band_data_writer().append_value(vec![0u8, 1, 2]);
         builder.finish_band().unwrap();
@@ -929,28 +940,30 @@ mod tests {
             .start_raster_nd(&transform, &["x", "y"], &[3, 2], None)
             .unwrap();
         builder
-            .start_band_nd(
-                Some("a"),
-                &["y", "x"],
-                &[2, 3],
-                BandDataType::UInt16,
-                Some(&[0xFFu8, 0xFE]),
-                Some("s3://bucket/a.tif"),
-                Some("GTiff"),
-            )
+            .start_band(StartBandArgs {
+                name: Some("a"),
+                dim_names: &["y", "x"],
+                source_shape: &[2, 3],
+                view: None,
+                data_type: BandDataType::UInt16,
+                nodata: Some(&[0xFFu8, 0xFE]),
+                outdb_uri: Some("s3://bucket/a.tif"),
+                outdb_format: Some("GTiff"),
+            })
             .unwrap();
         builder.band_data_writer().append_value(vec![0u8; 12]);
         builder.finish_band().unwrap();
         builder
-            .start_band_nd(
-                Some("b"),
-                &["y", "x"],
-                &[2, 3],
-                BandDataType::Float32,
-                None,
-                None,
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: Some("b"),
+                dim_names: &["y", "x"],
+                source_shape: &[2, 3],
+                view: None,
+                data_type: BandDataType::Float32,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder.band_data_writer().append_value(vec![0u8; 24]);
         builder.finish_band().unwrap();
@@ -1021,17 +1034,44 @@ mod tests {
             .start_raster_nd(&transform, &["x"], &[3], None)
             .unwrap();
         builder
-            .start_band_nd(None, &["x"], &[3], BandDataType::UInt8, None, None, None)
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["x"],
+                source_shape: &[3],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder.band_data_writer().append_value(vec![10u8, 20, 30]);
         builder.finish_band().unwrap();
         builder
-            .start_band_nd(None, &["x"], &[3], BandDataType::UInt8, None, None, None)
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["x"],
+                source_shape: &[3],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder.band_data_writer().append_value(vec![40u8, 50, 60]);
         builder.finish_band().unwrap();
         builder
-            .start_band_nd(None, &["x"], &[3], BandDataType::UInt8, None, None, None)
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["x"],
+                source_shape: &[3],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder
             .band_data_writer()
@@ -1044,14 +1084,32 @@ mod tests {
             .start_raster_nd(&transform, &["x"], &[4], None)
             .unwrap();
         builder
-            .start_band_nd(None, &["x"], &[4], BandDataType::UInt8, None, None, None)
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["x"],
+                source_shape: &[4],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder
             .band_data_writer()
             .append_value(vec![42u8, 43, 44, 45]);
         builder.finish_band().unwrap();
         builder
-            .start_band_nd(None, &["x"], &[4], BandDataType::UInt8, None, None, None)
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["x"],
+                source_shape: &[4],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder.band_data_writer().append_value(vec![1u8, 2, 3, 4]);
         builder.finish_band().unwrap();
@@ -1137,15 +1195,16 @@ mod tests {
             .start_raster_nd(&transform, &["x"], &[3], None)
             .unwrap();
         builder
-            .start_band_nd(
-                Some("a"),
-                &["x"],
-                &[3],
-                BandDataType::UInt16,
-                Some(&[0xFFu8, 0xFE]),
-                Some("s3://bucket/a.tif"),
-                Some("GTiff"),
-            )
+            .start_band(StartBandArgs {
+                name: Some("a"),
+                dim_names: &["x"],
+                source_shape: &[3],
+                view: None,
+                data_type: BandDataType::UInt16,
+                nodata: Some(&[0xFFu8, 0xFE]),
+                outdb_uri: Some("s3://bucket/a.tif"),
+                outdb_format: Some("GTiff"),
+            })
             .unwrap();
         builder.band_data_writer().append_value(vec![0u8; 6]);
         builder.finish_band().unwrap();
@@ -1182,15 +1241,16 @@ mod tests {
             .start_raster_2d(2, 2, 0.0, 2.0, 1.0, -1.0, 0.0, 0.0, None)
             .unwrap();
         builder
-            .start_band_nd(
-                Some("empty_time"),
-                &["time", "y", "x"],
-                &[0, 2, 2],
-                BandDataType::UInt8,
-                None,
-                None,
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: Some("empty_time"),
+                dim_names: &["time", "y", "x"],
+                source_shape: &[0, 2, 2],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder.band_data_writer().append_value([]); // 0 bytes, legitimately
         builder.finish_band().unwrap();

--- a/rust/sedona-raster/src/array.rs
+++ b/rust/sedona-raster/src/array.rs
@@ -570,13 +570,7 @@ mod tests {
         ib.start_raster_nd(&transform, &["x"], &[16], None).unwrap();
         ib.start_band(StartBandArgs {
             name: Some("orig"),
-            dim_names: &["x"],
-            source_shape: &[16],
-            view: None,
-            data_type: BandDataType::UInt8,
-            nodata: None,
-            outdb_uri: None,
-            outdb_format: None,
+            ..StartBandArgs::new(&["x"], &[16], BandDataType::UInt8)
         })
         .unwrap();
         ib.band_data_writer()
@@ -634,13 +628,7 @@ mod tests {
         ib.start_raster_nd(&transform, &["x"], &[4], None).unwrap();
         ib.start_band(StartBandArgs {
             name: Some("orig"),
-            dim_names: &["x"],
-            source_shape: &[4],
-            view: None,
-            data_type: BandDataType::UInt8,
-            nodata: None,
-            outdb_uri: None,
-            outdb_format: None,
+            ..StartBandArgs::new(&["x"], &[4], BandDataType::UInt8)
         })
         .unwrap();
         ib.band_data_writer().append_value(vec![1u8, 2, 3, 4]);
@@ -816,16 +804,7 @@ mod tests {
             .start_raster_nd(&transform, &["x"], &[3], None)
             .unwrap();
         builder
-            .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["x"],
-                source_shape: &[3],
-                view: None,
-                data_type: BandDataType::UInt8,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
-            })
+            .start_band(StartBandArgs::new(&["x"], &[3], BandDataType::UInt8))
             .unwrap();
         builder.band_data_writer().append_value(vec![0u8, 1, 2]);
         builder.finish_band().unwrap();
@@ -942,13 +921,10 @@ mod tests {
         builder
             .start_band(StartBandArgs {
                 name: Some("a"),
-                dim_names: &["y", "x"],
-                source_shape: &[2, 3],
-                view: None,
-                data_type: BandDataType::UInt16,
                 nodata: Some(&[0xFFu8, 0xFE]),
                 outdb_uri: Some("s3://bucket/a.tif"),
                 outdb_format: Some("GTiff"),
+                ..StartBandArgs::new(&["y", "x"], &[2, 3], BandDataType::UInt16)
             })
             .unwrap();
         builder.band_data_writer().append_value(vec![0u8; 12]);
@@ -956,13 +932,7 @@ mod tests {
         builder
             .start_band(StartBandArgs {
                 name: Some("b"),
-                dim_names: &["y", "x"],
-                source_shape: &[2, 3],
-                view: None,
-                data_type: BandDataType::Float32,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
+                ..StartBandArgs::new(&["y", "x"], &[2, 3], BandDataType::Float32)
             })
             .unwrap();
         builder.band_data_writer().append_value(vec![0u8; 24]);
@@ -1034,44 +1004,17 @@ mod tests {
             .start_raster_nd(&transform, &["x"], &[3], None)
             .unwrap();
         builder
-            .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["x"],
-                source_shape: &[3],
-                view: None,
-                data_type: BandDataType::UInt8,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
-            })
+            .start_band(StartBandArgs::new(&["x"], &[3], BandDataType::UInt8))
             .unwrap();
         builder.band_data_writer().append_value(vec![10u8, 20, 30]);
         builder.finish_band().unwrap();
         builder
-            .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["x"],
-                source_shape: &[3],
-                view: None,
-                data_type: BandDataType::UInt8,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
-            })
+            .start_band(StartBandArgs::new(&["x"], &[3], BandDataType::UInt8))
             .unwrap();
         builder.band_data_writer().append_value(vec![40u8, 50, 60]);
         builder.finish_band().unwrap();
         builder
-            .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["x"],
-                source_shape: &[3],
-                view: None,
-                data_type: BandDataType::UInt8,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
-            })
+            .start_band(StartBandArgs::new(&["x"], &[3], BandDataType::UInt8))
             .unwrap();
         builder
             .band_data_writer()
@@ -1084,32 +1027,14 @@ mod tests {
             .start_raster_nd(&transform, &["x"], &[4], None)
             .unwrap();
         builder
-            .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["x"],
-                source_shape: &[4],
-                view: None,
-                data_type: BandDataType::UInt8,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
-            })
+            .start_band(StartBandArgs::new(&["x"], &[4], BandDataType::UInt8))
             .unwrap();
         builder
             .band_data_writer()
             .append_value(vec![42u8, 43, 44, 45]);
         builder.finish_band().unwrap();
         builder
-            .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["x"],
-                source_shape: &[4],
-                view: None,
-                data_type: BandDataType::UInt8,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
-            })
+            .start_band(StartBandArgs::new(&["x"], &[4], BandDataType::UInt8))
             .unwrap();
         builder.band_data_writer().append_value(vec![1u8, 2, 3, 4]);
         builder.finish_band().unwrap();
@@ -1197,13 +1122,10 @@ mod tests {
         builder
             .start_band(StartBandArgs {
                 name: Some("a"),
-                dim_names: &["x"],
-                source_shape: &[3],
-                view: None,
-                data_type: BandDataType::UInt16,
                 nodata: Some(&[0xFFu8, 0xFE]),
                 outdb_uri: Some("s3://bucket/a.tif"),
                 outdb_format: Some("GTiff"),
+                ..StartBandArgs::new(&["x"], &[3], BandDataType::UInt16)
             })
             .unwrap();
         builder.band_data_writer().append_value(vec![0u8; 6]);
@@ -1243,13 +1165,7 @@ mod tests {
         builder
             .start_band(StartBandArgs {
                 name: Some("empty_time"),
-                dim_names: &["time", "y", "x"],
-                source_shape: &[0, 2, 2],
-                view: None,
-                data_type: BandDataType::UInt8,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
+                ..StartBandArgs::new(&["time", "y", "x"], &[0, 2, 2], BandDataType::UInt8)
             })
             .unwrap();
         builder.band_data_writer().append_value([]); // 0 bytes, legitimately

--- a/rust/sedona-raster/src/builder.rs
+++ b/rust/sedona-raster/src/builder.rs
@@ -158,6 +158,25 @@ pub struct StartBandArgs<'a> {
     pub outdb_format: Option<&'a str>,
 }
 
+impl<'a> StartBandArgs<'a> {
+    /// The required band descriptors; the optional fields (`name`, `view`,
+    /// `nodata`, `outdb_uri`, `outdb_format`) default to `None`. Override any of
+    /// them with struct-update syntax, e.g.
+    /// `StartBandArgs { nodata: Some(&nd), ..StartBandArgs::new(dims, shape, dtype) }`.
+    pub fn new(dim_names: &'a [&'a str], source_shape: &'a [i64], data_type: BandDataType) -> Self {
+        Self {
+            name: None,
+            dim_names,
+            source_shape,
+            view: None,
+            data_type,
+            nodata: None,
+            outdb_uri: None,
+            outdb_format: None,
+        }
+    }
+}
+
 impl RasterBuilder {
     /// Create a new raster builder with the specified capacity.
     pub fn new(capacity: usize) -> Self {
@@ -483,14 +502,12 @@ impl RasterBuilder {
             ));
         }
         self.start_band(StartBandArgs {
-            name: None,
-            dim_names: &["y", "x"],
-            source_shape: &[self.current_height, self.current_width],
-            view: None,
-            data_type,
             nodata,
-            outdb_uri: None,
-            outdb_format: None,
+            ..StartBandArgs::new(
+                &["y", "x"],
+                &[self.current_height, self.current_width],
+                data_type,
+            )
         })
     }
 
@@ -978,19 +995,14 @@ mod tests {
         // copies the N-D spatial grid, so add the band with an explicit shape
         // matching the source's [height, width].
         target_builder
-            .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["y", "x"],
-                source_shape: &[
+            .start_band(StartBandArgs::new(
+                &["y", "x"],
+                &[
                     source_raster.height().unwrap(),
                     source_raster.width().unwrap(),
                 ],
-                view: None,
-                data_type: BandDataType::UInt16,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
-            })
+                BandDataType::UInt16,
+            ))
             .unwrap();
         let new_data = vec![100u16; 1008]; // Different data, same dimensions
         let new_data_bytes: Vec<u8> = new_data.iter().flat_map(|&x| x.to_le_bytes()).collect();
@@ -1197,14 +1209,8 @@ mod tests {
         // with the SedonaDB `#band=N` fragment; the band's own `data` is empty.
         builder
             .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["y", "x"],
-                source_shape: &[1024, 1024],
-                view: None,
-                data_type: BandDataType::Float32,
-                nodata: None,
                 outdb_uri: Some("s3://mybucket/satellite_image.tif#band=2"),
-                outdb_format: None,
+                ..StartBandArgs::new(&["y", "x"], &[1024, 1024], BandDataType::Float32)
             })
             .unwrap();
         // For OutDbRef, data field could be empty or contain metadata/thumbnail
@@ -1390,13 +1396,7 @@ mod tests {
         builder
             .start_band(StartBandArgs {
                 name: Some("temperature"),
-                dim_names: &["time", "y", "x"],
-                source_shape: &[3, 4, 5],
-                view: None,
-                data_type: BandDataType::Float32,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
+                ..StartBandArgs::new(&["time", "y", "x"], &[3, 4, 5], BandDataType::Float32)
             })
             .unwrap();
         let data = vec![0u8; 3 * 4 * 5 * 4]; // 3*4*5 Float32 elements
@@ -1440,13 +1440,11 @@ mod tests {
         builder
             .start_band(StartBandArgs {
                 name: Some("sst"),
-                dim_names: &["latitude", "longitude"],
-                source_shape: &[180, 360],
-                view: None,
-                data_type: BandDataType::Float32,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
+                ..StartBandArgs::new(
+                    &["latitude", "longitude"],
+                    &[180, 360],
+                    BandDataType::Float32,
+                )
             })
             .unwrap();
         let data = vec![0u8; 180 * 360 * 4];
@@ -1478,13 +1476,7 @@ mod tests {
         builder
             .start_band(StartBandArgs {
                 name: Some("temperature"),
-                dim_names: &["time", "y", "x"],
-                source_shape: &[12, 64, 64],
-                view: None,
-                data_type: BandDataType::Float32,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
+                ..StartBandArgs::new(&["time", "y", "x"], &[12, 64, 64], BandDataType::Float32)
             })
             .unwrap();
         let data_3d = vec![0u8; 12 * 64 * 64 * 4];
@@ -1495,13 +1487,7 @@ mod tests {
         builder
             .start_band(StartBandArgs {
                 name: Some("elevation"),
-                dim_names: &["y", "x"],
-                source_shape: &[64, 64],
-                view: None,
-                data_type: BandDataType::Float64,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
+                ..StartBandArgs::new(&["y", "x"], &[64, 64], BandDataType::Float64)
             })
             .unwrap();
         let data_2d = vec![0u8; 64 * 64 * 8];
@@ -1539,16 +1525,11 @@ mod tests {
             .start_raster_nd(&transform, &["x", "y"], &[32, 32], None)
             .unwrap();
         builder
-            .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["time", "pressure", "y", "x"],
-                source_shape: &[6, 10, 32, 32],
-                view: None,
-                data_type: BandDataType::Float32,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
-            })
+            .start_band(StartBandArgs::new(
+                &["time", "pressure", "y", "x"],
+                &[6, 10, 32, 32],
+                BandDataType::Float32,
+            ))
             .unwrap();
         let data = vec![0u8; 6 * 10 * 32 * 32 * 4];
         builder.band_data_writer().append_value(&data);
@@ -1608,16 +1589,11 @@ mod tests {
             .start_raster_nd(&transform, &["x", "y"], &[4, 3], None)
             .unwrap();
         builder
-            .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["y", "x"],
-                source_shape: &[3, 4],
-                view: None,
-                data_type: BandDataType::UInt8,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
-            })
+            .start_band(StartBandArgs::new(
+                &["y", "x"],
+                &[3, 4],
+                BandDataType::UInt8,
+            ))
             .unwrap();
         builder.band_data_writer().append_value(vec![0u8; 12]);
         builder.finish_band().unwrap();
@@ -1628,16 +1604,11 @@ mod tests {
             .start_raster_nd(&transform, &["x", "y"], &[5, 3], None)
             .unwrap();
         builder
-            .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["z", "y", "x"],
-                source_shape: &[2, 3, 5],
-                view: None,
-                data_type: BandDataType::Float64,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
-            })
+            .start_band(StartBandArgs::new(
+                &["z", "y", "x"],
+                &[2, 3, 5],
+                BandDataType::Float64,
+            ))
             .unwrap();
         builder
             .band_data_writer()
@@ -1651,16 +1622,7 @@ mod tests {
             .start_raster_nd(&transform, &["x"], &[10], None)
             .unwrap();
         builder
-            .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["x"],
-                source_shape: &[10],
-                view: None,
-                data_type: BandDataType::UInt16,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
-            })
+            .start_band(StartBandArgs::new(&["x"], &[10], BandDataType::UInt16))
             .unwrap();
         builder.band_data_writer().append_value(vec![0u8; 20]);
         builder.finish_band().unwrap();
@@ -1715,13 +1677,7 @@ mod tests {
         builder
             .start_band(StartBandArgs {
                 name: Some("temperature"),
-                dim_names: &["y", "x"],
-                source_shape: &[4, 4],
-                view: None,
-                data_type: BandDataType::Float32,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
+                ..StartBandArgs::new(&["y", "x"], &[4, 4], BandDataType::Float32)
             })
             .unwrap();
         builder.band_data_writer().append_value(vec![0u8; 64]);
@@ -1752,16 +1708,11 @@ mod tests {
             .start_raster_nd(&transform, &["longitude", "latitude"], &[360, 180], None)
             .unwrap();
         builder
-            .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["latitude", "longitude"],
-                source_shape: &[180, 360],
-                view: None,
-                data_type: BandDataType::UInt8,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
-            })
+            .start_band(StartBandArgs::new(
+                &["latitude", "longitude"],
+                &[180, 360],
+                BandDataType::UInt8,
+            ))
             .unwrap();
         builder
             .band_data_writer()
@@ -1813,16 +1764,7 @@ mod tests {
             .unwrap();
         // Band is missing "y" entirely.
         builder
-            .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["x"],
-                source_shape: &[4],
-                view: None,
-                data_type: BandDataType::UInt8,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
-            })
+            .start_band(StartBandArgs::new(&["x"], &[4], BandDataType::UInt8))
             .unwrap();
         builder.band_data_writer().append_value(vec![0u8; 4]);
         builder.finish_band().unwrap();
@@ -1843,16 +1785,7 @@ mod tests {
         let transform = [0.0, 1.0, 0.0, 0.0, 0.0, -1.0];
         builder.start_raster_nd(&transform, &[], &[], None).unwrap();
         let err = builder
-            .start_band(StartBandArgs {
-                name: None,
-                dim_names: &[],
-                source_shape: &[],
-                view: None,
-                data_type: BandDataType::UInt8,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
-            })
+            .start_band(StartBandArgs::new(&[], &[], BandDataType::UInt8))
             .unwrap_err();
         assert!(
             err.to_string().contains("0-dimensional"),
@@ -1871,16 +1804,11 @@ mod tests {
             .start_raster_nd(&transform, &["x", "y"], &[3, 2], None)
             .unwrap();
         builder
-            .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["y", "x"],
-                source_shape: &[2, 3],
-                view: None,
-                data_type: BandDataType::UInt8,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
-            })
+            .start_band(StartBandArgs::new(
+                &["y", "x"],
+                &[2, 3],
+                BandDataType::UInt8,
+            ))
             .unwrap();
         let pixels: Vec<u8> = (0..6).collect();
         builder.band_data_writer().append_value(pixels.clone());
@@ -1916,16 +1844,11 @@ mod tests {
             .start_raster_nd(&transform, &["x", "y"], &[2, 2], None)
             .unwrap();
         builder
-            .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["y", "x"],
-                source_shape: &[2, 2],
-                view: None,
-                data_type: BandDataType::UInt8,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
-            })
+            .start_band(StartBandArgs::new(
+                &["y", "x"],
+                &[2, 2],
+                BandDataType::UInt8,
+            ))
             .unwrap();
         builder.band_data_writer().append_value(vec![0u8; 4]);
         builder.finish_band().unwrap();
@@ -1963,16 +1886,11 @@ mod tests {
             .unwrap();
         // Band has "x" and "y" but x-size disagrees with top-level shape.
         builder
-            .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["y", "x"],
-                source_shape: &[4, 8],
-                view: None,
-                data_type: BandDataType::UInt8,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
-            })
+            .start_band(StartBandArgs::new(
+                &["y", "x"],
+                &[4, 8],
+                BandDataType::UInt8,
+            ))
             .unwrap();
         builder.band_data_writer().append_value(vec![0u8; 32]);
         builder.finish_band().unwrap();
@@ -1999,16 +1917,11 @@ mod tests {
             .start_raster_nd(&transform, &["x", "y"], &[3, 2], None)
             .unwrap();
         builder
-            .start_band(StartBandArgs {
-                name: None,
-                dim_names: &["y", "x"],
-                source_shape: &[2, 3],
-                view: None,
-                data_type: BandDataType::UInt8,
-                nodata: None,
-                outdb_uri: None,
-                outdb_format: None,
-            })
+            .start_band(StartBandArgs::new(
+                &["y", "x"],
+                &[2, 3],
+                BandDataType::UInt8,
+            ))
             .unwrap();
         builder.band_data_writer().append_value(vec![0u8; 6]);
         builder.finish_band().unwrap();

--- a/rust/sedona-raster/src/builder.rs
+++ b/rust/sedona-raster/src/builder.rs
@@ -142,14 +142,16 @@ pub struct RasterBuilder {
     raster_validity: BooleanBuilder,
 }
 
-/// Arguments to [`RasterBuilder::start_band_with_view`]. Bundled into a
-/// struct to keep the call site readable — eight slots is enough that
-/// positional args invite mis-ordering bugs.
-pub(crate) struct StartBandWithViewArgs<'a> {
+/// Arguments to [`RasterBuilder::start_band`]. Bundled into a struct to keep
+/// the call site readable — eight slots is enough that positional args invite
+/// mis-ordering bugs.
+pub struct StartBandArgs<'a> {
     pub name: Option<&'a str>,
     pub dim_names: &'a [&'a str],
     pub source_shape: &'a [i64],
-    pub view: &'a [ViewEntry],
+    /// Per-axis window of offsets/steps over `source_shape`. `None` is the
+    /// canonical identity view (the whole source buffer in C order).
+    pub view: Option<&'a [ViewEntry]>,
     pub data_type: BandDataType,
     pub nodata: Option<&'a [u8]>,
     pub outdb_uri: Option<&'a str>,
@@ -257,7 +259,7 @@ impl RasterBuilder {
         self.current_raster_bands.clear();
         // Preserve legacy current_width/current_height for start_band_2d (set
         // by start_raster_2d). Callers using this direct entry point drive
-        // their own shapes via start_band_nd.
+        // their own shapes via start_band.
         self.current_width = 0;
         self.current_height = 0;
 
@@ -343,27 +345,68 @@ impl RasterBuilder {
     /// used to interpret the bytes at that location (e.g. `"geotiff"`,
     /// `"zarr"`). A null `outdb_format` means the band is in-memory — the
     /// band's `data` buffer is authoritative.
-    #[allow(clippy::too_many_arguments)]
-    pub fn start_band_nd(
-        &mut self,
-        name: Option<&str>,
-        dim_names: &[&str],
-        shape: &[i64],
-        data_type: BandDataType,
-        nodata: Option<&[u8]>,
-        outdb_uri: Option<&str>,
-        outdb_format: Option<&str>,
-    ) -> Result<(), ArrowError> {
+    ///
+    /// `view` is a per-axis window of offsets/steps over `source_shape`.
+    /// `None` is the canonical identity view — the whole source buffer in C
+    /// order — encoded as the identity null sentinel. A `Some` view is
+    /// validated against `source_shape`; the band schema stores a view only as
+    /// that identity null sentinel, so an identity `Some` view is stored the
+    /// same as `None` and a non-identity view is rejected. View persistence is
+    /// tracked in <https://github.com/apache/sedona-db/issues/897>.
+    pub fn start_band(&mut self, args: StartBandArgs<'_>) -> Result<(), ArrowError> {
+        let StartBandArgs {
+            name,
+            dim_names,
+            source_shape,
+            view,
+            data_type,
+            nodata,
+            outdb_uri,
+            outdb_format,
+        } = args;
+
+        // A caller-supplied view is validated against source_shape. The schema
+        // stores views only as the identity null sentinel today, so a
+        // non-identity view can't round-trip — reject it up front, before any
+        // column append, rather than persisting mislocated bytes.
+        if let Some(view) = view {
+            let ndim = dim_names.len();
+            if ndim == 0 {
+                return Err(ArrowError::InvalidArgumentError(
+                    "start_band: 0-dimensional bands are not supported".into(),
+                ));
+            }
+            if source_shape.len() != ndim || view.len() != ndim {
+                return Err(ArrowError::InvalidArgumentError(format!(
+                    "start_band: dim_names ({}), source_shape ({}), and view ({}) \
+                     must all have the same length",
+                    ndim,
+                    source_shape.len(),
+                    view.len()
+                )));
+            }
+            let view_entries = ViewEntries::new(view.to_vec());
+            view_entries.validate(source_shape)?;
+            if !view_entries.is_identity(source_shape) {
+                return Err(ArrowError::InvalidArgumentError(
+                    "start_band: persisting a non-identity band view is not yet \
+                     supported (see https://github.com/apache/sedona-db/issues/897); \
+                     materialize the band (e.g. via RS_EnsureContiguous) first"
+                        .into(),
+                ));
+            }
+        }
+
         if dim_names.is_empty() {
             return Err(ArrowError::InvalidArgumentError(
-                "start_band_nd: 0-dimensional bands are not supported".into(),
+                "start_band: 0-dimensional bands are not supported".into(),
             ));
         }
-        if dim_names.len() != shape.len() {
+        if dim_names.len() != source_shape.len() {
             return Err(ArrowError::InvalidArgumentError(format!(
-                "start_band_nd: dim_names ({}) and shape ({}) must have the same length",
+                "start_band: dim_names ({}) and shape ({}) must have the same length",
                 dim_names.len(),
-                shape.len(),
+                source_shape.len(),
             )));
         }
         // Name
@@ -380,10 +423,10 @@ impl RasterBuilder {
         self.band_dim_names_offsets.push(next);
 
         // Shape
-        for &s in shape {
+        for &s in source_shape {
             self.band_shape_values.append_value(s);
         }
-        let next = *self.band_shape_offsets.last().unwrap() + shape.len() as i32;
+        let next = *self.band_shape_offsets.last().unwrap() + source_shape.len() as i32;
         self.band_shape_offsets.push(next);
 
         // Data type
@@ -419,73 +462,10 @@ impl RasterBuilder {
         // Record this band's dims/shape for strict validation at finish_raster.
         self.current_raster_bands.push((
             dim_names.iter().map(|s| s.to_string()).collect(),
-            shape.to_vec(),
+            source_shape.to_vec(),
         ));
 
         Ok(())
-    }
-
-    /// Start a band carrying an explicit `view` — a per-axis window of
-    /// offsets/steps over `source_shape` — rather than the implicit identity.
-    ///
-    /// This is the entry point view persistence will use, so callers such as
-    /// [`BandRef::copy_into`] route through it unchanged once persistence
-    /// lands. Today the band schema stores a view only as the canonical
-    /// identity null sentinel, so a non-identity `view` is rejected; an
-    /// identity view is stored exactly as [`Self::start_band_nd`] does. View
-    /// persistence is tracked in
-    /// <https://github.com/apache/sedona-db/issues/897>.
-    pub(crate) fn start_band_with_view(
-        &mut self,
-        args: StartBandWithViewArgs<'_>,
-    ) -> Result<(), ArrowError> {
-        let StartBandWithViewArgs {
-            name,
-            dim_names,
-            source_shape,
-            view,
-            data_type,
-            nodata,
-            outdb_uri,
-            outdb_format,
-        } = args;
-        let ndim = dim_names.len();
-        if ndim == 0 {
-            return Err(ArrowError::InvalidArgumentError(
-                "start_band_with_view: 0-dimensional bands are not supported".into(),
-            ));
-        }
-        if source_shape.len() != ndim || view.len() != ndim {
-            return Err(ArrowError::InvalidArgumentError(format!(
-                "start_band_with_view: dim_names ({}), source_shape ({}), and view ({}) \
-                 must all have the same length",
-                ndim,
-                source_shape.len(),
-                view.len()
-            )));
-        }
-        let view_entries = ViewEntries::new(view.to_vec());
-        view_entries.validate(source_shape)?;
-        // The schema stores views only as the identity null sentinel today, so a
-        // non-identity view can't round-trip — reject it up front, before any
-        // column append, rather than persisting mislocated bytes.
-        if !view_entries.is_identity(source_shape) {
-            return Err(ArrowError::InvalidArgumentError(
-                "start_band_with_view: persisting a non-identity band view is not yet \
-                 supported (see https://github.com/apache/sedona-db/issues/897); \
-                 materialize the band (e.g. via RS_EnsureContiguous) first"
-                    .into(),
-            ));
-        }
-        self.start_band_nd(
-            name,
-            dim_names,
-            source_shape,
-            data_type,
-            nodata,
-            outdb_uri,
-            outdb_format,
-        )
     }
 
     /// Convenience: start a 2D band with `dim_names=["y","x"]` and `shape=[height, width]`.
@@ -502,15 +482,16 @@ impl RasterBuilder {
                 "start_band_2d requires prior start_raster_2d (width and height are 0)".into(),
             ));
         }
-        self.start_band_nd(
-            None,
-            &["y", "x"],
-            &[self.current_height, self.current_width],
+        self.start_band(StartBandArgs {
+            name: None,
+            dim_names: &["y", "x"],
+            source_shape: &[self.current_height, self.current_width],
+            view: None,
             data_type,
             nodata,
-            None,
-            None,
-        )
+            outdb_uri: None,
+            outdb_format: None,
+        })
     }
 
     /// Get direct access to the BinaryViewBuilder for writing the current band's data.
@@ -595,13 +576,13 @@ impl RasterBuilder {
 
     /// Finish writing the current band.
     ///
-    /// Validates that exactly one data value was appended since `start_band_nd()`.
+    /// Validates that exactly one data value was appended since `start_band()`.
     pub fn finish_band(&mut self) -> Result<(), ArrowError> {
         let current_count = self.band_data.len();
         if current_count != self.band_data_count_at_start + 1 {
             return Err(ArrowError::InvalidArgumentError(
                 format!(
-                    "Expected exactly one band data value per band, but got {} appended since start_band_nd()",
+                    "Expected exactly one band data value per band, but got {} appended since start_band()",
                     current_count - self.band_data_count_at_start
                 ),
             ));
@@ -997,18 +978,19 @@ mod tests {
         // copies the N-D spatial grid, so add the band with an explicit shape
         // matching the source's [height, width].
         target_builder
-            .start_band_nd(
-                None,
-                &["y", "x"],
-                &[
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["y", "x"],
+                source_shape: &[
                     source_raster.height().unwrap(),
                     source_raster.width().unwrap(),
                 ],
-                BandDataType::UInt16,
-                None,
-                None,
-                None,
-            )
+                view: None,
+                data_type: BandDataType::UInt16,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         let new_data = vec![100u16; 1008]; // Different data, same dimensions
         let new_data_bytes: Vec<u8> = new_data.iter().flat_map(|&x| x.to_le_bytes()).collect();
@@ -1214,15 +1196,16 @@ mod tests {
         // Test OutDbRef band: an out-db location is carried as an `outdb_uri`
         // with the SedonaDB `#band=N` fragment; the band's own `data` is empty.
         builder
-            .start_band_nd(
-                None,
-                &["y", "x"],
-                &[1024, 1024],
-                BandDataType::Float32,
-                None,
-                Some("s3://mybucket/satellite_image.tif#band=2"),
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["y", "x"],
+                source_shape: &[1024, 1024],
+                view: None,
+                data_type: BandDataType::Float32,
+                nodata: None,
+                outdb_uri: Some("s3://mybucket/satellite_image.tif#band=2"),
+                outdb_format: None,
+            })
             .unwrap();
         // For OutDbRef, data field could be empty or contain metadata/thumbnail
         builder.band_data_writer().append_value([]);
@@ -1405,15 +1388,16 @@ mod tests {
 
         // 3D band: [time=3, y=4, x=5]
         builder
-            .start_band_nd(
-                Some("temperature"),
-                &["time", "y", "x"],
-                &[3, 4, 5],
-                BandDataType::Float32,
-                None,
-                None,
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: Some("temperature"),
+                dim_names: &["time", "y", "x"],
+                source_shape: &[3, 4, 5],
+                view: None,
+                data_type: BandDataType::Float32,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         let data = vec![0u8; 3 * 4 * 5 * 4]; // 3*4*5 Float32 elements
         builder.band_data_writer().append_value(&data);
@@ -1454,15 +1438,16 @@ mod tests {
             )
             .unwrap();
         builder
-            .start_band_nd(
-                Some("sst"),
-                &["latitude", "longitude"],
-                &[180, 360],
-                BandDataType::Float32,
-                None,
-                None,
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: Some("sst"),
+                dim_names: &["latitude", "longitude"],
+                source_shape: &[180, 360],
+                view: None,
+                data_type: BandDataType::Float32,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         let data = vec![0u8; 180 * 360 * 4];
         builder.band_data_writer().append_value(&data);
@@ -1491,15 +1476,16 @@ mod tests {
 
         // Band 0: 3D [time=12, y=64, x=64]
         builder
-            .start_band_nd(
-                Some("temperature"),
-                &["time", "y", "x"],
-                &[12, 64, 64],
-                BandDataType::Float32,
-                None,
-                None,
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: Some("temperature"),
+                dim_names: &["time", "y", "x"],
+                source_shape: &[12, 64, 64],
+                view: None,
+                data_type: BandDataType::Float32,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         let data_3d = vec![0u8; 12 * 64 * 64 * 4];
         builder.band_data_writer().append_value(&data_3d);
@@ -1507,15 +1493,16 @@ mod tests {
 
         // Band 1: 2D [y=64, x=64]
         builder
-            .start_band_nd(
-                Some("elevation"),
-                &["y", "x"],
-                &[64, 64],
-                BandDataType::Float64,
-                None,
-                None,
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: Some("elevation"),
+                dim_names: &["y", "x"],
+                source_shape: &[64, 64],
+                view: None,
+                data_type: BandDataType::Float64,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         let data_2d = vec![0u8; 64 * 64 * 8];
         builder.band_data_writer().append_value(&data_2d);
@@ -1552,15 +1539,16 @@ mod tests {
             .start_raster_nd(&transform, &["x", "y"], &[32, 32], None)
             .unwrap();
         builder
-            .start_band_nd(
-                None,
-                &["time", "pressure", "y", "x"],
-                &[6, 10, 32, 32],
-                BandDataType::Float32,
-                None,
-                None,
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["time", "pressure", "y", "x"],
+                source_shape: &[6, 10, 32, 32],
+                view: None,
+                data_type: BandDataType::Float32,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         let data = vec![0u8; 6 * 10 * 32 * 32 * 4];
         builder.band_data_writer().append_value(&data);
@@ -1620,15 +1608,16 @@ mod tests {
             .start_raster_nd(&transform, &["x", "y"], &[4, 3], None)
             .unwrap();
         builder
-            .start_band_nd(
-                None,
-                &["y", "x"],
-                &[3, 4],
-                BandDataType::UInt8,
-                None,
-                None,
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["y", "x"],
+                source_shape: &[3, 4],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder.band_data_writer().append_value(vec![0u8; 12]);
         builder.finish_band().unwrap();
@@ -1639,15 +1628,16 @@ mod tests {
             .start_raster_nd(&transform, &["x", "y"], &[5, 3], None)
             .unwrap();
         builder
-            .start_band_nd(
-                None,
-                &["z", "y", "x"],
-                &[2, 3, 5],
-                BandDataType::Float64,
-                None,
-                None,
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["z", "y", "x"],
+                source_shape: &[2, 3, 5],
+                view: None,
+                data_type: BandDataType::Float64,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder
             .band_data_writer()
@@ -1661,7 +1651,16 @@ mod tests {
             .start_raster_nd(&transform, &["x"], &[10], None)
             .unwrap();
         builder
-            .start_band_nd(None, &["x"], &[10], BandDataType::UInt16, None, None, None)
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["x"],
+                source_shape: &[10],
+                view: None,
+                data_type: BandDataType::UInt16,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder.band_data_writer().append_value(vec![0u8; 20]);
         builder.finish_band().unwrap();
@@ -1714,15 +1713,16 @@ mod tests {
 
         // Named band
         builder
-            .start_band_nd(
-                Some("temperature"),
-                &["y", "x"],
-                &[4, 4],
-                BandDataType::Float32,
-                None,
-                None,
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: Some("temperature"),
+                dim_names: &["y", "x"],
+                source_shape: &[4, 4],
+                view: None,
+                data_type: BandDataType::Float32,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder.band_data_writer().append_value(vec![0u8; 64]);
         builder.finish_band().unwrap();
@@ -1752,15 +1752,16 @@ mod tests {
             .start_raster_nd(&transform, &["longitude", "latitude"], &[360, 180], None)
             .unwrap();
         builder
-            .start_band_nd(
-                None,
-                &["latitude", "longitude"],
-                &[180, 360],
-                BandDataType::UInt8,
-                None,
-                None,
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["latitude", "longitude"],
+                source_shape: &[180, 360],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder
             .band_data_writer()
@@ -1812,7 +1813,16 @@ mod tests {
             .unwrap();
         // Band is missing "y" entirely.
         builder
-            .start_band_nd(None, &["x"], &[4], BandDataType::UInt8, None, None, None)
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["x"],
+                source_shape: &[4],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder.band_data_writer().append_value(vec![0u8; 4]);
         builder.finish_band().unwrap();
@@ -1827,13 +1837,22 @@ mod tests {
     #[test]
     fn test_start_band_rejects_zero_dim() {
         // 0-D bands carry no spatial extent and no caller has a use for
-        // them. start_band_nd must reject an empty dim_names slice eagerly so
+        // them. start_band must reject an empty dim_names slice eagerly so
         // the malformed band never reaches the buffer layer.
         let mut builder = RasterBuilder::new(1);
         let transform = [0.0, 1.0, 0.0, 0.0, 0.0, -1.0];
         builder.start_raster_nd(&transform, &[], &[], None).unwrap();
         let err = builder
-            .start_band_nd(None, &[], &[], BandDataType::UInt8, None, None, None)
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &[],
+                source_shape: &[],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap_err();
         assert!(
             err.to_string().contains("0-dimensional"),
@@ -1852,15 +1871,16 @@ mod tests {
             .start_raster_nd(&transform, &["x", "y"], &[3, 2], None)
             .unwrap();
         builder
-            .start_band_nd(
-                None,
-                &["y", "x"],
-                &[2, 3],
-                BandDataType::UInt8,
-                None,
-                None,
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["y", "x"],
+                source_shape: &[2, 3],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         let pixels: Vec<u8> = (0..6).collect();
         builder.band_data_writer().append_value(pixels.clone());
@@ -1896,15 +1916,16 @@ mod tests {
             .start_raster_nd(&transform, &["x", "y"], &[2, 2], None)
             .unwrap();
         builder
-            .start_band_nd(
-                None,
-                &["y", "x"],
-                &[2, 2],
-                BandDataType::UInt8,
-                None,
-                None,
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["y", "x"],
+                source_shape: &[2, 2],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder.band_data_writer().append_value(vec![0u8; 4]);
         builder.finish_band().unwrap();
@@ -1942,15 +1963,16 @@ mod tests {
             .unwrap();
         // Band has "x" and "y" but x-size disagrees with top-level shape.
         builder
-            .start_band_nd(
-                None,
-                &["y", "x"],
-                &[4, 8],
-                BandDataType::UInt8,
-                None,
-                None,
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["y", "x"],
+                source_shape: &[4, 8],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder.band_data_writer().append_value(vec![0u8; 32]);
         builder.finish_band().unwrap();
@@ -1965,7 +1987,7 @@ mod tests {
 
     #[test]
     fn test_view_null_round_trips_through_arrow_ipc() {
-        // Schema invariant: a band built via start_band_nd serialises with a
+        // Schema invariant: a band built via start_band serialises with a
         // null view row, and the null must survive an Arrow IPC round-trip.
         // If a future change accidentally writes a non-null empty list
         // instead, downstream readers (DuckDB, PyArrow, sedona-py) will
@@ -1977,15 +1999,16 @@ mod tests {
             .start_raster_nd(&transform, &["x", "y"], &[3, 2], None)
             .unwrap();
         builder
-            .start_band_nd(
-                None,
-                &["y", "x"],
-                &[2, 3],
-                BandDataType::UInt8,
-                None,
-                None,
-                None,
-            )
+            .start_band(StartBandArgs {
+                name: None,
+                dim_names: &["y", "x"],
+                source_shape: &[2, 3],
+                view: None,
+                data_type: BandDataType::UInt8,
+                nodata: None,
+                outdb_uri: None,
+                outdb_format: None,
+            })
             .unwrap();
         builder.band_data_writer().append_value(vec![0u8; 6]);
         builder.finish_band().unwrap();

--- a/rust/sedona-raster/src/traits.rs
+++ b/rust/sedona-raster/src/traits.rs
@@ -482,13 +482,11 @@ pub trait BandRef {
         };
         builder.start_band(StartBandArgs {
             name: overrides.name,
-            dim_names: &dim_names,
-            source_shape: &source_shape,
             view: Some(effective_view.as_slice()),
-            data_type: self.data_type(),
             nodata: overrides.nodata.or_else(|| self.nodata()),
             outdb_uri: overrides.outdb_uri.or_else(|| self.outdb_uri()),
             outdb_format: overrides.outdb_format.or_else(|| self.outdb_format()),
+            ..StartBandArgs::new(&dim_names, &source_shape, self.data_type())
         })?;
         self.append_data_into(builder)
     }

--- a/rust/sedona-raster/src/traits.rs
+++ b/rust/sedona-raster/src/traits.rs
@@ -18,7 +18,7 @@
 use arrow_schema::ArrowError;
 use sedona_schema::raster::BandDataType;
 
-use crate::builder::{RasterBuilder, StartBandWithViewArgs};
+use crate::builder::{RasterBuilder, StartBandArgs};
 use crate::view_entries::{ViewEntries, ViewEntry};
 
 /// Recognized spatial dimension-name pairs, in band C-order: the slower-
@@ -443,7 +443,7 @@ pub trait BandRef {
     /// `overrides` from `self`, and carrying the source bytes over.
     ///
     /// This is the canonical "derive a band from an existing one" path — it
-    /// replaces hand-rebuilding via `start_band_nd` + a manual data append. The
+    /// replaces hand-rebuilding via `start_band` + a manual data append. The
     /// data transfer is zero-copy when the implementation supports it (see
     /// [`Self::append_data_into`]).
     ///
@@ -455,7 +455,7 @@ pub trait BandRef {
     /// inherits the source's view unchanged.
     ///
     /// The composition + persistence is delegated to
-    /// [`RasterBuilder::start_band_with_view`]. Today that stores views only as
+    /// [`RasterBuilder::start_band`]. Today that stores views only as
     /// the canonical identity null sentinel, so a non-identity effective view
     /// is rejected rather than copying mislocated bytes; in practice the source
     /// is identity-viewed and any override must compose back to the identity.
@@ -480,11 +480,11 @@ pub trait BandRef {
             Some(v) => source_view.compose(&ViewEntries::new(v.to_vec()))?,
             None => source_view,
         };
-        builder.start_band_with_view(StartBandWithViewArgs {
+        builder.start_band(StartBandArgs {
             name: overrides.name,
             dim_names: &dim_names,
             source_shape: &source_shape,
-            view: effective_view.as_slice(),
+            view: Some(effective_view.as_slice()),
             data_type: self.data_type(),
             nodata: overrides.nodata.or_else(|| self.nodata()),
             outdb_uri: overrides.outdb_uri.or_else(|| self.outdb_uri()),

--- a/rust/sedona-testing/src/raster_spec.rs
+++ b/rust/sedona-testing/src/raster_spec.rs
@@ -381,13 +381,10 @@ impl RasterSpec {
             builder
                 .start_band(StartBandArgs {
                     name: band.name.as_deref(),
-                    dim_names: &dims,
-                    source_shape: &band.shape,
-                    view: None,
-                    data_type: band.data_type,
                     nodata: band.nodata.as_deref(),
                     outdb_uri: band.outdb_uri.as_deref(),
                     outdb_format: band.outdb_format.as_deref(),
+                    ..StartBandArgs::new(&dims, &band.shape, band.data_type)
                 })
                 .expect("start band");
             let bytes = match &band.data {

--- a/rust/sedona-testing/src/raster_spec.rs
+++ b/rust/sedona-testing/src/raster_spec.rs
@@ -42,7 +42,7 @@ use arrow_array::{
 use datafusion_common::ScalarValue;
 use datafusion_expr::{Expr, Literal};
 use sedona_raster::array::RasterStructArray;
-use sedona_raster::builder::RasterBuilder;
+use sedona_raster::builder::{RasterBuilder, StartBandArgs};
 use sedona_raster::traits::is_spatial_dim_pair;
 use sedona_schema::crs::lnglat;
 use sedona_schema::raster::BandDataType;
@@ -379,15 +379,16 @@ impl RasterSpec {
         for band in &self.bands {
             let dims: Vec<&str> = band.dims.iter().map(|d| d.as_str()).collect();
             builder
-                .start_band_nd(
-                    band.name.as_deref(),
-                    &dims,
-                    &band.shape,
-                    band.data_type,
-                    band.nodata.as_deref(),
-                    band.outdb_uri.as_deref(),
-                    band.outdb_format.as_deref(),
-                )
+                .start_band(StartBandArgs {
+                    name: band.name.as_deref(),
+                    dim_names: &dims,
+                    source_shape: &band.shape,
+                    view: None,
+                    data_type: band.data_type,
+                    nodata: band.nodata.as_deref(),
+                    outdb_uri: band.outdb_uri.as_deref(),
+                    outdb_format: band.outdb_format.as_deref(),
+                })
                 .expect("start band");
             let bytes = match &band.data {
                 Some(bytes) => bytes.clone(),


### PR DESCRIPTION
Pure refactor, behavior-identical to main: `start_band_nd` + `start_band_with_view` collapse into one `start_band(StartBandArgs)` where `view: Option<&[ViewEntry]>` (`None` = identity). Non-identity views are still rejected (unchanged); `start_band_2d` keeps its 2-arg convenience signature. First of two PRs — the follow-up flips the single `start_band`'s non-identity arm from reject to persist.