### PR TITLE
Auto-register common OGR formats so file URLs work as tables

### DIFF
--- a/docs/working-with-sql-sedonadb.md
+++ b/docs/working-with-sql-sedonadb.md
@@ -81,3 +81,19 @@ This approach provides the same functionality and is the standard practice in Sp
 # Step 3: You can now successfully query the view using SQL
 >>> sd.sql("SELECT * FROM b LIMIT 5").show()
 ```
+
+## Reading Files Directly in SQL
+
+You can query a file directly in a `FROM` clause by quoting its path or URL, with no separate `read_*` call. This works for Parquet out of the box:
+
+```python
+>>> sd.sql("SELECT * FROM '/path/to/buildings.parquet' LIMIT 5").show()
+```
+
+When `pyogrio` is installed, the common single-file OGR formats (`.fgb`, `.gpkg`, `.shp`, `.geojson`) are auto-registered on each connection, so their file URLs resolve the same way. This behavior is **experimental** and may change:
+
+```python
+>>> sd.sql("SELECT * FROM 'file:///path/to/roads.fgb'").show()
+```
+
+The geometry column name is set by the underlying OGR driver, not by SedonaDB: FlatGeobuf, GeoJSON, and Shapefile expose an unnamed geometry field, which reads back as `wkb_geometry`, whereas GeoPackage carries its stored geometry-column name (for example `geom`).

--- a/docs/working-with-sql-sedonadb.md
+++ b/docs/working-with-sql-sedonadb.md
@@ -90,7 +90,7 @@ You can query a file directly in a `FROM` clause by quoting its path or URL, wit
 >>> sd.sql("SELECT * FROM '/path/to/buildings.parquet' LIMIT 5").show()
 ```
 
-When `pyogrio` is installed, the common single-file OGR formats (`.fgb`, `.gpkg`, `.shp`, `.geojson`) are auto-registered on each connection, so their file URLs resolve the same way. This behavior is **experimental** and may change:
+The common single-file OGR formats (`.fgb`, `.gpkg`, `.shp`, `.geojson`) are auto-registered on each connection, so their file URLs resolve the same way. Reading them requires `pyogrio` to be installed — if it isn't, you get a clear error at read time. This behavior is **experimental** and may change:
 
 ```python
 >>> sd.sql("SELECT * FROM 'file:///path/to/roads.fgb'").show()

--- a/python/sedonadb/python/sedonadb/context.py
+++ b/python/sedonadb/python/sedonadb/context.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import importlib.util
 import os
 import sys
 from functools import cached_property
@@ -136,18 +135,10 @@ class SedonaContext:
 
         This makes `SELECT * FROM 'file:///path/to/data.<ext>'` work
         zero-config for the common pyogrio/GDAL formats, matching the way
-        Parquet is handled. pyogrio is an optional dependency, so this is a
-        no-op when it is not installed (the availability check does not import
-        pyogrio, which keeps context creation cheap and side-effect free).
+        Parquet is handled. Registering does not import pyogrio — that happens
+        lazily in `PyogrioFormatSpec.open_reader` when a file is actually read —
+        so this is safe even when pyogrio is not installed.
         """
-        try:
-            pyogrio_available = importlib.util.find_spec("pyogrio") is not None
-        except (ImportError, ValueError):
-            pyogrio_available = False
-
-        if not pyogrio_available:
-            return
-
         from sedonadb.datasource import PyogrioFormatSpec
 
         for extension in _DEFAULT_PYOGRIO_EXTENSIONS:

--- a/python/sedonadb/python/sedonadb/context.py
+++ b/python/sedonadb/python/sedonadb/context.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import importlib.util
 import os
 import sys
 from functools import cached_property
@@ -50,6 +51,12 @@ from sedonadb.expr.expression import (
 )
 from sedonadb.expr.literal import lit as lit_expr, Literal as LiteralExpr
 from sedonadb.utility import sedona  # noqa: F401
+
+
+# Single-file OGR formats auto-registered (via pyogrio/GDAL) when a context is
+# created, so that `SELECT * FROM 'file:///path/to/data.<ext>'` works without a
+# manual `register()` call. Add an extension here to enable another format.
+_DEFAULT_PYOGRIO_EXTENSIONS = ("fgb", "gpkg", "shp", "geojson")
 
 
 class SedonaContext:
@@ -121,7 +128,30 @@ class SedonaContext:
             impl = InternalContext(opts)
             self.__impl = impl
             self.options.freeze_runtime()
+            self._register_default_formats()
         return self.__impl
+
+    def _register_default_formats(self):
+        """Auto-register the built-in single-file OGR formats.
+
+        This makes `SELECT * FROM 'file:///path/to/data.<ext>'` work
+        zero-config for the common pyogrio/GDAL formats, matching the way
+        Parquet is handled. pyogrio is an optional dependency, so this is a
+        no-op when it is not installed (the availability check does not import
+        pyogrio, which keeps context creation cheap and side-effect free).
+        """
+        try:
+            pyogrio_available = importlib.util.find_spec("pyogrio") is not None
+        except (ImportError, ValueError):
+            pyogrio_available = False
+
+        if not pyogrio_available:
+            return
+
+        from sedonadb.datasource import PyogrioFormatSpec
+
+        for extension in _DEFAULT_PYOGRIO_EXTENSIONS:
+            self.register(PyogrioFormatSpec(extension))
 
     def create_data_frame(self, obj: Any, schema: Any = None) -> DataFrame:
         """Create a DataFrame from an in-memory or protocol-enabled object.

--- a/python/sedonadb/python/sedonadb/datasource.py
+++ b/python/sedonadb/python/sedonadb/datasource.py
@@ -141,7 +141,12 @@ class PyogrioFormatSpec(ExternalFormatSpec):
         return self._extension
 
     def open_reader(self, args):
-        import pyogrio.raw
+        try:
+            import pyogrio.raw
+        except ImportError as e:
+            raise ImportError(
+                f"pyogrio must be installed to read {self.extension!r} files"
+            ) from e
 
         url = args.src.to_url()
         if url is None:

--- a/python/sedonadb/tests/io/test_pyogrio.py
+++ b/python/sedonadb/tests/io/test_pyogrio.py
@@ -395,3 +395,60 @@ def test_pyogrio_format_register():
         # Should be able to SELECT * from 'file' after registering the format
         df = sd.sql(f"SELECT * FROM '{temp_fgb_path}' ORDER BY idx")
         geopandas.testing.assert_geodataframe_equal(df.to_pandas(), gdf)
+
+
+@pytest.mark.parametrize(
+    ("extension", "geometry_column"),
+    [
+        ("fgb", "wkb_geometry"),
+        ("gpkg", "geom"),
+        ("geojson", "wkb_geometry"),
+        ("shp", "wkb_geometry"),
+    ],
+)
+def test_url_table_autoregistered(extension, geometry_column):
+    # The common single-file OGR formats are auto-registered when a context is
+    # created, so a bare file URL resolves as a table without a manual
+    # register() call (the way GeoParquet already does). A fresh connection is
+    # used so this exercises context-creation wiring rather than any state left
+    # on the shared session fixture.
+    pytest.importorskip("pyogrio")
+    sd = sedonadb.connect()
+
+    gdf = geopandas.GeoDataFrame(
+        {"idx": [0, 1, 2]},
+        geometry=geopandas.GeoSeries.from_xy([0, 1, 2], [1, 2, 3], crs="EPSG:4326"),
+    )
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / f"data.{extension}"
+        gdf.to_file(path)
+
+        # to_arrow_table() runs the full execution path.
+        table = sd.sql(f"SELECT * FROM '{path.as_uri()}' ORDER BY idx").to_arrow_table()
+        assert table.num_rows == 3
+        assert table.column_names == ["idx", geometry_column]
+        assert table.column("idx").to_pylist() == [0, 1, 2]
+
+        # Pass-through geometry values round-trip exactly (no reprojection).
+        result = sd.sql(f"SELECT * FROM '{path.as_uri()}' ORDER BY idx").to_pandas()
+        assert result.geometry.tolist() == gdf.geometry.tolist()
+
+
+def test_url_table_smoke_bare_path(con):
+    # SQL-text smoke covering the plain (non file://) path form the SQL URL
+    # table also accepts.
+    pytest.importorskip("pyogrio")
+
+    gdf = geopandas.GeoDataFrame(
+        {"idx": [0, 1, 2]},
+        geometry=geopandas.GeoSeries.from_xy([0, 1, 2], [1, 2, 3], crs="EPSG:4326"),
+    )
+
+    with tempfile.TemporaryDirectory() as td:
+        path = f"{td}/data.fgb"
+        gdf.to_file(path)
+
+        table = con.sql(f"SELECT * FROM '{path}' ORDER BY idx").to_arrow_table()
+        assert table.num_rows == 3
+        assert table.column("idx").to_pylist() == [0, 1, 2]

--- a/python/sedonadb/tests/io/test_pyogrio.py
+++ b/python/sedonadb/tests/io/test_pyogrio.py
@@ -397,6 +397,9 @@ def test_pyogrio_format_register():
         geopandas.testing.assert_geodataframe_equal(df.to_pandas(), gdf)
 
 
+# The geometry-column name is GDAL's OGR reader's, not ours: fgb/geojson/shp
+# store no named geometry field, so GDAL falls back to `wkb_geometry`, whereas
+# GeoPackage persists a named geometry column (GDAL defaults it to `geom`).
 @pytest.mark.parametrize(
     ("extension", "geometry_column"),
     [


### PR DESCRIPTION
Auto-registers the common single-file OGR formats (`fgb`, `gpkg`, `shp`, `geojson`) at context creation so `SELECT * FROM 'file:///path/to/data.fgb'` works zero-config, the way GeoParquet already does. No-op when pyogrio is not installed.