### PR TITLE
ci(python-wheels): cache vcpkg binaries on Windows and macOS

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -66,14 +66,27 @@ jobs:
           ref: ${{ env.VCPKG_REF }}
           path: vcpkg
 
+      # Persist vcpkg's built binaries across runs. The pinned VCPKG_REF and
+      # custom triplets fully determine what gets built, so a hit turns the
+      # ~40-minute `vcpkg install` into a seconds-long unpack.
+      - name: Cache vcpkg binaries
+        uses: actions/cache@v6
+        with:
+          path: ${{ github.workspace }}/vcpkg-bincache
+          key: vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_REF }}-${{ hashFiles('ci/scripts/custom-triplets/**', 'ci/scripts/wheels-build-windows.ps1') }}
+          restore-keys: |
+            vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_REF }}-
+
       - name: Build and test wheels (sedonadb)
         run: |
           Remove-Item -Force .test_failed -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Force -Path "$env:VCPKG_DEFAULT_BINARY_CACHE" | Out-Null
           cd ci/scripts
           .\wheels-build-windows.ps1
         env:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
           VCPKG_DEFAULT_TRIPLET: x64-windows-dynamic-release
+          VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg-bincache
           CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
           CIBW_BUILD: "*-win_amd64"
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas
@@ -113,13 +126,26 @@ jobs:
           ref: ${{ env.VCPKG_REF }}
           path: vcpkg
 
+      # Persist vcpkg's built binaries across runs. The pinned VCPKG_REF and
+      # custom triplets fully determine what gets built, so a hit turns the
+      # ~40-minute `vcpkg install` into a seconds-long unpack.
+      - name: Cache vcpkg binaries
+        uses: actions/cache@v6
+        with:
+          path: ${{ github.workspace }}/vcpkg-bincache
+          key: vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_REF }}-${{ hashFiles('ci/scripts/custom-triplets/**', 'ci/scripts/wheels-bootstrap-vcpkg.sh') }}
+          restore-keys: |
+            vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_REF }}-
+
       - name: Build and test wheels (sedonadb)
         run: |
           rm -f .test_failed
+          mkdir -p "$VCPKG_DEFAULT_BINARY_CACHE"
           cd ci/scripts
           ./wheels-build-macos.sh sedonadb
         env:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
+          VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg-bincache
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas duckdb
           # Test command exits 0 even on failure so CIBW continues building all wheels;
           # failures are recorded in .test_failed and checked after upload.
@@ -155,13 +181,26 @@ jobs:
           ref: ${{ env.VCPKG_REF }}
           path: vcpkg
 
+      # Persist vcpkg's built binaries across runs. The pinned VCPKG_REF and
+      # custom triplets fully determine what gets built, so a hit turns the
+      # ~40-minute `vcpkg install` into a seconds-long unpack.
+      - name: Cache vcpkg binaries
+        uses: actions/cache@v6
+        with:
+          path: ${{ github.workspace }}/vcpkg-bincache
+          key: vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_REF }}-${{ hashFiles('ci/scripts/custom-triplets/**', 'ci/scripts/wheels-bootstrap-vcpkg.sh') }}
+          restore-keys: |
+            vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_REF }}-
+
       - name: Build and test wheels (sedonadb)
         run: |
           rm -f .test_failed
+          mkdir -p "$VCPKG_DEFAULT_BINARY_CACHE"
           cd ci/scripts
           ./wheels-build-macos.sh sedonadb
         env:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
+          VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg-bincache
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas duckdb
           # Test command exits 0 even on failure so CIBW continues building all wheels;
           # failures are recorded in .test_failed and checked after upload.

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -68,9 +68,13 @@ jobs:
 
       # Persist vcpkg's built binaries across runs. The pinned VCPKG_REF and
       # custom triplets fully determine what gets built, so a hit turns the
-      # ~40-minute `vcpkg install` into a seconds-long unpack.
-      - name: Cache vcpkg binaries
-        uses: actions/cache@v6
+      # ~40-minute `vcpkg install` into a seconds-long unpack. Restore and save
+      # are split so the cache is written even when the build/test step fails —
+      # a failing build still produces reusable binaries, and the combined
+      # cache action skips its save on job failure.
+      - name: Restore vcpkg binaries
+        id: vcpkg-cache
+        uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/vcpkg-bincache
           key: vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_REF }}-${{ hashFiles('ci/scripts/custom-triplets/**', 'ci/scripts/wheels-build-windows.ps1') }}
@@ -95,6 +99,15 @@ jobs:
           # We use Python here to be absolutely sure there are no shell escaping issues.
           CIBW_TEST_COMMAND: >-
             python -c "import subprocess,sys,pathlib; proj=pathlib.Path(r'{project}'); r=subprocess.run([sys.executable,'-m','pytest',str(pathlib.Path(r'{package}')/'tests'),'-vv','-o','faulthandler_timeout=600']); r.returncode and (print(f'Tests failed (exit {r.returncode}), creating .test_failed marker at {proj.absolute()}') or (proj/'.test_failed').touch() or True); sys.exit(0)"
+
+      # Save even on failure (hence a standalone save step gated only on a miss):
+      # binaries built before a later test failure stay cached for the next run.
+      - name: Save vcpkg binaries
+        if: always() && steps.vcpkg-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ github.workspace }}/vcpkg-bincache
+          key: ${{ steps.vcpkg-cache.outputs.cache-primary-key }}
 
       - uses: actions/upload-artifact@v7
         with:
@@ -128,9 +141,13 @@ jobs:
 
       # Persist vcpkg's built binaries across runs. The pinned VCPKG_REF and
       # custom triplets fully determine what gets built, so a hit turns the
-      # ~40-minute `vcpkg install` into a seconds-long unpack.
-      - name: Cache vcpkg binaries
-        uses: actions/cache@v6
+      # ~40-minute `vcpkg install` into a seconds-long unpack. Restore and save
+      # are split so the cache is written even when the build/test step fails —
+      # a failing build still produces reusable binaries, and the combined
+      # cache action skips its save on job failure.
+      - name: Restore vcpkg binaries
+        id: vcpkg-cache
+        uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/vcpkg-bincache
           key: vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_REF }}-${{ hashFiles('ci/scripts/custom-triplets/**', 'ci/scripts/wheels-bootstrap-vcpkg.sh') }}
@@ -150,6 +167,13 @@ jobs:
           # Test command exits 0 even on failure so CIBW continues building all wheels;
           # failures are recorded in .test_failed and checked after upload.
           CIBW_TEST_COMMAND: "pytest {package}/tests -vv -o faulthandler_timeout=600 || touch {project}/.test_failed"
+
+      - name: Save vcpkg binaries
+        if: always() && steps.vcpkg-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ github.workspace }}/vcpkg-bincache
+          key: ${{ steps.vcpkg-cache.outputs.cache-primary-key }}
 
       - uses: actions/upload-artifact@v7
         with:
@@ -183,9 +207,13 @@ jobs:
 
       # Persist vcpkg's built binaries across runs. The pinned VCPKG_REF and
       # custom triplets fully determine what gets built, so a hit turns the
-      # ~40-minute `vcpkg install` into a seconds-long unpack.
-      - name: Cache vcpkg binaries
-        uses: actions/cache@v6
+      # ~40-minute `vcpkg install` into a seconds-long unpack. Restore and save
+      # are split so the cache is written even when the build/test step fails —
+      # a failing build still produces reusable binaries, and the combined
+      # cache action skips its save on job failure.
+      - name: Restore vcpkg binaries
+        id: vcpkg-cache
+        uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/vcpkg-bincache
           key: vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_REF }}-${{ hashFiles('ci/scripts/custom-triplets/**', 'ci/scripts/wheels-bootstrap-vcpkg.sh') }}
@@ -206,6 +234,13 @@ jobs:
           # failures are recorded in .test_failed and checked after upload.
           CIBW_TEST_COMMAND: "pytest {package}/tests -vv -o faulthandler_timeout=600 || touch {project}/.test_failed"
           SEDONADB_MACOS_ARCH: x86_64
+
+      - name: Save vcpkg binaries
+        if: always() && steps.vcpkg-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ github.workspace }}/vcpkg-bincache
+          key: ${{ steps.vcpkg-cache.outputs.cache-primary-key }}
 
       - uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
Caches vcpkg's built binaries (`VCPKG_DEFAULT_BINARY_CACHE` + `actions/cache`) so `vcpkg install` restores instead of rebuilding GEOS/Abseil/OpenSSL/S2 from source each run.

This should cut out the first 40 minutes of  the Windows and macOS wheel jobs.

Keyed on OS/arch + `VCPKG_REF` + triplet hashes.
 
Linux builds vcpkg inside the manylinux container and needs the cache threaded through the mount; left as a follow-up.