### PR TITLE
ci(python-wheels): cache vcpkg binaries on Linux via container mount

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -270,6 +270,21 @@ jobs:
 
       - uses: ./.github/actions/setup-wheel-build
 
+      # Persist vcpkg's built binaries across runs. vcpkg runs inside the
+      # manylinux container, so wheels-build-linux.sh bind-mounts this host
+      # directory in and points VCPKG_DEFAULT_BINARY_CACHE at it; a hit turns
+      # the from-source `vcpkg install` into a seconds-long unpack. Restore and
+      # save are split so the cache is written even when the build/test step
+      # fails, and the combined cache action skips its save on job failure.
+      - name: Restore vcpkg binaries
+        id: vcpkg-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ github.workspace }}/vcpkg-bincache
+          key: vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_REF }}-${{ hashFiles('ci/scripts/custom-triplets/**', 'ci/scripts/wheels-bootstrap-vcpkg.sh') }}
+          restore-keys: |
+            vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_REF }}-
+
       - name: Build and test wheels (sedonadb)
         run: |
           rm -f .test_failed
@@ -277,10 +292,18 @@ jobs:
           ./wheels-build-linux.sh ${{ matrix.config.arch }} sedonadb
         env:
           CIBW_SKIP: "*musllinux*"
+          VCPKG_BINARY_CACHE_HOST: ${{ github.workspace }}/vcpkg-bincache
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas duckdb
           # Test command exits 0 even on failure so CIBW continues building all wheels;
           # failures are recorded in .test_failed and checked after upload.
           CIBW_TEST_COMMAND: "pytest {package}/tests -vv -o faulthandler_timeout=600 || touch {project}/.test_failed"
+
+      - name: Save vcpkg binaries
+        if: always() && steps.vcpkg-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ github.workspace }}/vcpkg-bincache
+          key: ${{ steps.vcpkg-cache.outputs.cache-primary-key }}
 
       - uses: actions/upload-artifact@v7
         with:

--- a/ci/scripts/wheels-build-linux.sh
+++ b/ci/scripts/wheels-build-linux.sh
@@ -49,6 +49,17 @@ BEFORE_ALL_MANYLINUX="yum install -y curl zip unzip tar clang perl"
 # The native and Rust builds are cached on each image such that compile work is effectively
 # cached between Python versions (just not between invocations of this script).
 export CIBW_ENVIRONMENT_LINUX="VCPKG_ROOT=/vcpkg VCPKG_REF=$VCPKG_REF VCPKG_DEFAULT_TRIPLET=$VCPKG_DEFAULT_TRIPLET CMAKE_TOOLCHAIN_FILE=/vcpkg/scripts/buildsystems/vcpkg.cmake PKG_CONFIG_PATH=/vcpkg/installed/$VCPKG_DEFAULT_TRIPLET/lib/pkgconfig LD_LIBRARY_PATH=/vcpkg/installed/$VCPKG_DEFAULT_TRIPLET/lib MATURIN_PEP517_ARGS='--features s2geography,pyo3/extension-module'"
+
+# When a persistent vcpkg binary cache is provided (CI), bind-mount it into the
+# build container and point vcpkg at it, so `vcpkg install` restores prebuilt
+# binaries instead of rebuilding from source. Left unset for local builds, which
+# fall back to vcpkg's in-container default cache and mount nothing.
+if [ -n "${VCPKG_BINARY_CACHE_HOST}" ]; then
+    mkdir -p "${VCPKG_BINARY_CACHE_HOST}"
+    export CIBW_CONTAINER_ENGINE="docker; create_args: --volume ${VCPKG_BINARY_CACHE_HOST}:/vcpkg-bincache"
+    export CIBW_ENVIRONMENT_LINUX="$CIBW_ENVIRONMENT_LINUX VCPKG_DEFAULT_BINARY_CACHE=/vcpkg-bincache"
+fi
+
 export CIBW_BEFORE_ALL="$BEFORE_ALL_MANYLINUX && git clone https://github.com/microsoft/vcpkg.git /vcpkg && bash {package}/../../ci/scripts/wheels-bootstrap-vcpkg.sh"
 
 pushd "${SEDONADB_DIR}"


### PR DESCRIPTION
Stacked on #1131 — extends the vcpkg binary cache to the manylinux wheel jobs. 