### PR TITLE
chore(dev/release): Improve/update cargo publish script

### DIFF
--- a/c/sedona-extension/Cargo.toml
+++ b/c/sedona-extension/Cargo.toml
@@ -47,7 +47,6 @@ libc = "0.2.178"
 sedona-common = { workspace = true }
 sedona-expr = { workspace = true }
 sedona-schema = { workspace = true }
-sedona-testing = { path = "../../rust/sedona-testing" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
@@ -55,3 +54,4 @@ tokio-stream = { workspace = true }
 
 [dev-dependencies]
 datafusion = { workspace = true, features = ["sql"] }
+sedona-testing = { workspace = true }

--- a/c/sedona-libgpuspatial/Cargo.toml
+++ b/c/sedona-libgpuspatial/Cargo.toml
@@ -46,6 +46,6 @@ sedona-schema = { workspace = true }
 [dev-dependencies]
 wkt = { workspace = true }
 geo = { workspace = true }
-sedona-expr = { path = "../../rust/sedona-expr" }
-sedona-geos = { path = "../sedona-geos" }
-sedona-testing = { path = "../../rust/sedona-testing" }
+sedona-expr = { workspace = true }
+sedona-geos = { workspace = true }
+sedona-testing = { workspace = true }

--- a/dev/release/publish-crates.sh
+++ b/dev/release/publish-crates.sh
@@ -341,8 +341,8 @@ for crate_path in "${CRATES[@]}"; do
             PUBLISHED_CRATES+=("$pkg_name")
 
             # Wait for crates.io to index the new crate
-            echo "    Waiting 120 seconds for crates.io to index..."
-            sleep 120
+            echo "    Waiting 10 seconds for crates.io to index..."
+            sleep 10
         else
             echo -e "    ${RED}Publish failed${NC}"
             FAILED_CRATES+=("$pkg_name")

--- a/dev/release/publish-crates.sh
+++ b/dev/release/publish-crates.sh
@@ -127,7 +127,6 @@ CRATES=(
     # Tier 3 - Basic types
     "rust/sedona-raster"            # depends on: sedona-common, sedona-schema
     "rust/sedona-expr"              # depends on: sedona-common, sedona-geometry, sedona-schema
-    "c/sedona-libgpuspatial"        # depends on: sedona-schema
 
     # Tier 4 - Higher-level crates
     "rust/sedona-functions"         # depends on: sedona-common, sedona-expr, sedona-geometry, sedona-raster, sedona-schema
@@ -141,14 +140,15 @@ CRATES=(
     # Tier 5 - C wrappers (depend on functions)
     "c/sedona-tg"                   # depends on: sedona-expr, sedona-functions, sedona-schema
     "c/sedona-geos"                 # depends on: sedona-common, sedona-expr, sedona-functions, sedona-geometry, sedona-schema
+    "c/sedona-libgpuspatial"        # depends on: sedona-schema, sedona-geos
     "c/sedona-proj"                 # depends on: sedona-common, sedona-expr, sedona-functions, sedona-geometry, sedona-schema
     "c/sedona-geoarrow-c"           # depends on: sedona-expr, sedona-functions, sedona-schema
     "rust/sedona-geo"               # depends on: sedona-common, sedona-expr, sedona-functions, sedona-geo-generic-alg, sedona-geometry, sedona-schema
+    "c/sedona-s2geography"          # depends on: sedona-common, sedona-expr, sedona-extension, sedona-functions, sedona-geometry, sedona-schema
     "rust/sedona-geoparquet"        # depends on: sedona-common, sedona-expr, sedona-functions, sedona-geometry, sedona-schema
 
     # Tier 6 - Raster functions and s2geography
     "rust/sedona-raster-functions"  # depends on: sedona-common, sedona-expr, sedona-geometry, sedona-proj, sedona-raster, sedona-schema, sedona-tg
-    "c/sedona-s2geography"          # depends on: sedona-common, sedona-expr, sedona-extension, sedona-functions, sedona-geometry, sedona-schema
     "rust/sedona-raster-gdal"       # depends on: sedona-common, sedona-expr, sedona-functions, sedona-gdal, sedona-raster, sedona-raster-functions, sedona-schema
 
     # Tier 7 - Spatial join
@@ -324,34 +324,69 @@ for crate_path in "${CRATES[@]}"; do
             fi
         else
             # Full dry run - validates against crates.io
-            echo "    Running: cargo publish --dry-run"
-            if cargo publish --dry-run 2>&1; then
-                echo -e "    ${GREEN}Validation passed${NC}"
-                PUBLISHED_CRATES+=("$pkg_name")
+            # Skip verification for sedona-gdal (default features require bindgen gdal-sys feature)
+            if [ "$pkg_name" = "sedona-gdal" ]; then
+                echo "    Running: cargo publish --dry-run --no-verify"
+                if cargo publish --dry-run --no-verify 2>&1; then
+                    echo -e "    ${GREEN}Validation passed (no-verify)${NC}"
+                    PUBLISHED_CRATES+=("$pkg_name")
+                else
+                    echo -e "    ${RED}Validation failed${NC}"
+                    FAILED_CRATES+=("$pkg_name")
+                fi
             else
-                echo -e "    ${RED}Validation failed${NC}"
-                FAILED_CRATES+=("$pkg_name")
+                echo "    Running: cargo publish --dry-run"
+                if cargo publish --dry-run 2>&1; then
+                    echo -e "    ${GREEN}Validation passed${NC}"
+                    PUBLISHED_CRATES+=("$pkg_name")
+                else
+                    echo -e "    ${RED}Validation failed${NC}"
+                    FAILED_CRATES+=("$pkg_name")
+                fi
             fi
         fi
     else
         # Actual publish
-        echo "    Running: cargo publish"
-        if cargo publish 2>&1; then
-            echo -e "    ${GREEN}Published successfully${NC}"
-            PUBLISHED_CRATES+=("$pkg_name")
+        # Skip verification for sedona-gdal (default features require GDAL bindings that may not exist)
+        if [ "$pkg_name" = "sedona-gdal" ]; then
+            echo "    Running: cargo publish --no-verify"
+            if cargo publish --no-verify 2>&1; then
+                echo -e "    ${GREEN}Published successfully (no-verify)${NC}"
+                PUBLISHED_CRATES+=("$pkg_name")
 
-            # Wait for crates.io to index the new crate
-            echo "    Waiting 10 seconds for crates.io to index..."
-            sleep 10
+                # Wait for crates.io to index the new crate
+                echo "    Waiting 10 seconds for crates.io to index..."
+                sleep 10
+            else
+                echo -e "    ${RED}Publish failed${NC}"
+                FAILED_CRATES+=("$pkg_name")
+
+                # Ask whether to continue
+                read -p "    Continue with remaining crates? (y/N) " -n 1 -r
+                echo
+                if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+                    break
+                fi
+            fi
         else
-            echo -e "    ${RED}Publish failed${NC}"
-            FAILED_CRATES+=("$pkg_name")
+            echo "    Running: cargo publish"
+            if cargo publish 2>&1; then
+                echo -e "    ${GREEN}Published successfully${NC}"
+                PUBLISHED_CRATES+=("$pkg_name")
 
-            # Ask whether to continue
-            read -p "    Continue with remaining crates? (y/N) " -n 1 -r
-            echo
-            if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-                break
+                # Wait for crates.io to index the new crate
+                echo "    Waiting 10 seconds for crates.io to index..."
+                sleep 10
+            else
+                echo -e "    ${RED}Publish failed${NC}"
+                FAILED_CRATES+=("$pkg_name")
+
+                # Ask whether to continue
+                read -p "    Continue with remaining crates? (y/N) " -n 1 -r
+                echo
+                if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+                    break
+                fi
             fi
         fi
     fi

--- a/dev/release/publish-crates.sh
+++ b/dev/release/publish-crates.sh
@@ -44,7 +44,7 @@ NC='\033[0m' # No Color
 
 # Script directory and workspace root
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # Parse arguments
 DRY_RUN=true
@@ -112,44 +112,54 @@ done
 
 # Crates in dependency order (leaf crates first)
 # This order ensures that when publishing a crate, all its dependencies are already published
+# Updated: 2026-08-07 - Added missing crates and fixed dependency order
 CRATES=(
     # Tier 1 - Foundation crates (no internal dependencies)
     "rust/sedona-geo-traits-ext"
-    "rust/sedona-geo-generic-alg"
-
-    # Tier 2 - Core types (no internal deps)
     "rust/sedona-geometry"
     "rust/sedona-common"
+    "c/sedona-gdal"
 
-    # Tier 3 - Schema (depends on common)
-    "rust/sedona-schema"
+    # Tier 2 - Depends only on tier 1
+    "rust/sedona-geo-generic-alg"   # depends on: sedona-geo-traits-ext
+    "rust/sedona-schema"            # depends on: sedona-common
 
-    # Tier 4 - Expression (depends on common, geometry, schema)
-    "rust/sedona-expr"
+    # Tier 3 - Basic types
+    "rust/sedona-raster"            # depends on: sedona-common, sedona-schema
+    "rust/sedona-expr"              # depends on: sedona-common, sedona-geometry, sedona-schema
+    "c/sedona-libgpuspatial"        # depends on: sedona-schema
 
-    # Tier 5 - Functions (depends on expr, geometry, schema, common)
-    "rust/sedona-functions"
+    # Tier 4 - Higher-level crates
+    "rust/sedona-functions"         # depends on: sedona-common, sedona-expr, sedona-geometry, sedona-raster, sedona-schema
+    "rust/sedona-testing"           # depends on: sedona-common, sedona-expr, sedona-geometry, sedona-raster, sedona-schema (required by sedona main crate)
+    "c/sedona-extension"            # depends on: sedona-common, sedona-expr, sedona-schema
+    "rust/sedona-datasource"        # depends on: sedona-common, sedona-expr, sedona-schema
+    "rust/sedona-query-planner"     # depends on: sedona-common, sedona-expr, sedona-schema
+    "rust/sedona-pointcloud"        # depends on: sedona-expr, sedona-geometry
+    "rust/sedona-raster-zarr"       # depends on: sedona-common, sedona-raster, sedona-schema
 
-    # Tier 6 - C wrappers and sedona-geo (all depend on functions)
-    "c/sedona-tg"
-    "c/sedona-geos"
-    "c/sedona-proj"
-    "c/sedona-s2geography"
-    "c/sedona-geoarrow-c"
-    "rust/sedona-geo"
+    # Tier 5 - C wrappers (depend on functions)
+    "c/sedona-tg"                   # depends on: sedona-expr, sedona-functions, sedona-schema
+    "c/sedona-geos"                 # depends on: sedona-common, sedona-expr, sedona-functions, sedona-geometry, sedona-schema
+    "c/sedona-proj"                 # depends on: sedona-common, sedona-expr, sedona-functions, sedona-geometry, sedona-schema
+    "c/sedona-geoarrow-c"           # depends on: sedona-expr, sedona-functions, sedona-schema
+    "rust/sedona-geo"               # depends on: sedona-common, sedona-expr, sedona-functions, sedona-geo-generic-alg, sedona-geometry, sedona-schema
+    "rust/sedona-geoparquet"        # depends on: sedona-common, sedona-expr, sedona-functions, sedona-geometry, sedona-schema
 
-    # Tier 7 - Higher-level features
-    "rust/sedona-geoparquet"
-    "rust/sedona-raster"
-    "rust/sedona-raster-functions"
-    "rust/sedona-spatial-join"
-    "rust/sedona-datasource"
+    # Tier 6 - Raster functions and s2geography
+    "rust/sedona-raster-functions"  # depends on: sedona-common, sedona-expr, sedona-geometry, sedona-proj, sedona-raster, sedona-schema, sedona-tg
+    "c/sedona-s2geography"          # depends on: sedona-common, sedona-expr, sedona-extension, sedona-functions, sedona-geometry, sedona-schema
+    "rust/sedona-raster-gdal"       # depends on: sedona-common, sedona-expr, sedona-functions, sedona-gdal, sedona-raster, sedona-raster-functions, sedona-schema
 
-    # Tier 8 - Testing utilities (depends on expr, geometry, schema, raster)
-    "rust/sedona-testing"
+    # Tier 7 - Spatial join
+    "rust/sedona-spatial-join"      # depends on: sedona-common, sedona-expr, sedona-functions, sedona-geo, sedona-geo-generic-alg, sedona-geo-traits-ext, sedona-geometry, sedona-geos, sedona-query-planner, sedona-schema, sedona-tg
 
-    # Tier 9 - Main library (depends on most crates including sedona-testing)
-    "rust/sedona"
+    # Tier 8 - GPU and geography spatial joins
+    "rust/sedona-spatial-join-gpu"         # depends on: sedona-spatial-join, sedona-libgpuspatial, sedona-query-planner
+    "rust/sedona-spatial-join-geography"   # depends on: sedona-spatial-join, sedona-s2geography, sedona-query-planner
+
+    # Tier 9 - Main library
+    "rust/sedona"                   # depends on: most crates including sedona-testing
 
     # Tier 10 - Crates that depend on main library
     "rust/sedona-adbc"
@@ -158,9 +168,9 @@ CRATES=(
 
 # Crates that should NOT be published
 EXCLUDED_CRATES=(
-    "python/sedonadb"      # Python bindings - use PyPI
-    "r/sedonadb/src/rust"  # R bindings - use CRAN
-    "rust/sedona-testing"  # Test utilities only
+    "python/sedonadb"       # Python bindings - use PyPI
+    "python/sedonadb-zarr"  # Python bindings - use PyPI
+    "r/sedonadb/src/rust"   # R bindings - use CRAN
 )
 
 echo -e "${BLUE}============================================${NC}"


### PR DESCRIPTION
Our cargo publishing script is a little out of date since we have some new crates. This is the script I used to publish the 0.4.0 crates, although we needed a few modifications because of sedona-testing as a dev-dependency causing circular deps that made it impossible to publish (there's a PR up to fix this for the next release).