### PR TITLE
fix(python/sedonadb-geopandas): add missing geoarrow-pyarrow dependency

### DIFF
--- a/.github/workflows/wheels-geopandas.yml
+++ b/.github/workflows/wheels-geopandas.yml
@@ -78,14 +78,16 @@ jobs:
 
       - name: Install and test
         run: |
-          # geopandas is an optional extra of this package but is required to
-          # exercise the from_geopandas/to_geopandas interop in the tests.
-          pip install pytest geopandas
-
           cd python/sedonadb-geopandas
           pip install --no-deps --pre --find-links prebuilt sedonadb sedonadb-expr
           pip install --pre --find-links prebuilt sedonadb sedonadb-expr
-          pip install dist/*.whl
+          # Install the built wheel with its test extra so the test-time
+          # dependencies (pytest, geopandas, geoarrow-pyarrow) come from
+          # pyproject.toml. Listing them here instead lets the two drift apart,
+          # which is how geoarrow-pyarrow came to be missing: geopandas interop
+          # goes through sedonadb's conversion layer, which needs it, so without
+          # it every to_geopandas() call fails with `No module named 'geoarrow'`.
+          pip install "$(ls dist/*.whl)[test]"
           pytest tests -vv
 
       - uses: actions/upload-artifact@v7

--- a/python/sedonadb-geopandas/pyproject.toml
+++ b/python/sedonadb-geopandas/pyproject.toml
@@ -47,13 +47,24 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-# geopandas is only needed for the from_geopandas / to_geopandas interop
-# helpers, so it is an opt-in extra rather than a hard dependency.
-geopandas = ["geopandas"]
+# GeoPandas interop is opt-in rather than a hard dependency. It routes through
+# sedonadb's pandas/GeoPandas conversion, which needs geoarrow-pyarrow as well
+# as geopandas itself — without it, anything calling to_geopandas() fails with
+# `ModuleNotFoundError: No module named 'geoarrow'`.
+#
+# These are listed directly rather than as `sedonadb[geopandas]` so that
+# installing this package can never cause pip to re-resolve sedonadb itself:
+# in CI sedonadb is an editable build from source, and a resolver that decided
+# to satisfy it from PyPI instead would quietly stop testing the source tree.
+geopandas = [
+    "geopandas",
+    "geoarrow-pyarrow",
+]
 test = [
     "pytest",
     "pandas",
     "geopandas",
+    "geoarrow-pyarrow",
 ]
 
 [tool.hatch.version]


### PR DESCRIPTION
Fixes the `geopandas / geopandas-build` failure on `main` introduced by #1095, reported in https://github.com/apache/sedona-db/pull/1095#issuecomment-5220839172.

Scoped deliberately to the fix so it can land without waiting on discussion: the fast nightly-based test workflow that was originally part of this PR has been pulled out and will be proposed separately, since the question of what it should build against deserves its own thread.

## The failure

The wheels job for `sedonadb-geopandas` ran for the first time after #1095 merged — before that it was always skipped, because the extension jobs were gated behind platform jobs that were failing — and its test step failed:

```
E       ModuleNotFoundError: No module named 'geoarrow'
========================= 14 failed, 9 passed in 0.88s =========================
```

GeoPandas interop in this package routes through sedonadb's own pandas/GeoPandas conversion, which imports `geoarrow.pyarrow`. Without it, anything that materializes a frame through `to_geopandas()` fails.

## Two places were missing it

- **`pyproject.toml` extras.** The `geopandas` and `test` extras listed only `geopandas`, so `pip install sedonadb-geopandas[geopandas]` produced a package whose interop could not run. This part is user-facing and independent of CI.
- **The wheels job.** It listed its test dependencies inline (`pip install pytest geopandas`) and then installed the bare wheel, which brings only hard dependencies — so it never saw the extras at all. Fixing the extras alone would have left `main` red.

The wheels job now installs the built wheel with its own extra:

```
pip install "$(ls dist/*.whl)[test]"
```

so the test dependency list has a single home in `pyproject.toml` and the two cannot drift apart again.

Why this stayed hidden: both the local development environment and the `python.yml` CI job install `sedonadb[test]`, which happens to provide `geoarrow-pyarrow`. Only a clean environment exposes it, and until #1095 merged, nothing built this package in one.

## Verification

Reproduced and confirmed in clean virtual environments, installing `sedonadb` and `sedonadb-expr` from the nightly index:

- `main` as merged: `geoarrow-pyarrow` absent, 14 failed / 9 passed — matching the CI failure exactly.
- this branch: `geoarrow-pyarrow` present, 23 passed.
- mirroring the wheels job step by step (build the wheel, install sedonadb + sedonadb-expr, install the wheel with `[test]`, run pytest): 23 passed.
