### PR TITLE
fix(sedona-gdal): skip GDALClose during interpreter shutdown

### DIFF
--- a/c/sedona-gdal/src/dataset.rs
+++ b/c/sedona-gdal/src/dataset.rs
@@ -46,7 +46,11 @@ unsafe impl Send for Dataset {}
 
 impl Drop for Dataset {
     fn drop(&mut self) {
-        if !self.c_dataset.is_null() {
+        // Once the process is shutting down, leave the handle open. On Windows,
+        // closing a dataset while GDAL's shared library is being unloaded
+        // corrupts teardown and aborts the process (0xC0000409); leaking the
+        // handle at process exit is harmless since the OS reclaims it.
+        if !self.c_dataset.is_null() && !crate::global::is_gdal_shutting_down() {
             unsafe { call_gdal_api!(self.api, GDALClose, self.c_dataset) };
         }
     }

--- a/c/sedona-gdal/src/global.rs
+++ b/c/sedona-gdal/src/global.rs
@@ -19,7 +19,31 @@ use crate::errors::GdalInitLibraryError;
 use crate::gdal::Gdal;
 use crate::gdal_api::GdalApi;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, OnceLock};
+
+/// Set once the process is shutting down so GDAL datasets are left open during
+/// teardown instead of being closed.
+///
+/// On Windows, running `GDALClose` from a (thread-local) dataset cache's
+/// destructor while the GDAL shared library is being unloaded corrupts the
+/// teardown and aborts the process (`0xC0000409`). Leaking the handles at
+/// process exit is harmless — the OS reclaims them — so once shutdown begins
+/// [`crate::dataset::Dataset`]'s `Drop` skips `GDALClose`.
+static GDAL_SHUTTING_DOWN: AtomicBool = AtomicBool::new(false);
+
+/// Signal that the process is shutting down; see [`GDAL_SHUTTING_DOWN`].
+///
+/// Intended to run on the interpreter thread during finalization (e.g. a Python
+/// `atexit` callback), before GDAL's library is unloaded.
+pub fn begin_gdal_shutdown() {
+    GDAL_SHUTTING_DOWN.store(true, Ordering::SeqCst);
+}
+
+/// Whether [`begin_gdal_shutdown`] has been called.
+pub fn is_gdal_shutting_down() -> bool {
+    GDAL_SHUTTING_DOWN.load(Ordering::SeqCst)
+}
 
 /// Minimum GDAL version required by sedona-gdal.
 const MIN_GDAL_VERSION_MAJOR: i32 = 3;

--- a/python/sedonadb/python/sedonadb/__init__.py
+++ b/python/sedonadb/python/sedonadb/__init__.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import atexit
+
 from sedonadb import _lib
 from sedonadb.context import connect, configure_proj, configure_gdal
 
@@ -30,3 +32,8 @@ __all__ = ["connect", "options"]
 # GDAL-backed operation (e.g., raster I/O).
 configure_proj("auto")
 configure_gdal("auto")
+
+# During interpreter shutdown, leave GDAL datasets open instead of closing them:
+# on Windows, closing a dataset while GDAL's library is being unloaded aborts the
+# process. Registered here so it runs before the extension is torn down.
+atexit.register(_lib.begin_gdal_shutdown)

--- a/python/sedonadb/src/lib.rs
+++ b/python/sedonadb/src/lib.rs
@@ -140,11 +140,21 @@ fn gdal_version() -> Result<Option<String>, PySedonaError> {
     }
 }
 
+/// Signal that GDAL is shutting down so datasets are left open during
+/// interpreter/library teardown. Registered as a Python `atexit` callback to
+/// avoid a Windows process-exit abort (`0xC0000409`) when a GDAL dataset is
+/// closed while the library is being unloaded.
+#[pyfunction]
+fn begin_gdal_shutdown() {
+    sedona_gdal::global::begin_gdal_shutdown();
+}
+
 #[pymodule(gil_used = false)]
 fn _lib(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     #[cfg(feature = "mimalloc")]
     configure_tg_allocator();
 
+    m.add_function(wrap_pyfunction!(begin_gdal_shutdown, m)?)?;
     m.add_function(wrap_pyfunction!(configure_gdal_shared, m)?)?;
     m.add_function(wrap_pyfunction!(configure_proj_shared, m)?)?;
     m.add_function(wrap_pyfunction!(expr::expr_binary, m)?)?;


### PR DESCRIPTION
The Windows wheel job passes every test, then aborts at process exit with `0xC0000409`. Root cause: thread-local GDAL dataset caches (`Rc<Dataset>`) run `GDALClose` from their destructors while GDAL's shared library is being unloaded, which corrupts teardown on Windows. A Python `atexit` callback now latches a shutdown flag; `Dataset::drop` then leaves the handle open (harmless — the OS reclaims it at process exit).

Localized and validated with a subprocess probe on cp313: `raster_only` went from 10/10 crashes to 0/10 (and the full suite 12/12 → 0/12), with all 3217 tests still passing.


This should make the wheels all green now 🥳 