### PR TITLE
docs: add missing geography kernels to SQL function reference pages

### DIFF
--- a/docs/reference/sql/st_asewkb.qmd
+++ b/docs/reference/sql/st_asewkb.qmd
@@ -21,6 +21,8 @@ description: Returns the EWKB representation of a geometry or geography.
 kernels:
   - returns: binary
     args: [geometry]
+  - returns: binary
+    args: [geography]
 ---
 
 ## Description

--- a/docs/reference/sql/st_collect_agg.qmd
+++ b/docs/reference/sql/st_collect_agg.qmd
@@ -17,17 +17,19 @@
 # under the License.
 
 title: ST_Collect_Agg
-description: Combines multiple geometries from a set of rows into a single collection.
+description: Combines multiple geometries or geographies from a set of rows into a single collection.
 kernels:
   - returns: geometry
     args: [geometry]
+  - returns: geography
+    args: [geography]
 ---
 
 ## Description
 
-An aggregate function that collects multiple geometries into a single
-GeometryCollection or the appropriate Multi-type if all inputs share the same
-geometry type.
+An aggregate function that collects multiple geometries or geographies into a
+single GeometryCollection or the appropriate Multi-type if all inputs share the
+same geometry type. Collecting geographies returns a geography.
 
 ## Examples
 

--- a/docs/reference/sql/st_crs.qmd
+++ b/docs/reference/sql/st_crs.qmd
@@ -21,6 +21,8 @@ description: Returns the Coordinate Reference System (CRS) metadata associated w
 kernels:
   - returns: string
     args: [geometry]
+  - returns: string
+    args: [geography]
 ---
 
 ## Description

--- a/docs/reference/sql/st_dump.qmd
+++ b/docs/reference/sql/st_dump.qmd
@@ -21,6 +21,8 @@ description: Expands multi-part geometries into child parts
 kernels:
   - returns: struct
     args: [geometry]
+  - returns: struct
+    args: [geography]
 ---
 
 ## Description

--- a/docs/reference/sql/st_endpoint.qmd
+++ b/docs/reference/sql/st_endpoint.qmd
@@ -21,6 +21,8 @@ description: Returns last point of a linestring.
 kernels:
   - returns: geometry
     args: [geometry]
+  - returns: geography
+    args: [geography]
 ---
 
 ## Examples

--- a/docs/reference/sql/st_envelope_agg.qmd
+++ b/docs/reference/sql/st_envelope_agg.qmd
@@ -21,11 +21,13 @@ description: An aggregate function that returns the collective bounding box (env
 kernels:
   - returns: geometry
     args: [geometry]
+  - returns: geometry
+    args: [geography]
 ---
 
 ## Description
 
-An aggregate function that computes the collective bounding box (envelope) of all geometries in a group.
+An aggregate function that computes the collective bounding box (envelope) of all geometries in a group. Geography input is also accepted; the envelope is always returned as a geometry.
 
 ## Examples
 

--- a/docs/reference/sql/st_envelope_agg.qmd
+++ b/docs/reference/sql/st_envelope_agg.qmd
@@ -27,7 +27,7 @@ kernels:
 
 ## Description
 
-An aggregate function that computes the collective bounding box (envelope) of all geometries in a group. Geography input is also accepted; the envelope is always returned as a geometry.
+An aggregate function that computes the collective bounding box (envelope) of all geometries in a group. Geography input is also accepted; the envelope is always returned as a geometry. For geographies that cross the antimeridian, a multi geometry is returned with one polygon each for the west and east component.
 
 ## Examples
 

--- a/docs/reference/sql/st_hasm.qmd
+++ b/docs/reference/sql/st_hasm.qmd
@@ -21,6 +21,8 @@ description: Returns true if the geometry has a M dimension.
 kernels:
   - returns: boolean
     args: [geometry]
+  - returns: boolean
+    args: [geography]
 ---
 
 ## Examples

--- a/docs/reference/sql/st_hasz.qmd
+++ b/docs/reference/sql/st_hasz.qmd
@@ -21,6 +21,8 @@ description: Returns true if the geometry has a Z dimension.
 kernels:
   - returns: boolean
     args: [geometry]
+  - returns: boolean
+    args: [geography]
 ---
 
 ## Examples

--- a/docs/reference/sql/st_m.qmd
+++ b/docs/reference/sql/st_m.qmd
@@ -21,6 +21,8 @@ description: Returns the M (measure) coordinate of a Point geometry.
 kernels:
   - returns: double
     args: [geometry]
+  - returns: double
+    args: [geography]
 ---
 
 ## Description

--- a/docs/reference/sql/st_makeline.qmd
+++ b/docs/reference/sql/st_makeline.qmd
@@ -17,15 +17,17 @@
 # under the License.
 
 title: ST_MakeLine
-description: Creates a LineString from two or more input geometries.
+description: Creates a LineString from two or more input geometries or geographies.
 kernels:
   - returns: geometry
     args: [geometry, geometry]
+  - returns: geography
+    args: [geography, geography]
 ---
 
 ## Description
 
-Creates a `LineString` from two or more input `Point`, `MultiPoint`, or `LineString` geometries. The function connects the input geometries in the order they are provided to form a single continuous line.
+Creates a `LineString` from two or more input `Point`, `MultiPoint`, or `LineString` geometries or geographies. The function connects the inputs in the order they are provided to form a single continuous line. Combining geographies returns a geography.
 
 ## Examples
 

--- a/docs/reference/sql/st_setsrid.qmd
+++ b/docs/reference/sql/st_setsrid.qmd
@@ -24,6 +24,11 @@ kernels:
     - geometry
     - name: srid
       type: integer
+  - returns: geography
+    args:
+    - geography
+    - name: srid
+      type: integer
 ---
 
 ## Description

--- a/docs/reference/sql/st_srid.qmd
+++ b/docs/reference/sql/st_srid.qmd
@@ -21,6 +21,8 @@ description: Returns the SRID (spatial reference identifier) of a geometry.
 kernels:
   - returns: integer
     args: [geometry]
+  - returns: integer
+    args: [geography]
 ---
 
 See [Coordinate Reference Systems](../../concepts/crs.md) for how SedonaDB represents and compares CRS.

--- a/docs/reference/sql/st_startpoint.qmd
+++ b/docs/reference/sql/st_startpoint.qmd
@@ -21,6 +21,8 @@ description: Returns the start point of a linestring geometry.
 kernels:
   - returns: geometry
     args: [geometry]
+  - returns: geography
+    args: [geography]
 ---
 
 ## Examples

--- a/docs/reference/sql/st_transform.qmd
+++ b/docs/reference/sql/st_transform.qmd
@@ -31,6 +31,18 @@ kernels:
       type: string
     - name: target_crs
       type: string
+  - returns: geography
+    args:
+    - geography
+    - name: target_crs
+      type: string
+  - returns: geography
+    args:
+    - geography
+    - name: source_crs
+      type: string
+    - name: target_crs
+      type: string
 ---
 
 ## Description
@@ -40,6 +52,8 @@ Transforms the coordinate reference system of a geometry between EPSG reference 
 See [Coordinate Reference Systems](../../concepts/crs.md) for how SedonaDB represents and compares CRS.
 
 When 3 arguments are provided, a source_crs can be used to specify the source CRS in case the input geometry doesn't have an SRID defined. The source_crs takes precedence over the geometry's SRID.
+
+Geography input is also accepted; because geography is always defined on a geographic (longitude/latitude) CRS, the target_crs must be geographic as well.
 
 ## Examples
 

--- a/docs/reference/sql/st_z.qmd
+++ b/docs/reference/sql/st_z.qmd
@@ -21,6 +21,8 @@ description: Returns the Z coordinate of the point, or NULL if not available.
 kernels:
   - returns: double
     args: [geometry]
+  - returns: double
+    args: [geography]
 ---
 
 ## Description

--- a/docs/reference/sql/st_zmflag.qmd
+++ b/docs/reference/sql/st_zmflag.qmd
@@ -21,6 +21,8 @@ description: Returns a code indicating the dimension of the coordinates in a geo
 kernels:
   - returns: integer
     args: [geometry]
+  - returns: integer
+    args: [geography]
 ---
 
 ## Description


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds the missing `geography` entries to the `kernels:` frontmatter of the SQL function reference, so the docs match what the function registry actually accepts.

The two pages reported in #1087:

- `st_collect_agg.qmd` — `geography -> geography`
- `st_makeline.qmd` — `(geography, geography) -> geography`

Following the issue's suggestion, I also audited every other `.qmd` kernel list against the registry and found 14 more pages with working-but-undocumented geography signatures:

- `ST_AsEWKB`, `ST_CRS`, `ST_Dump`, `ST_EndPoint`, `ST_StartPoint`, `ST_HasM`, `ST_HasZ`, `ST_M`, `ST_Z`, `ST_SRID`, `ST_Zmflag`, `ST_SetSRID`
- `ST_Transform` — 2- and 3-arg geography kernels; the description notes the target CRS must be geographic
- `ST_Envelope_Agg` — geography input, but the envelope is returned as **geometry** (planar edges), which the description now calls out

## How was the audit done?

For every documented geometry kernel I built the geography twin and checked it against the registry at plan time, on two builds (the 0.4.0 wheel with `s2geography` and a dev build for the core kernels), then executed each candidate signature and inspected the output type's `edges`/`crs` metadata to get the correct `returns:` value. Each addition was also cross-checked against the `ArgMatcher` definitions in the Rust source. Probes that fail on argument *values* rather than types (CRS strings, SRIDs) can hide real kernels, which is how `ST_SetSRID` and `ST_Transform` were initially missed and then confirmed with valid values.

Deliberately excluded: `ST_KNN` type-matches geography arguments but the KNN join rewrite has no geography path, so it always fails with "Can't execute ST_KNN() outside a spatial join" — that's tracked in #1086 (see also #783/#801), and documenting it here would repeat the inverse of this bug.

All edited frontmatter renders cleanly through `docs/reference/sql/_render_meta.py`, showing both overloads in the Usage section.

## Are these changes tested?

Docs-only. Every added kernel signature was verified by executing it against the registry as described above; the rendering pipeline was exercised on all 16 edited pages.

## Are there any user-facing changes?

Yes — the SQL reference now documents the geography overloads for 16 functions.

Closes #1087
