### PR TITLE
feat(python/sedonadb-geopandas): add sjoin (spatial join)

### DIFF
--- a/python/sedonadb-geopandas/README.md
+++ b/python/sedonadb-geopandas/README.md
@@ -69,11 +69,19 @@ Division follows pandas rather than SQL: `/` is true division, so integer
 columns do not silently truncate. `//` is not implemented, since SQL division
 truncates toward zero where Python floors.
 
-`dissolve()` aggregates non-geometry columns with `"first"`, which skips SQL
-nulls but treats a NaN loaded from pandas as an ordinary value where GeoPandas
-would skip it. Dissolving an empty frame without a group key returns one all-null
-row rather than zero rows, because that is what a grouping-free SQL aggregate
-produces.
+`dissolve()` aggregates non-geometry columns with `"first"`, which is an
+unordered aggregate: it returns *some* value from the group rather than the one
+from the first row, and unlike GeoPandas it does not skip missing values, so a
+group containing a null or NaN may aggregate to that. Dissolving an empty frame
+without a group key returns one all-null row rather than zero rows, because that
+is what a grouping-free SQL aggregate produces, and a group mixing 2D and 3D
+geometries raises rather than being promoted to 3D.
+
+`sjoin(predicate="dwithin")` misses geometries that properly cross without
+sharing a vertex, because `ST_Distance` reports their endpoint gap rather than
+zero (apache/sedona-db#1156). Composing the predicate to work around it would
+stop the planner recognising it and turn the join into a nested loop, so the
+deviation stands until the engine is fixed.
 
 See the SedonaDB "Migrating from GeoPandas" guide for the relational model that
 underlies each method.

--- a/python/sedonadb-geopandas/README.md
+++ b/python/sedonadb-geopandas/README.md
@@ -31,9 +31,14 @@ import sedonadb_geopandas as sgpd
 
 gdf = sgpd.from_geopandas(geopandas.read_file("cities.geojson"))
 big = gdf[gdf["pop"] > 1_000_000]          # boolean-mask filter
+gdf["density"] = gdf["pop"] / gdf["area"]  # assign a computed column
 buffered = gdf.geometry.buffer(0.5)        # element-wise .geo operation
 web = gdf.to_crs("EPSG:3857")              # reproject (CRS tracked through)
-result = web.to_geopandas()                # back to a real GeoDataFrame
+
+joined = gdf.sjoin(regions, predicate="within")   # spatial join
+zones = joined.dissolve(by="region")              # group and union geometry
+
+result = zones.to_geopandas()               # back to a real GeoDataFrame
 ```
 
 ## Intentional differences from GeoPandas
@@ -44,10 +49,23 @@ deliberately *not* identical to GeoPandas:
 - **Lazy, not eager**: operations build a query; data materializes on
   `to_geopandas()` / `to_pandas()` / display.
 - **No row index / alignment**: there is no pandas `Index`; joins and filters
-  are positional/relational, not index-aligned.
+  are positional/relational, not index-aligned. Consequently `sjoin()` produces
+  no `index_left`/`index_right` column, and `dissolve()` leaves the group keys as
+  ordinary columns instead of moving them into the index.
 - **Immutable under the hood**: "in-place" style operations return a new frame.
+  Assigning a column with `gdf["x"] = ...` rebinds the frame, so a `Series` read
+  before the assignment is stale and cannot be combined with later reads.
+- **Columns cannot be mixed across frames**: without row alignment, combining
+  columns from two different frames raises rather than guessing. Join first.
 - **Plotting and arbitrary `apply`**: use the `to_geopandas()` escape hatch and
   operate on the materialized result.
+- **Expression escape hatch**: `series.expr` exposes the underlying SedonaDB
+  expression for anything the wrapper does not cover, and the result can be
+  assigned back with `gdf["name"] = ...`.
+
+Division follows pandas rather than SQL: `/` is true division, so integer
+columns do not silently truncate. `//` is not implemented, since SQL division
+truncates toward zero where Python floors.
 
 See the SedonaDB "Migrating from GeoPandas" guide for the relational model that
 underlies each method.

--- a/python/sedonadb-geopandas/README.md
+++ b/python/sedonadb-geopandas/README.md
@@ -77,11 +77,5 @@ without a group key returns one all-null row rather than zero rows, because that
 is what a grouping-free SQL aggregate produces, and a group mixing 2D and 3D
 geometries raises rather than being promoted to 3D.
 
-`sjoin(predicate="dwithin")` misses geometries that properly cross without
-sharing a vertex, because `ST_Distance` reports their endpoint gap rather than
-zero (apache/sedona-db#1156). Composing the predicate to work around it would
-stop the planner recognising it and turn the join into a nested loop, so the
-deviation stands until the engine is fixed.
-
 See the SedonaDB "Migrating from GeoPandas" guide for the relational model that
 underlies each method.

--- a/python/sedonadb-geopandas/README.md
+++ b/python/sedonadb-geopandas/README.md
@@ -73,9 +73,17 @@ truncates toward zero where Python floors.
 unordered aggregate: it returns *some* value from the group rather than the one
 from the first row, and unlike GeoPandas it does not skip missing values, so a
 group containing a null or NaN may aggregate to that. Dissolving an empty frame
-without a group key returns one all-null row rather than zero rows, because that
-is what a grouping-free SQL aggregate produces, and a group mixing 2D and 3D
-geometries raises rather than being promoted to 3D.
+without a group key returns one row — empty geometry collection, null attribute
+values — rather than zero rows, because that is what a grouping-free SQL
+aggregate produces, and a group mixing 2D and 3D geometries raises rather than
+being promoted to 3D.
+
+Two known engine-side issues surface through `sjoin` and are tracked upstream
+rather than worked around here: `touches` misses a line whose *interior* passes
+exactly through a polygon corner (an endpoint meeting the corner works), and
+`within` wrongly matches a line lying exactly on a hole's boundary; and an outer
+join whose preserved side is empty (`how="left"` with an empty left frame) fails
+with an internal error where GeoPandas returns an empty frame.
 
 See the SedonaDB "Migrating from GeoPandas" guide for the relational model that
 underlies each method.

--- a/python/sedonadb-geopandas/README.md
+++ b/python/sedonadb-geopandas/README.md
@@ -59,13 +59,21 @@ deliberately *not* identical to GeoPandas:
   columns from two different frames raises rather than guessing. Join first.
 - **Plotting and arbitrary `apply`**: use the `to_geopandas()` escape hatch and
   operate on the materialized result.
-- **Expression escape hatch**: `series.expr` exposes the underlying SedonaDB
-  expression for anything the wrapper does not cover, and the result can be
-  assigned back with `gdf["name"] = ...`.
+- **Assignment takes a column or a scalar, not a bare expression**: a SedonaDB
+  expression records no origin, so one built from another frame would resolve
+  against the destination and silently write the wrong values. Assign a `Series`
+  read from the same frame, or a scalar (a geometry included). For anything the
+  wrapper does not cover, drop to the SedonaDB `DataFrame` API directly.
 
 Division follows pandas rather than SQL: `/` is true division, so integer
 columns do not silently truncate. `//` is not implemented, since SQL division
 truncates toward zero where Python floors.
+
+`dissolve()` aggregates non-geometry columns with `"first"`, which skips SQL
+nulls but treats a NaN loaded from pandas as an ordinary value where GeoPandas
+would skip it. Dissolving an empty frame without a group key returns one all-null
+row rather than zero rows, because that is what a grouping-free SQL aggregate
+produces.
 
 See the SedonaDB "Migrating from GeoPandas" guide for the relational model that
 underlies each method.

--- a/python/sedonadb-geopandas/pyproject.toml
+++ b/python/sedonadb-geopandas/pyproject.toml
@@ -26,13 +26,13 @@ readme = "README.md"
 requires-python = ">=3.9"
 dynamic = ["version"]
 dependencies = [
-    # The `.geo` accessor and `DataFrame.unnest` this package builds on landed in
-    # 0.4.0. Keep this floor at a *released* version rather than raising it to
-    # the current development version: nightlies are versioned `X.Y.ZaN`, which
-    # PEP 440 orders *below* `X.Y.Z`, so a floor equal to the version being
-    # developed would reject the matching nightly wheels.
-    "sedonadb>=0.4.0",
-    "sedonadb-expr>=0.4.0",
+    # `DataFrame.mutate`, which `to_crs()` and column assignment are built on, is
+    # not in 0.4.0 — it first ships in 0.5.0. The floor is written as the
+    # prerelease `0.5.0a0` rather than `0.5.0` because nightlies version as
+    # `0.5.0aN`, which PEP 440 orders *below* `0.5.0`; a plain `>=0.5.0` would
+    # reject exactly the nightly wheels this is developed against.
+    "sedonadb>=0.5.0a0",
+    "sedonadb-expr>=0.5.0a0",
     "pyarrow",
 ]
 classifiers = [

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
@@ -289,7 +289,7 @@ class GeoDataFrame:
         geometry = self._geometry_name if keep_left_geom else other._geometry_name
         return GeoDataFrame(joined.select(*projection), geometry)
 
-    def dissolve(self, by=None, aggfunc="first"):
+    def dissolve(self, by=None, aggfunc="first", dropna=True):
         """Group rows and union each group's geometry.
 
         Args:
@@ -297,10 +297,21 @@ class GeoDataFrame:
                 row is dissolved into one.
             aggfunc: How to aggregate the remaining non-geometry columns.
                 Only `"first"` is currently supported.
+            dropna: Drop rows whose group key is missing, as GeoPandas does.
 
         Returns:
             A `GeoDataFrame` with one row per group. Unlike GeoPandas, the group
             keys stay ordinary columns rather than becoming the index.
+
+        Two remaining differences from GeoPandas, both consequences of doing this
+        as a lazy aggregation:
+
+        - `aggfunc="first"` skips SQL nulls, but a NaN loaded from pandas is an
+          ordinary floating-point value to the engine, so a group whose first row
+          is NaN aggregates to NaN where GeoPandas would skip it.
+        - Dissolving an empty frame with `by=None` yields one all-null row rather
+          than zero rows, because that is what a grouping-free SQL aggregate
+          returns. Detecting it would require executing the query first.
         """
         if self._geometry_name is None:
             raise ValueError("dissolve() requires an active geometry column")
@@ -322,19 +333,39 @@ class GeoDataFrame:
         if unknown:
             raise KeyError(f"Column(s) {unknown} not found. Columns: {self.columns}")
 
+        source = self._df
+        if keys and dropna:
+            # GeoPandas drops rows with a missing group key by default.
+            for key in keys:
+                source = source.filter(source[key].is_not_null())
+
+        # Collect each group into one geometry and union it afterwards, rather than
+        # using ST_Union_Agg: that aggregate only initializes for polygonal input,
+        # so a group of points or linestrings dissolves to NULL
+        # (apache/sedona-db#1093). Collect-then-unary-union is geometry-general and
+        # also produces the geometry types GeoPandas produces.
+        #
+        # The union is a separate projection because a scalar function wrapped
+        # around an aggregate is not a valid aggregate expression.
         aggregates = [
-            self._df[self._geometry_name].geo.union_agg().alias(self._geometry_name)
+            source[self._geometry_name].geo.collect_agg().alias(self._geometry_name)
         ]
         for name in self.columns:
             if name == self._geometry_name or name in keys:
                 continue
-            aggregates.append(self._df[name].funcs.first_value().alias(name))
+            aggregates.append(source[name].funcs.first_value().alias(name))
 
         if keys:
-            new_df = self._df.group_by(*keys).agg(*aggregates)
+            collected = source.group_by(*keys).agg(*aggregates)
         else:
-            new_df = self._df.agg(*aggregates)
-        return GeoDataFrame(new_df, self._geometry_name)
+            collected = source.agg(*aggregates)
+
+        unioned = collected.mutate(
+            **{
+                self._geometry_name: collected[self._geometry_name].geo.unary_union(),
+            }
+        )
+        return GeoDataFrame(unioned, self._geometry_name)
 
     def to_geopandas(self):
         """Execute and return a `geopandas.GeoDataFrame` (or plain DataFrame).

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
@@ -295,37 +295,60 @@ class GeoDataFrame:
 
         left_geom = left[self._geometry_name]
         right_geom = right[other._geometry_name]
-        method = getattr(left_geom.geo, _SJOIN_PREDICATES[predicate])
-        on = (
-            method(right_geom, distance)
-            if predicate == "dwithin"
-            else method(right_geom)
-        )
+        if predicate == "dwithin":
+            # ST_Distance reports the endpoint gap rather than zero for geometries
+            # that properly cross without sharing a vertex, so ST_DWithin misses
+            # crossing linestrings that GeoPandas matches. Anything that crosses
+            # intersects, and intersecting means a distance of zero, which is
+            # within any non-negative bound — so the union of the two predicates
+            # covers that case without changing any other.
+            on = left_geom.geo.d_within(
+                right_geom, distance
+            ) | left_geom.geo.intersects(right_geom)
+        else:
+            on = getattr(left_geom.geo, _SJOIN_PREDICATES[predicate])(right_geom)
 
         joined = left.join(right, on=on, how=how)
 
-        # Keep exactly one geometry column — whichever side GeoPandas keeps — and
-        # suffix the non-geometry names that occur on both sides.
+        # Keep exactly one geometry column — whichever side GeoPandas keeps.
         keep_left_geom = how != "right"
-        left_names = list(self.columns)
-        right_names = list(other.columns)
-        overlap = (set(left_names) - {self._geometry_name}) & (
-            set(right_names) - {other._geometry_name}
-        )
-
-        projection = []
-        for name in left_names:
-            if name == self._geometry_name and not keep_left_geom:
-                continue
-            out = f"{name}_{lsuffix}" if name in overlap else name
-            projection.append(left[name].alias(out))
-        for name in right_names:
-            if name == other._geometry_name and keep_left_geom:
-                continue
-            out = f"{name}_{rsuffix}" if name in overlap else name
-            projection.append(right[name].alias(out))
-
         geometry = self._geometry_name if keep_left_geom else other._geometry_name
+
+        # Collisions are computed over the columns actually emitted, so a dropped
+        # geometry does not count as a collision while an ordinary column sharing
+        # the *retained* geometry's name does. Following GeoPandas, the retained
+        # geometry keeps its name and only the opposite side's column is suffixed;
+        # ordinary collisions suffix both sides.
+        emitted_left = [
+            name
+            for name in self.columns
+            if keep_left_geom or name != self._geometry_name
+        ]
+        emitted_right = [
+            name
+            for name in other.columns
+            if not keep_left_geom or name != other._geometry_name
+        ]
+        collisions = set(emitted_left) & set(emitted_right)
+
+        def out_name(name, suffix, is_retained_geometry):
+            if name not in collisions or is_retained_geometry:
+                return name
+            return f"{name}_{suffix}"
+
+        projection = [
+            left[name].alias(
+                out_name(name, lsuffix, keep_left_geom and name == geometry)
+            )
+            for name in emitted_left
+        ]
+        projection += [
+            right[name].alias(
+                out_name(name, rsuffix, not keep_left_geom and name == geometry)
+            )
+            for name in emitted_right
+        ]
+
         return GeoDataFrame(joined.select(*projection), geometry)
 
     def dissolve(self, by=None, aggfunc="first", dropna=True):

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
@@ -25,6 +25,19 @@ _REPR_HTML_ROWS = 10
 # heuristic" from an explicit `None` meaning "this frame has no active geometry".
 _DERIVE = object()
 
+# GeoPandas sjoin predicate -> the corresponding method on the `.geo` accessor.
+_SJOIN_PREDICATES = {
+    "intersects": "intersects",
+    "within": "within",
+    "contains": "contains",
+    "touches": "touches",
+    "crosses": "crosses",
+    "overlaps": "overlaps",
+    "covers": "covers",
+    "covered_by": "covered_by",
+    "dwithin": "d_within",
+}
+
 
 def _geometry_column_names(df):
     names = df.schema.names
@@ -115,6 +128,52 @@ class GeoDataFrame:
             f"boolean mask, not {type(key).__name__}"
         )
 
+    def __setitem__(self, key, value):
+        """Add or replace a column, as in `gdf["buffered"] = gdf.geometry.buffer(1)`.
+
+        The underlying frame is immutable, so this rebinds this object to a new
+        frame rather than mutating data in place. A consequence worth knowing:
+        `Series` objects taken from this frame *before* the assignment still
+        refer to the previous frame, so combining one with a column read
+        afterwards raises rather than silently mixing two frames.
+
+        Args:
+            key: Column name to add or replace.
+            value: A `Series`/`GeoSeries` from this same frame, a SedonaDB
+                expression, or a scalar to broadcast to every row.
+        """
+        if not isinstance(key, str):
+            raise TypeError(f"Column name must be a string, not {type(key).__name__}")
+
+        from sedonadb.expr import Expr, Literal, lit
+
+        if isinstance(value, Series):
+            if value._df is not self._df:
+                raise ValueError(
+                    "Cannot assign a Series that comes from a different "
+                    "DataFrame: there is no row alignment, so the result would "
+                    "be silently wrong. Note that assigning to this frame "
+                    "rebinds it, so a Series read before an earlier assignment "
+                    "is already stale; re-read it as gdf[...] and try again."
+                )
+            expr = value._expr
+        elif isinstance(value, (Expr, Literal)):
+            expr = value
+        elif hasattr(value, "__array__"):
+            raise TypeError(
+                "Assigning a pandas/numpy array-like isn't supported (there is "
+                "no row alignment). Build the column from this frame's own "
+                "columns, or load the data as a frame and join it."
+            )
+        else:
+            expr = lit(value)
+
+        self._df = self._df.mutate(**{key: expr})
+        # Assigning geometry to a frame that had none makes it the active column,
+        # matching what `from_geopandas` would have inferred for such a frame.
+        if self._geometry_name is None and key in _geometry_column_names(self._df):
+            self._geometry_name = key
+
     def head(self, n=5):
         """Return a `GeoDataFrame` of at most `n` rows.
 
@@ -131,6 +190,150 @@ class GeoDataFrame:
 
         transformed = self._df[self._geometry_name].geo.transform(lit(crs))
         new_df = self._df.mutate(**{self._geometry_name: transformed})
+        return GeoDataFrame(new_df, self._geometry_name)
+
+    def sjoin(
+        self,
+        other,
+        how="inner",
+        predicate="intersects",
+        lsuffix="left",
+        rsuffix="right",
+        distance=None,
+    ):
+        """Join two frames on a spatial predicate.
+
+        The predicate reads left-relative-to-right, as in GeoPandas: with
+        `predicate="within"`, rows are matched where the left geometry is within
+        the right geometry.
+
+        Args:
+            other: The right-hand `GeoDataFrame`.
+            how: `"inner"`, `"left"`, or `"right"`.
+            predicate: One of `intersects`, `within`, `contains`, `touches`,
+                `crosses`, `overlaps`, `covers`, `covered_by`, `dwithin`.
+            lsuffix: Suffix for left columns whose names also occur on the right.
+            rsuffix: Suffix for the corresponding right columns.
+            distance: Required by (and only used with) `predicate="dwithin"`.
+
+        Returns:
+            A `GeoDataFrame` carrying one geometry column: the left frame's for
+            `how="inner"`/`"left"`, the right frame's for `how="right"`, matching
+            which side GeoPandas keeps.
+
+        Unlike GeoPandas, no `index_left`/`index_right` column is produced —
+        there is no row index to report.
+        """
+        if not isinstance(other, GeoDataFrame):
+            raise TypeError(
+                f"sjoin() expects a GeoDataFrame, got {type(other).__name__}"
+            )
+        if self._geometry_name is None or other._geometry_name is None:
+            raise ValueError(
+                "sjoin() requires an active geometry column on both frames"
+            )
+
+        if how not in ("inner", "left", "right"):
+            raise ValueError(
+                f"sjoin() `how` must be 'inner', 'left', or 'right', got {how!r}"
+            )
+
+        if predicate not in _SJOIN_PREDICATES:
+            raise ValueError(
+                f"sjoin() `predicate` must be one of "
+                f"{sorted(_SJOIN_PREDICATES)}, got {predicate!r}"
+            )
+        if (predicate == "dwithin") != (distance is not None):
+            raise ValueError(
+                "sjoin() `distance` is required for predicate='dwithin' and "
+                "accepted only for that predicate"
+            )
+
+        # Alias both sides so the predicate and the output projection can name
+        # columns unambiguously even when both frames use the same names.
+        left = self._df.alias("sjoin_left")
+        right = other._df.alias("sjoin_right")
+
+        left_geom = left[self._geometry_name]
+        right_geom = right[other._geometry_name]
+        method = getattr(left_geom.geo, _SJOIN_PREDICATES[predicate])
+        on = (
+            method(right_geom, distance)
+            if predicate == "dwithin"
+            else method(right_geom)
+        )
+
+        joined = left.join(right, on=on, how=how)
+
+        # Keep exactly one geometry column — whichever side GeoPandas keeps — and
+        # suffix the non-geometry names that occur on both sides.
+        keep_left_geom = how != "right"
+        left_names = list(self.columns)
+        right_names = list(other.columns)
+        overlap = (set(left_names) - {self._geometry_name}) & (
+            set(right_names) - {other._geometry_name}
+        )
+
+        projection = []
+        for name in left_names:
+            if name == self._geometry_name and not keep_left_geom:
+                continue
+            out = f"{name}_{lsuffix}" if name in overlap else name
+            projection.append(left[name].alias(out))
+        for name in right_names:
+            if name == other._geometry_name and keep_left_geom:
+                continue
+            out = f"{name}_{rsuffix}" if name in overlap else name
+            projection.append(right[name].alias(out))
+
+        geometry = self._geometry_name if keep_left_geom else other._geometry_name
+        return GeoDataFrame(joined.select(*projection), geometry)
+
+    def dissolve(self, by=None, aggfunc="first"):
+        """Group rows and union each group's geometry.
+
+        Args:
+            by: Column name, or list of names, to group on. With `None`, every
+                row is dissolved into one.
+            aggfunc: How to aggregate the remaining non-geometry columns.
+                Only `"first"` is currently supported.
+
+        Returns:
+            A `GeoDataFrame` with one row per group. Unlike GeoPandas, the group
+            keys stay ordinary columns rather than becoming the index.
+        """
+        if self._geometry_name is None:
+            raise ValueError("dissolve() requires an active geometry column")
+        if aggfunc != "first":
+            raise NotImplementedError(
+                f"dissolve() currently supports aggfunc='first' only, got "
+                f"{aggfunc!r}. Aggregate explicitly with group_by/agg on the "
+                f"underlying SedonaDB DataFrame if you need something else."
+            )
+
+        if by is None:
+            keys = []
+        elif isinstance(by, str):
+            keys = [by]
+        else:
+            keys = list(by)
+
+        unknown = [k for k in keys if k not in self.columns]
+        if unknown:
+            raise KeyError(f"Column(s) {unknown} not found. Columns: {self.columns}")
+
+        aggregates = [
+            self._df[self._geometry_name].geo.union_agg().alias(self._geometry_name)
+        ]
+        for name in self.columns:
+            if name == self._geometry_name or name in keys:
+                continue
+            aggregates.append(self._df[name].funcs.first_value().alias(name))
+
+        if keys:
+            new_df = self._df.group_by(*keys).agg(*aggregates)
+        else:
+            new_df = self._df.agg(*aggregates)
         return GeoDataFrame(new_df, self._geometry_name)
 
     def to_geopandas(self):

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
@@ -45,17 +45,27 @@ def _geometry_column_names(df):
 
 
 def _is_floating(df, name):
-    """Whether column `name` is a scalar floating-point column, so it can hold NaN.
+    """Whether column `name` holds scalar floating-point values, so it can hold NaN.
 
     The Arrow datatype is checked rather than its string form: a rendered type such
     as `list<item: double>` or `struct<x: double>` contains "float"/"double" while
     being nothing `isnan()` can be applied to, and passing one to `isnan()` fails
-    at planning time.
+    at planning time. Dictionary encoding is unwrapped — a
+    `dictionary<values=double>` column is floating for NaN purposes, and `isnan()`
+    handles it.
     """
     import pyarrow as pa
 
-    field = pa.schema(df.schema).field(name)
-    return pa.types.is_floating(field.type)
+    dtype = pa.schema(df.schema).field(name).type
+    if pa.types.is_dictionary(dtype):
+        dtype = dtype.value_type
+    return pa.types.is_floating(dtype)
+
+
+def _expr_crs(df, expr):
+    """The CRS carried by `expr`, read from a projected schema (a plan build)."""
+    field = df.select(expr.alias("x")).schema.field("x")
+    return getattr(field.type, "crs", None)
 
 
 def _is_missing(value):
@@ -256,7 +266,10 @@ class GeoDataFrame:
         """
         from sedonadb.expr import Literal, lit
 
+        from sedonadb_geopandas._series import normalize_scalar
+
         raw = value._value if isinstance(value, Literal) else value
+        raw = normalize_scalar(raw)
 
         # Only geometry values inherit the column's type and CRS. Assigning a number
         # over a geometry column is a legitimate way to turn it into an ordinary
@@ -265,7 +278,7 @@ class GeoDataFrame:
         is_geometry_value = missing or hasattr(raw, "__geo_interface__")
         replacing_geometry = key in _geometry_column_names(self._df)
         if not (replacing_geometry and is_geometry_value):
-            return value if isinstance(value, Literal) else lit(value)
+            return lit(raw)
 
         crs = self._df.schema.field(key).type.crs
         # A context-bound literal is needed to call functions on it.
@@ -274,7 +287,11 @@ class GeoDataFrame:
             expr = ctx.lit(None).funcs.st_geomfromwkt()
         else:
             expr = ctx.lit(raw)
-        if crs is not None:
+        # The destination CRS is inherited only by genuinely CRS-less geometry.
+        # A value that carries its own CRS (a GeoSeries literal, say) keeps it:
+        # stamping the destination CRS over it would relabel the coordinates
+        # without transforming them, which is silently wrong data.
+        if crs is not None and _expr_crs(self._df, expr) is None:
             expr = expr.funcs.st_setcrs(ctx.lit(crs.to_json()))
         return expr
 
@@ -352,6 +369,23 @@ class GeoDataFrame:
                 "sjoin() `distance` is required for predicate='dwithin' and "
                 "accepted only for that predicate"
             )
+        if distance is not None:
+            # Only a plain number. A Series or expression cannot be accepted here:
+            # the predicate is built against re-aliased copies of both frames, so a
+            # column reference would resolve by name inside the join rather than
+            # against whatever frame it was read from — silently using the wrong
+            # values in the worst case, failing obscurely in the best.
+            import numbers
+
+            from sedonadb_geopandas._series import normalize_scalar
+
+            distance = normalize_scalar(distance) if is_scalar(distance) else distance
+            if not isinstance(distance, numbers.Real):
+                raise TypeError(
+                    f"sjoin() `distance` must be a number, got "
+                    f"{type(distance).__name__}. A per-row distance column isn't "
+                    f"supported; filter on st_distance explicitly if you need one."
+                )
 
         # Alias both sides so the predicate and the output projection can name
         # columns unambiguously even when both frames use the same names.
@@ -455,9 +489,10 @@ class GeoDataFrame:
           the group, not necessarily the one from the first row, and it does not
           skip missing values the way GeoPandas' `first` does. A group containing a
           null or NaN may therefore aggregate to that value.
-        - Dissolving an empty frame with `by=None` yields one all-null row rather
-          than zero rows, because that is what a grouping-free SQL aggregate
-          returns. Detecting it would require executing the query first.
+        - Dissolving an empty frame with `by=None` yields one row — empty geometry
+          collection, null attribute values — rather than zero rows, because that
+          is what a grouping-free SQL aggregate returns. Detecting emptiness would
+          require executing the query first.
         - A group mixing 2D and 3D geometries raises, because the collect step
           rejects mixed coordinate dimensions; GeoPandas promotes to 3D with NaN.
           Normalize the dimension first if a group can contain both.

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
@@ -44,6 +44,25 @@ def _geometry_column_names(df):
     return {names[i] for i in df.schema.geometry_column_indices}
 
 
+def _is_scalar(value):
+    """Whether `value` is a single value that can be broadcast to every row.
+
+    Checking for `__array__` alone is not enough in either direction: a list or
+    tuple has no `__array__` yet is a sequence, while a NumPy scalar has one and
+    *is* a single value. So sequences are rejected explicitly, and anything
+    array-like is judged by its dimensionality — 0-d is a scalar, anything else
+    holds multiple values and has no defined row alignment here.
+    """
+    if isinstance(value, (str, bytes, bytearray)):
+        return True
+    if isinstance(value, (list, tuple, set, frozenset, dict, range)):
+        return False
+    if hasattr(value, "__array__"):
+        return getattr(value, "ndim", None) == 0
+    # Non-sequence objects (numbers, shapely geometries, None, ...) broadcast.
+    return not hasattr(value, "__len__")
+
+
 class GeoDataFrame:
     """A lazy SedonaDB frame in the shape of a `geopandas.GeoDataFrame`.
 
@@ -139,8 +158,13 @@ class GeoDataFrame:
 
         Args:
             key: Column name to add or replace.
-            value: A `Series`/`GeoSeries` from this same frame, a SedonaDB
-                expression, or a scalar to broadcast to every row.
+            value: A `Series`/`GeoSeries` from this same frame, or a scalar (which
+                may be a geometry) to broadcast to every row.
+
+        A bare SedonaDB expression is deliberately not accepted. An expression
+        carries no record of the frame it was built from, so a column reference
+        taken from another frame would resolve against this one and silently
+        produce this frame's values instead of the intended ones.
         """
         if not isinstance(key, str):
             raise TypeError(f"Column name must be a string, not {type(key).__name__}")
@@ -157,21 +181,36 @@ class GeoDataFrame:
                     "is already stale; re-read it as gdf[...] and try again."
                 )
             expr = value._expr
-        elif isinstance(value, (Expr, Literal)):
+        elif isinstance(value, Literal):
+            # A literal holds a value rather than a column reference, so there is
+            # no frame for it to be misattributed to.
             expr = value
-        elif hasattr(value, "__array__"):
+        elif isinstance(value, Expr):
             raise TypeError(
-                "Assigning a pandas/numpy array-like isn't supported (there is "
-                "no row alignment). Build the column from this frame's own "
-                "columns, or load the data as a frame and join it."
+                "Assigning a bare expression isn't supported: an expression does "
+                "not record which frame its columns came from, so one built "
+                "against another frame would silently resolve against this one. "
+                "Assign a Series read from this frame, or a literal."
+            )
+        elif not _is_scalar(value):
+            raise TypeError(
+                f"Assigning a {type(value).__name__} isn't supported (there is no "
+                f"row alignment, so the values could not be matched to rows). "
+                f"Build the column from this frame's own columns, or load the "
+                f"data as a frame and join it."
             )
         else:
             expr = lit(value)
 
         self._df = self._df.mutate(**{key: expr})
-        # Assigning geometry to a frame that had none makes it the active column,
-        # matching what `from_geopandas` would have inferred for such a frame.
-        if self._geometry_name is None and key in _geometry_column_names(self._df):
+
+        # Assignment can change whether the active geometry column is still a
+        # geometry: replacing it with a number leaves nothing to be active, and
+        # giving a frame without geometry one makes that column active.
+        geometry_columns = _geometry_column_names(self._df)
+        if key == self._geometry_name and key not in geometry_columns:
+            self._geometry_name = None
+        elif self._geometry_name is None and key in geometry_columns:
             self._geometry_name = key
 
     def head(self, n=5):

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
@@ -44,6 +44,11 @@ def _geometry_column_names(df):
     return {names[i] for i in df.schema.geometry_column_indices}
 
 
+def _is_floating(df, name):
+    """Whether column `name` is a floating-point column, so it can hold NaN."""
+    return "float" in str(df.schema.field(name).type).lower()
+
+
 def _is_scalar(value):
     """Whether `value` is a single value that can be broadcast to every row.
 
@@ -109,6 +114,18 @@ class GeoDataFrame:
     def __getitem__(self, key):
         # Boolean mask -> row filter (gdf[gdf["pop"] > 1000]).
         if isinstance(key, Series):
+            if key._df is not self._df:
+                # Same check assignment makes. Without it a mask captured before an
+                # assignment is silently reused against the rebound frame: it
+                # happens to resolve while the referenced column still exists, and
+                # fails obscurely at collection when it does not.
+                raise ValueError(
+                    "Cannot filter with a mask built from a different DataFrame: "
+                    "there is no row alignment, so the result would be silently "
+                    "wrong. Note that assigning a column rebinds this frame, so a "
+                    "mask taken beforehand is stale; re-read it as gdf[...] > ... "
+                    "and try again."
+                )
             return GeoDataFrame(self._df.filter(key._expr), self._geometry_name)
 
         # Column subset -> GeoDataFrame. Matching GeoPandas, the active geometry
@@ -169,7 +186,7 @@ class GeoDataFrame:
         if not isinstance(key, str):
             raise TypeError(f"Column name must be a string, not {type(key).__name__}")
 
-        from sedonadb.expr import Expr, Literal, lit
+        from sedonadb.expr import Expr, Literal
 
         if isinstance(value, Series):
             if value._df is not self._df:
@@ -200,7 +217,7 @@ class GeoDataFrame:
                 f"data as a frame and join it."
             )
         else:
-            expr = lit(value)
+            expr = self._scalar_expr(key, value)
 
         self._df = self._df.mutate(**{key: expr})
 
@@ -212,6 +229,37 @@ class GeoDataFrame:
             self._geometry_name = None
         elif self._geometry_name is None and key in geometry_columns:
             self._geometry_name = key
+
+    def _scalar_expr(self, key, value):
+        """Build the expression for broadcasting `value` into column `key`.
+
+        Replacing an existing geometry column keeps that column's CRS, as GeoPandas
+        does: a bare Shapely geometry (or `None`) carries no CRS of its own, and
+        letting the assignment silently reset the column to no CRS loses
+        information the frame already had. `None` is additionally built as a typed
+        null geometry so the column stays a geometry column rather than becoming
+        untyped.
+        """
+        from sedonadb.expr import lit
+
+        # Only geometry values inherit the column's CRS. Assigning a number over a
+        # geometry column is a legitimate way to turn it into an ordinary column,
+        # and must not be dressed up as geometry.
+        is_geometry_value = value is None or hasattr(value, "__geo_interface__")
+        replacing_geometry = key in _geometry_column_names(self._df)
+        if not (replacing_geometry and is_geometry_value):
+            return lit(value)
+
+        crs = self._df.schema.field(key).type.crs
+        # A context-bound literal is needed to call functions on it.
+        ctx = self._df._ctx
+        if value is None:
+            expr = ctx.lit(None).funcs.st_geomfromwkt()
+        else:
+            expr = ctx.lit(value)
+        if crs is not None:
+            expr = expr.funcs.st_setcrs(ctx.lit(crs.to_json()))
+        return expr
 
     def head(self, n=5):
         """Return a `GeoDataFrame` of at most `n` rows.
@@ -295,16 +343,15 @@ class GeoDataFrame:
 
         left_geom = left[self._geometry_name]
         right_geom = right[other._geometry_name]
+        # Always a single spatial predicate. The planner recognizes one and rewrites
+        # it into a spatial join; composing predicates (`a OR b`) still returns
+        # correct rows but drops the plan to a nested-loop join, which is quadratic.
+        # That matters more than the one case a composition would fix: ST_DWithin
+        # misses properly crossing linestrings, because ST_Distance reports their
+        # endpoint gap rather than zero (apache/sedona-db#1156). That belongs in the
+        # engine rather than being worked around at the cost of every join's plan.
         if predicate == "dwithin":
-            # ST_Distance reports the endpoint gap rather than zero for geometries
-            # that properly cross without sharing a vertex, so ST_DWithin misses
-            # crossing linestrings that GeoPandas matches. Anything that crosses
-            # intersects, and intersecting means a distance of zero, which is
-            # within any non-negative bound — so the union of the two predicates
-            # covers that case without changing any other.
-            on = left_geom.geo.d_within(
-                right_geom, distance
-            ) | left_geom.geo.intersects(right_geom)
+            on = left_geom.geo.d_within(right_geom, distance)
         else:
             on = getattr(left_geom.geo, _SJOIN_PREDICATES[predicate])(right_geom)
 
@@ -336,17 +383,35 @@ class GeoDataFrame:
                 return name
             return f"{name}_{suffix}"
 
-        projection = [
-            left[name].alias(
-                out_name(name, lsuffix, keep_left_geom and name == geometry)
-            )
+        left_out = [
+            out_name(name, lsuffix, keep_left_geom and name == geometry)
             for name in emitted_left
         ]
-        projection += [
-            right[name].alias(
-                out_name(name, rsuffix, not keep_left_geom and name == geometry)
-            )
+        right_out = [
+            out_name(name, rsuffix, not keep_left_geom and name == geometry)
             for name in emitted_right
+        ]
+
+        # Suffixing can itself collide — left columns `v` and `v_left` against a
+        # right `v` both want to be `v_left`. The engine cannot represent duplicate
+        # output names, so say so here rather than letting the planner fail on a
+        # generated name the caller never wrote. (GeoPandas currently allows the
+        # duplicate with a FutureWarning that it will become an error.)
+        final_names = left_out + right_out
+        duplicates = sorted({n for n in final_names if final_names.count(n) > 1})
+        if duplicates:
+            raise ValueError(
+                f"sjoin() would produce duplicate column name(s) {duplicates}: "
+                f"applying the suffixes {lsuffix!r}/{rsuffix!r} collides with a "
+                f"column that already exists. Pass different lsuffix/rsuffix "
+                f"values, or rename the conflicting column first."
+            )
+
+        projection = [
+            left[name].alias(out) for name, out in zip(emitted_left, left_out)
+        ]
+        projection += [
+            right[name].alias(out) for name, out in zip(emitted_right, right_out)
         ]
 
         return GeoDataFrame(joined.select(*projection), geometry)
@@ -365,15 +430,18 @@ class GeoDataFrame:
             A `GeoDataFrame` with one row per group. Unlike GeoPandas, the group
             keys stay ordinary columns rather than becoming the index.
 
-        Two remaining differences from GeoPandas, both consequences of doing this
-        as a lazy aggregation:
+        Three remaining differences from GeoPandas:
 
-        - `aggfunc="first"` skips SQL nulls, but a NaN loaded from pandas is an
-          ordinary floating-point value to the engine, so a group whose first row
-          is NaN aggregates to NaN where GeoPandas would skip it.
+        - `aggfunc="first"` is an unordered aggregate: it returns *some* value from
+          the group, not necessarily the one from the first row, and it does not
+          skip missing values the way GeoPandas' `first` does. A group containing a
+          null or NaN may therefore aggregate to that value.
         - Dissolving an empty frame with `by=None` yields one all-null row rather
           than zero rows, because that is what a grouping-free SQL aggregate
           returns. Detecting it would require executing the query first.
+        - A group mixing 2D and 3D geometries raises, because the collect step
+          rejects mixed coordinate dimensions; GeoPandas promotes to 3D with NaN.
+          Normalize the dimension first if a group can contain both.
         """
         if self._geometry_name is None:
             raise ValueError("dissolve() requires an active geometry column")
@@ -397,9 +465,16 @@ class GeoDataFrame:
 
         source = self._df
         if keys and dropna:
-            # GeoPandas drops rows with a missing group key by default.
+            # GeoPandas drops rows with a missing group key by default. "Missing"
+            # has to cover IEEE NaN as well as SQL null: a float column read from
+            # pandas carries NaN, and grouping treats it as an ordinary value, so
+            # filtering nulls alone would leave it as its own group.
             for key in keys:
-                source = source.filter(source[key].is_not_null())
+                column = source[key]
+                keep = column.is_not_null()
+                if _is_floating(source, key):
+                    keep = keep & ~column.funcs.isnan()
+                source = source.filter(keep)
 
         # Collect each group into one geometry and union it afterwards, rather than
         # using ST_Union_Agg: that aggregate only initializes for polygonal input,

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
@@ -365,12 +365,10 @@ class GeoDataFrame:
         # predicate, so a composition drops the plan to a nested-loop join and makes
         # the join quadratic; and OR-ing ST_Intersects in also broke the bound's
         # semantics, matching coincident geometries at a negative or NaN distance
-        # where GeoPandas matches nothing.
-        #
-        # The case a composition would have fixed is that ST_DWithin misses properly
-        # crossing linestrings, because ST_Distance reports their endpoint gap rather
-        # than zero (apache/sedona-db#1156). That belongs in the engine rather than
-        # being worked around here at the cost of both plan shape and semantics.
+        # where GeoPandas matches nothing. (The composition was a workaround for
+        # ST_Distance mis-measuring crossing linestrings, fixed in the engine by
+        # apache/sedona-db#1164 — keeping the engine honest beats patching over it
+        # here.)
         if predicate == "dwithin":
             on = left_geom.geo.d_within(right_geom, distance)
         else:

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
@@ -16,7 +16,7 @@
 # under the License.
 """GeoPandas-style GeoDataFrame backed by a lazy SedonaDB frame."""
 
-from sedonadb_geopandas._series import GeoSeries, Series
+from sedonadb_geopandas._series import GeoSeries, Series, is_scalar
 
 # Rows to collect for the Jupyter rich-text (`_repr_html_`) preview.
 _REPR_HTML_ROWS = 10
@@ -45,27 +45,36 @@ def _geometry_column_names(df):
 
 
 def _is_floating(df, name):
-    """Whether column `name` is a floating-point column, so it can hold NaN."""
-    return "float" in str(df.schema.field(name).type).lower()
+    """Whether column `name` is a scalar floating-point column, so it can hold NaN.
 
-
-def _is_scalar(value):
-    """Whether `value` is a single value that can be broadcast to every row.
-
-    Checking for `__array__` alone is not enough in either direction: a list or
-    tuple has no `__array__` yet is a sequence, while a NumPy scalar has one and
-    *is* a single value. So sequences are rejected explicitly, and anything
-    array-like is judged by its dimensionality — 0-d is a scalar, anything else
-    holds multiple values and has no defined row alignment here.
+    The Arrow datatype is checked rather than its string form: a rendered type such
+    as `list<item: double>` or `struct<x: double>` contains "float"/"double" while
+    being nothing `isnan()` can be applied to, and passing one to `isnan()` fails
+    at planning time.
     """
-    if isinstance(value, (str, bytes, bytearray)):
+    import pyarrow as pa
+
+    field = pa.schema(df.schema).field(name)
+    return pa.types.is_floating(field.type)
+
+
+def _is_missing(value):
+    """Whether `value` is one of the missing-value sentinels.
+
+    `None`, NaN, and `pandas.NA` all mean "no value" to GeoPandas, and a geometry
+    column assigned any of them keeps its type and CRS rather than becoming an
+    ordinary column of nulls.
+    """
+    if value is None:
         return True
-    if isinstance(value, (list, tuple, set, frozenset, dict, range)):
-        return False
-    if hasattr(value, "__array__"):
-        return getattr(value, "ndim", None) == 0
-    # Non-sequence objects (numbers, shapely geometries, None, ...) broadcast.
-    return not hasattr(value, "__len__")
+    try:
+        import pandas as pd
+
+        # Safe for scalars; geometries and numbers simply return False.
+        return bool(pd.isna(value))
+    except Exception:
+        # Without pandas, catch NaN via its self-inequality.
+        return isinstance(value, float) and value != value
 
 
 class GeoDataFrame:
@@ -200,8 +209,10 @@ class GeoDataFrame:
             expr = value._expr
         elif isinstance(value, Literal):
             # A literal holds a value rather than a column reference, so there is
-            # no frame for it to be misattributed to.
-            expr = value
+            # no frame for it to be misattributed to. It still goes through the
+            # scalar path so that a literal geometry gets the same CRS treatment as
+            # a plain one.
+            expr = self._scalar_expr(key, value)
         elif isinstance(value, Expr):
             raise TypeError(
                 "Assigning a bare expression isn't supported: an expression does "
@@ -209,7 +220,7 @@ class GeoDataFrame:
                 "against another frame would silently resolve against this one. "
                 "Assign a Series read from this frame, or a literal."
             )
-        elif not _is_scalar(value):
+        elif not is_scalar(value):
             raise TypeError(
                 f"Assigning a {type(value).__name__} isn't supported (there is no "
                 f"row alignment, so the values could not be matched to rows). "
@@ -233,30 +244,36 @@ class GeoDataFrame:
     def _scalar_expr(self, key, value):
         """Build the expression for broadcasting `value` into column `key`.
 
-        Replacing an existing geometry column keeps that column's CRS, as GeoPandas
-        does: a bare Shapely geometry (or `None`) carries no CRS of its own, and
-        letting the assignment silently reset the column to no CRS loses
-        information the frame already had. `None` is additionally built as a typed
-        null geometry so the column stays a geometry column rather than becoming
-        untyped.
-        """
-        from sedonadb.expr import lit
+        Replacing an existing geometry column keeps that column's type and CRS, as
+        GeoPandas does. A bare Shapely geometry carries no CRS of its own, and any
+        missing-value sentinel (`None`, NaN, `pandas.NA`) means "no geometry" rather
+        than "no longer a geometry column", so neither should silently reset what
+        the frame already knew.
 
-        # Only geometry values inherit the column's CRS. Assigning a number over a
-        # geometry column is a legitimate way to turn it into an ordinary column,
-        # and must not be dressed up as geometry.
-        is_geometry_value = value is None or hasattr(value, "__geo_interface__")
+        A `Literal` is unwrapped and rebuilt on this frame's context: a literal
+        constructed by the bare `lit()` has no context, so functions cannot be
+        applied to it, and passing it straight through would skip the CRS handling.
+        """
+        from sedonadb.expr import Literal, lit
+
+        raw = value._value if isinstance(value, Literal) else value
+
+        # Only geometry values inherit the column's type and CRS. Assigning a number
+        # over a geometry column is a legitimate way to turn it into an ordinary
+        # column, and must not be dressed up as geometry.
+        missing = _is_missing(raw)
+        is_geometry_value = missing or hasattr(raw, "__geo_interface__")
         replacing_geometry = key in _geometry_column_names(self._df)
         if not (replacing_geometry and is_geometry_value):
-            return lit(value)
+            return value if isinstance(value, Literal) else lit(value)
 
         crs = self._df.schema.field(key).type.crs
         # A context-bound literal is needed to call functions on it.
         ctx = self._df._ctx
-        if value is None:
+        if missing:
             expr = ctx.lit(None).funcs.st_geomfromwkt()
         else:
-            expr = ctx.lit(value)
+            expr = ctx.lit(raw)
         if crs is not None:
             expr = expr.funcs.st_setcrs(ctx.lit(crs.to_json()))
         return expr
@@ -343,13 +360,17 @@ class GeoDataFrame:
 
         left_geom = left[self._geometry_name]
         right_geom = right[other._geometry_name]
-        # Always a single spatial predicate. The planner recognizes one and rewrites
-        # it into a spatial join; composing predicates (`a OR b`) still returns
-        # correct rows but drops the plan to a nested-loop join, which is quadratic.
-        # That matters more than the one case a composition would fix: ST_DWithin
-        # misses properly crossing linestrings, because ST_Distance reports their
-        # endpoint gap rather than zero (apache/sedona-db#1156). That belongs in the
-        # engine rather than being worked around at the cost of every join's plan.
+        # Always a single spatial predicate. Composing them (`a OR b`) was tried and
+        # reverted, for two independent reasons: the planner only recognizes a single
+        # predicate, so a composition drops the plan to a nested-loop join and makes
+        # the join quadratic; and OR-ing ST_Intersects in also broke the bound's
+        # semantics, matching coincident geometries at a negative or NaN distance
+        # where GeoPandas matches nothing.
+        #
+        # The case a composition would have fixed is that ST_DWithin misses properly
+        # crossing linestrings, because ST_Distance reports their endpoint gap rather
+        # than zero (apache/sedona-db#1156). That belongs in the engine rather than
+        # being worked around here at the cost of both plan shape and semantics.
         if predicate == "dwithin":
             on = left_geom.geo.d_within(right_geom, distance)
         else:
@@ -497,11 +518,23 @@ class GeoDataFrame:
         else:
             collected = source.agg(*aggregates)
 
-        unioned = collected.mutate(
-            **{
-                self._geometry_name: collected[self._geometry_name].geo.unary_union(),
-            }
+        # A group whose geometries are all null unions to null; GeoPandas yields an
+        # empty geometry collection, which behaves differently for isna, is_empty,
+        # predicates, and serialization. Coalescing loses the geometry type, so the
+        # result is re-typed and the source column's CRS re-applied.
+        ctx = self._df._ctx
+        crs = self._df.schema.field(self._geometry_name).type.crs
+        empty = ctx.lit("GEOMETRYCOLLECTION EMPTY").funcs.st_geomfromwkt()
+        geometry_expr = (
+            collected[self._geometry_name]
+            .geo.unary_union()
+            .funcs.coalesce(empty)
+            .funcs.st_geomfromwkb()
         )
+        if crs is not None:
+            geometry_expr = geometry_expr.funcs.st_setcrs(ctx.lit(crs.to_json()))
+
+        unioned = collected.mutate(**{self._geometry_name: geometry_expr})
         return GeoDataFrame(unioned, self._geometry_name)
 
     def to_geopandas(self):

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
@@ -94,7 +94,63 @@ class Series:
     def __invert__(self):
         return Series(self._df, ~self._expr, self._name)
 
+    # -- arithmetic --------------------------------------------------------
+    # The reflected forms build `other <op> self._expr`; for a scalar left
+    # operand Python falls through to the underlying expression's reflected
+    # operator, so no special-casing is needed here.
+    def __add__(self, other):
+        return Series(self._df, self._expr + _operand(self._df, other), self._name)
+
+    def __radd__(self, other):
+        return Series(self._df, _operand(self._df, other) + self._expr, self._name)
+
+    def __sub__(self, other):
+        return Series(self._df, self._expr - _operand(self._df, other), self._name)
+
+    def __rsub__(self, other):
+        return Series(self._df, _operand(self._df, other) - self._expr, self._name)
+
+    def __mul__(self, other):
+        return Series(self._df, self._expr * _operand(self._df, other), self._name)
+
+    def __rmul__(self, other):
+        return Series(self._df, _operand(self._df, other) * self._expr, self._name)
+
+    # `/` is true division here, as in pandas. The engine follows SQL, where
+    # dividing two integers truncates (`1 / 2` is 0), so the numerator is cast to
+    # double first — otherwise integer columns would silently return floored
+    # results. `//` is deliberately not implemented rather than mapped onto SQL
+    # division, which truncates toward zero where Python floors.
+    def __truediv__(self, other):
+        return Series(
+            self._df, self._as_double() / _operand(self._df, other), self._name
+        )
+
+    def __rtruediv__(self, other):
+        return Series(
+            self._df, _operand(self._df, other) / self._as_double(), self._name
+        )
+
+    def __neg__(self):
+        return Series(self._df, -self._expr, self._name)
+
+    def _as_double(self):
+        """This column cast to double, so integer division does not truncate."""
+        import pyarrow as pa
+
+        return self._expr.cast(pa.float64())
+
     __hash__ = None
+
+    @property
+    def expr(self):
+        """The underlying SedonaDB expression.
+
+        An escape hatch to the full expression API for anything this wrapper does
+        not cover — for example `series.expr.funcs.st_point(other.expr)`. The
+        result can be assigned back onto a frame with `gdf["name"] = ...`.
+        """
+        return self._expr
 
     # -- materialization ---------------------------------------------------
     def to_pandas(self):

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
@@ -39,6 +39,29 @@ def is_scalar(value):
     return not hasattr(value, "__len__")
 
 
+def normalize_scalar(value):
+    """Normalize an accepted scalar into something a literal can hold.
+
+    Passing the classifier is not the same as being constructible: a 0-d NumPy
+    array is a scalar but `lit()` cannot take it, and `pandas.NA` is a missing
+    sentinel `lit()` does not recognize. Unwrap the former to its Python value
+    and convert missing sentinels to `None` (SQL null). Callers apply this only
+    after `is_scalar` has accepted the value.
+    """
+    if hasattr(value, "__array__") and getattr(value, "ndim", None) == 0:
+        value = value.item()
+    try:
+        import pandas as pd
+
+        # NaN is deliberately left as-is — pandas keeps NaN a float value; only
+        # the NA sentinel becomes SQL null.
+        if value is pd.NA:
+            return None
+    except ImportError:
+        pass
+    return value
+
+
 def _operand(df, other):
     """Coerce the right-hand side of an operator into something usable.
 
@@ -81,8 +104,9 @@ def _operand(df, other):
             f"to_pandas() first."
         )
     # A 0-d value such as a NumPy scalar reaches here and broadcasts, matching
-    # what assignment accepts.
-    return other
+    # what assignment accepts; normalization unwraps it into something a
+    # literal can actually hold.
+    return normalize_scalar(other)
 
 
 class Series:
@@ -93,6 +117,13 @@ class Series:
     as a filter mask (`gdf[gdf["pop"] > 1000]`). Nothing is computed until
     `to_pandas()`.
     """
+
+    # Without this, `np.array([...]) + series` never reaches our reflected
+    # operator: NumPy broadcasts element-by-element and returns an object array
+    # of lazy Series. Opting out of ufunc dispatch makes NumPy defer, so the
+    # whole array reaches `__radd__` and is rejected by `_operand` like any
+    # other multi-element operand.
+    __array_ufunc__ = None
 
     def __init__(self, df, expr, name):
         self._df = df
@@ -151,28 +182,38 @@ class Series:
         return Series(self._df, _operand(self._df, other) * self._expr, self._name)
 
     # `/` is true division here, as in pandas. The engine follows SQL, where
-    # dividing two integers truncates (`1 / 2` is 0), so the numerator is cast to
-    # double first — otherwise integer columns would silently return floored
-    # results. `//` is deliberately not implemented rather than mapped onto SQL
-    # division, which truncates toward zero where Python floors.
+    # dividing two integers truncates (`1 / 2` is 0), so an *integer* numerator is
+    # cast to double first. The cast is restricted to integers because it is
+    # lossy elsewhere: a decimal forced through double picks up binary rounding
+    # (1.23/0.1 -> 12.299999...), and a duration would become a float nanosecond
+    # count instead of staying a duration. `//` is deliberately not implemented
+    # rather than mapped onto SQL division, which truncates toward zero where
+    # Python floors.
     def __truediv__(self, other):
         return Series(
-            self._df, self._as_double() / _operand(self._df, other), self._name
+            self._df, self._for_division() / _operand(self._df, other), self._name
         )
 
     def __rtruediv__(self, other):
         return Series(
-            self._df, _operand(self._df, other) / self._as_double(), self._name
+            self._df, _operand(self._df, other) / self._for_division(), self._name
         )
 
     def __neg__(self):
         return Series(self._df, -self._expr, self._name)
 
-    def _as_double(self):
-        """This column cast to double, so integer division does not truncate."""
+    def _for_division(self):
+        """This expression, cast to double only when it is integer-typed.
+
+        The type is read from the projected schema, which is a plan build, not an
+        execution.
+        """
         import pyarrow as pa
 
-        return self._expr.cast(pa.float64())
+        projected = pa.schema(self._df.select(self._expr.alias("x")).schema)
+        if pa.types.is_integer(projected.field("x").type):
+            return self._expr.cast(pa.float64())
+        return self._expr
 
     __hash__ = None
 

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
@@ -23,11 +23,11 @@ def _operand(df, other):
     A `Series` is unwrapped to its expression, but only if it came from the same
     source frame as `df`: combining columns from two different frames has no
     defined meaning here (there is no row alignment) and would otherwise build a
-    plan that silently returns wrong rows. A raw SedonaDB `Expr` or `Literal` is
-    passed through as-is (`lit()` is a useful escape hatch for specifying a
-    literal that carries a CRS); other scalars pass through unchanged. A
-    pandas/numpy array-like is rejected with a clear message, since it would
-    otherwise fail obscurely as a multi-element literal.
+    plan that silently returns wrong rows. A `Literal` passes through, since it
+    holds a value rather than a column reference (`lit()` is a useful escape hatch
+    for specifying a literal that carries a CRS). Other scalars pass through
+    unchanged. A pandas/numpy array-like is rejected with a clear message, since it
+    would otherwise fail obscurely as a multi-element literal.
     """
     from sedonadb.expr import Expr, Literal
 
@@ -40,8 +40,18 @@ def _operand(df, other):
                 "frames first."
             )
         return other._expr
-    if isinstance(other, (Expr, Literal)):
+    if isinstance(other, Literal):
         return other
+    if isinstance(other, Expr):
+        # A bare expression records no origin, so a column reference built against
+        # another frame would resolve against this one and quietly contribute this
+        # frame's values. Same reasoning as assignment, which also refuses these.
+        raise TypeError(
+            "Cannot combine with a bare expression: an expression does not "
+            "record which frame its columns came from, so one built against "
+            "another frame would silently resolve against this one. Use a "
+            "Series read from the same frame, or a literal."
+        )
     if hasattr(other, "__array__"):
         raise TypeError(
             "Operating against a pandas/numpy array-like isn't supported "

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
@@ -17,6 +17,28 @@
 """pandas/GeoPandas-style Series backed by a SedonaDB expression."""
 
 
+def is_scalar(value):
+    """Whether `value` is a single value that can be broadcast to every row.
+
+    Checking for `__array__` alone is not enough in either direction: a list or
+    tuple has no `__array__` yet is a sequence, while a NumPy scalar has one and
+    *is* a single value. So sequences are rejected explicitly, and anything
+    array-like is judged by its dimensionality — 0-d is a scalar, anything else
+    holds multiple values and has no defined row alignment here.
+
+    Shared by operators and assignment so the two cannot disagree about what
+    counts as a scalar.
+    """
+    if isinstance(value, (str, bytes, bytearray)):
+        return True
+    if isinstance(value, (list, tuple, set, frozenset, dict, range)):
+        return False
+    if hasattr(value, "__array__"):
+        return getattr(value, "ndim", None) == 0
+    # Non-sequence objects (numbers, shapely geometries, None, ...) broadcast.
+    return not hasattr(value, "__len__")
+
+
 def _operand(df, other):
     """Coerce the right-hand side of an operator into something usable.
 
@@ -52,12 +74,14 @@ def _operand(df, other):
             "another frame would silently resolve against this one. Use a "
             "Series read from the same frame, or a literal."
         )
-    if hasattr(other, "__array__"):
+    if not is_scalar(other):
         raise TypeError(
-            "Operating against a pandas/numpy array-like isn't supported "
-            "(there is no row alignment). Operate within this frame, or collect "
-            "with to_pandas() first."
+            f"Operating against a {type(other).__name__} isn't supported (there "
+            f"is no row alignment). Operate within this frame, or collect with "
+            f"to_pandas() first."
         )
+    # A 0-d value such as a NumPy scalar reaches here and broadcasts, matching
+    # what assignment accepts.
     return other
 
 

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
@@ -142,16 +142,6 @@ class Series:
 
     __hash__ = None
 
-    @property
-    def expr(self):
-        """The underlying SedonaDB expression.
-
-        An escape hatch to the full expression API for anything this wrapper does
-        not cover — for example `series.expr.funcs.st_point(other.expr)`. The
-        result can be assigned back onto a frame with `gdf["name"] = ...`.
-        """
-        return self._expr
-
     # -- materialization ---------------------------------------------------
     def to_pandas(self):
         """Execute and return this column as a pandas (or GeoPandas) Series."""

--- a/python/sedonadb-geopandas/tests/test_geopandas_compat.py
+++ b/python/sedonadb-geopandas/tests/test_geopandas_compat.py
@@ -602,9 +602,15 @@ def test_setitem_over_active_geometry_clears_it(points):
         gdf.geometry
 
 
-def test_sjoin_dwithin_matches_crossing_lines():
-    # ST_Distance reports the endpoint gap for properly crossing linestrings, so
-    # dwithin used to miss a pair GeoPandas matches.
+def test_sjoin_dwithin_misses_crossing_lines_pending_engine_fix():
+    """Documents a known deviation, so it cannot change unnoticed.
+
+    ST_Distance reports the endpoint gap rather than zero for properly crossing
+    linestrings (apache/sedona-db#1156), so dwithin misses a pair GeoPandas
+    matches. Composing the predicate with ST_Intersects would recover the pair but
+    is not recognized by the planner, which turns the join into a nested loop, so
+    the deviation is accepted until the engine is fixed.
+    """
     a = gpd.GeoDataFrame(
         {"i": [1]},
         geometry=gpd.GeoSeries.from_wkt(["LINESTRING (0 0, 2 2)"]),
@@ -618,11 +624,24 @@ def test_sjoin_dwithin_matches_crossing_lines():
     got = sgpd.from_geopandas(a).sjoin(
         sgpd.from_geopandas(b), predicate="dwithin", distance=0
     )
-    assert (
-        len(got.to_geopandas())
-        == len(gpd.sjoin(a, b, predicate="dwithin", distance=0))
-        == 1
+    assert len(gpd.sjoin(a, b, predicate="dwithin", distance=0)) == 1
+    assert len(got.to_geopandas()) == 0  # change this when #1156 is fixed
+
+
+def test_sjoin_uses_a_planner_recognizable_spatial_predicate():
+    # A composed predicate returns the same rows but drops the plan to a nested
+    # loop join, which is quadratic; every predicate must stay rewritable.
+    points = gpd.GeoDataFrame(
+        {"i": [1, 2]},
+        geometry=gpd.GeoSeries.from_wkt(["POINT (0 0)", "POINT (5 5)"]),
+        crs="EPSG:3857",
     )
+    joined = sgpd.from_geopandas(points).sjoin(
+        sgpd.from_geopandas(points), predicate="dwithin", distance=1.0
+    )
+    plan = joined._df.explain().to_pandas().to_string()
+    assert "SpatialJoinExec" in plan
+    assert "NestedLoopJoin" not in plan
 
 
 @pytest.mark.parametrize("distance", [0.5, 1.0, 2.0])
@@ -666,3 +685,96 @@ def test_sjoin_collision_with_retained_geometry_name():
     # side's conflicting column.
     assert got.columns == _without_index_cols(expected)
     assert got._geometry_name == expected.geometry.name
+
+
+# -- regressions from the second review pass --------------------------------
+
+
+def test_operators_reject_bare_expression(points):
+    # Same provenance hole as assignment: a bare expression built from another
+    # frame resolved against this one and silently contributed this frame's values.
+    gdf = sgpd.from_geopandas(points)
+    other_raw = sgpd.default_context().create_data_frame(points)
+    with pytest.raises(TypeError, match="bare expression"):
+        gdf["v"] + other_raw["v"]
+
+
+def test_operators_still_accept_literals(points):
+    from sedonadb.expr import lit
+
+    gdf = sgpd.from_geopandas(points)
+    assert sorted((gdf["v"] > lit(1)).to_pandas().tolist()) == [False, True, True]
+
+
+def test_getitem_rejects_stale_mask(points):
+    # Assignment rebinds the frame, so a mask captured beforehand belongs to the
+    # previous one. It used to be accepted and quietly resolve against the new
+    # frame while the referenced column happened to still exist.
+    gdf = sgpd.from_geopandas(points)
+    mask = gdf["v"] > 1
+    gdf["k"] = 1
+    with pytest.raises(ValueError, match="different DataFrame"):
+        gdf[mask]
+
+
+def test_sjoin_rejects_suffix_generated_duplicates():
+    # Suffixing can collide with a column that already carries the suffix.
+    left = gpd.GeoDataFrame(
+        {"v": [1], "v_left": [9]},
+        geometry=gpd.GeoSeries.from_wkt(["POINT (0 0)"]),
+        crs="EPSG:3857",
+    )
+    right = gpd.GeoDataFrame(
+        {"v": [1]},
+        geometry=gpd.GeoSeries.from_wkt(["POLYGON ((-1 -1, 1 -1, 1 1, -1 1, -1 -1))"]),
+        crs="EPSG:3857",
+    )
+    with pytest.raises(ValueError, match="duplicate column name"):
+        sgpd.from_geopandas(left).sjoin(sgpd.from_geopandas(right), predicate="within")
+
+    # Different suffixes resolve it.
+    got = sgpd.from_geopandas(left).sjoin(
+        sgpd.from_geopandas(right), predicate="within", lsuffix="a", rsuffix="b"
+    )
+    assert len(got.columns) == len(set(got.columns))
+
+
+def test_dissolve_drops_nan_group_keys():
+    # dropna has to cover IEEE NaN as well as SQL null: a float key read from
+    # pandas carries NaN, which grouping otherwise treats as its own group.
+    df = sgpd.default_context().sql(
+        "SELECT CAST('NaN' AS DOUBLE) k, ST_Point(0.0, 0.0) geometry "
+        "UNION ALL SELECT 1.0, ST_Point(1.0, 1.0)"
+    )
+    assert len(GeoDataFrame(df).dissolve(by="k").to_geopandas()) == 1
+    assert len(GeoDataFrame(df).dissolve(by="k", dropna=False).to_geopandas()) == 2
+
+
+def test_setitem_scalar_geometry_keeps_crs(points):
+    # A bare Shapely geometry carries no CRS; GeoPandas keeps the column's.
+    from shapely.geometry import Point
+
+    gdf = sgpd.from_geopandas(points)
+    before = str(gdf.crs)
+    gdf["geometry"] = Point(5, 5)
+    assert gdf._geometry_name == "geometry"
+    assert "3857" in str(gdf.crs)
+    assert "3857" in before
+
+
+def test_setitem_none_keeps_geometry_column(points):
+    # Assigning None used to turn the column untyped and clear the active geometry;
+    # GeoPandas keeps a geometry column with its CRS.
+    gdf = sgpd.from_geopandas(points)
+    gdf["geometry"] = None
+    assert gdf._geometry_name == "geometry"
+    assert "3857" in str(gdf.crs)
+    assert gdf.to_geopandas().geometry.isna().all()
+
+
+def test_setitem_non_geometry_over_geometry_still_clears(points):
+    # The CRS-preserving path must not dress a number up as geometry.
+    gdf = sgpd.from_geopandas(points)
+    gdf["geometry"] = 7
+    assert gdf._geometry_name is None
+    assert gdf.to_geopandas()["geometry"].tolist() == [7, 7, 7]

--- a/python/sedonadb-geopandas/tests/test_geopandas_compat.py
+++ b/python/sedonadb-geopandas/tests/test_geopandas_compat.py
@@ -32,6 +32,55 @@ def cities():
 
 
 @pytest.fixture
+def points():
+    """Left-hand frame for spatial joins, in a projected CRS.
+
+    `v` is deliberately also a column of `regions`, so overlap suffixing gets
+    exercised. `C` falls outside every polygon, so `how` actually matters.
+    """
+    return gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.GeoSeries.from_wkt(["POINT (0 0)", "POINT (5 5)", "POINT (9 9)"]),
+        crs="EPSG:3857",
+    )
+
+
+@pytest.fixture
+def regions():
+    return gpd.GeoDataFrame(
+        {"region": ["w", "e"], "v": [9, 8]},
+        geometry=gpd.GeoSeries.from_wkt(
+            [
+                "POLYGON ((-1 -1, 2 -1, 2 2, -1 2, -1 -1))",
+                "POLYGON ((4 4, 6 4, 6 6, 4 6, 4 4))",
+            ]
+        ),
+        crs="EPSG:3857",
+    )
+
+
+@pytest.fixture
+def parcels():
+    """Overlapping polygons per zone, so a dissolve has something to union."""
+    return gpd.GeoDataFrame(
+        {"zone": ["A", "A", "B"], "v": [1, 2, 3]},
+        geometry=gpd.GeoSeries.from_wkt(
+            [
+                "POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))",
+                "POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1))",
+                "POLYGON ((5 5, 7 5, 7 7, 5 7, 5 5))",
+            ]
+        ),
+        crs="EPSG:3857",
+    )
+
+
+def _without_index_cols(gdf):
+    """GeoPandas sjoin reports index_left/index_right; this wrapper has no index."""
+    return [c for c in gdf.columns if not c.startswith("index_")]
+
+
+@pytest.fixture
 def con_free_geom_frame():
     """A frame whose active geometry column is *not* the heuristic's pick.
 
@@ -242,3 +291,210 @@ def test_head(cities):
     assert len(gdf.head(2)) == 2
     # head() keeps the active geometry column.
     assert isinstance(gdf.head(2).geometry, GeoSeries)
+
+
+# -- sjoin -------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("how", ["inner", "left", "right"])
+def test_sjoin_matches_geopandas(points, regions, how):
+    ours = sgpd.from_geopandas(points).sjoin(
+        sgpd.from_geopandas(regions), how=how, predicate="within"
+    )
+    got = ours.to_geopandas()
+    expected = gpd.sjoin(points, regions, how=how, predicate="within")
+
+    # Same columns (minus the index_* columns GeoPandas adds), and the same side's
+    # geometry kept active: the left frame's, except for how="right".
+    assert list(got.columns) == _without_index_cols(expected)
+    assert got.geometry.name == expected.geometry.name
+    assert len(got) == len(expected)
+
+
+def test_sjoin_pairs_rows_like_geopandas(points, regions):
+    got = (
+        sgpd.from_geopandas(points)
+        .sjoin(sgpd.from_geopandas(regions), predicate="within")
+        .to_geopandas()
+        .sort_values("name")
+    )
+    expected = gpd.sjoin(points, regions, predicate="within").sort_values("name")
+    assert got[["name", "region"]].to_dict("records") == expected[
+        ["name", "region"]
+    ].to_dict("records")
+
+
+def test_sjoin_suffixes_overlapping_columns(points, regions):
+    got = sgpd.from_geopandas(points).sjoin(
+        sgpd.from_geopandas(regions), predicate="within"
+    )
+    # `v` exists on both sides and is suffixed; `name`/`region` are unique and are
+    # left alone; only one geometry column survives.
+    assert "v_left" in got.columns and "v_right" in got.columns
+    assert "v" not in got.columns
+    assert [c for c in got.columns].count("geometry") == 1
+
+
+def test_sjoin_custom_suffixes(points, regions):
+    got = sgpd.from_geopandas(points).sjoin(
+        sgpd.from_geopandas(regions), predicate="within", lsuffix="a", rsuffix="b"
+    )
+    assert "v_a" in got.columns and "v_b" in got.columns
+
+
+def test_sjoin_dwithin(points, regions):
+    got = sgpd.from_geopandas(points).sjoin(
+        sgpd.from_geopandas(regions), predicate="dwithin", distance=2.0
+    )
+    assert len(got) == len(
+        gpd.sjoin(points, regions, predicate="dwithin", distance=2.0)
+    )
+
+
+def test_sjoin_validation(points, regions):
+    L, R = sgpd.from_geopandas(points), sgpd.from_geopandas(regions)
+    with pytest.raises(TypeError, match="expects a GeoDataFrame"):
+        L.sjoin(regions)
+    with pytest.raises(ValueError, match="`how` must be"):
+        L.sjoin(R, how="outer")
+    with pytest.raises(ValueError, match="`predicate` must be"):
+        L.sjoin(R, predicate="nearby")
+    # distance is required by dwithin, and rejected for anything else.
+    with pytest.raises(ValueError, match="distance"):
+        L.sjoin(R, predicate="dwithin")
+    with pytest.raises(ValueError, match="distance"):
+        L.sjoin(R, predicate="intersects", distance=1.0)
+
+
+def test_sjoin_requires_geometry(points, regions):
+    no_geom = sgpd.from_geopandas(points)[["name", "v"]]
+    with pytest.raises(ValueError, match="active geometry"):
+        no_geom.sjoin(sgpd.from_geopandas(regions))
+
+
+# -- dissolve ----------------------------------------------------------------
+
+
+def test_dissolve_matches_geopandas(parcels):
+    got = (
+        sgpd.from_geopandas(parcels)
+        .dissolve(by="zone")
+        .to_geopandas()
+        .sort_values("zone")
+    )
+    expected = parcels.dissolve(by="zone")
+    # Unioned geometry per group, and non-geometry columns aggregated as "first",
+    # both matching GeoPandas.
+    assert got.area.round(6).tolist() == expected.area.round(6).tolist()
+    assert got["v"].tolist() == expected["v"].tolist()
+    # The group key stays a column here rather than becoming the index.
+    assert "zone" in got.columns
+
+
+def test_dissolve_without_by(parcels):
+    got = sgpd.from_geopandas(parcels).dissolve().to_geopandas()
+    assert len(got) == len(parcels.dissolve()) == 1
+
+
+def test_dissolve_multiple_keys(parcels):
+    got = sgpd.from_geopandas(parcels).dissolve(by=["zone"]).to_geopandas()
+    assert sorted(got["zone"]) == ["A", "B"]
+
+
+def test_dissolve_validation(parcels):
+    gdf = sgpd.from_geopandas(parcels)
+    with pytest.raises(NotImplementedError, match="aggfunc"):
+        gdf.dissolve(by="zone", aggfunc="sum")
+    with pytest.raises(KeyError, match="not found"):
+        gdf.dissolve(by="nope")
+    with pytest.raises(ValueError, match="active geometry"):
+        gdf[["zone", "v"]].dissolve(by="zone")
+
+
+# -- __setitem__ and arithmetic ---------------------------------------------
+
+
+def test_setitem_from_series(points):
+    gdf = sgpd.from_geopandas(points)
+    gdf["v2"] = gdf["v"] * 10 - 1
+    got = gdf.to_geopandas().sort_values("name")
+    assert got["v2"].tolist() == (points["v"] * 10 - 1).tolist()
+
+
+def test_setitem_scalar_broadcasts(points):
+    gdf = sgpd.from_geopandas(points)
+    gdf["k"] = 7
+    assert gdf.to_geopandas()["k"].tolist() == [7, 7, 7]
+
+
+def test_setitem_geometry_column(points):
+    gdf = sgpd.from_geopandas(points)
+    gdf["buffered"] = gdf.geometry.buffer(0.5)
+    assert "buffered" in gdf.columns
+    # The active geometry column is unchanged by adding another one.
+    assert gdf.geometry._name == "geometry"
+
+
+def test_setitem_replaces_existing_column(points):
+    gdf = sgpd.from_geopandas(points)
+    gdf["v"] = gdf["v"] + 100
+    assert sorted(gdf.to_geopandas()["v"]) == [101, 102, 103]
+    assert gdf.columns.count("v") == 1
+
+
+def test_setitem_makes_geometry_active_when_frame_had_none():
+    # Building geometry from coordinate columns, as points_from_xy would: a frame
+    # that starts without geometry gains an active one on assignment.
+    plain = GeoDataFrame(sgpd.default_context().sql("SELECT 1.0 AS x, 2.0 AS y"))
+    assert plain._geometry_name is None
+
+    plain["geometry"] = plain["x"].expr.funcs.st_point(plain["y"].expr)
+    assert plain._geometry_name == "geometry"
+    assert plain.to_geopandas().geometry.to_wkt().tolist() == ["POINT (1 2)"]
+
+
+def test_setitem_non_geometry_leaves_frame_without_geometry():
+    plain = GeoDataFrame(sgpd.default_context().sql("SELECT 1.0 AS x"))
+    plain["doubled"] = plain["x"] * 2
+    assert plain._geometry_name is None
+
+
+def test_setitem_rejects_bad_inputs(points):
+    gdf = sgpd.from_geopandas(points)
+    with pytest.raises(TypeError, match="must be a string"):
+        gdf[0] = 1
+    with pytest.raises(TypeError, match="array-like"):
+        gdf["x"] = points["v"]
+    # A Series from a different frame has no row alignment.
+    other = sgpd.from_geopandas(points)
+    with pytest.raises(ValueError, match="different"):
+        gdf["y"] = other["v"]
+
+
+def test_setitem_stale_series_raises(points):
+    # Assignment rebinds the frame, so a Series read beforehand is stale.
+    gdf = sgpd.from_geopandas(points)
+    before = gdf["v"]
+    gdf["k"] = 1
+    with pytest.raises(ValueError, match="different"):
+        gdf["z"] = before
+
+
+def test_series_arithmetic(points):
+    gdf = sgpd.from_geopandas(points)
+    for label, series, expected in [
+        ("add", gdf["v"] + 1, (points["v"] + 1).tolist()),
+        ("radd", 1 + gdf["v"], (1 + points["v"]).tolist()),
+        ("sub", gdf["v"] - 1, (points["v"] - 1).tolist()),
+        ("rsub", 10 - gdf["v"], (10 - points["v"]).tolist()),
+        ("mul", gdf["v"] * 2, (points["v"] * 2).tolist()),
+        ("truediv", gdf["v"] / 2, (points["v"] / 2).tolist()),
+        ("neg", -gdf["v"], (-points["v"]).tolist()),
+    ]:
+        assert sorted(series.to_pandas().tolist()) == sorted(expected), label
+
+
+def test_series_arithmetic_between_columns(points):
+    gdf = sgpd.from_geopandas(points)
+    got = (gdf["v"] + gdf["v"]).to_pandas().tolist()
+    assert sorted(got) == sorted((points["v"] + points["v"]).tolist())

--- a/python/sedonadb-geopandas/tests/test_geopandas_compat.py
+++ b/python/sedonadb-geopandas/tests/test_geopandas_compat.py
@@ -863,3 +863,99 @@ def test_operators_still_reject_arrays(points):
     gdf = sgpd.from_geopandas(points)
     with pytest.raises(TypeError, match="isn't supported"):
         gdf["v"] + np.array([1, 2, 3])
+
+
+# -- regressions from the fourth review pass --------------------------------
+
+
+def test_sjoin_dwithin_distance_must_be_a_number(points, regions):
+    # A Series or expression cannot be a distance: the predicate is built against
+    # re-aliased copies of both frames, so a column reference would resolve by
+    # name inside the join rather than against its own frame.
+    L = sgpd.from_geopandas(points)
+    R = sgpd.from_geopandas(regions)
+    with pytest.raises(TypeError, match="must be a number"):
+        L.sjoin(R, predicate="dwithin", distance=L["v"])
+    raw = sgpd.default_context().create_data_frame(points)["v"]
+    with pytest.raises(TypeError, match="must be a number"):
+        L.sjoin(R, predicate="dwithin", distance=raw)
+    # NumPy numeric scalars are fine.
+    import numpy as np
+
+    got = L.sjoin(R, predicate="dwithin", distance=np.float64(1.0))
+    assert len(got.to_geopandas()) >= 1
+
+
+def test_setitem_crs_carrying_literal_keeps_its_crs(points):
+    # A literal that carries its own CRS must not be relabeled with the
+    # destination column's CRS — that changes what the coordinates mean without
+    # transforming them.
+    from sedonadb.expr import lit
+
+    src = gpd.GeoSeries.from_wkt(["POINT (10 10)"], crs="EPSG:4326")
+    gdf = sgpd.from_geopandas(points)  # column is EPSG:3857
+    gdf["geometry"] = lit(src)
+    assert "4326" in str(gdf.crs)
+
+
+def test_division_preserves_decimal_exactness():
+    from decimal import Decimal
+
+    import pandas as pd
+
+    df = sgpd.default_context().create_data_frame(
+        pd.DataFrame({"d": [Decimal("1.23")]})
+    )
+    got = (GeoDataFrame(df)["d"] / Decimal("0.1")).to_pandas().tolist()
+    # Forced through double this would be 12.299999999999999.
+    assert got == [Decimal("12.300000")]
+
+
+def test_division_still_true_for_integers():
+    df = sgpd.default_context().sql("SELECT 1 AS n UNION ALL SELECT 3")
+    assert sorted((GeoDataFrame(df)["n"] / 2).to_pandas().tolist()) == [0.5, 1.5]
+
+
+def test_numpy_array_plus_series_is_rejected_whole(points):
+    # Without opting out of ufunc dispatch, NumPy broadcasts element-by-element
+    # and returns an object array of lazy Series instead of an error.
+    import numpy as np
+
+    gdf = sgpd.from_geopandas(points)
+    with pytest.raises(TypeError):
+        np.array([10, 20, 30]) + gdf["v"]
+    with pytest.raises(TypeError):
+        gdf["v"] + np.array([10, 20, 30])
+
+
+def test_zero_dimensional_array_normalizes(points):
+    import numpy as np
+
+    gdf = sgpd.from_geopandas(points)
+    gdf["z"] = np.array(5)  # 0-d: scalar by classification, unwrapped on use
+    assert gdf.to_geopandas()["z"].tolist() == [5, 5, 5]
+
+
+def test_pandas_na_assigns_as_null_to_ordinary_column(points):
+    import pandas as pd
+
+    gdf = sgpd.from_geopandas(points)
+    gdf["z"] = pd.NA
+    assert gdf.to_geopandas()["z"].isna().all()
+
+
+def test_is_floating_unwraps_dictionary_encoding():
+    import pyarrow as pa
+
+    from sedonadb_geopandas._frame import _is_floating
+
+    tbl = pa.table(
+        {
+            "k": pa.DictionaryArray.from_arrays(
+                pa.array([0, 1], type=pa.int8()), pa.array([1.0, float("nan")])
+            ),
+            "x": [1, 2],
+        }
+    )
+    df = sgpd.default_context().create_data_frame(tbl)
+    assert _is_floating(df, "k")

--- a/python/sedonadb-geopandas/tests/test_geopandas_compat.py
+++ b/python/sedonadb-geopandas/tests/test_geopandas_compat.py
@@ -228,7 +228,7 @@ def test_repr_is_lazy(cities):
 
 def test_operand_rejects_arraylike(cities):
     gdf = sgpd.from_geopandas(cities)
-    with pytest.raises(TypeError, match="array-like"):
+    with pytest.raises(TypeError, match="isn't supported"):
         gdf["pop"] > cities["pop"]  # a real pandas Series
 
 
@@ -778,3 +778,87 @@ def test_setitem_non_geometry_over_geometry_still_clears(points):
     gdf["geometry"] = 7
     assert gdf._geometry_name is None
     assert gdf.to_geopandas()["geometry"].tolist() == [7, 7, 7]
+
+
+# -- regressions from the third review pass ---------------------------------
+
+
+def test_dissolve_by_nested_float_column():
+    # _is_floating used to match the rendered type string, so `list<item: double>`
+    # looked like a float column and dropna called isnan() on it, failing at
+    # planning time.
+    df = sgpd.default_context().sql(
+        "SELECT [1.0, 2.0] AS k, ST_Point(0.0, 0.0) AS geometry"
+    )
+    got = GeoDataFrame(df).dissolve(by="k").to_geopandas()
+    assert len(got) == 1
+
+
+@pytest.mark.parametrize(
+    "value_name",
+    ["none", "nan", "pandas_na", "geometry", "literal_geometry", "literal_none"],
+)
+def test_setitem_geometry_scalars_keep_type_and_crs(points, value_name):
+    # Every supported scalar path has to go through the CRS-preserving branch:
+    # GeoPandas treats None, NaN and pd.NA as missing geometry and keeps the typed
+    # column and its CRS.
+    import numpy as np
+    import pandas as pd
+    from shapely.geometry import Point
+
+    from sedonadb.expr import lit
+
+    values = {
+        "none": None,
+        "nan": np.nan,
+        "pandas_na": pd.NA,
+        "geometry": Point(5, 5),
+        "literal_geometry": lit(Point(5, 5)),
+        "literal_none": lit(None),
+    }
+    gdf = sgpd.from_geopandas(points)
+    gdf["geometry"] = values[value_name]
+    assert gdf._geometry_name == "geometry"
+    assert "3857" in str(gdf.crs)
+
+
+def test_dissolve_all_null_group_is_empty_geometry(points):
+    # GeoPandas returns GEOMETRYCOLLECTION EMPTY rather than None, which behaves
+    # differently for isna, is_empty, predicates and serialization.
+    df = sgpd.default_context().sql(
+        "SELECT 'A' AS z, "
+        "ST_SetSRID(ST_GeomFromText(CAST(NULL AS VARCHAR)), 3857) AS geometry "
+        "UNION ALL SELECT 'A', "
+        "ST_SetSRID(ST_GeomFromText(CAST(NULL AS VARCHAR)), 3857)"
+    )
+    got = GeoDataFrame(df).dissolve(by="z").to_geopandas()
+    expected = gpd.GeoDataFrame(
+        {"z": ["A", "A"]},
+        geometry=gpd.GeoSeries.from_wkt([None, None]),
+        crs="EPSG:3857",
+    ).dissolve(by="z")
+    assert got.geometry.iloc[0].equals(expected.geometry.iloc[0])
+    assert got.geometry.iloc[0].is_empty
+    assert not got.geometry.isna().any()
+
+
+def test_operators_accept_numpy_scalars(points):
+    # Operators rejected anything with __array__, including NumPy scalars, even
+    # though assignment already accepted them.
+    import numpy as np
+
+    gdf = sgpd.from_geopandas(points)
+    assert sorted((gdf["v"] + np.int64(1)).to_pandas().tolist()) == [2, 3, 4]
+    assert sorted((gdf["v"] > np.float64(1)).to_pandas().tolist()) == [
+        False,
+        True,
+        True,
+    ]
+
+
+def test_operators_still_reject_arrays(points):
+    import numpy as np
+
+    gdf = sgpd.from_geopandas(points)
+    with pytest.raises(TypeError, match="isn't supported"):
+        gdf["v"] + np.array([1, 2, 3])

--- a/python/sedonadb-geopandas/tests/test_geopandas_compat.py
+++ b/python/sedonadb-geopandas/tests/test_geopandas_compat.py
@@ -443,12 +443,14 @@ def test_setitem_replaces_existing_column(points):
 
 
 def test_setitem_makes_geometry_active_when_frame_had_none():
-    # Building geometry from coordinate columns, as points_from_xy would: a frame
-    # that starts without geometry gains an active one on assignment.
-    plain = GeoDataFrame(sgpd.default_context().sql("SELECT 1.0 AS x, 2.0 AS y"))
+    # A frame that starts without geometry gains an active geometry column when
+    # one is assigned.
+    from shapely.geometry import Point
+
+    plain = GeoDataFrame(sgpd.default_context().sql("SELECT 1 AS a"))
     assert plain._geometry_name is None
 
-    plain["geometry"] = plain["x"].expr.funcs.st_point(plain["y"].expr)
+    plain["geometry"] = Point(1, 2)
     assert plain._geometry_name == "geometry"
     assert plain.to_geopandas().geometry.to_wkt().tolist() == ["POINT (1 2)"]
 
@@ -463,7 +465,7 @@ def test_setitem_rejects_bad_inputs(points):
     gdf = sgpd.from_geopandas(points)
     with pytest.raises(TypeError, match="must be a string"):
         gdf[0] = 1
-    with pytest.raises(TypeError, match="array-like"):
+    with pytest.raises(TypeError, match="isn't supported"):
         gdf["x"] = points["v"]
     # A Series from a different frame has no row alignment.
     other = sgpd.from_geopandas(points)
@@ -498,3 +500,169 @@ def test_series_arithmetic_between_columns(points):
     gdf = sgpd.from_geopandas(points)
     got = (gdf["v"] + gdf["v"]).to_pandas().tolist()
     assert sorted(got) == sorted((points["v"] + points["v"]).tolist())
+
+
+# -- regressions from review -------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "wkts",
+    [
+        ["POINT (0 0)", "POINT (1 1)"],
+        ["LINESTRING (0 0, 1 1)", "LINESTRING (1 1, 2 2)"],
+        ["POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))", "POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1))"],
+    ],
+    ids=["points", "lines", "polygons"],
+)
+def test_dissolve_handles_every_geometry_type(wkts):
+    # ST_Union_Agg only initializes for polygonal input, so points and linestrings
+    # used to dissolve to NULL geometry.
+    g = gpd.GeoDataFrame(
+        {"zone": ["A", "A"]},
+        geometry=gpd.GeoSeries.from_wkt(wkts),
+        crs="EPSG:3857",
+    )
+    got = sgpd.from_geopandas(g).dissolve(by="zone").to_geopandas()
+    expected = g.dissolve(by="zone")
+    assert got.geometry.iloc[0] is not None
+    assert got.geometry.iloc[0].geom_type == expected.geometry.iloc[0].geom_type
+    assert got.geometry.iloc[0].equals(expected.geometry.iloc[0])
+
+
+def test_dissolve_dropna_matches_geopandas():
+    g = gpd.GeoDataFrame(
+        {"zone": ["A", None], "v": [1, 2]},
+        geometry=gpd.GeoSeries.from_wkt(
+            [
+                "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))",
+                "POLYGON ((2 2, 3 2, 3 3, 2 3, 2 2))",
+            ]
+        ),
+        crs="EPSG:3857",
+    )
+    gdf = sgpd.from_geopandas(g)
+    # GeoPandas drops the missing key by default; dropna=False keeps it.
+    assert len(gdf.dissolve(by="zone").to_geopandas()) == len(g.dissolve(by="zone"))
+    assert len(gdf.dissolve(by="zone", dropna=False).to_geopandas()) == 2
+
+
+def test_setitem_rejects_bare_expression(points):
+    # A bare expression carries no origin, so one built from another frame would
+    # resolve against this frame and silently write this frame's values.
+    left = sgpd.from_geopandas(points)
+    right = sgpd.from_geopandas(points)
+    with pytest.raises(TypeError, match="bare expression"):
+        left["copied"] = right["v"]._expr
+
+
+def test_series_has_no_unguarded_expr_escape_hatch(points):
+    assert not hasattr(sgpd.from_geopandas(points)["v"], "expr")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [[10, 20, 30], (10, 20, 30), {10, 20}],
+    ids=["list", "tuple", "set"],
+)
+def test_setitem_rejects_sequences(points, value):
+    # Sequences have no __array__, so they used to be broadcast whole into every
+    # row rather than rejected.
+    gdf = sgpd.from_geopandas(points)
+    with pytest.raises(TypeError, match="isn't supported"):
+        gdf["x"] = value
+
+
+def test_setitem_accepts_numpy_scalar(points):
+    # NumPy scalars do have __array__ but are single values, so they used to be
+    # rejected as array-likes.
+    import numpy as np
+
+    gdf = sgpd.from_geopandas(points)
+    gdf["x"] = np.int64(5)
+    assert gdf.to_geopandas()["x"].tolist() == [5, 5, 5]
+
+
+def test_setitem_rejects_numpy_array(points):
+    import numpy as np
+
+    gdf = sgpd.from_geopandas(points)
+    with pytest.raises(TypeError, match="isn't supported"):
+        gdf["x"] = np.array([1, 2, 3])
+
+
+def test_setitem_over_active_geometry_clears_it(points):
+    # Replacing the active geometry with a number used to leave the name pointing
+    # at an integer column, so .geometry still returned a GeoSeries and .area
+    # failed later with a kernel error.
+    gdf = sgpd.from_geopandas(points)
+    gdf["geometry"] = 7
+    assert gdf._geometry_name is None
+    assert gdf.crs is None
+    with pytest.raises(AttributeError, match="no active geometry"):
+        gdf.geometry
+
+
+def test_sjoin_dwithin_matches_crossing_lines():
+    # ST_Distance reports the endpoint gap for properly crossing linestrings, so
+    # dwithin used to miss a pair GeoPandas matches.
+    a = gpd.GeoDataFrame(
+        {"i": [1]},
+        geometry=gpd.GeoSeries.from_wkt(["LINESTRING (0 0, 2 2)"]),
+        crs="EPSG:3857",
+    )
+    b = gpd.GeoDataFrame(
+        {"j": [1]},
+        geometry=gpd.GeoSeries.from_wkt(["LINESTRING (0 2, 2 0)"]),
+        crs="EPSG:3857",
+    )
+    got = sgpd.from_geopandas(a).sjoin(
+        sgpd.from_geopandas(b), predicate="dwithin", distance=0
+    )
+    assert (
+        len(got.to_geopandas())
+        == len(gpd.sjoin(a, b, predicate="dwithin", distance=0))
+        == 1
+    )
+
+
+@pytest.mark.parametrize("distance", [0.5, 1.0, 2.0])
+def test_sjoin_dwithin_unchanged_for_non_crossing(distance):
+    p = gpd.GeoDataFrame(
+        {"i": [1, 2]},
+        geometry=gpd.GeoSeries.from_wkt(["POINT (0 0)", "POINT (9 9)"]),
+        crs="EPSG:3857",
+    )
+    q = gpd.GeoDataFrame(
+        {"j": [1]},
+        geometry=gpd.GeoSeries.from_wkt(["POINT (0 1)"]),
+        crs="EPSG:3857",
+    )
+    got = sgpd.from_geopandas(p).sjoin(
+        sgpd.from_geopandas(q), predicate="dwithin", distance=distance
+    )
+    assert len(got.to_geopandas()) == len(
+        gpd.sjoin(p, q, predicate="dwithin", distance=distance)
+    )
+
+
+def test_sjoin_collision_with_retained_geometry_name():
+    # The retained geometry was named `geom` and the other frame had an ordinary
+    # `geom` column, so both projected as `geom` and planning failed.
+    left = gpd.GeoDataFrame(
+        {"x": [1]},
+        geometry=gpd.GeoSeries.from_wkt(["POINT (0 0)"]),
+        crs="EPSG:3857",
+    ).rename_geometry("geom")
+    right = gpd.GeoDataFrame(
+        {"geom": ["ordinary"]},
+        geometry=gpd.GeoSeries.from_wkt(["POLYGON ((-1 -1, 1 -1, 1 1, -1 1, -1 -1))"]),
+        crs="EPSG:3857",
+    )
+    got = sgpd.from_geopandas(left).sjoin(
+        sgpd.from_geopandas(right), predicate="within"
+    )
+    expected = gpd.sjoin(left, right, predicate="within")
+    # GeoPandas keeps the retained geometry's name and suffixes only the other
+    # side's conflicting column.
+    assert got.columns == _without_index_cols(expected)
+    assert got._geometry_name == expected.geometry.name

--- a/python/sedonadb-geopandas/tests/test_geopandas_compat.py
+++ b/python/sedonadb-geopandas/tests/test_geopandas_compat.py
@@ -602,14 +602,12 @@ def test_setitem_over_active_geometry_clears_it(points):
         gdf.geometry
 
 
-def test_sjoin_dwithin_misses_crossing_lines_pending_engine_fix():
-    """Documents a known deviation, so it cannot change unnoticed.
+def test_sjoin_dwithin_matches_crossing_lines():
+    """Crossing linestrings at distance 0 match, as in GeoPandas.
 
-    ST_Distance reports the endpoint gap rather than zero for properly crossing
-    linestrings (apache/sedona-db#1156), so dwithin misses a pair GeoPandas
-    matches. Composing the predicate with ST_Intersects would recover the pair but
-    is not recognized by the planner, which turns the join into a nested loop, so
-    the deviation is accepted until the engine is fixed.
+    This was a documented deviation while ST_Distance reported the endpoint gap
+    for properly crossing linestrings; the engine fix (apache/sedona-db#1164)
+    made the single ST_DWithin predicate correct, with no workaround needed here.
     """
     a = gpd.GeoDataFrame(
         {"i": [1]},
@@ -624,8 +622,11 @@ def test_sjoin_dwithin_misses_crossing_lines_pending_engine_fix():
     got = sgpd.from_geopandas(a).sjoin(
         sgpd.from_geopandas(b), predicate="dwithin", distance=0
     )
-    assert len(gpd.sjoin(a, b, predicate="dwithin", distance=0)) == 1
-    assert len(got.to_geopandas()) == 0  # change this when #1156 is fixed
+    assert (
+        len(got.to_geopandas())
+        == len(gpd.sjoin(a, b, predicate="dwithin", distance=0))
+        == 1
+    )
 
 
 def test_sjoin_uses_a_planner_recognizable_spatial_predicate():


### PR DESCRIPTION
Adds `sjoin(other, how, predicate, lsuffix, rsuffix, distance)` to the experimental `sedonadb-geopandas` package: inner/left/right joins over the `intersects`, `within`, `contains`, `touches`, `crosses`, `overlaps`, `covers`, `covered_by`, and `dwithin` predicates, with GeoPandas' column shape — one geometry column (the left frame's, or the right's for `how="right"`), overlap suffixing including the asymmetric retained-geometry rule, and validation that rejects suffix-generated duplicates and non-numeric `dwithin` distances.

**Scope note:** this PR originally also carried column assignment, `Series` arithmetic, and `dissolve`; those are split out to #1184 so they can land independently, and this PR now holds only the spatial join.

## Blocked on engine fixes

Held as a draft until the following land, since they surface directly through `sjoin` as wrong rows or errors:

- #1165 — `ST_Touches` misses a line whose interior passes through a polygon corner, and `ST_Within` wrongly matches a line lying on a hole boundary. Both mean `sjoin(predicate="touches")` / `sjoin(predicate="within")` can return silently wrong pairs for boundary-only linework.
- #1166 — a spatial LEFT join whose preserved side is empty fails with an internal error where GeoPandas returns an empty frame, so "filter, then left-join" crashes data-dependently.

A third engine issue found by this work, `ST_Distance` mis-measuring crossing linestrings (#1156), was fixed by #1164 and the parity test here asserts the corrected behaviour.

## Design points

- The predicate is always a single spatial call, never a composition: the planner only recognizes a single predicate, and a composed one drops the plan from `SpatialJoinExec` to a quadratic `NestedLoopJoinExec`. A test asserts the plan shape.
- `dwithin` distances must be plain numbers. The predicate is built against re-aliased copies of both frames, so a column reference as a distance would resolve by name inside the join rather than against its own frame.
- No `index_left`/`index_right` columns — there is no row index to report.

## Tests

Seventeen sjoin test instances asserted against GeoPandas: column shapes for all three `how` values, row pairings, suffixing (including custom suffixes, the retained-geometry collision, and suffix-generated duplicates), `dwithin` including the crossing-lines case, distance validation, and the plan-shape guard.
