### PR TITLE
fix(c/sedona-s2geography): Make geography ring orientation less surprising for rings with crossing edges

### DIFF
--- a/c/sedona-s2geography/benches/s2geography-functions.rs
+++ b/c/sedona-s2geography/benches/s2geography-functions.rs
@@ -44,6 +44,22 @@ fn criterion_benchmark(c: &mut Criterion) {
         c,
         &f,
         "s2geography",
+        "st_area",
+        Transformed(Polygon(500).into(), to_geography()),
+    );
+
+    benchmark::scalar(
+        c,
+        &f,
+        "s2geography",
+        "st_area",
+        Transformed(PolygonWithHole(500).into(), to_geography()),
+    );
+
+    benchmark::scalar(
+        c,
+        &f,
+        "s2geography",
         "st_length",
         Transformed(LineString(10).into(), to_geography()),
     );

--- a/python/sedonadb/tests/geography/test_geog_measures.py
+++ b/python/sedonadb/tests/geography/test_geog_measures.py
@@ -77,6 +77,31 @@ def test_st_area(eng, geog, expected):
     )
 
 
+@pytest.mark.parametrize("eng", [SedonaDB])
+def test_st_area_self_intersecting_ring(eng):
+    # A counterclockwise ring with a "spike" whose return path crosses its
+    # outgoing path. The crossing makes the ring's turning angle useless for
+    # determining its winding direction, which previously inverted the
+    # polygon's interior to cover nearly the entire sphere (negative area,
+    # and predicates matching points anywhere on Earth). See #1085.
+    ring = "POLYGON ((0 0, 10 0, 10 10, 6 10, 7 14, 6.2 10.5, 5 10, 0 10, 0 0))"
+
+    eng = eng.create_or_skip()
+    eng.assert_query_result(
+        f"SELECT ST_Area(ST_GeogFromWKT('{ring}'))",
+        1231926073889.81,
+        numeric_epsilon=1e-9,
+    )
+    eng.assert_query_result(
+        f"SELECT ST_Within(ST_GeogFromWKT('POINT (5 5)'), ST_GeogFromWKT('{ring}'))",
+        True,
+    )
+    eng.assert_query_result(
+        f"SELECT ST_Within(ST_GeogFromWKT('POINT (-150 0)'), ST_GeogFromWKT('{ring}'))",
+        False,
+    )
+
+
 @pytest.mark.parametrize("eng", [SedonaDB, BigQuery, PostGIS])
 @pytest.mark.parametrize(
     ("geog", "expected"),


### PR DESCRIPTION
## Description

Fixes #1085.

Rings with crossing edges are invalid, and geography behaviour for them is undefined — but the default `ST_GeogFromWKB`/`ST_GeogFromWKT` accepts them, and the orientation heuristic could invert such a polygon's interior to cover nearly the entire sphere: `ST_Area` returned a negative value and `ST_Within`/`ST_Intersects` matched points anywhere on Earth, silently corrupting every spatial join against the table. This change makes the orientation heuristic derive the winding direction in a way that stays correct for this kind of input, at no cost to valid input.

### Root cause

Every geography UDF materializes WKB through `GeoArrowGeography::Init`, which calls `GeoArrowLaxPolygonShape::NormalizeOrientation()` to make shells counterclockwise and holes clockwise. That function derived each ring's winding direction from the sign of its curvature (turning angle). The affected ring is digitized with an out-and-back tail whose return path is offset by ~10 m; interpreted as geodesics, the return path crosses the outgoing path once. The crossing collapses the ring's turning number to zero, making the curvature sign meaningless, so the shell was reversed in place and its interior inverted. (This also explains why `ST_Reverse`/`ST_Normalize` had no effect: orientation is re-derived, and re-broken, on every evaluation.)

### Change

paleolimbot/s2geography#125 updates `NormalizeOrientation()` to trust the curvature only when it is unambiguous and consult the ring's signed area otherwise: a valid ring has `|curvature| == |2π − area(left side)|`, so its curvature can only fall within `(−π, π)` when the ring encloses between a quarter and three quarters of the sphere. Outside that band the curvature sign is trusted, so the common case costs exactly what it costs today; inside it — unusually large valid rings, or invalid rings whose crossing edges collapse the turning number toward zero — the signed area decides, which reflects the ring's net winding direction even for self-crossing input. For every valid ring the decisions are identical to before.

This PR bumps the s2geography submodule to that change, adds a Python regression test with a minimal self-crossing sliver ring, and adds `st_area` benchmarks for `Polygon(500)` and `PolygonWithHole(500)` (the existing benchmark only covered `Polygon(10)`).

paleolimbot/s2geography#125 has merged, and the submodule now points at the merged upstream commit (`3ab3dd9`).

### Benchmarks

Criterion, `ST_Area` over batches of random valid polygons (Apple Silicon), relative to the curvature-only baseline at the current submodule pin:

| benchmark | curvature (baseline) | signed area only | curvature + signed-area fallback (this PR) |
|---|---|---|---|
| `st_area` Polygon(10) | 140.4 ms | +36.1% | +3.4% |
| `st_area` Polygon(500) | 6.95 s | +114% (CI +73% … +160%) | +4.4% |
| `st_area` PolygonWithHole(500) | 14.29 s | +55.1% | −0.8% (p = 0.66, no change) |

### Verification

Against the original 258-point ring from #1085:

| Expression | Before | After |
|---|---|---|
| `ST_Area(geog)` | −11 876 076 760.37 | +11 876 076 760.37 |
| `ST_Perimeter(geog)` | 574 613.63 | 574 613.63 (unchanged) |
| `ST_Within(POINT (-150 0), geog)` | true | false |
| `ST_Within(POINT (33.5 16.5), geog)` | — | true |

- s2geography C++ suite: 947/947 (new regression tests fail without the change, pass with it)
- `cargo test -p sedona-s2geography`: 68/68
- `pytest tests/geography/`: 1456 passed

Also filed #1154 for a geography `ST_IsValid`/`ST_MakeValid` as the principled follow-up for repairing this class of input.
