### PR TITLE
Add chunk_index to the Band schema

### DIFF
--- a/rust/sedona-raster/src/array.rs
+++ b/rust/sedona-raster/src/array.rs
@@ -44,6 +44,8 @@ struct BandRefImpl<'a> {
     outdb_uri_array: &'a StringArray,
     outdb_format_array: &'a StringViewArray,
     data_array: &'a BinaryViewArray,
+    chunk_index_list: &'a ListArray,
+    chunk_index_values: &'a Int64Array,
     /// Absolute row index within the flattened bands arrays
     band_row: usize,
     /// Resolved at construction so accessors don't re-decode the discriminant.
@@ -110,6 +112,16 @@ impl<'a> BandRef for BandRefImpl<'a> {
             None
         } else {
             Some(self.outdb_format_array.value(self.band_row))
+        }
+    }
+
+    fn chunk_index(&self) -> Option<&[i64]> {
+        if self.chunk_index_list.is_null(self.band_row) {
+            None
+        } else {
+            let start = self.chunk_index_list.value_offsets()[self.band_row] as usize;
+            let end = self.chunk_index_list.value_offsets()[self.band_row + 1] as usize;
+            Some(&self.chunk_index_values.values()[start..end])
         }
     }
 
@@ -180,6 +192,8 @@ pub struct RasterRefImpl<'a> {
     band_outdb_uri_array: &'a StringArray,
     band_outdb_format_array: &'a StringViewArray,
     band_data_array: &'a BinaryViewArray,
+    band_chunk_index_list: &'a ListArray,
+    band_chunk_index_values: &'a Int64Array,
     raster_index: usize,
 }
 
@@ -281,6 +295,8 @@ impl<'a> RasterRef for RasterRefImpl<'a> {
             outdb_uri_array: self.band_outdb_uri_array,
             outdb_format_array: self.band_outdb_format_array,
             data_array: self.band_data_array,
+            chunk_index_list: self.band_chunk_index_list,
+            chunk_index_values: self.band_chunk_index_values,
             band_row,
             data_type,
             view_entries,
@@ -411,6 +427,8 @@ pub struct RasterStructArray<'a> {
     band_outdb_uri_array: &'a StringArray,
     band_outdb_format_array: &'a StringViewArray,
     band_data_array: &'a BinaryViewArray,
+    band_chunk_index_list: &'a ListArray,
+    band_chunk_index_values: &'a Int64Array,
 }
 
 impl<'a> RasterStructArray<'a> {
@@ -458,6 +476,8 @@ impl<'a> RasterStructArray<'a> {
         let band_outdb_format_array =
             as_string_view_array(bands_struct.column(band_indices::OUTDB_FORMAT))?;
         let band_data_array = as_binary_view_array(bands_struct.column(band_indices::DATA))?;
+        let band_chunk_index_list = as_list_array(bands_struct.column(band_indices::CHUNK_INDEX))?;
+        let band_chunk_index_values = as_int64_array(band_chunk_index_list.values())?;
 
         Ok(Self {
             raster_array,
@@ -480,6 +500,8 @@ impl<'a> RasterStructArray<'a> {
             band_outdb_uri_array,
             band_outdb_format_array,
             band_data_array,
+            band_chunk_index_list,
+            band_chunk_index_values,
         })
     }
 
@@ -523,6 +545,8 @@ impl<'a> RasterStructArray<'a> {
             band_outdb_uri_array: self.band_outdb_uri_array,
             band_outdb_format_array: self.band_outdb_format_array,
             band_data_array: self.band_data_array,
+            band_chunk_index_list: self.band_chunk_index_list,
+            band_chunk_index_values: self.band_chunk_index_values,
             raster_index: index,
         })
     }
@@ -616,6 +640,60 @@ mod tests {
         assert_eq!(out_raster.band_name(0), Some("derived"));
         assert_eq!(out_band.dim_names(), vec!["x"]);
         assert_eq!(out_band.data_type(), BandDataType::UInt8);
+    }
+
+    #[test]
+    fn copy_into_inherits_and_overrides_chunk_index() {
+        let transform = [0.0, 1.0, 0.0, 0.0, 0.0, -1.0];
+        let mut ib = RasterBuilder::new(1);
+        ib.start_raster_nd(&transform, &["x"], &[4], None).unwrap();
+        ib.start_band(StartBandArgs {
+            chunk_index: Some(&[7]),
+            ..StartBandArgs::new(&["x"], &[4], BandDataType::UInt8)
+        })
+        .unwrap();
+        ib.band_data_writer().append_value([0u8; 4]);
+        ib.finish_band().unwrap();
+        ib.finish_raster().unwrap();
+        let input_array = ib.finish().unwrap();
+        let input_rasters = RasterStructArray::try_new(&input_array).unwrap();
+        let input_raster = input_rasters.get(0).unwrap();
+        let input_band = input_raster.band(0).unwrap();
+        assert_eq!(input_band.chunk_index(), Some(&[7i64][..]));
+
+        // No override -- inherits the source's chunk_index unchanged.
+        let mut ob = RasterBuilder::new(1);
+        ob.start_raster_nd(&transform, &["x"], &[4], None).unwrap();
+        input_band
+            .copy_into(&mut ob, BandOverrides::default())
+            .unwrap();
+        ob.finish_band().unwrap();
+        ob.finish_raster().unwrap();
+        let out_array = ob.finish().unwrap();
+        let out_rasters = RasterStructArray::try_new(&out_array).unwrap();
+        let out_raster = out_rasters.get(0).unwrap();
+        let out_band = out_raster.band(0).unwrap();
+        assert_eq!(out_band.chunk_index(), Some(&[7i64][..]));
+
+        // Explicit override replaces the inherited value.
+        let mut ob2 = RasterBuilder::new(1);
+        ob2.start_raster_nd(&transform, &["x"], &[4], None).unwrap();
+        input_band
+            .copy_into(
+                &mut ob2,
+                BandOverrides {
+                    chunk_index: Some(&[9]),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        ob2.finish_band().unwrap();
+        ob2.finish_raster().unwrap();
+        let out_array2 = ob2.finish().unwrap();
+        let out_rasters2 = RasterStructArray::try_new(&out_array2).unwrap();
+        let out_raster2 = out_rasters2.get(0).unwrap();
+        let out_band2 = out_raster2.band(0).unwrap();
+        assert_eq!(out_band2.chunk_index(), Some(&[9i64][..]));
     }
 
     #[test]

--- a/rust/sedona-raster/src/builder.rs
+++ b/rust/sedona-raster/src/builder.rs
@@ -115,6 +115,14 @@ pub struct RasterBuilder {
     band_outdb_uri: StringBuilder,
     band_outdb_format: StringViewBuilder,
     band_data: BinaryViewBuilder,
+    // CHUNK_INDEX field — one entry per dim per band, nullable at the list
+    // level (same shape as source_shape's values+offsets, plus a validity
+    // vector like the VIEW field's since, unlike source_shape, most bands
+    // genuinely have no chunk_index at all rather than a not-yet-supported
+    // non-identity case).
+    band_chunk_index_values: Int64Builder,
+    band_chunk_index_offsets: Vec<i32>,
+    band_chunk_index_validity: Vec<bool>,
 
     // List structure tracking
     band_offsets: Vec<i32>,  // Track where each raster's bands start/end
@@ -156,12 +164,17 @@ pub struct StartBandArgs<'a> {
     pub nodata: Option<&'a [u8]>,
     pub outdb_uri: Option<&'a str>,
     pub outdb_format: Option<&'a str>,
+    /// This band's block coordinate within the larger logical array it's
+    /// one chunk of, one entry per `dim_names` entry. `None` for a band
+    /// playing its ordinary role inside `Raster.bands` (addressed by
+    /// index/name, not block coordinate) — see `RasterSchema::chunk_index_type`.
+    pub chunk_index: Option<&'a [i64]>,
 }
 
 impl<'a> StartBandArgs<'a> {
     /// The required band descriptors; the optional fields (`name`, `view`,
-    /// `nodata`, `outdb_uri`, `outdb_format`) default to `None`. Override any of
-    /// them with struct-update syntax, e.g.
+    /// `nodata`, `outdb_uri`, `outdb_format`, `chunk_index`) default to
+    /// `None`. Override any of them with struct-update syntax, e.g.
     /// `StartBandArgs { nodata: Some(&nd), ..StartBandArgs::new(dims, shape, dtype) }`.
     pub fn new(dim_names: &'a [&'a str], source_shape: &'a [i64], data_type: BandDataType) -> Self {
         Self {
@@ -173,6 +186,7 @@ impl<'a> StartBandArgs<'a> {
             nodata: None,
             outdb_uri: None,
             outdb_format: None,
+            chunk_index: None,
         }
     }
 }
@@ -205,6 +219,9 @@ impl RasterBuilder {
             band_outdb_uri: StringBuilder::with_capacity(capacity, capacity),
             band_outdb_format: StringViewBuilder::with_capacity(capacity),
             band_data: BinaryViewBuilder::with_capacity(capacity),
+            band_chunk_index_values: Int64Builder::with_capacity(capacity * 2),
+            band_chunk_index_offsets: vec![0],
+            band_chunk_index_validity: Vec::with_capacity(capacity),
 
             band_offsets: vec![0],
             current_band_count: 0,
@@ -382,7 +399,19 @@ impl RasterBuilder {
             nodata,
             outdb_uri,
             outdb_format,
+            chunk_index,
         } = args;
+
+        if let Some(chunk_index) = chunk_index {
+            if chunk_index.len() != dim_names.len() {
+                return Err(ArrowError::InvalidArgumentError(format!(
+                    "start_band: chunk_index ({}) must have one entry per \
+                     dim_names entry ({})",
+                    chunk_index.len(),
+                    dim_names.len()
+                )));
+            }
+        }
 
         // A caller-supplied view is validated against source_shape. The schema
         // stores views only as the identity null sentinel today, so a
@@ -473,6 +502,26 @@ impl RasterBuilder {
         match outdb_format {
             Some(format) => self.band_outdb_format.append_value(format),
             None => self.band_outdb_format.append_null(),
+        }
+
+        // Chunk index — unlike VIEW, a genuinely present value is stored
+        // (not just validated then discarded): most bands have none at all
+        // (the ordinary Raster.bands role), so absence is the common case,
+        // not an unsupported one.
+        match chunk_index {
+            Some(ci) => {
+                for &v in ci {
+                    self.band_chunk_index_values.append_value(v);
+                }
+                let next = *self.band_chunk_index_offsets.last().unwrap() + ci.len() as i32;
+                self.band_chunk_index_offsets.push(next);
+                self.band_chunk_index_validity.push(true);
+            }
+            None => {
+                let next = *self.band_chunk_index_offsets.last().unwrap();
+                self.band_chunk_index_offsets.push(next);
+                self.band_chunk_index_validity.push(false);
+            }
         }
 
         self.current_band_count += 1;
@@ -790,6 +839,30 @@ impl RasterBuilder {
             view_nulls,
         );
 
+        // Build band chunk_index nested list (List<Int64>, nullable — most
+        // bands have none at all, unlike source_shape which every band has).
+        let chunk_index_values = self.band_chunk_index_values.finish();
+        let chunk_index_offsets =
+            OffsetBuffer::new(ScalarBuffer::from(self.band_chunk_index_offsets));
+        let DataType::List(chunk_index_field) = RasterSchema::chunk_index_type() else {
+            return Err(ArrowError::SchemaError(
+                "Expected list type for chunk_index".to_string(),
+            ));
+        };
+        let chunk_index_nulls = if self.band_chunk_index_validity.iter().all(|&b| b) {
+            None
+        } else {
+            Some(NullBuffer::from_iter(
+                self.band_chunk_index_validity.iter().copied(),
+            ))
+        };
+        let chunk_index_list = ListArray::new(
+            chunk_index_field,
+            chunk_index_offsets,
+            Arc::new(chunk_index_values),
+            chunk_index_nulls,
+        );
+
         // Build band struct
         let DataType::Struct(band_fields) = RasterSchema::band_type() else {
             return Err(ArrowError::SchemaError(
@@ -807,6 +880,7 @@ impl RasterBuilder {
             Arc::new(self.band_outdb_uri.finish()),
             Arc::new(self.band_outdb_format.finish()),
             Arc::new(self.band_data.finish()),
+            Arc::new(chunk_index_list),
         ];
         let band_struct = StructArray::new(band_fields, band_arrays, None);
 
@@ -1422,6 +1496,160 @@ mod tests {
         let buf = band.nd_buffer().unwrap();
         assert_eq!(buf.strides, &[80, 20, 4]);
         assert_eq!(buf.offset, 0);
+    }
+
+    #[test]
+    fn test_chunk_index_round_trips() {
+        let mut builder = RasterBuilder::new(1);
+        builder
+            .start_raster_nd(&[0.0, 1.0, 0.0, 0.0, 0.0, -1.0], &["x", "y"], &[2, 2], None)
+            .unwrap();
+        builder
+            .start_band(StartBandArgs {
+                chunk_index: Some(&[1, 2]),
+                ..StartBandArgs::new(&["y", "x"], &[2, 2], BandDataType::UInt8)
+            })
+            .unwrap();
+        builder.band_data_writer().append_value([0u8; 4]);
+        builder.finish_band().unwrap();
+        builder.finish_raster().unwrap();
+
+        let array = builder.finish().unwrap();
+        let rasters = RasterStructArray::try_new(&array).unwrap();
+        let raster = rasters.get(0).unwrap();
+        let band = raster.band(0).unwrap();
+
+        assert_eq!(band.chunk_index(), Some(&[1i64, 2][..]));
+    }
+
+    #[test]
+    fn test_chunk_index_defaults_to_none() {
+        // The ordinary Raster.bands role -- no chunk_index given -- must
+        // round-trip as None, not e.g. an empty slice or a zero-filled one.
+        let mut builder = RasterBuilder::new(1);
+        builder
+            .start_raster_nd(&[0.0, 1.0, 0.0, 0.0, 0.0, -1.0], &["x", "y"], &[2, 2], None)
+            .unwrap();
+        builder
+            .start_band(StartBandArgs::new(
+                &["y", "x"],
+                &[2, 2],
+                BandDataType::UInt8,
+            ))
+            .unwrap();
+        builder.band_data_writer().append_value([0u8; 4]);
+        builder.finish_band().unwrap();
+        builder.finish_raster().unwrap();
+
+        let array = builder.finish().unwrap();
+        let rasters = RasterStructArray::try_new(&array).unwrap();
+        let raster = rasters.get(0).unwrap();
+        let band = raster.band(0).unwrap();
+
+        assert_eq!(band.chunk_index(), None);
+    }
+
+    #[test]
+    fn test_chunk_index_mixed_present_and_absent_across_bands() {
+        // A validity bitmap bug (e.g. an off-by-one in offsets vs. the
+        // validity vec) would only surface with a mix of present/absent
+        // rows in one array -- a single-band test can't catch it.
+        let mut builder = RasterBuilder::new(2);
+        builder
+            .start_raster_nd(&[0.0, 1.0, 0.0, 0.0, 0.0, -1.0], &["x", "y"], &[1, 1], None)
+            .unwrap();
+        builder
+            .start_band(StartBandArgs::new(
+                &["y", "x"],
+                &[1, 1],
+                BandDataType::UInt8,
+            ))
+            .unwrap();
+        builder.band_data_writer().append_value([0u8]);
+        builder.finish_band().unwrap();
+        builder.finish_raster().unwrap();
+
+        builder
+            .start_raster_nd(&[0.0, 1.0, 0.0, 0.0, 0.0, -1.0], &["x", "y"], &[1, 1], None)
+            .unwrap();
+        builder
+            .start_band(StartBandArgs {
+                chunk_index: Some(&[3, 4]),
+                ..StartBandArgs::new(&["y", "x"], &[1, 1], BandDataType::UInt8)
+            })
+            .unwrap();
+        builder.band_data_writer().append_value([0u8]);
+        builder.finish_band().unwrap();
+        builder.finish_raster().unwrap();
+
+        let array = builder.finish().unwrap();
+        let rasters = RasterStructArray::try_new(&array).unwrap();
+        assert_eq!(rasters.get(0).unwrap().band(0).unwrap().chunk_index(), None);
+        assert_eq!(
+            rasters.get(1).unwrap().band(0).unwrap().chunk_index(),
+            Some(&[3i64, 4][..])
+        );
+    }
+
+    #[test]
+    fn test_chunk_index_length_mismatch_rejected() {
+        let mut builder = RasterBuilder::new(1);
+        builder
+            .start_raster_nd(&[0.0, 1.0, 0.0, 0.0, 0.0, -1.0], &["x", "y"], &[2, 2], None)
+            .unwrap();
+        let err = builder
+            .start_band(StartBandArgs {
+                chunk_index: Some(&[1]), // 2 dims, only 1 chunk_index entry
+                ..StartBandArgs::new(&["y", "x"], &[2, 2], BandDataType::UInt8)
+            })
+            .unwrap_err();
+        assert!(err.to_string().contains("chunk_index"));
+    }
+
+    #[test]
+    fn test_chunk_index_round_trips_through_arrow_ipc() {
+        // Same regression-shape as test_view_null_round_trips_through_arrow_ipc:
+        // a nullable list field's null bitmap must survive a real IPC
+        // serialize/deserialize cycle, not just an in-process check.
+        let mut builder = RasterBuilder::new(1);
+        builder
+            .start_raster_nd(&[0.0, 1.0, 0.0, 0.0, 0.0, -1.0], &["x", "y"], &[1, 1], None)
+            .unwrap();
+        builder
+            .start_band(StartBandArgs {
+                chunk_index: Some(&[5, 6]),
+                ..StartBandArgs::new(&["y", "x"], &[1, 1], BandDataType::UInt8)
+            })
+            .unwrap();
+        builder.band_data_writer().append_value([0u8]);
+        builder.finish_band().unwrap();
+        builder.finish_raster().unwrap();
+        let array = builder.finish().unwrap();
+        let schema = Arc::new(Schema::new(vec![Arc::new(arrow_schema::Field::new(
+            "raster",
+            array.data_type().clone(),
+            true,
+        )) as arrow_schema::FieldRef]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(array)]).unwrap();
+
+        let mut buf = Vec::new();
+        {
+            let mut writer = StreamWriter::try_new(&mut buf, schema.as_ref()).unwrap();
+            writer.write(&batch).unwrap();
+            writer.finish().unwrap();
+        }
+        let mut reader = StreamReader::try_new(Cursor::new(buf), None).unwrap();
+        let roundtripped = reader.next().unwrap().unwrap();
+        let roundtripped_array = roundtripped
+            .column(0)
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+
+        let rasters = RasterStructArray::try_new(roundtripped_array).unwrap();
+        let raster = rasters.get(0).unwrap();
+        let band = raster.band(0).unwrap();
+        assert_eq!(band.chunk_index(), Some(&[5i64, 6][..]));
     }
 
     #[test]

--- a/rust/sedona-raster/src/traits.rs
+++ b/rust/sedona-raster/src/traits.rs
@@ -300,6 +300,9 @@ pub struct BandOverrides<'a> {
     /// view unchanged. (A non-identity result isn't persistable yet and
     /// `copy_into` rejects it; see <https://github.com/apache/sedona-db/issues/897>.)
     pub view: Option<&'a [ViewEntry]>,
+    /// Override the chunk index; `None` inherits the source's (which is
+    /// itself usually `None` — see [`BandRef::chunk_index`]).
+    pub chunk_index: Option<&'a [i64]>,
 }
 
 /// Trait for accessing a single band/variable within an N-D raster.
@@ -389,6 +392,19 @@ pub trait BandRef {
     /// (e.g. `"geotiff"`, `"zarr"`). None means in-memory — the band's
     /// `contiguous_data()` / `nd_buffer()` is authoritative.
     fn outdb_format(&self) -> Option<&str> {
+        None
+    }
+
+    /// This band's block coordinate within the larger logical array it's one
+    /// chunk of, one entry per `dim_names` entry (`chunk_index()[i]` is the
+    /// zero-based block number along `dim_names()[i]`) — a chunk *number*,
+    /// not a pixel offset, so it stays meaningful across uneven/remainder
+    /// chunk sizes. `None` (the default) for a band playing its ordinary
+    /// role inside `Raster.bands` (addressed by index/name, not block
+    /// coordinate); required and validated by whichever accessor or
+    /// function actually depends on it for a standalone chunked-table
+    /// (DataArray) use case — see `RasterSchema::chunk_index_type`.
+    fn chunk_index(&self) -> Option<&[i64]> {
         None
     }
 
@@ -486,6 +502,7 @@ pub trait BandRef {
             nodata: overrides.nodata.or_else(|| self.nodata()),
             outdb_uri: overrides.outdb_uri.or_else(|| self.outdb_uri()),
             outdb_format: overrides.outdb_format.or_else(|| self.outdb_format()),
+            chunk_index: overrides.chunk_index.or_else(|| self.chunk_index()),
             ..StartBandArgs::new(&dim_names, &source_shape, self.data_type())
         })?;
         self.append_data_into(builder)
@@ -823,6 +840,7 @@ mod tests {
         source_shape: Vec<i64>,
         shape: Vec<i64>,
         view: Vec<ViewEntry>,
+        chunk_index: Option<Vec<i64>>,
     }
 
     impl BandRef for StubBand {
@@ -847,6 +865,9 @@ mod tests {
         fn nodata(&self) -> Option<&[u8]> {
             None
         }
+        fn chunk_index(&self) -> Option<&[i64]> {
+            self.chunk_index.as_deref()
+        }
         fn nd_buffer(&self) -> Result<NdBuffer<'_>, ArrowError> {
             unimplemented!("not used in is_spatial_2d tests")
         }
@@ -862,6 +883,7 @@ mod tests {
             source_shape: source_shape.to_vec(),
             shape,
             view: view.to_vec(),
+            chunk_index: None,
         }
     }
 

--- a/rust/sedona-schema/src/raster.rs
+++ b/rust/sedona-schema/src/raster.rs
@@ -94,7 +94,23 @@ impl RasterSchema {
             Field::new(column::OUTDB_URI, DataType::Utf8, true),
             Field::new(column::OUTDB_FORMAT, DataType::Utf8View, true),
             Field::new(column::DATA, DataType::BinaryView, false),
+            Field::new(column::CHUNK_INDEX, Self::chunk_index_type(), true),
         ]))
+    }
+
+    /// Chunk-index list type — one entry per `dim_names` entry, in the same
+    /// order. `chunk_index[i]` is the zero-based block coordinate this band
+    /// occupies along `dim_names[i]` within the larger logical (multi-row)
+    /// array it's one piece of — a chunk *number*, not a pixel offset, so it
+    /// stays meaningful across uneven/remainder chunk sizes.
+    ///
+    /// Nullable at the schema level, same as `crs`/`transform` on `Raster`
+    /// today: required and validated by whichever accessor or function
+    /// actually depends on it (a chunked-table/DataArray use case), left
+    /// unset by a band's ordinary role inside `Raster.bands` (bands there
+    /// are addressed by index/name, not block coordinate).
+    pub fn chunk_index_type() -> DataType {
+        DataType::List(FieldRef::new(Field::new("item", DataType::Int64, false)))
     }
 
     /// Dimension names list type
@@ -249,7 +265,8 @@ pub mod band_indices {
     pub const OUTDB_URI: usize = 6;
     pub const OUTDB_FORMAT: usize = 7;
     pub const DATA: usize = 8;
-    pub const FIELD_COUNT: usize = 9;
+    pub const CHUNK_INDEX: usize = 9;
+    pub const FIELD_COUNT: usize = 10;
 }
 
 /// Field indices within the `view` struct (`(source_axis, start, step, steps)`).
@@ -282,6 +299,7 @@ pub mod column {
     pub const OUTDB_URI: &str = "outdb_uri";
     pub const OUTDB_FORMAT: &str = "outdb_format";
     pub const DATA: &str = "data";
+    pub const CHUNK_INDEX: &str = "chunk_index";
 }
 
 #[cfg(test)]
@@ -336,7 +354,7 @@ mod tests {
         // Test band indices
         let band_type = RasterSchema::band_type();
         if let DataType::Struct(band_fields) = band_type {
-            assert_eq!(band_fields.len(), 9, "Expected exactly 9 band fields");
+            assert_eq!(band_fields.len(), 10, "Expected exactly 10 band fields");
             assert_eq!(band_fields[band_indices::NAME].name(), column::NAME);
             assert_eq!(
                 band_fields[band_indices::DIM_NAMES].name(),
@@ -365,6 +383,17 @@ mod tests {
                 column::OUTDB_FORMAT
             );
             assert_eq!(band_fields[band_indices::DATA].name(), column::DATA);
+            assert_eq!(
+                band_fields[band_indices::CHUNK_INDEX].name(),
+                column::CHUNK_INDEX
+            );
+            assert!(
+                band_fields[band_indices::CHUNK_INDEX].is_nullable(),
+                "chunk_index must be nullable — unset for a band's ordinary \
+                 role inside Raster.bands, required only by whichever \
+                 accessor/function depends on it for a standalone \
+                 chunked-table use case"
+            );
         } else {
             panic!("Expected Struct type for band");
         }


### PR DESCRIPTION
## What

Adds `chunk_index: List<Int64> NULLABLE` to the Band schema: one entry per `dim_names` entry, the zero-based block coordinate this band occupies along that axis within a larger logical array it's one chunk of — a chunk *number*, not a pixel offset, so it stays meaningful across uneven/remainder chunk sizes.

Nullable at the schema level, same as `crs`/`transform` on `Raster` today: unset for a band's ordinary role inside `Raster.bands` (addressed by index/name, not block coordinate), required and validated by whichever accessor or function actually depends on it for a standalone chunked-table (DataArray-style) use case — a chunked table with one row per block, where each chunk currently has nowhere to carry its own position except external sibling columns the caller has to build and maintain by hand.

## Why

A chunk keeps its own block coordinate wherever it goes — through a `SELECT`, out of a function's return value, across a join, eventually through `UNNEST` — instead of losing it the moment it's separated from the specific row it started in. Carrying this on the value itself, rather than requiring a consumer to invent and maintain separate `dim_0_idx`/`dim_1_idx`-style columns alongside it, means the block-coordinate alignment a chunked-array join needs can match directly on `chunk_index` with no dependency on external bookkeeping.

## What's in it

- `RasterSchema`: new `chunk_index_type()`, the field appended to `band_type()`, `column::CHUNK_INDEX`/`band_indices::CHUNK_INDEX`, `band_indices::FIELD_COUNT` bumped 9→10.
- `RasterBuilder`: `StartBandArgs.chunk_index` (validated against `dim_names.len()`), threaded through `start_band`/`finish` following the same values+offsets+validity pattern already used for `source_shape`/`view`.
- `BandRef`: new `chunk_index()` accessor (default `None`), a real implementation in the Arrow-backed `BandRefImpl`.
- `BandRef::copy_into`: `BandOverrides.chunk_index`, inherited by default (`overrides.chunk_index.or_else(|| self.chunk_index())`) — same pattern as `nodata`/`outdb_uri`/`outdb_format` — so a chunk's position survives a derive operation, not just a raw copy.

All ~30 existing `StartBandArgs` construction sites are unaffected: every one already uses `..StartBandArgs::new(...)` struct-update syntax, so the new field's `None` default requires no changes there — verified directly by compiling the whole workspace, not assumed.

## Verification

- New tests: round-trip (present and absent), a mixed-validity case across multiple bands in one array (the case most likely to catch an offset/validity-bitmap bug), length-mismatch validation, an Arrow IPC serialize/deserialize round-trip, and `copy_into`'s inherit-by-default + explicit-override paths.
- `cargo test` for `sedona-schema`, `sedona-raster`, `sedona-raster-functions`, `sedona-raster-zarr`, `sedona-spatial-join-raster`, `sedona-testing` — all pass, no regressions.
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` — clean.
- Full workspace `cargo test` (excluding the environment-only `gdal-sys`/`sedona-gdal` bindgen issue on this machine, unrelated to this change) — clean.
