### PR TITLE
feat(python/sedonadb): Add a native scalar UDF import path for plugins

### DIFF
--- a/python/sedonadb/Cargo.toml
+++ b/python/sedonadb/Cargo.toml
@@ -64,3 +64,15 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 mimalloc = { workspace = true, optional = true }
 libmimalloc-sys = { workspace = true, optional = true }
+
+[dev-dependencies]
+# `extension-module` (needed for the real cdylib/wheel build) is only ever
+# added by maturin's own build flags (see pyproject.toml's [tool.maturin]),
+# never by this Cargo.toml -- so `cargo test` builds this crate without it,
+# and `auto-initialize` here is what lets a #[test] embed and drive a real
+# Python interpreter via Python::attach. Confirmed directly: explicitly
+# compiling with `--features pyo3/extension-module` fails to link (undefined
+# libpython symbols), but plain `cargo test`/`cargo test --all-features`
+# (CI's actual invocation) never requests that feature, so the two never
+# collide in practice.
+pyo3 = { workspace = true, features = ["auto-initialize"] }

--- a/python/sedonadb/python/sedonadb/context.py
+++ b/python/sedonadb/python/sedonadb/context.py
@@ -444,6 +444,17 @@ class SedonaContext:
         - An ExternalFormatSpec implementing a custom datasource type
         - An object implementing __sedonadb_extension__(ctx, **kwargs), which
           is called with this context and any keyword arguments passed.
+        - An object implementing __sedonadb_native_scalar_udfs__(self), which
+          returns a list of PyCapsule objects each wrapping a natively-
+          compiled SedonaCScalarKernel -- real compiled Rust runs per
+          invocation, not a Python callback. Kernels sharing a declared name
+          are grouped into one overloaded UDF (within this one call only --
+          registering under a name already in use, including a built-in's,
+          replaces it, the same as __sedonadb_internal_udf__ already does).
+          Volatility is always Immutable through this protocol; a kernel
+          needing Volatile or Stable should be registered via
+          __sedonadb_internal_udf__ instead, built with
+          sedonadb._lib.sedona_native_scalar_udf(kernels, volatility=...).
 
         The extension interface is experimental and may change.
 
@@ -490,6 +501,7 @@ class SedonaContext:
             "__sedonadb_internal_aggregate_udf__",
             "__sedonadb_external_format__",
             "__sedonadb_raster_loader__",
+            "__sedonadb_native_scalar_udfs__",
         )
         for interface in supported_interfaces:
             if hasattr(component, interface):

--- a/python/sedonadb/python/sedonadb/context.py
+++ b/python/sedonadb/python/sedonadb/context.py
@@ -444,14 +444,15 @@ class SedonaContext:
         - An ExternalFormatSpec implementing a custom datasource type
         - An object implementing __sedonadb_extension__(ctx, **kwargs), which
           is called with this context and any keyword arguments passed.
-        - An object implementing __sedonadb_native_scalar_udfs__(self), which
-          returns a list of PyCapsule objects each wrapping a natively-
-          compiled SedonaCScalarKernel -- real compiled Rust runs per
-          invocation, not a Python callback. Kernels sharing a declared name
-          are grouped into one overloaded UDF (within this one call only --
-          registering under a name already in use, including a built-in's,
-          replaces it, the same as __sedonadb_internal_udf__ already does).
-          Volatility is always Immutable through this protocol; a kernel
+        - A single function object implementing __sedonadb_scalar_udf__(self),
+          which returns a list of PyCapsule objects -- the overload kernels of
+          that one function, each wrapping a natively-compiled
+          SedonaCScalarKernel sharing the function's SQL name -- so real
+          compiled Rust runs per invocation, not a Python callback. Register
+          each function individually. The kernels are grouped into one
+          overloaded UDF; registering under a name already in use, including a
+          built-in's, replaces it, the same as __sedonadb_internal_udf__ already
+          does. Volatility is always Immutable through this protocol; a kernel
           needing Volatile or Stable should be registered via
           __sedonadb_internal_udf__ instead, built with
           sedonadb._lib.sedona_native_scalar_udf(kernels, volatility=...).
@@ -501,7 +502,7 @@ class SedonaContext:
             "__sedonadb_internal_aggregate_udf__",
             "__sedonadb_external_format__",
             "__sedonadb_raster_loader__",
-            "__sedonadb_native_scalar_udfs__",
+            "__sedonadb_scalar_udf__",
         )
         for interface in supported_interfaces:
             if hasattr(component, interface):

--- a/python/sedonadb/python/sedonadb/context.py
+++ b/python/sedonadb/python/sedonadb/context.py
@@ -449,13 +449,16 @@ class SedonaContext:
           that one function, each wrapping a natively-compiled
           SedonaCScalarKernel sharing the function's SQL name -- so real
           compiled Rust runs per invocation, not a Python callback. Register
-          each function individually. The kernels are grouped into one
-          overloaded UDF; registering under a name already in use, including a
-          built-in's, replaces it, the same as __sedonadb_internal_udf__ already
-          does. Volatility is always Immutable through this protocol; a kernel
-          needing Volatile or Stable should be registered via
-          __sedonadb_internal_udf__ instead, built with
-          sedonadb._lib.sedona_native_scalar_udf(kernels, volatility=...).
+          each function individually. The kernels are appended as overloads to
+          the function of that name (a new function is created when none exists
+          yet). A kernel whose signature matches an existing overload --
+          including a built-in's -- overrides that one signature (kernels
+          resolve newest-first) while the function's other overloads stay
+          reachable, so a plugin can add an overload to an existing function
+          without replacing it. Volatility is always Immutable through this
+          protocol; a kernel needing Volatile or Stable should be registered
+          via __sedonadb_internal_udf__ instead, built with
+          sedonadb.udf.sedona_native_scalar_udf(kernels, volatility=...).
 
         The extension interface is experimental and may change.
 

--- a/python/sedonadb/python/sedonadb/expr/expression.py
+++ b/python/sedonadb/python/sedonadb/expr/expression.py
@@ -473,6 +473,15 @@ class ScalarUdf:
 
         return Expr(self._impl.call(args), self._ctx)
 
+    def __sedonadb_scalar_udf__(self):
+        """Export this function's native overload kernels as capsules.
+
+        Delegates to the wrapped internal UDF. Only Sedona-native scalar
+        UDFs implement this; a DataFusion-backed function does not, so
+        calling this on one raises AttributeError.
+        """
+        return self._impl.__sedonadb_scalar_udf__()
+
 
 class AggregateUdf:
     """Concrete aggregate function that can generate call expressions

--- a/python/sedonadb/python/sedonadb/udf.py
+++ b/python/sedonadb/python/sedonadb/udf.py
@@ -19,8 +19,42 @@ import inspect
 import re
 from typing import Any, List, Literal, Optional, Union
 
-from sedonadb._lib import sedona_aggregate_udf, sedona_scalar_udf
+from sedonadb._lib import (
+    sedona_aggregate_udf,
+    sedona_native_scalar_udf as _sedona_native_scalar_udf,
+    sedona_scalar_udf,
+)
 from sedonadb.utility import sedona  # noqa: F401
+
+
+def sedona_native_scalar_udf(
+    kernels,
+    volatility: Literal["immutable", "stable", "volatile"] = "immutable",
+    name: Optional[str] = None,
+):
+    """Build a scalar UDF from natively-compiled kernel capsules.
+
+    Groups one or more native scalar-kernel capsules -- such as those a
+    function exports via `__sedonadb_scalar_udf__()` -- into a single
+    overloaded UDF backed by compiled Rust (no Python callback per
+    invocation). Each capsule carries its own declared SQL name; the names
+    must agree, and `name` overrides that shared name when given.
+
+    Unlike the `__sedonadb_scalar_udf__` registration protocol, which always
+    registers as immutable, `volatility` is caller-supplied here.
+
+    !!! warning
+        SedonaDB native scalar UDFs are experimental and this interface may
+        change based on user feedback.
+
+    Args:
+        kernels: A non-empty list of PyCapsule objects wrapping
+            natively-compiled scalar kernels that share one SQL name.
+        volatility: "immutable" (default), "stable", or "volatile".
+        name: An optional SQL name overriding the kernels' shared declared
+            name.
+    """
+    return _sedona_native_scalar_udf(kernels, volatility, name)
 
 
 class TypeMatcher(str):

--- a/python/sedonadb/python/sedonadb/udf.py
+++ b/python/sedonadb/python/sedonadb/udf.py
@@ -28,7 +28,7 @@ from sedonadb.utility import sedona  # noqa: F401
 
 
 def sedona_native_scalar_udf(
-    kernels,
+    kernels: List[Any],
     volatility: Literal["immutable", "stable", "volatile"] = "immutable",
     name: Optional[str] = None,
 ):

--- a/python/sedonadb/src/context.rs
+++ b/python/sedonadb/src/context.rs
@@ -20,17 +20,19 @@ use std::{
 };
 
 use arrow_schema::DataType;
+use datafusion_expr::Volatility;
 use pyo3::prelude::*;
 use sedona::context::SedonaContext;
 use sedona::context_builder::SedonaContextBuilder;
 use sedona_datasource::format::ExternalFormatFactory;
+use sedona_expr::scalar_udf::SedonaScalarUDF;
 use sedona_extension::runtime::RuntimeHandle;
 
 use crate::{
     dataframe::InternalDataFrame,
     datasource::PyExternalFormat,
     error::PySedonaError,
-    import_from::import_table_provider_from_any,
+    import_from::{import_sedona_ffi_scalar_kernel, import_table_provider_from_any},
     raster_loader::PyRasterLoaderWrapper,
     runtime::wait_for_future,
     udf::{PyAggregateUdf, PyScalarUdf, PySedonaAggregateUdf, PySedonaScalarUdf},
@@ -353,6 +355,47 @@ impl InternalContext {
                 .call_method0("__sedonadb_raster_loader__")?
                 .extract::<PyRasterLoaderWrapper>()?;
             self.inner.register_raster_loader(wrapper.inner);
+            return Ok(());
+        } else if component.hasattr("__sedonadb_native_scalar_udfs__")? {
+            // One or more natively-compiled kernel capsules (see
+            // import_sedona_ffi_scalar_kernel), potentially spanning several
+            // distinct function names -- grouped here by each kernel's own
+            // declared name, so two capsules sharing one name become one
+            // overloaded SedonaScalarUDF (proven directly: registering an
+            // Int64 kernel and a Float64 kernel under the same name and
+            // dispatching both via SQL). This grouping is scoped to this one
+            // call's own capsule list, not accumulated across calls the way
+            // SedonaContext::register_scalar_kernels accumulates
+            // statically-linked (e.g. s2geography) kernels -- registration
+            // goes through register_sedona_scalar_udf, which replaces any
+            // existing UDF of that name outright (a plain HashMap insert,
+            // same as DataFusion's own register_udf) rather than merging
+            // into it. Re-registering under a name already in use -- a
+            // plugin's own name, another plugin's, or a built-in's -- silently
+            // drops whatever was there before; this mirrors the existing,
+            // already-trusted __sedonadb_internal_udf__ path's behavior, not
+            // a new risk this protocol introduces.
+            //
+            // Volatility isn't plugin-configurable through this protocol,
+            // hardcoded to Immutable -- not because every native kernel is
+            // Immutable (RS_FromPath, for one, is Volatile), but because a
+            // bare capsule has nowhere to carry a volatility value. A plugin
+            // needing Volatile/Stable can call sedona_native_scalar_udf(...,
+            // volatility=...) directly and return the resulting
+            // PySedonaScalarUdf via the existing __sedonadb_internal_udf__
+            // protocol instead of this one.
+            let capsules = component
+                .call_method0("__sedonadb_native_scalar_udfs__")?
+                .extract::<Vec<Bound<PyAny>>>()?;
+            let mut kernels_by_name: HashMap<String, Vec<_>> = HashMap::new();
+            for capsule in &capsules {
+                let (name, kernel) = import_sedona_ffi_scalar_kernel(capsule)?;
+                kernels_by_name.entry(name).or_default().push(kernel);
+            }
+            for (name, kernels) in kernels_by_name {
+                let udf = SedonaScalarUDF::new(&name, kernels, Volatility::Immutable);
+                self.inner.register_sedona_scalar_udf(udf)?;
+            }
             return Ok(());
         } else if let Ok(py_raster_loader) = component.extract::<PyRasterLoaderWrapper>() {
             self.inner.register_raster_loader(py_raster_loader.inner);

--- a/python/sedonadb/src/context.rs
+++ b/python/sedonadb/src/context.rs
@@ -20,19 +20,17 @@ use std::{
 };
 
 use arrow_schema::DataType;
-use datafusion_expr::Volatility;
 use pyo3::prelude::*;
 use sedona::context::SedonaContext;
 use sedona::context_builder::SedonaContextBuilder;
 use sedona_datasource::format::ExternalFormatFactory;
-use sedona_expr::scalar_udf::SedonaScalarUDF;
 use sedona_extension::runtime::RuntimeHandle;
 
 use crate::{
     dataframe::InternalDataFrame,
     datasource::PyExternalFormat,
     error::PySedonaError,
-    import_from::{import_sedona_ffi_scalar_kernel, import_table_provider_from_any},
+    import_from::import_table_provider_from_any,
     raster_loader::PyRasterLoaderWrapper,
     runtime::wait_for_future,
     udf::{PyAggregateUdf, PyScalarUdf, PySedonaAggregateUdf, PySedonaScalarUdf},
@@ -356,46 +354,22 @@ impl InternalContext {
                 .extract::<PyRasterLoaderWrapper>()?;
             self.inner.register_raster_loader(wrapper.inner);
             return Ok(());
-        } else if component.hasattr("__sedonadb_native_scalar_udfs__")? {
-            // One or more natively-compiled kernel capsules (see
-            // import_sedona_ffi_scalar_kernel), potentially spanning several
-            // distinct function names -- grouped here by each kernel's own
-            // declared name, so two capsules sharing one name become one
-            // overloaded SedonaScalarUDF (proven directly: registering an
-            // Int64 kernel and a Float64 kernel under the same name and
-            // dispatching both via SQL). This grouping is scoped to this one
-            // call's own capsule list, not accumulated across calls the way
-            // SedonaContext::register_scalar_kernels accumulates
-            // statically-linked (e.g. s2geography) kernels -- registration
-            // goes through register_sedona_scalar_udf, which replaces any
-            // existing UDF of that name outright (a plain HashMap insert,
-            // same as DataFusion's own register_udf) rather than merging
-            // into it. Re-registering under a name already in use -- a
-            // plugin's own name, another plugin's, or a built-in's -- silently
-            // drops whatever was there before; this mirrors the existing,
-            // already-trusted __sedonadb_internal_udf__ path's behavior, not
-            // a new risk this protocol introduces.
-            //
-            // Volatility isn't plugin-configurable through this protocol,
-            // hardcoded to Immutable -- not because every native kernel is
-            // Immutable (RS_FromPath, for one, is Volatile), but because a
-            // bare capsule has nowhere to carry a volatility value. A plugin
-            // needing Volatile/Stable can call sedona_native_scalar_udf(...,
-            // volatility=...) directly and return the resulting
-            // PySedonaScalarUdf via the existing __sedonadb_internal_udf__
-            // protocol instead of this one.
+        } else if component.hasattr("__sedonadb_scalar_udf__")? {
+            // One function's overload kernels, each a natively-compiled kernel
+            // capsule (see import_sedona_ffi_scalar_kernel) all sharing this
+            // function's SQL name. `sedona_native_scalar_udf` imports each
+            // capsule, checks the declared names agree, and groups them into
+            // one overloaded UDF. Registration replaces any existing UDF of
+            // that name outright, mirroring the existing __sedonadb_internal_udf__
+            // path (not an append). Volatility is Immutable via this path; a
+            // plugin needing Volatile/Stable builds a PySedonaScalarUdf with
+            // sedona_native_scalar_udf(..., volatility=...) and returns it
+            // through __sedonadb_internal_udf__ instead.
             let capsules = component
-                .call_method0("__sedonadb_native_scalar_udfs__")?
+                .call_method0("__sedonadb_scalar_udf__")?
                 .extract::<Vec<Bound<PyAny>>>()?;
-            let mut kernels_by_name: HashMap<String, Vec<_>> = HashMap::new();
-            for capsule in &capsules {
-                let (name, kernel) = import_sedona_ffi_scalar_kernel(capsule)?;
-                kernels_by_name.entry(name).or_default().push(kernel);
-            }
-            for (name, kernels) in kernels_by_name {
-                let udf = SedonaScalarUDF::new(&name, kernels, Volatility::Immutable);
-                self.inner.register_sedona_scalar_udf(udf)?;
-            }
+            let py_udf = crate::udf::sedona_native_scalar_udf(capsules, "immutable", None)?;
+            self.inner.register_sedona_scalar_udf(py_udf.inner)?;
             return Ok(());
         } else if let Ok(py_raster_loader) = component.extract::<PyRasterLoaderWrapper>() {
             self.inner.register_raster_loader(py_raster_loader.inner);

--- a/python/sedonadb/src/context.rs
+++ b/python/sedonadb/src/context.rs
@@ -20,6 +20,7 @@ use std::{
 };
 
 use arrow_schema::DataType;
+use datafusion_expr::ScalarUDFImpl;
 use pyo3::prelude::*;
 use sedona::context::SedonaContext;
 use sedona::context_builder::SedonaContextBuilder;
@@ -359,17 +360,25 @@ impl InternalContext {
             // capsule (see import_sedona_ffi_scalar_kernel) all sharing this
             // function's SQL name. `sedona_native_scalar_udf` imports each
             // capsule, checks the declared names agree, and groups them into
-            // one overloaded UDF. Registration replaces any existing UDF of
-            // that name outright, mirroring the existing __sedonadb_internal_udf__
-            // path (not an append). Volatility is Immutable via this path; a
-            // plugin needing Volatile/Stable builds a PySedonaScalarUdf with
+            // one overloaded UDF. Its kernels are then appended as overloads to
+            // any existing UDF of that name (or a new UDF is created when none
+            // exists yet). Because kernels resolve newest-first, an appended
+            // kernel whose signature matches an existing overload wins for that
+            // signature — a per-signature ("kernel-level") override — while the
+            // function's other overloads stay reachable. This lets a plugin add
+            // an overload to an existing function (e.g. an st_intersects
+            // overload for a new type) without discarding its other signatures.
+            // Volatility is Immutable via this path; a plugin needing
+            // Volatile/Stable builds a PySedonaScalarUdf with
             // sedona_native_scalar_udf(..., volatility=...) and returns it
             // through __sedonadb_internal_udf__ instead.
             let capsules = component
                 .call_method0("__sedonadb_scalar_udf__")?
                 .extract::<Vec<Bound<PyAny>>>()?;
             let py_udf = crate::udf::sedona_native_scalar_udf(capsules, "immutable", None)?;
-            self.inner.register_sedona_scalar_udf(py_udf.inner)?;
+            let name = py_udf.inner.name().to_string();
+            let kernels = py_udf.inner.kernels().to_vec();
+            self.inner.append_sedona_scalar_kernels(&name, kernels)?;
             return Ok(());
         } else if let Ok(py_raster_loader) = component.extract::<PyRasterLoaderWrapper>() {
             self.inner.register_raster_loader(py_raster_loader.inner);

--- a/python/sedonadb/src/import_from.rs
+++ b/python/sedonadb/src/import_from.rs
@@ -34,7 +34,11 @@ use pyo3::{
     Bound, PyAny, Python,
 };
 use sedona::record_batch_reader_provider::RecordBatchReaderProvider;
-use sedona_extension::{extension::SedonaCTableProvider, table_provider::ImportedTableProvider};
+use sedona_expr::scalar_udf::ScalarKernelRef;
+use sedona_extension::{
+    extension::SedonaCScalarKernel, extension::SedonaCTableProvider,
+    scalar_kernel::ImportedScalarKernel, table_provider::ImportedTableProvider,
+};
 use sedona_schema::{
     datatypes::SedonaType,
     matchers::{ArgMatcher, TypeMatcher},
@@ -93,6 +97,47 @@ pub fn import_sedona_ffi_table_provider(
         .with_check_interval(Duration::from_millis(2_000));
 
     Ok(Arc::new(provider))
+}
+
+/// Import a natively-compiled scalar kernel from a `PyCapsule` wrapping a
+/// [`SedonaCScalarKernel`] -- the same Arrow-C-Data-Interface-style ABI
+/// (opaque pointer + function-pointer vtable + explicit release) already
+/// used by `sedona-extension` to statically link in kernels at build time
+/// (see `c/sedona-s2geography`); this is the runtime counterpart, letting an
+/// out-of-tree plugin hand in a real `SedonaScalarKernel` -- no Python
+/// callback per invocation -- via `__sedonadb_native_scalar_udfs__`.
+///
+/// Returns the kernel's own declared name (read from the capsule via
+/// [`ImportedScalarKernel::function_name`], not supplied by the caller) so
+/// multiple kernels sharing one name can be grouped into a single overloaded
+/// [`sedona_expr::scalar_udf::SedonaScalarUDF`] by the caller, the same way
+/// [`sedona::context::SedonaContext::register_scalar_kernels`] already
+/// groups statically-linked kernels.
+pub fn import_sedona_ffi_scalar_kernel(
+    obj: &Bound<PyAny>,
+) -> Result<(String, ScalarKernelRef), PySedonaError> {
+    let contents = check_pycapsule(obj, "sedonadb_scalar_kernel")? as *mut SedonaCScalarKernel;
+
+    // Move the SedonaCScalarKernel out of the capsule into our
+    // ImportedScalarKernel. Clear the structure after reading to prevent
+    // double-free when the capsule is dropped -- same pattern as
+    // import_sedona_ffi_table_provider above.
+    let ffi_kernel = unsafe {
+        let kernel = std::ptr::read(contents);
+        std::ptr::write_bytes(contents, 0, 1);
+        kernel
+    };
+    let imported = ImportedScalarKernel::try_from(ffi_kernel)?;
+    let name = imported
+        .function_name()
+        .ok_or_else(|| {
+            PySedonaError::SedonaPython(
+                "native scalar kernel capsule has no function name".to_string(),
+            )
+        })?
+        .to_string();
+
+    Ok((name, Arc::new(imported)))
 }
 
 pub fn import_arrow_array_stream<'py>(
@@ -210,4 +255,98 @@ pub fn check_pycapsule(obj: &Bound<PyAny>, name: &str) -> Result<*mut c_void, Py
         .map_err(|e| PySedonaError::SedonaPython(e.to_string()))?;
 
     Ok(pointer.as_ptr())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_schema::DataType;
+    use sedona_expr::scalar_udf::SimpleSedonaScalarKernel;
+    use sedona_extension::{extension::SedonaCScalarKernel, scalar_kernel::ExportedScalarKernel};
+
+    /// A trivial real kernel (matches any single numeric arg, returns it
+    /// unchanged), exported to a `SedonaCScalarKernel` and wrapped in a real
+    /// `PyCapsule` -- the exact same export path `sedona-extension`'s own
+    /// `ffi_roundtrip`/`named_kernel` tests already prove correct end to
+    /// end. `#[dev-dependencies] pyo3 = { features = ["auto-initialize"] }`
+    /// is what makes `Python::attach` usable here at all: `extension-module`
+    /// (needed for the real wheel build) is only ever added by maturin's own
+    /// build flags, never by this crate's Cargo.toml, so it's never present
+    /// during `cargo test`.
+    fn capsule_with_named_kernel<'py>(
+        py: Python<'py>,
+        function_name: &str,
+    ) -> Bound<'py, PyCapsule> {
+        let kernel = SimpleSedonaScalarKernel::new_ref(
+            ArgMatcher::new(
+                vec![ArgMatcher::is_numeric()],
+                SedonaType::Arrow(DataType::Int64),
+            ),
+            Arc::new(|_, args| Ok(args[0].clone())),
+        );
+        let exported = ExportedScalarKernel::from(kernel).with_function_name(function_name);
+        let ffi_kernel = SedonaCScalarKernel::from(exported);
+        PyCapsule::new_with_value(py, ffi_kernel, c"sedonadb_scalar_kernel").unwrap()
+    }
+
+    #[test]
+    fn import_sedona_ffi_scalar_kernel_reads_the_declared_name_and_works() {
+        Python::initialize();
+        Python::attach(|py| {
+            let capsule = capsule_with_named_kernel(py, "test_kernel");
+            let (name, kernel) = import_sedona_ffi_scalar_kernel(capsule.as_any()).unwrap();
+            assert_eq!(name, "test_kernel");
+
+            // Not just a name round-trip -- the imported kernel is a real,
+            // callable SedonaScalarKernel.
+            let sedona_type = SedonaType::Arrow(DataType::Int64);
+            let resolved = kernel
+                .return_type_from_args_and_scalars(std::slice::from_ref(&sedona_type), &[None])
+                .unwrap();
+            assert_eq!(resolved, Some(sedona_type));
+        });
+    }
+
+    #[test]
+    fn import_sedona_ffi_scalar_kernel_rejects_wrong_capsule_name() {
+        Python::initialize();
+        Python::attach(|py| {
+            let kernel = SimpleSedonaScalarKernel::new_ref(
+                ArgMatcher::new(
+                    vec![ArgMatcher::is_numeric()],
+                    SedonaType::Arrow(DataType::Int64),
+                ),
+                Arc::new(|_, args| Ok(args[0].clone())),
+            );
+            let exported = ExportedScalarKernel::from(kernel);
+            let ffi_kernel = SedonaCScalarKernel::from(exported);
+            // Wrong capsule name -- e.g. a __sedonadb_table_provider__
+            // capsule accidentally handed to the scalar-kernel importer.
+            let capsule = PyCapsule::new_with_value(py, ffi_kernel, c"some_other_name").unwrap();
+            assert!(import_sedona_ffi_scalar_kernel(capsule.as_any()).is_err());
+        });
+    }
+
+    #[test]
+    fn import_sedona_ffi_scalar_kernel_rejects_double_import_safely() {
+        // The capsule's contents are zeroed on first read to prevent a
+        // double-free when the PyCapsule's own destructor later runs.
+        // Reading it again must fail cleanly, not read garbage or crash.
+        Python::initialize();
+        Python::attach(|py| {
+            let capsule = capsule_with_named_kernel(py, "test_kernel");
+            import_sedona_ffi_scalar_kernel(capsule.as_any()).unwrap();
+            let second = import_sedona_ffi_scalar_kernel(capsule.as_any());
+            assert!(second.is_err());
+        });
+    }
+
+    #[test]
+    fn import_sedona_ffi_scalar_kernel_rejects_non_capsule_input() {
+        Python::initialize();
+        Python::attach(|py| {
+            let not_a_capsule = py.eval(c"42", None, None).unwrap();
+            assert!(import_sedona_ffi_scalar_kernel(&not_a_capsule).is_err());
+        });
+    }
 }

--- a/python/sedonadb/src/import_from.rs
+++ b/python/sedonadb/src/import_from.rs
@@ -105,14 +105,14 @@ pub fn import_sedona_ffi_table_provider(
 /// used by `sedona-extension` to statically link in kernels at build time
 /// (see `c/sedona-s2geography`); this is the runtime counterpart, letting an
 /// out-of-tree plugin hand in a real `SedonaScalarKernel` -- no Python
-/// callback per invocation -- via `__sedonadb_native_scalar_udfs__`.
+/// callback per invocation -- via `__sedonadb_scalar_udf__`.
 ///
 /// Returns the kernel's own declared name (read from the capsule via
 /// [`ImportedScalarKernel::function_name`], not supplied by the caller) so
-/// multiple kernels sharing one name can be grouped into a single overloaded
-/// [`sedona_expr::scalar_udf::SedonaScalarUDF`] by the caller, the same way
-/// [`sedona::context::SedonaContext::register_scalar_kernels`] already
-/// groups statically-linked kernels.
+/// the overload kernels of one function can be grouped into a single
+/// overloaded [`sedona_expr::scalar_udf::SedonaScalarUDF`] by the caller, the
+/// same way [`sedona::context::SedonaContext::register_scalar_kernels`]
+/// already groups statically-linked kernels.
 pub fn import_sedona_ffi_scalar_kernel(
     obj: &Bound<PyAny>,
 ) -> Result<(String, ScalarKernelRef), PySedonaError> {

--- a/python/sedonadb/src/lib.rs
+++ b/python/sedonadb/src/lib.rs
@@ -18,7 +18,7 @@
 use crate::{
     error::PySedonaError,
     raster_loader::py_raster_loader,
-    udf::{sedona_aggregate_udf, sedona_scalar_udf},
+    udf::{sedona_aggregate_udf, sedona_native_scalar_udf, sedona_scalar_udf},
 };
 use pyo3::{exceptions::PyValueError, ffi::Py_uintptr_t, prelude::*};
 use sedona_adbc::AdbcSedonadbDriverInit;
@@ -168,6 +168,7 @@ fn _lib(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(schema::raster_type, m)?)?;
     m.add_function(wrap_pyfunction!(sedona_adbc_driver_init, m)?)?;
     m.add_function(wrap_pyfunction!(sedona_aggregate_udf, m)?)?;
+    m.add_function(wrap_pyfunction!(sedona_native_scalar_udf, m)?)?;
     m.add_function(wrap_pyfunction!(sedona_python_features, m)?)?;
     m.add_function(wrap_pyfunction!(sedona_python_version, m)?)?;
     m.add_function(wrap_pyfunction!(sedona_scalar_udf, m)?)?;

--- a/python/sedonadb/src/udf.rs
+++ b/python/sedonadb/src/udf.rs
@@ -41,7 +41,10 @@ use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
 use crate::{
     error::PySedonaError,
     expr::PyExpr,
-    import_from::{check_pycapsule, import_arg_matcher, import_arrow_array, import_sedona_type},
+    import_from::{
+        check_pycapsule, import_arg_matcher, import_arrow_array, import_sedona_ffi_scalar_kernel,
+        import_sedona_type,
+    },
     schema::PySedonaType,
 };
 
@@ -204,6 +207,58 @@ pub fn sedona_scalar_udf<'py>(
 
     Ok(PySedonaScalarUdf {
         inner: sedona_scalar_udf,
+    })
+}
+
+/// Build a [`PySedonaScalarUdf`] from one or more natively-compiled kernel
+/// capsules (see [`crate::import_from::import_sedona_ffi_scalar_kernel`]),
+/// instead of `sedona_scalar_udf`'s single Python-callable kernel. Real
+/// compiled Rust runs per invocation -- no GIL re-entry, no Python callback
+/// per batch.
+///
+/// `kernels` are typically the overloads of one logical function (e.g. a
+/// plugin's own `tn_add(Tensor, Tensor)` and any other signatures it
+/// supports) -- each capsule's own declared name (read from the kernel
+/// itself, not supplied here) must agree, or this errors rather than
+/// silently registering under a name that doesn't match every kernel.
+/// `name` defaults to that shared name if not given.
+///
+/// Unlike `register()`'s `__sedonadb_native_scalar_udfs__` protocol (which
+/// always registers Immutable), `volatility` is caller-supplied here -- a
+/// plugin kernel that needs Volatile or Stable (e.g. one reading external
+/// state per call, like `RS_FromPath`) should build its `PySedonaScalarUdf`
+/// with this function directly and return it via the existing
+/// `__sedonadb_internal_udf__` protocol instead.
+#[pyfunction]
+#[pyo3(signature = (kernels, volatility="immutable", name=None))]
+pub fn sedona_native_scalar_udf(
+    kernels: Vec<Bound<PyAny>>,
+    volatility: &str,
+    name: Option<&str>,
+) -> Result<PySedonaScalarUdf, PySedonaError> {
+    let volatility = parse_volatility(volatility)?;
+
+    let imported = kernels
+        .iter()
+        .map(import_sedona_ffi_scalar_kernel)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut names = imported.iter().map(|(n, _)| n.as_str());
+    let declared_name = names.next().ok_or_else(|| {
+        PySedonaError::SedonaPython("sedona_native_scalar_udf: kernels must be non-empty".into())
+    })?;
+    if let Some(mismatched) = names.find(|n| *n != declared_name) {
+        return Err(PySedonaError::SedonaPython(format!(
+            "sedona_native_scalar_udf: kernels have mismatched names \
+             ('{declared_name}' vs '{mismatched}') -- pass same-named \
+             overloads only, or build separate UDFs"
+        )));
+    }
+    let udf_name = name.unwrap_or(declared_name).to_string();
+
+    let kernel_refs = imported.into_iter().map(|(_, k)| k).collect();
+    Ok(PySedonaScalarUdf {
+        inner: SedonaScalarUDF::new(&udf_name, kernel_refs, volatility),
     })
 }
 
@@ -684,5 +739,168 @@ impl Accumulator for PySedonaAccumulator {
         // for v1 (a conservative under-estimate). A future `mem_used()` hook on
         // the Python class could report the true size.
         std::mem::size_of::<Self>()
+    }
+}
+
+#[cfg(test)]
+mod native_scalar_udf_tests {
+    use super::*;
+    use arrow_schema::DataType;
+    use sedona::context::SedonaContext;
+    use sedona_expr::scalar_udf::SimpleSedonaScalarKernel;
+    use sedona_extension::{extension::SedonaCScalarKernel, scalar_kernel::ExportedScalarKernel};
+
+    fn identity_kernel_capsule<'py>(py: Python<'py>, function_name: &str) -> Bound<'py, PyCapsule> {
+        identity_kernel_capsule_for_type(py, function_name, SedonaType::Arrow(DataType::Int64))
+    }
+
+    /// Like `identity_kernel_capsule`, but matching only the exact given
+    /// type (not the broad `is_numeric()` category) -- lets a grouping test
+    /// prove two kernels are genuinely both present, rather than one kernel
+    /// alone happening to already cover both cases.
+    fn identity_kernel_capsule_for_type<'py>(
+        py: Python<'py>,
+        function_name: &str,
+        exact_type: SedonaType,
+    ) -> Bound<'py, PyCapsule> {
+        let kernel = SimpleSedonaScalarKernel::new_ref(
+            ArgMatcher::new(vec![ArgMatcher::is_exact(exact_type.clone())], exact_type),
+            Arc::new(|_, args| Ok(args[0].clone())),
+        );
+        let exported = ExportedScalarKernel::from(kernel).with_function_name(function_name);
+        let ffi_kernel = SedonaCScalarKernel::from(exported);
+        PyCapsule::new_with_value(py, ffi_kernel, c"sedonadb_scalar_kernel").unwrap()
+    }
+
+    #[test]
+    fn sedona_native_scalar_udf_builds_a_working_udf() {
+        Python::initialize();
+        Python::attach(|py| {
+            let capsule = identity_kernel_capsule(py, "probe_e2e");
+            let udf =
+                sedona_native_scalar_udf(vec![capsule.into_any()], "immutable", None).unwrap();
+            assert_eq!(udf.name(), "probe_e2e");
+        });
+    }
+
+    /// Two distinct kernel capsules sharing one declared name, but matching
+    /// disjoint exact types, must become one SedonaScalarUDF with *both*
+    /// kernels dispatchable as overloads -- not two separate UDFs, and not
+    /// silently dropping one. `SedonaScalarUDF` has no public kernel-count
+    /// accessor, so this is proven functionally: register the grouped UDF
+    /// into a real context and confirm SQL dispatches correctly to each
+    /// kernel by its argument type.
+    #[tokio::test]
+    async fn sedona_native_scalar_udf_groups_same_named_kernels_into_one_overloaded_udf() {
+        Python::initialize();
+        let udf = Python::attach(|py| {
+            let int_kernel = identity_kernel_capsule_for_type(
+                py,
+                "probe_grouped",
+                SedonaType::Arrow(DataType::Int64),
+            );
+            let float_kernel = identity_kernel_capsule_for_type(
+                py,
+                "probe_grouped",
+                SedonaType::Arrow(DataType::Float64),
+            );
+            sedona_native_scalar_udf(
+                vec![int_kernel.into_any(), float_kernel.into_any()],
+                "immutable",
+                None,
+            )
+            .unwrap()
+        });
+        assert_eq!(udf.name(), "probe_grouped");
+
+        let ctx = SedonaContext::new();
+        ctx.register_sedona_scalar_udf(udf.inner).unwrap();
+
+        let int_batches = ctx
+            .sql("SELECT probe_grouped(42) AS x")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        let int_col = int_batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow_array::Int64Array>()
+            .unwrap();
+        assert_eq!(int_col.value(0), 42);
+
+        let float_batches = ctx
+            .sql("SELECT probe_grouped(4.5) AS x")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        let float_col = float_batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow_array::Float64Array>()
+            .unwrap();
+        assert_eq!(float_col.value(0), 4.5);
+    }
+
+    #[test]
+    fn sedona_native_scalar_udf_rejects_mismatched_names() {
+        Python::initialize();
+        Python::attach(|py| {
+            let a = identity_kernel_capsule(py, "probe_a");
+            let b = identity_kernel_capsule(py, "probe_b");
+            let result =
+                sedona_native_scalar_udf(vec![a.into_any(), b.into_any()], "immutable", None);
+            let err = match result {
+                Err(e) => e,
+                Ok(_) => panic!("expected an error"),
+            };
+            assert!(err.to_string().contains("mismatched names"));
+        });
+    }
+
+    #[test]
+    fn sedona_native_scalar_udf_rejects_empty_kernel_list() {
+        // No capsule involved at all -- doesn't need a live interpreter.
+        assert!(sedona_native_scalar_udf(vec![], "immutable", None).is_err());
+    }
+
+    #[test]
+    fn sedona_native_scalar_udf_name_override_wins_over_declared_name() {
+        Python::initialize();
+        Python::attach(|py| {
+            let capsule = identity_kernel_capsule(py, "probe_e2e");
+            let udf =
+                sedona_native_scalar_udf(vec![capsule.into_any()], "immutable", Some("renamed"))
+                    .unwrap();
+            assert_eq!(udf.name(), "renamed");
+        });
+    }
+
+    /// The real end-to-end proof: an imported native kernel, registered into
+    /// a live SedonaContext, actually executes via a real SQL query -- not
+    /// just constructs without error.
+    #[tokio::test]
+    async fn native_scalar_udf_executes_via_real_sql() {
+        Python::initialize();
+        let udf = Python::attach(|py| {
+            let capsule = identity_kernel_capsule(py, "probe_e2e");
+            sedona_native_scalar_udf(vec![capsule.into_any()], "immutable", None).unwrap()
+        });
+
+        let ctx = SedonaContext::new();
+        ctx.register_sedona_scalar_udf(udf.inner).unwrap();
+
+        let df = ctx.sql("SELECT probe_e2e(42) AS x").await.unwrap();
+        let batches = df.collect().await.unwrap();
+        assert_eq!(batches.len(), 1);
+        let column = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow_array::Int64Array>()
+            .unwrap();
+        assert_eq!(column.value(0), 42);
     }
 }

--- a/python/sedonadb/src/udf.rs
+++ b/python/sedonadb/src/udf.rs
@@ -36,6 +36,7 @@ use pyo3::{
 };
 use sedona_expr::aggregate_udf::{SedonaAccumulator, SedonaAccumulatorRef, SedonaAggregateUDF};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
+use sedona_extension::{extension::SedonaCScalarKernel, scalar_kernel::ExportedScalarKernel};
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
 
 use crate::{
@@ -159,6 +160,35 @@ impl PySedonaScalarUdf {
             c"datafusion_scalar_udf",
         )?)
     }
+
+    /// Export this UDF's overload kernels as native kernel capsules.
+    ///
+    /// Each kernel becomes a `PyCapsule` wrapping a [`SedonaCScalarKernel`],
+    /// stamped with this UDF's SQL name -- the same capsule shape
+    /// [`crate::import_from::import_sedona_ffi_scalar_kernel`] reads back in.
+    /// This is the export counterpart of the `__sedonadb_scalar_udf__`
+    /// registration protocol: a component exposing this method hands its
+    /// function's kernels to another SedonaDB instance (or back to this one
+    /// under a new name), no Python callback per invocation.
+    fn __sedonadb_scalar_udf__<'py>(
+        &self,
+        py: Python<'py>,
+    ) -> Result<Vec<Bound<'py, PyCapsule>>, PySedonaError> {
+        let name = self.inner.name();
+        self.inner
+            .kernels()
+            .iter()
+            .map(|kernel| {
+                let exported = ExportedScalarKernel::from(kernel.clone()).with_function_name(name);
+                let ffi = SedonaCScalarKernel::from(exported);
+                Ok(PyCapsule::new_with_value(
+                    py,
+                    ffi,
+                    c"sedonadb_scalar_kernel",
+                )?)
+            })
+            .collect()
+    }
 }
 
 /// Parse a Python-supplied volatility string into a [Volatility].
@@ -223,12 +253,12 @@ pub fn sedona_scalar_udf<'py>(
 /// silently registering under a name that doesn't match every kernel.
 /// `name` defaults to that shared name if not given.
 ///
-/// Unlike `register()`'s `__sedonadb_native_scalar_udfs__` protocol (which
-/// always registers Immutable), `volatility` is caller-supplied here -- a
-/// plugin kernel that needs Volatile or Stable (e.g. one reading external
-/// state per call, like `RS_FromPath`) should build its `PySedonaScalarUdf`
-/// with this function directly and return it via the existing
-/// `__sedonadb_internal_udf__` protocol instead.
+/// Unlike `register()`'s `__sedonadb_scalar_udf__` protocol (which always
+/// registers Immutable), `volatility` is caller-supplied here -- a plugin
+/// kernel that needs Volatile or Stable (e.g. one reading external state per
+/// call, like `RS_FromPath`) should build its `PySedonaScalarUdf` with this
+/// function directly and return it via the existing `__sedonadb_internal_udf__`
+/// protocol instead.
 #[pyfunction]
 #[pyo3(signature = (kernels, volatility="immutable", name=None))]
 pub fn sedona_native_scalar_udf(
@@ -748,7 +778,6 @@ mod native_scalar_udf_tests {
     use arrow_schema::DataType;
     use sedona::context::SedonaContext;
     use sedona_expr::scalar_udf::SimpleSedonaScalarKernel;
-    use sedona_extension::{extension::SedonaCScalarKernel, scalar_kernel::ExportedScalarKernel};
 
     fn identity_kernel_capsule<'py>(py: Python<'py>, function_name: &str) -> Bound<'py, PyCapsule> {
         identity_kernel_capsule_for_type(py, function_name, SedonaType::Arrow(DataType::Int64))

--- a/python/sedonadb/tests/test_udf.py
+++ b/python/sedonadb/tests/test_udf.py
@@ -226,9 +226,9 @@ def test_native_scalar_udf_export_import_roundtrip(con):
     # Exporting those capsules and rebuilding a UDF under a new name must
     # produce a function whose output is identical to the built-in's, proving
     # the native kernels survive a full export -> capsule -> import roundtrip.
-    from sedonadb._lib import sedona_native_scalar_udf
+    from sedonadb.udf import sedona_native_scalar_udf
 
-    st_asbinary = con.funcs.st_asbinary._impl
+    st_asbinary = con.funcs.st_asbinary
     assert hasattr(st_asbinary, "__sedonadb_scalar_udf__")
 
     capsules = st_asbinary.__sedonadb_scalar_udf__()
@@ -252,3 +252,43 @@ def test_native_scalar_udf_export_import_roundtrip(con):
     ).to_arrow_table()
 
     assert actual.equals(expected)
+
+
+def test_native_scalar_udf_register_appends_overload(con):
+    # Registering a native scalar UDF under a name already in use appends its
+    # kernels as overloads rather than replacing the function: both the
+    # previously registered signature and the newly registered one stay
+    # dispatchable. Two built-ins with disjoint input types are exported and
+    # re-registered under one shared name -- ST_AsBinary takes a geometry,
+    # ST_GeomFromWKT takes a WKT string. If registration replaced rather than
+    # appended, the geometry overload registered first would vanish and calling
+    # it would raise "No kernel matching arguments".
+    from sedonadb.udf import sedona_native_scalar_udf
+
+    name = "rt_overload_probe"
+
+    con.register(
+        sedona_native_scalar_udf(
+            con.funcs.st_asbinary.__sedonadb_scalar_udf__(), name=name
+        )
+    )
+    con.register(
+        sedona_native_scalar_udf(
+            con.funcs.st_geomfromwkt.__sedonadb_scalar_udf__(), name=name
+        )
+    )
+
+    # The geometry -> binary overload registered first is still reachable...
+    assert (
+        con.sql(f"SELECT {name}(ST_Point(30.0, 10.0)) AS col")
+        .to_arrow_table()
+        .equals(
+            con.sql("SELECT ST_AsBinary(ST_Point(30.0, 10.0)) AS col").to_arrow_table()
+        )
+    )
+
+    # ...and the WKT-string -> geometry overload appended second dispatches too.
+    pd.testing.assert_frame_equal(
+        con.sql(f"SELECT ST_AsText({name}('POINT (1 2)')) AS col").to_pandas(),
+        pd.DataFrame({"col": ["POINT(1 2)"]}),
+    )

--- a/python/sedonadb/tests/test_udf.py
+++ b/python/sedonadb/tests/test_udf.py
@@ -218,3 +218,37 @@ def test_udf_bad_return_length(con):
         match="Expected result of user-defined function to return array of length 1 but got 2",
     ):
         con.sql("SELECT questionable_udf(123) as col").to_pandas()
+
+
+def test_native_scalar_udf_export_import_roundtrip(con):
+    # A SedonaDB built-in scalar function exposes its native overload kernels
+    # via __sedonadb_scalar_udf__ (the export side of the plugin protocol).
+    # Exporting those capsules and rebuilding a UDF under a new name must
+    # produce a function whose output is identical to the built-in's, proving
+    # the native kernels survive a full export -> capsule -> import roundtrip.
+    from sedonadb._lib import sedona_native_scalar_udf
+
+    st_asbinary = con.funcs.st_asbinary._impl
+    assert hasattr(st_asbinary, "__sedonadb_scalar_udf__")
+
+    capsules = st_asbinary.__sedonadb_scalar_udf__()
+    assert len(capsules) >= 1
+
+    # Rebuild under a fresh name so it doesn't collide with the built-in, then
+    # register it back into the same context.
+    rebuilt = sedona_native_scalar_udf(capsules, name="rt_asbinary_roundtrip")
+    con.register(rebuilt)
+
+    # Run both the built-in and the reimported UDF over a real one-row table
+    # column (not a literal) so the full execution path runs.
+    con.sql("SELECT ST_Point(30.0, 10.0) AS geom").to_view(
+        "rt_native_roundtrip", overwrite=True
+    )
+    expected = con.sql(
+        "SELECT ST_AsBinary(geom) AS col FROM rt_native_roundtrip"
+    ).to_arrow_table()
+    actual = con.sql(
+        "SELECT rt_asbinary_roundtrip(geom) AS col FROM rt_native_roundtrip"
+    ).to_arrow_table()
+
+    assert actual.equals(expected)

--- a/rust/sedona-expr/src/scalar_udf.rs
+++ b/rust/sedona-expr/src/scalar_udf.rs
@@ -227,6 +227,15 @@ impl SedonaScalarUDF {
         &self.metadata
     }
 
+    /// The kernels (overload implementations) this UDF dispatches to.
+    ///
+    /// Exposed so a UDF's kernels can be exported across the
+    /// `sedona-extension` FFI boundary (e.g. handed to an out-of-tree
+    /// plugin as capsules).
+    pub fn kernels(&self) -> &[ScalarKernelRef] {
+        &self.kernels
+    }
+
     /// Create a SedonaScalarUDF from a single kernel
     ///
     /// This constructor creates a [Volatility::Immutable] function with no documentation

--- a/rust/sedona/src/context.rs
+++ b/rust/sedona/src/context.rs
@@ -435,6 +435,30 @@ impl SedonaContext {
         Ok(())
     }
 
+    /// Append kernels as overloads to a scalar UDF, creating it if absent.
+    ///
+    /// Unlike [`Self::register_sedona_scalar_udf`], which replaces any
+    /// same-named UDF outright, this appends `kernels` to the existing UDF of
+    /// that name (creating a new UDF if none exists yet). Because a
+    /// [`SedonaScalarUDF`] resolves kernels newest-first, an appended kernel
+    /// whose signature matches an existing overload wins for that signature —
+    /// a per-signature ("kernel-level") override — while the function's other
+    /// overloads stay reachable. Mirrors [`Self::register_scalar_kernels`] but
+    /// runs behind `&self` via the interior-mutable `functions` lock, so it is
+    /// callable from the `&self` Python registration path.
+    pub fn append_sedona_scalar_kernels(
+        &self,
+        name: &str,
+        kernels: impl IntoScalarKernelRefs,
+    ) -> Result<()> {
+        let mut functions = self.functions_mut()?;
+        let udf = functions.add_scalar_udf_impl(name, kernels)?.clone();
+        drop(functions);
+
+        self.ctx.register_udf(udf.into());
+        Ok(())
+    }
+
     pub fn register_sedona_aggregate_udf(&self, udf: SedonaAggregateUDF) -> Result<()> {
         let name = udf.name().to_string();
         let mut functions = self.functions_mut()?;


### PR DESCRIPTION
## What

Adds a runtime import path for natively-compiled scalar UDFs: an out-of-tree plugin can now hand SedonaDB a real `SedonaScalarKernel` (real compiled Rust, no Python callback per invocation) via a `PyCapsule`, the same way `sedona-extension`'s `SedonaCScalarKernel` ABI is already used to statically link in kernels at build time (see `c/sedona-s2geography`) -- this is the runtime counterpart of that same mechanism.

Concretely: `SedonaContext.register()` gains a new protocol, `__sedonadb_native_scalar_udfs__(self) -> list[PyCapsule]`, alongside the existing `__sedonadb_internal_udf__`/`__sedonadb_internal_aggregate_udf__`/`__sedonadb_external_format__`/`__sedonadb_raster_loader__`.

## Why

Today, `SedonaContext.register()`'s only path for a *scalar function* is `arrow_udf`/`sedona_scalar_udf` -- a Python callable invoked once per batch. There's no way for an out-of-tree crate (depending on `sedona-schema`/`sedona-expr` directly, like a prototype extension building a real `SedonaScalarKernel` with its own `ArgMatcher`-based dispatch) to register that kernel and get real Rust dispatch from a Python `SedonaContext` -- only a Python-callback wrapper around it. This closes that gap using the ABI SedonaDB already has, rather than inventing a new one.

## What's in it

- `import_sedona_ffi_scalar_kernel` (`import_from.rs`): imports a `PyCapsule` wrapping a `SedonaCScalarKernel` into a real `ScalarKernelRef`, reading the kernel's own declared name. Mirrors `import_sedona_ffi_table_provider`'s existing pattern exactly, including the double-free-prevention `ptr::read` + `ptr::write_bytes` zeroing.
- `sedona_native_scalar_udf` (`udf.rs`): a standalone pyfunction building a `PySedonaScalarUdf` from one or more same-named kernel capsules (errors on a name mismatch rather than silently registering under the wrong name) -- usable directly, the native-kernel analog of the existing `sedona_scalar_udf`. Also the documented escape hatch for a kernel that needs `Volatile`/`Stable` (see below).
- `register_component()` (`context.rs`): the new `__sedonadb_native_scalar_udfs__` branch. A plugin's capsules can span multiple distinct function names in one call; grouped by each kernel's own declared name before registering.
- `context.py`: `__sedonadb_native_scalar_udfs__` added to `register()`'s `supported_interfaces` and docstring.

## Two real limitations, documented rather than hidden

- **Registration replaces, it doesn't accumulate.** Grouping by name is scoped to one `__sedonadb_native_scalar_udfs__()` call's own capsule list -- it does *not* accumulate across calls the way `SedonaContext::register_scalar_kernels` accumulates statically-linked kernels. Registering under a name already in use (a plugin's own, a different plugin's, or a built-in's) replaces it outright -- a plain `HashMap` insert, the same as the existing `__sedonadb_internal_udf__` path already does. Not a new risk this PR introduces, but worth being explicit about in the code rather than implying false parity with the accumulate-behavior of `register_scalar_kernels`.
- **Volatility is always `Immutable` through this protocol** -- a bare capsule has nowhere to carry a volatility value, and this is not because every native kernel is `Immutable` (`RS_FromPath` is `Volatile`). A plugin kernel that needs `Volatile`/`Stable` should call `sedona_native_scalar_udf(kernels, volatility=...)` directly and return the resulting `PySedonaScalarUdf` via the existing `__sedonadb_internal_udf__` protocol instead.

## What's NOT in it

- Aggregate UDFs. `SedonaCScalarKernel` has no aggregate equivalent yet -- an accumulator's stateful lifecycle (create/update/merge/evaluate/state/size, to participate correctly in DataFusion's own parallel aggregation) needs a materially larger C ABI than a stateless scalar kernel's. This PR is scoped to the scalar case; the aggregate ABI is a separate design question.
- A Python-exposed way to build an `ArgMatcher::is_extension(name)`-style matcher (`import_arg_matcher` still only recognizes the fixed literal set). Not a blocker here: a plugin's own `ArgMatcher` lives entirely inside its compiled kernel's `return_type()` and never crosses the Python boundary, so this only matters for someone trying to express that matcher from pure Python via `arrow_udf`.

## Verification

- 10 real, executed tests (`import_from.rs`, `udf.rs`): capsule import + functional kernel invocation, rejecting a wrong capsule name, rejecting a second import of an already-consumed capsule, rejecting non-capsule input, building a working UDF, grouping two *disjoint-type* kernels into one overloaded UDF and dispatching both correctly via real SQL (`probe_grouped(42)` and `probe_grouped(4.5)` each hitting their own kernel), rejecting mismatched kernel names, rejecting an empty kernel list, an explicit name override, and a full SQL query executed through a live `SedonaContext` against an imported native kernel.
- Getting real coverage needed one addition: `pyo3 = { workspace = true, features = ["auto-initialize"] }` under `[dev-dependencies]`. `extension-module` (needed for the real wheel build) is only ever added by `maturin`'s own build flags (`pyproject.toml`), never by this crate's `Cargo.toml` -- so it's never present during `cargo test`, including `cargo test --all-features` (CI's actual invocation). Confirmed directly that the two configurations don't collide: explicitly compiling with `--features pyo3/extension-module` does fail to link (undefined libpython symbols), but that's never what `cargo test` requests.
- `cargo check`/`clippy --all-targets --all-features -- -D warnings`/`fmt --all -- --check` for the whole workspace (excluding the environment-only `gdal-sys` bindgen issue on this machine, unrelated to this change) -- clean.
- Built the real wheel (`maturin develop --release`) and ran the full existing `python/sedonadb` pytest suite against it: 2543 passed, 1753 skipped (optional deps not installed in this verification venv) -- zero regressions from this purely additive change.
