### PR TITLE
fix(rust/sedona-spatial-join): Fix geography scalar functions failing over spatial join output

### DIFF
--- a/c/sedona-extension/src/scalar_kernel.rs
+++ b/c/sedona-extension/src/scalar_kernel.rs
@@ -17,7 +17,7 @@
 
 use arrow_array::{
     ffi::{from_ffi_and_data_type, FFI_ArrowArray, FFI_ArrowSchema},
-    make_array, ArrayRef,
+    make_array, new_empty_array, ArrayRef,
 };
 use arrow_schema::{ArrowError, Field};
 use datafusion_common::config::ConfigOptions;
@@ -104,6 +104,19 @@ impl SedonaScalarKernel for ImportedScalarKernel {
         num_rows: usize,
         _config_options: Option<&ConfigOptions>,
     ) -> Result<ColumnarValue> {
+        // Zero-length array inputs can't be passed to the C kernel: implementations
+        // may broadcast scalar arguments using modulo indexing (e.g., the
+        // sedona-s2geography kernels reject empty arrays for this reason).
+        if num_rows == 0
+            && args
+                .iter()
+                .any(|arg| matches!(arg, ColumnarValue::Array(_)))
+        {
+            return Ok(ColumnarValue::Array(new_empty_array(
+                return_type.storage_type(),
+            )));
+        }
+
         let arg_scalars = args
             .iter()
             .map(|arg| {
@@ -737,6 +750,43 @@ mod test {
             err.message(),
             "simple_udf_from_ffi(): No kernel matching arguments"
         );
+    }
+
+    #[test]
+    fn empty_array_input() {
+        // Mimic the sedona-s2geography kernels, which reject zero-length array
+        // inputs because they broadcast scalar arguments using modulo indexing
+        let kernel = SimpleSedonaScalarKernel::new_ref(
+            ArgMatcher::new(vec![ArgMatcher::is_geometry()], WKB_GEOMETRY),
+            Arc::new(|_, args| {
+                for arg in args {
+                    if let ColumnarValue::Array(array) = arg {
+                        if array.is_empty() {
+                            return exec_err!("Array input must not be empty");
+                        }
+                    }
+                }
+                Ok(args[0].clone())
+            }),
+        );
+
+        let exported_kernel = ExportedScalarKernel::from(kernel.clone());
+        let ffi_kernel = SedonaCScalarKernel::from(exported_kernel);
+        let imported_kernel = ImportedScalarKernel::try_from(ffi_kernel).unwrap();
+
+        let udf_from_ffi = SedonaScalarUDF::new(
+            "simple_udf_from_ffi",
+            vec![Arc::new(imported_kernel)],
+            Volatility::Immutable,
+        );
+
+        let tester = ScalarUdfTester::new(udf_from_ffi.into(), vec![WKB_GEOMETRY]);
+        tester.assert_return_type(WKB_GEOMETRY);
+
+        let empty_array = create_array(&[], &WKB_GEOMETRY);
+        let result = tester.invoke_array(empty_array).unwrap();
+        assert_eq!(result.len(), 0);
+        assert_eq!(result.data_type(), WKB_GEOMETRY.storage_type());
     }
 
     #[test]

--- a/rust/sedona-spatial-join/src/stream.rs
+++ b/rust/sedona-spatial-join/src/stream.rs
@@ -1375,7 +1375,15 @@ impl SpatialJoinBatchIterator {
             probe_indices_array,
             probe_range,
         )?;
-        Ok(Some(batch))
+
+        // Join types that don't produce unmatched probe rows (e.g. inner joins) end up
+        // with an empty batch here; don't emit it. build_joined_batch was still called
+        // for its visited-bitmap bookkeeping.
+        if batch.num_rows() > 0 {
+            Ok(Some(batch))
+        } else {
+            Ok(None)
+        }
     }
 
     fn drain_produced_indices(&self, progress: &mut ProbeProgress) {

--- a/rust/sedona-spatial-join/tests/spatial_join_integration.rs
+++ b/rust/sedona-spatial-join/tests/spatial_join_integration.rs
@@ -619,6 +619,62 @@ async fn test_spatial_join_with_filter() -> Result<()> {
     Ok(())
 }
 
+/// The spatial join should never emit empty batches. Scalar UDFs backed by C
+/// implementations reject zero-length array inputs, and some consumers of our
+/// Arrow output (e.g. lonboard) reject empty batches, so a selective join used
+/// to break any query applying a scalar function on top of its output.
+/// See https://github.com/apache/sedona-db/issues/1084
+#[tokio::test]
+async fn test_no_empty_batches_in_join_output() -> Result<()> {
+    let ((left_schema, left_partitions), (right_schema, right_partitions)) =
+        create_test_data_with_size_range((0.1, 10.0), WKB_GEOMETRY)?;
+
+    let ctx = setup_context(Some(SpatialJoinOptions::default()), 10)?;
+    let mem_table_left: Arc<dyn TableProvider> =
+        Arc::new(MemTable::try_new(left_schema, left_partitions)?);
+    let mem_table_right: Arc<dyn TableProvider> =
+        Arc::new(MemTable::try_new(right_schema, right_partitions)?);
+    ctx.register_table("L", mem_table_left)?;
+    ctx.register_table("R", mem_table_right)?;
+
+    // A join producing matches for some probe batches, and a very selective join
+    // producing no matches at all; neither should emit empty batches
+    for sql in [
+        "SELECT L.id, R.id FROM L JOIN R ON ST_Intersects(L.geometry, R.geometry)",
+        "SELECT L.id, R.id FROM L JOIN R ON ST_Intersects(L.geometry, R.geometry) AND L.dist > R.dist + 1e9",
+    ] {
+        let df = ctx.sql(sql).await?;
+        let plan = df.create_physical_plan().await?;
+        let spatial_join =
+            find_spatial_join_exec_arc(&plan)?.expect("plan should contain SpatialJoinExec");
+
+        for partition in 0..spatial_join.output_partitioning().partition_count() {
+            let stream = spatial_join.execute(partition, ctx.task_ctx())?;
+            let batches = datafusion_physical_plan::common::collect(stream).await?;
+            assert!(
+                batches.iter().all(|batch| batch.num_rows() > 0),
+                "Spatial join emitted an empty batch for partition {partition} of query {sql}"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn find_spatial_join_exec_arc(
+    plan: &Arc<dyn ExecutionPlan>,
+) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+    let mut found = None;
+    plan.apply(|node| {
+        if node.as_any().downcast_ref::<SpatialJoinExec>().is_some() {
+            found = Some(Arc::clone(node));
+            return Ok(TreeNodeRecursion::Stop);
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })?;
+    Ok(found)
+}
+
 #[rstest]
 #[tokio::test]
 async fn test_spatial_join_swap_inputs_produces_same_plan(


### PR DESCRIPTION
## What changes were proposed in this PR?

Applying a geography scalar function (`ST_Area`, `ST_Distance`, `ST_Intersection`, ...) to the output of a spatial join failed with `SedonaCScalarKernelImpl::execute failed: Array input must not be empty`. Two fixes, following the two directions suggested in the issue:

1. **Stop the spatial join from emitting empty batches.** `produce_last_result_batch` unconditionally returned the assembled "unmatched tail rows" batch, which is always zero-row for join types that don't produce unmatched probe rows (e.g. inner joins). So every probe batch whose trailing rows had no match pushed one empty batch downstream. It now suppresses empty batches (`build_joined_batch` is still called for its visited-bitmap bookkeeping). This also helps consumers that reject empty batches, such as lonboard.

2. **Handle zero-length array inputs in `ImportedScalarKernel`.** Imported C scalar kernels (sedona-s2geography) reject zero-length arrays because they broadcast scalar arguments using modulo indexing. The FFI wrapper now short-circuits `num_rows == 0` and returns an empty array of the return type without crossing the C boundary. Empty batches are legal in DataFusion streams, so scalar UDFs must tolerate them regardless of which operator produced them.

Note the bug was broader than reported in the issue: joins *with* matches also failed whenever any probe batch had unmatched trailing rows (which is nearly always the case for selective joins), so this broke most geography spatial joins with scalar functions applied on top.

## How was this patch tested?

- New unit test `empty_array_input` in `c/sedona-extension/src/scalar_kernel.rs`: an imported kernel that rejects empty input (mimicking the sedona-s2geography kernels) invoked with a zero-length array now returns a zero-length array. Fails without fix 2.
- New integration test `test_no_empty_batches_in_join_output` in `rust/sedona-spatial-join`: executes `SpatialJoinExec` partitions directly for a join with matches and a join with zero matches, asserting no emitted batch is empty. Fails without fix 1.
- Verified the reproduction from #1084 end to end with a `--features s2geography` build: the selective geography self-join now returns `0, NaN` (matching the empty equi-join behavior), and `ST_Area`/`ST_Intersection`/`ST_Distance` work over join output with and without matches.
- Full `sedona-extension` and `sedona-spatial-join` test suites pass.

## Did this PR include necessary documentation updates?

- No, this PR does not affect documentation.

Fixes #1084.
