### PR TITLE
fix(rust/sedona): Disable the default memory limit to avoid excessive spilling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2651,16 +2651,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dispatch2"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
-dependencies = [
- "bitflags",
- "objc2",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4367,15 +4357,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ntapi"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4477,63 +4458,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "objc2"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
-dependencies = [
- "objc2-encode",
-]
-
-[[package]]
-name = "objc2-core-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
-dependencies = [
- "bitflags",
- "dispatch2",
- "objc2",
-]
-
-[[package]]
-name = "objc2-encode"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
-
-[[package]]
-name = "objc2-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
-dependencies = [
- "bitflags",
- "objc2",
-]
-
-[[package]]
-name = "objc2-io-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
-dependencies = [
- "libc",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-open-directory"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
-dependencies = [
- "objc2",
- "objc2-core-foundation",
- "objc2-foundation",
 ]
 
 [[package]]
@@ -5785,7 +5709,6 @@ dependencies = [
  "sedona-tg",
  "serde",
  "serde_json",
- "sysinfo",
  "tempfile",
  "tokio",
  "url",
@@ -6966,21 +6889,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sysinfo"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9f9fe3d2b7b75cf4f2805e5b9926e8ac47146667b16b86298c4a8bf08cc469"
-dependencies = [
- "libc",
- "memchr",
- "ntapi",
- "objc2-core-foundation",
- "objc2-io-kit",
- "objc2-open-directory",
- "windows",
-]
-
-[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7681,27 +7589,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
-dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
-dependencies = [
- "windows-core",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7712,17 +7599,6 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
-dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
 ]
 
 [[package]]
@@ -7752,16 +7628,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
-dependencies = [
- "windows-core",
- "windows-link",
-]
 
 [[package]]
 name = "windows-result"
@@ -7848,15 +7714,6 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,6 @@ rand = "0.10"
 regex = "1.12"
 rstest = "0.26.1"
 serde = { version = "1", features = ["derive"] }
-sysinfo = "0.39"
 serde_json = { version = "1" }
 serde_with = { version = "3" }
 tempfile = { version = "3"}

--- a/docs/memory-management.ipynb
+++ b/docs/memory-management.ipynb
@@ -26,9 +26,9 @@
     "\n",
     "# Memory Management and Spilling\n",
     "\n",
-    "SedonaDB uses memory-limited execution with automatic spill-to-disk out of the box. By default, the memory limit is set to **75% of the system's physical memory** and memory is managed by a **fair** pool. When operators exceed their memory budget they automatically spill intermediate data to temporary files on disk and read them back as needed.\n",
+    "SedonaDB supports memory-limited execution with automatic spill-to-disk. When a memory limit is set, memory is managed by a **fair** pool by default, and operators that exceed their memory budget automatically spill intermediate data to temporary files on disk and read them back as needed.\n",
     "\n",
-    "This means SedonaDB works well for large datasets without any configuration. The sections below explain how to tune the defaults when needed."
+    "By default, no memory limit is enforced: operators can use as much memory as needed (until the process hits system limits) and won't spill to disk. The sections below explain how to enable and tune memory-limited execution."
    ]
   },
   {
@@ -38,7 +38,7 @@
    "source": [
     "## Configuring Memory Limits\n",
     "\n",
-    "By default, SedonaDB limits query execution memory to **75% of the system's physical memory**. You can override this by setting `memory_limit` on the context options before running your first query. The limit accepts an integer (bytes) or a human-readable string such as `\"4gb\"`, `\"512m\"`, or `\"1.5g\"`."
+    "To enable memory-limited execution, set `memory_limit` on the context options before running your first query. The limit accepts an integer (bytes) or a human-readable string such as `\"4gb\"`, `\"512m\"`, or `\"1.5g\"`."
    ]
   },
   {
@@ -59,14 +59,7 @@
    "id": "1fdc73aa",
    "metadata": {},
    "source": [
-    "To disable the memory limit entirely and use an unbounded memory pool, set `memory_limit` to `\"unlimited\"`:\n",
-    "\n",
-    "```python\n",
-    "sd = sedona.db.connect()\n",
-    "sd.options.memory_limit = \"unlimited\"\n",
-    "```\n",
-    "\n",
-    "In unbounded mode, operators can use as much memory as needed (until the process hits system limits) and typically won't spill to disk because there is no memory budget to enforce.\n",
+    "When no memory limit is set (the default), an unbounded memory pool is used: operators can use as much memory as needed (until the process hits system limits) and typically won't spill to disk because there is no memory budget to enforce.\n",
     "\n",
     "> **Note:** All runtime options (`memory_limit`, `memory_pool_type`, `temp_dir`, `unspillable_reserve_ratio`) must be set before the internal context is initialized. The internal context is created on the first call to `sd.sql(...)` (including `SET` statements) or any read method (for example, `sd.read_parquet(...)`) -- not when you call `.execute()` on the returned DataFrame. Once the internal context is created, these runtime options become read-only."
    ]
@@ -105,7 +98,7 @@
    "id": "bd4c0a76",
    "metadata": {},
    "source": [
-    "> **Note:** `memory_pool_type` only takes effect when a memory limit is active (i.e., `memory_limit` is not set to `\"unlimited\"`)."
+    "> **Note:** `memory_pool_type` only takes effect when a memory limit is set."
    ]
   },
   {

--- a/docs/memory-management.md
+++ b/docs/memory-management.md
@@ -19,13 +19,13 @@
 
 # Memory Management and Spilling
 
-SedonaDB uses memory-limited execution with automatic spill-to-disk out of the box. By default, the memory limit is set to **75% of the system's physical memory** and memory is managed by a **fair** pool. When operators exceed their memory budget they automatically spill intermediate data to temporary files on disk and read them back as needed.
+SedonaDB supports memory-limited execution with automatic spill-to-disk. When a memory limit is set, memory is managed by a **fair** pool by default, and operators that exceed their memory budget automatically spill intermediate data to temporary files on disk and read them back as needed.
 
-This means SedonaDB works well for large datasets without any configuration. The sections below explain how to tune the defaults when needed.
+By default, no memory limit is enforced: operators can use as much memory as needed (until the process hits system limits) and won't spill to disk. The sections below explain how to enable and tune memory-limited execution.
 
 ## Configuring Memory Limits
 
-By default, SedonaDB limits query execution memory to **75% of the system's physical memory**. You can override this by setting `memory_limit` on the context options before running your first query. The limit accepts an integer (bytes) or a human-readable string such as `"4gb"`, `"512m"`, or `"1.5g"`.
+To enable memory-limited execution, set `memory_limit` on the context options before running your first query. The limit accepts an integer (bytes) or a human-readable string such as `"4gb"`, `"512m"`, or `"1.5g"`.
 
 
 ```python
@@ -35,14 +35,7 @@ sd = sedona.db.connect()
 sd.options.memory_limit = "4gb"
 ```
 
-To disable the memory limit entirely and use an unbounded memory pool, set `memory_limit` to `"unlimited"`:
-
-```python
-sd = sedona.db.connect()
-sd.options.memory_limit = "unlimited"
-```
-
-In unbounded mode, operators can use as much memory as needed (until the process hits system limits) and typically won't spill to disk because there is no memory budget to enforce.
+When no memory limit is set (the default), an unbounded memory pool is used: operators can use as much memory as needed (until the process hits system limits) and typically won't spill to disk because there is no memory budget to enforce.
 
 > **Note:** All runtime options (`memory_limit`, `memory_pool_type`, `temp_dir`, `unspillable_reserve_ratio`) must be set before the internal context is initialized. The internal context is created on the first call to `sd.sql(...)` (including `SET` statements) or any read method (for example, `sd.read_parquet(...)`) -- not when you call `.execute()` on the returned DataFrame. Once the internal context is created, these runtime options become read-only.
 
@@ -64,7 +57,7 @@ sd.options.memory_limit = "4gb"
 sd.options.memory_pool_type = "greedy"
 ```
 
-> **Note:** `memory_pool_type` only takes effect when a memory limit is active (i.e., `memory_limit` is not set to `"unlimited"`).
+> **Note:** `memory_pool_type` only takes effect when a memory limit is set.
 
 ### Unspillable reserve ratio
 

--- a/python/sedonadb/python/sedonadb/_options.py
+++ b/python/sedonadb/python/sedonadb/_options.py
@@ -37,9 +37,9 @@ class Options:
     created will raise a `RuntimeError`:
 
     - `memory_limit`: Maximum memory for execution, in bytes or as a
-      human-readable string (e.g., `"4gb"`, `"512m"`). Set to
-      `"unlimited"` to disable the memory limit. Defaults to 75% of
-      system physical memory.
+      human-readable string (e.g., `"4gb"`, `"512m"`). Unlimited by
+      default; setting a limit enables memory-limited execution with
+      spill-to-disk.
     - `temp_dir`: Directory for temporary/spill files.
     - `memory_pool_type`: Memory pool type (`"greedy"` or `"fair"`).
       Defaults to `"fair"`.
@@ -49,7 +49,7 @@ class Options:
     Examples:
 
         >>> sd = sedona.db.connect()
-        >>> sd.options.memory_limit = "4gb"          # override default (75% of RAM)
+        >>> sd.options.memory_limit = "4gb"          # enable memory-limited execution
         >>> sd.options.memory_pool_type = "greedy"    # override default (fair)
         >>> sd.options.temp_dir = "/tmp/sedona-spill"
         >>> sd.options.interactive = True
@@ -129,9 +129,9 @@ class Options:
         """Maximum memory for query execution.
 
         Accepts an integer (bytes) or a human-readable string such as
-        `"4gb"`, `"512m"`, or `"1.5g"`. Set to `"unlimited"` to disable
-        the memory limit entirely. When `None`, the Rust-side default
-        (75% of system physical memory) is used.
+        `"4gb"`, `"512m"`, or `"1.5g"`. When `None` (the default), no
+        memory limit is enforced. Setting a limit enables memory-limited
+        execution with spill-to-disk.
 
         Must be set before the first query is executed.
 

--- a/rust/sedona/Cargo.toml
+++ b/rust/sedona/Cargo.toml
@@ -100,6 +100,5 @@ sedona-testing = { workspace = true }
 sedona-tg = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-sysinfo = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }

--- a/rust/sedona/src/context_builder.rs
+++ b/rust/sedona/src/context_builder.rs
@@ -33,18 +33,6 @@ use crate::{
     size_parser,
 };
 
-/// The fraction of total physical memory to use as the default memory limit.
-const DEFAULT_MEMORY_FRACTION: f64 = 0.75;
-
-/// Compute the default memory limit as 75% of total physical memory.
-fn default_memory_limit() -> usize {
-    let mut sys = sysinfo::System::new();
-    sys.refresh_memory();
-    // `System::total_memory()` returns bytes since sysinfo 0.23+.
-    let total = sys.total_memory() as f64;
-    (total * DEFAULT_MEMORY_FRACTION) as usize
-}
-
 /// Builder for constructing a [`SedonaContext`] with configurable runtime
 /// environment settings.
 ///
@@ -52,9 +40,10 @@ fn default_memory_limit() -> usize {
 /// and runtime environments so that the same logic can be reused across the
 /// CLI, Python bindings, ADBC driver, and any future entry points.
 ///
-/// By default, the builder uses 75% of the system's physical memory as the
-/// memory limit and a fair memory pool. Use [`without_memory_limit`](Self::without_memory_limit)
-/// or pass `"unlimited"` as the `memory_limit` option to disable the limit.
+/// By default, no memory limit is enforced and DataFusion's unbounded memory
+/// pool is used. Set a limit with [`with_memory_limit`](Self::with_memory_limit)
+/// or the `memory_limit` option to enable memory-limited execution with
+/// spill-to-disk.
 ///
 /// # Examples
 ///
@@ -63,7 +52,7 @@ fn default_memory_limit() -> usize {
 /// use sedona::context_builder::SedonaContextBuilder;
 /// use sedona::pool_type::PoolType;
 ///
-/// // Uses defaults: 75% of physical memory, fair pool
+/// // Uses defaults: unlimited memory
 /// let ctx = SedonaContextBuilder::new()
 ///     .build()
 ///     .await?;
@@ -76,11 +65,6 @@ fn default_memory_limit() -> usize {
 ///     .build()
 ///     .await?;
 ///
-/// // Disable memory limit entirely
-/// let ctx = SedonaContextBuilder::new()
-///     .without_memory_limit()
-///     .build()
-///     .await?;
 /// # Ok(())
 /// # }
 /// ```
@@ -122,13 +106,13 @@ impl SedonaContextBuilder {
     /// Create a new builder with default settings.
     ///
     /// Defaults:
-    /// - `memory_limit`: 75% of total physical memory
+    /// - `memory_limit`: `None` (unlimited; uses DataFusion's unbounded memory pool)
     /// - `pool_type`: `PoolType::Fair`
     /// - `unspillable_reserve_ratio`: `0.2`
     /// - `temp_dir`: `None` (uses DataFusion's default temp directory)
     pub fn new() -> Self {
         Self {
-            memory_limit: Some(default_memory_limit()),
+            memory_limit: None,
             temp_dir: None,
             pool_type: PoolType::Fair,
             unspillable_reserve_ratio: DEFAULT_UNSPILLABLE_RESERVE_RATIO,
@@ -286,10 +270,8 @@ mod tests {
     #[test]
     fn test_default_builder() {
         let builder = SedonaContextBuilder::new();
-        // Default memory limit should be 75% of physical memory
-        let expected_limit = default_memory_limit();
-        assert_eq!(builder.memory_limit, Some(expected_limit));
-        assert!(builder.memory_limit.unwrap() > 0);
+        // No memory limit by default (unbounded memory pool, no spilling)
+        assert!(builder.memory_limit.is_none());
         assert!(builder.temp_dir.is_none());
         assert_eq!(builder.pool_type, PoolType::Fair);
         assert!(
@@ -353,8 +335,8 @@ mod tests {
     fn test_from_options_empty() {
         let opts = HashMap::new();
         let builder = SedonaContextBuilder::from_options(&opts).unwrap();
-        // Empty options should use defaults (75% memory, Fair pool)
-        assert!(builder.memory_limit.is_some());
+        // Empty options should use defaults (unlimited memory, Fair pool)
+        assert!(builder.memory_limit.is_none());
         assert!(builder.temp_dir.is_none());
         assert_eq!(builder.pool_type, PoolType::Fair);
     }
@@ -425,8 +407,8 @@ mod tests {
         let mut opts = HashMap::new();
         opts.insert("unknown_key".to_string(), "value".to_string());
         let builder = SedonaContextBuilder::from_options(&opts).unwrap();
-        // Default memory limit should still be set
-        assert!(builder.memory_limit.is_some());
+        // Defaults should be preserved (no memory limit)
+        assert!(builder.memory_limit.is_none());
     }
 
     #[test]
@@ -458,7 +440,7 @@ mod tests {
 
     #[test]
     fn test_build_runtime_env_default() {
-        // Default builder should build successfully with 75% memory + fair pool
+        // Default builder should build successfully with the unbounded memory pool
         let builder = SedonaContextBuilder::new();
         let result = builder.build_runtime_env();
         assert!(result.is_ok());

--- a/sedona-cli/src/main.rs
+++ b/sedona-cli/src/main.rs
@@ -66,7 +66,7 @@ struct Args {
     #[clap(
         short = 'm',
         long,
-        help = "The memory pool limitation (e.g. '10g'), default to 75% of physical memory. Use 'unlimited' to disable",
+        help = "The memory pool limitation (e.g. '10g'), default to unlimited. Setting a limit enables spilling to disk",
         value_parser(parse_memory_limit)
     )]
     memory_limit: Option<MemoryLimitArg>,


### PR DESCRIPTION
## What changes are proposed in this pull request?

The 0.4.0 release enabled memory-limited execution by default: `SedonaContextBuilder::new()` set the memory limit to 75% of physical memory with a fair spill pool. Under this default, spilling operators can write large amounts of intermediate data to disk, which broke SpatialBench SF1 Q12 and SF10 Q5/Q12 with `No space left on device` errors and slowed down queries that previously ran fine.

This PR reverts the default to unlimited memory so spilling is opt-in:

- `SedonaContextBuilder::new()` no longer sets a memory limit by default; DataFusion's unbounded memory pool is used unless a limit is explicitly configured via the builder, the CLI `--memory-limit` flag, or context options. Setting a limit still enables the fair pool and spill-to-disk behavior exactly as before.
- Removed the now-unused `default_memory_limit()` helper and the `sysinfo` dependency.
- Updated the CLI help text, Python option docstrings, and the memory-management guide (notebook + generated markdown) to describe the opt-in behavior.

## How was this change tested?

- `cargo test -p sedona --lib context_builder` (19 tests, updated to assert the new default)
- `cargo test -p sedona --lib test_auto_configure_spilled_batch_threshold`
- `cargo test -p sedona --doc context_builder`
- `cargo check -p sedona-cli`
- pre-commit on all changed files

## Does this PR introduce any user-facing change?

Yes. Contexts no longer enforce a memory limit by default; memory-limited execution with spill-to-disk is now opt-in via `memory_limit`. This restores the pre-0.4.0 default behavior.

Closes #1040