### PR TITLE
refactor(rust/sedona-raster): extract BandArrayBuilder from RasterBuilder

### DIFF
--- a/rust/sedona-raster/src/array.rs
+++ b/rust/sedona-raster/src/array.rs
@@ -25,7 +25,7 @@ use datafusion_common::cast::{
     as_string_array, as_string_view_array, as_struct_array, as_uint32_array,
 };
 
-use crate::builder::RasterBuilder;
+use crate::band_builder::BandWriter;
 use crate::traits::{BandRef, NdBuffer, RasterRef};
 use crate::view_entries::{ViewEntries, ViewEntry};
 use sedona_schema::raster::{band_indices, band_view_indices, raster_indices, BandDataType};
@@ -153,7 +153,7 @@ impl<'a> BandRef for BandRefImpl<'a> {
     /// Zero-copy override: share the source row's backing `Buffer` into the
     /// builder (refcount bump) instead of copying the visible bytes. OutDb
     /// bands have an empty data column by design.
-    fn append_data_into(&self, builder: &mut RasterBuilder) -> Result<(), ArrowError> {
+    fn append_data_into(&self, builder: &mut dyn BandWriter) -> Result<(), ArrowError> {
         if self.is_indb() {
             builder.append_band_data_from(self.data_array, self.band_row)
         } else {
@@ -796,8 +796,8 @@ impl<'a> RasterStructArray<'a> {
 
     /// The flattened band `data` column (BinaryView) shared by every raster
     /// in this array. Pair with [`Self::band_data_row`] to address a single
-    /// band's bytes — e.g. for zero-copy passthrough into a [`RasterBuilder`]
-    /// via `append_band_data_from`.
+    /// band's bytes — e.g. for zero-copy passthrough into a
+    /// [`crate::builder::RasterBuilder`] via `append_band_data_from`.
     #[inline(always)]
     pub fn band_data_array(&self) -> &'a BinaryViewArray {
         self.band_data_array

--- a/rust/sedona-raster/src/band_builder.rs
+++ b/rust/sedona-raster/src/band_builder.rs
@@ -1,0 +1,614 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow_array::{
+    builder::{
+        ArrayBuilder, BinaryBuilder, BinaryViewBuilder, Int64Builder, StringBuilder,
+        StringViewBuilder, UInt32Builder,
+    },
+    ArrayRef, BinaryViewArray, ListArray, StructArray,
+};
+use arrow_buffer::{Buffer, NullBuffer, OffsetBuffer, ScalarBuffer};
+use arrow_schema::{ArrowError, DataType};
+
+use sedona_schema::raster::RasterSchema;
+
+use crate::builder::StartBandArgs;
+use crate::view_entries::ViewEntries;
+
+/// Maximum byte length of an inline `BinaryViewArray` view. Views this short
+/// store their bytes in the 16-byte view itself; longer views reference a data
+/// block by `(buffer_index, offset)`. Fixed by the Arrow columnar format spec.
+const MAX_INLINE_VIEW_LEN: u32 = 12;
+
+/// The subset of [`BandArrayBuilder`]'s API that [`crate::traits::BandRef::
+/// copy_into`] and [`crate::traits::BandRef::append_data_into`] need, as a
+/// trait so those methods work whether the derived band is being written into
+/// a bare [`BandArrayBuilder`] (no enclosing raster) or into a
+/// [`crate::builder::RasterBuilder`] (which implements this trait by
+/// delegating to its own internal `BandArrayBuilder` plus its own per-raster
+/// bookkeeping).
+///
+/// `start_band` returns the band's recorded `(dim_names, visible_shape)` —
+/// `RasterBuilder`'s implementation needs it to validate the band against its
+/// current raster's spatial grid; a bare `BandArrayBuilder` caller can ignore
+/// it.
+pub trait BandWriter {
+    fn start_band(
+        &mut self,
+        args: StartBandArgs<'_>,
+    ) -> Result<(Vec<String>, Vec<i64>), ArrowError>;
+    fn band_data_writer(&mut self) -> &mut BinaryViewBuilder;
+    fn append_band_data_from(
+        &mut self,
+        src: &BinaryViewArray,
+        row: usize,
+    ) -> Result<(), ArrowError>;
+}
+
+/// Builder for the flat, per-band columns of `RasterSchema::band_type()` —
+/// one row per band, with none of the raster-envelope concerns (`crs`,
+/// `transform`, `spatial_dims`/`spatial_shape`, or grouping bands into a
+/// per-raster list). [`crate::builder::RasterBuilder`] holds one of these
+/// internally and wraps it with that envelope; a caller with no envelope to
+/// carry (e.g. a bare Band-shaped value with no raster around it) can use
+/// this directly.
+///
+/// Required steps to build a band: call [`Self::start_band`], write its data
+/// via [`Self::band_data_writer`] (or [`Self::append_band_data_from`] to
+/// share an existing row's backing buffer zero-copy), then
+/// [`Self::finish_band`]. After all bands are added, [`Self::finish`] returns
+/// the band `StructArray`.
+pub struct BandArrayBuilder {
+    name: StringBuilder,
+    dim_names_values: StringBuilder,
+    dim_names_offsets: Vec<i32>,
+    shape_values: Int64Builder,
+    shape_offsets: Vec<i32>,
+    datatype: UInt32Builder,
+    nodata: BinaryBuilder,
+    // VIEW field — one entry per visible dimension per band. Stored as four
+    // parallel Int64 columns + a List offset vector; assembled into a
+    // `ListArray<StructArray<Int64,Int64,Int64,Int64>>` in `finish()`.
+    view_source_axis_values: Int64Builder,
+    view_start_values: Int64Builder,
+    view_step_values: Int64Builder,
+    view_steps_values: Int64Builder,
+    view_offsets: Vec<i32>,
+    // Per-band validity for the view list. `false` means the row is null —
+    // the canonical representation of an identity view. `true` means the row
+    // carries an explicit view in the four parallel value builders.
+    view_validity: Vec<bool>,
+    outdb_uri: StringBuilder,
+    outdb_format: StringViewBuilder,
+    data: BinaryViewBuilder,
+
+    // Track band data count at the start of each band for finish_band validation.
+    data_count_at_start: usize,
+
+    // Zero-copy band-data dedup: maps an already-appended source `Buffer`'s
+    // data pointer to its block index in `data`, so the same backing buffer
+    // (e.g. many bands sharing one source column block) is attached once and
+    // referenced by multiple views. See `append_band_data_buffer`.
+    data_blocks: HashMap<usize, u32>,
+}
+
+impl BandArrayBuilder {
+    /// Create a new band builder with the specified capacity (in bands).
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            name: StringBuilder::with_capacity(capacity, capacity),
+            dim_names_values: StringBuilder::with_capacity(capacity * 2, capacity * 4),
+            dim_names_offsets: vec![0],
+            shape_values: Int64Builder::with_capacity(capacity * 2),
+            shape_offsets: vec![0],
+            datatype: UInt32Builder::with_capacity(capacity),
+            nodata: BinaryBuilder::with_capacity(capacity, capacity),
+            view_source_axis_values: Int64Builder::with_capacity(capacity * 2),
+            view_start_values: Int64Builder::with_capacity(capacity * 2),
+            view_step_values: Int64Builder::with_capacity(capacity * 2),
+            view_steps_values: Int64Builder::with_capacity(capacity * 2),
+            view_offsets: vec![0],
+            view_validity: Vec::with_capacity(capacity),
+            outdb_uri: StringBuilder::with_capacity(capacity, capacity),
+            outdb_format: StringViewBuilder::with_capacity(capacity),
+            data: BinaryViewBuilder::with_capacity(capacity),
+
+            data_count_at_start: 0,
+            data_blocks: HashMap::new(),
+        }
+    }
+
+    /// Number of band rows appended so far (via [`Self::start_band`]).
+    pub fn len(&self) -> usize {
+        self.name.len()
+    }
+
+    /// True iff no bands have been appended yet.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Start a new band with explicit N-D parameters. See
+    /// [`crate::builder::RasterBuilder::start_band`] for the full
+    /// documentation of `args`' fields — this is the same logic, minus the
+    /// per-raster bookkeeping `RasterBuilder`'s own `start_band` layers on
+    /// top.
+    ///
+    /// Returns the band's recorded `(dim_names, visible_shape)` — see
+    /// [`BandWriter::start_band`].
+    fn start_band_impl(
+        &mut self,
+        args: StartBandArgs<'_>,
+    ) -> Result<(Vec<String>, Vec<i64>), ArrowError> {
+        let StartBandArgs {
+            name,
+            dim_names,
+            source_shape,
+            view,
+            data_type,
+            nodata,
+            outdb_uri,
+            outdb_format,
+        } = args;
+
+        // A caller-supplied view is validated against source_shape. An identity
+        // view falls through to the null-sentinel storage path below (identical
+        // to `None`) so downstream readers agree on the canonical
+        // representation; a genuinely non-identity view is persisted explicitly
+        // into the band's four parallel view columns here.
+        if let Some(view) = view {
+            let ndim = dim_names.len();
+            if ndim == 0 {
+                return Err(ArrowError::InvalidArgumentError(
+                    "start_band: 0-dimensional bands are not supported".into(),
+                ));
+            }
+            if source_shape.len() != ndim || view.len() != ndim {
+                return Err(ArrowError::InvalidArgumentError(format!(
+                    "start_band: dim_names ({}), source_shape ({}), and view ({}) \
+                     must all have the same length",
+                    ndim,
+                    source_shape.len(),
+                    view.len()
+                )));
+            }
+            let view_entries = ViewEntries::new(view.to_vec());
+            view_entries.validate(source_shape)?;
+
+            if !view_entries.is_identity(source_shape) {
+                // -- Non-identity view: persist the explicit ViewEntry list. --
+                match name {
+                    Some(n) => self.name.append_value(n),
+                    None => self.name.append_null(),
+                }
+
+                for dn in dim_names {
+                    self.dim_names_values.append_value(dn);
+                }
+                let next = *self.dim_names_offsets.last().unwrap() + ndim as i32;
+                self.dim_names_offsets.push(next);
+
+                // The `shape` column stores the *source* shape; the visible
+                // shape is derived from the view at read time.
+                for &s in source_shape {
+                    self.shape_values.append_value(s);
+                }
+                let next = *self.shape_offsets.last().unwrap() + ndim as i32;
+                self.shape_offsets.push(next);
+
+                self.datatype.append_value(data_type as u32);
+
+                match nodata {
+                    Some(b) => self.nodata.append_value(b),
+                    None => self.nodata.append_null(),
+                }
+
+                // VIEW: one entry per visible axis written into the four
+                // parallel columns, offset advanced by the entry count,
+                // validity bit set — the mirror of the null-sentinel path below
+                // (validity false, offset unchanged).
+                for v in view {
+                    self.view_source_axis_values.append_value(v.source_axis);
+                    self.view_start_values.append_value(v.start);
+                    self.view_step_values.append_value(v.step);
+                    self.view_steps_values.append_value(v.steps);
+                }
+                let next = *self.view_offsets.last().unwrap() + ndim as i32;
+                self.view_offsets.push(next);
+                self.view_validity.push(true);
+
+                match outdb_uri {
+                    Some(uri) => self.outdb_uri.append_value(uri),
+                    None => self.outdb_uri.append_null(),
+                }
+                match outdb_format {
+                    Some(format) => self.outdb_format.append_value(format),
+                    None => self.outdb_format.append_null(),
+                }
+
+                self.data_count_at_start = self.data.len();
+
+                // The caller (e.g. `RasterBuilder::finish_raster`) compares
+                // the band's *visible* shape against its raster's spatial_shape.
+                return Ok((
+                    dim_names.iter().map(|s| s.to_string()).collect(),
+                    view_entries.visible_shape(),
+                ));
+            }
+        }
+
+        if dim_names.is_empty() {
+            return Err(ArrowError::InvalidArgumentError(
+                "start_band: 0-dimensional bands are not supported".into(),
+            ));
+        }
+        if dim_names.len() != source_shape.len() {
+            return Err(ArrowError::InvalidArgumentError(format!(
+                "start_band: dim_names ({}) and shape ({}) must have the same length",
+                dim_names.len(),
+                source_shape.len(),
+            )));
+        }
+        // Name
+        match name {
+            Some(n) => self.name.append_value(n),
+            None => self.name.append_null(),
+        }
+
+        // Dim names
+        for dn in dim_names {
+            self.dim_names_values.append_value(dn);
+        }
+        let next = *self.dim_names_offsets.last().unwrap() + dim_names.len() as i32;
+        self.dim_names_offsets.push(next);
+
+        // Shape
+        for &s in source_shape {
+            self.shape_values.append_value(s);
+        }
+        let next = *self.shape_offsets.last().unwrap() + source_shape.len() as i32;
+        self.shape_offsets.push(next);
+
+        // Data type
+        self.datatype.append_value(data_type as u32);
+
+        // Nodata
+        match nodata {
+            Some(nodata_bytes) => self.nodata.append_value(nodata_bytes),
+            None => self.nodata.append_null(),
+        }
+
+        // VIEW: canonical identity is encoded as a null list entry — no
+        // values appended, offset unchanged, validity bit cleared.
+        let next = *self.view_offsets.last().unwrap();
+        self.view_offsets.push(next);
+        self.view_validity.push(false);
+
+        // OutDb URI
+        match outdb_uri {
+            Some(uri) => self.outdb_uri.append_value(uri),
+            None => self.outdb_uri.append_null(),
+        }
+
+        // OutDb format
+        match outdb_format {
+            Some(format) => self.outdb_format.append_value(format),
+            None => self.outdb_format.append_null(),
+        }
+
+        self.data_count_at_start = self.data.len();
+
+        // Record this band's dims/shape for the caller's own validation.
+        Ok((
+            dim_names.iter().map(|s| s.to_string()).collect(),
+            source_shape.to_vec(),
+        ))
+    }
+
+    /// Append the current band's data as a **zero-copy** view into an
+    /// existing Arrow [`Buffer`], rather than copying bytes via
+    /// `append_value`. See
+    /// [`crate::builder::RasterBuilder::append_band_data_buffer`] for the
+    /// full documentation — identical logic.
+    pub fn append_band_data_buffer(
+        &mut self,
+        buffer: &Buffer,
+        offset: u32,
+        len: u32,
+    ) -> Result<(), ArrowError> {
+        if len <= MAX_INLINE_VIEW_LEN {
+            self.data
+                .append_value(&buffer.as_slice()[offset as usize..(offset + len) as usize]);
+            return Ok(());
+        }
+        let block = match self.data_blocks.get(&(buffer.as_ptr() as usize)) {
+            Some(&idx) => idx,
+            None => {
+                // `clone` bumps the buffer's refcount; the bytes are not copied.
+                let idx = self.data.append_block(buffer.clone());
+                self.data_blocks.insert(buffer.as_ptr() as usize, idx);
+                idx
+            }
+        };
+        self.data.try_append_view(block, offset, len)
+    }
+
+    /// Finish writing the current band.
+    ///
+    /// Validates that exactly one data value was appended since `start_band()`.
+    pub fn finish_band(&mut self) -> Result<(), ArrowError> {
+        let current_count = self.data.len();
+        if current_count != self.data_count_at_start + 1 {
+            return Err(ArrowError::InvalidArgumentError(
+                format!(
+                    "Expected exactly one band data value per band, but got {} appended since start_band()",
+                    current_count - self.data_count_at_start
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Finish building and return the flat band `StructArray` — one row per
+    /// band appended via [`Self::start_band`], in order.
+    pub fn finish(mut self) -> Result<StructArray, ArrowError> {
+        // Build band dim_names nested list
+        let dim_names_values = self.dim_names_values.finish();
+        let dim_names_offsets = OffsetBuffer::new(ScalarBuffer::from(self.dim_names_offsets));
+        let DataType::List(dim_names_field) = RasterSchema::dim_names_type() else {
+            return Err(ArrowError::SchemaError(
+                "Expected list type for dim_names".to_string(),
+            ));
+        };
+        let dim_names_list = ListArray::new(
+            dim_names_field,
+            dim_names_offsets,
+            Arc::new(dim_names_values),
+            None,
+        );
+
+        // Build band source_shape nested list
+        let source_shape_values = self.shape_values.finish();
+        let source_shape_offsets = OffsetBuffer::new(ScalarBuffer::from(self.shape_offsets));
+        let DataType::List(source_shape_field) = RasterSchema::source_shape_type() else {
+            return Err(ArrowError::SchemaError(
+                "Expected list type for source_shape".to_string(),
+            ));
+        };
+        let source_shape_list = ListArray::new(
+            source_shape_field,
+            source_shape_offsets,
+            Arc::new(source_shape_values),
+            None,
+        );
+
+        // Build band view nested list (List<Struct<Int64×4>>).
+        let view_source_axis = self.view_source_axis_values.finish();
+        let view_start = self.view_start_values.finish();
+        let view_step = self.view_step_values.finish();
+        let view_steps = self.view_steps_values.finish();
+        let view_offsets = OffsetBuffer::new(ScalarBuffer::from(self.view_offsets));
+        let DataType::List(view_list_field) = RasterSchema::view_type() else {
+            return Err(ArrowError::SchemaError(
+                "Expected list type for view".to_string(),
+            ));
+        };
+        let DataType::Struct(view_struct_fields) = view_list_field.data_type().clone() else {
+            return Err(ArrowError::SchemaError(
+                "Expected struct type inside view list".to_string(),
+            ));
+        };
+        let view_struct = StructArray::new(
+            view_struct_fields,
+            vec![
+                Arc::new(view_source_axis) as ArrayRef,
+                Arc::new(view_start) as ArrayRef,
+                Arc::new(view_step) as ArrayRef,
+                Arc::new(view_steps) as ArrayRef,
+            ],
+            None,
+        );
+        let view_nulls = if self.view_validity.iter().all(|&b| b) {
+            None
+        } else {
+            Some(NullBuffer::from_iter(self.view_validity.iter().copied()))
+        };
+        let view_list = ListArray::new(
+            view_list_field,
+            view_offsets,
+            Arc::new(view_struct),
+            view_nulls,
+        );
+
+        // Build band struct
+        let DataType::Struct(band_fields) = RasterSchema::band_type() else {
+            return Err(ArrowError::SchemaError(
+                "Expected struct type for band".to_string(),
+            ));
+        };
+
+        let band_arrays: Vec<ArrayRef> = vec![
+            Arc::new(self.name.finish()),
+            Arc::new(dim_names_list),
+            Arc::new(source_shape_list),
+            Arc::new(self.datatype.finish()),
+            Arc::new(self.nodata.finish()),
+            Arc::new(view_list),
+            Arc::new(self.outdb_uri.finish()),
+            Arc::new(self.outdb_format.finish()),
+            Arc::new(self.data.finish()),
+        ];
+        Ok(StructArray::new(band_fields, band_arrays, None))
+    }
+}
+
+impl BandWriter for BandArrayBuilder {
+    fn start_band(
+        &mut self,
+        args: StartBandArgs<'_>,
+    ) -> Result<(Vec<String>, Vec<i64>), ArrowError> {
+        self.start_band_impl(args)
+    }
+
+    fn band_data_writer(&mut self) -> &mut BinaryViewBuilder {
+        &mut self.data
+    }
+
+    fn append_band_data_from(
+        &mut self,
+        src: &BinaryViewArray,
+        row: usize,
+    ) -> Result<(), ArrowError> {
+        // Arrow BYTE_VIEW layout (u128, little-endian fields), fixed by the
+        // columnar format spec:
+        //   bits   0..32  length
+        //   bits  32..64  prefix
+        //   bits  64..96  buffer_index
+        //   bits  96..128 offset
+        // A view of `length <= MAX_INLINE_VIEW_LEN` stores its bytes inline and
+        // has no backing buffer to share.
+        let view = src.views()[row];
+        let len = view as u32;
+        if len <= MAX_INLINE_VIEW_LEN {
+            self.data.append_value(src.value(row));
+            Ok(())
+        } else {
+            let buffer_index = (view >> 64) as u32;
+            let offset = (view >> 96) as u32;
+            self.append_band_data_buffer(&src.data_buffers()[buffer_index as usize], offset, len)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::array::RasterStructArray;
+    use crate::builder::RasterBuilder;
+    use crate::traits::{BandOverrides, RasterRef};
+    use arrow_array::{Array, BinaryViewArray, StringArray, UInt32Array};
+    use sedona_schema::raster::{band_indices, BandDataType};
+
+    /// The point of this whole refactor: a bare `BandArrayBuilder`, with no
+    /// enclosing `RasterBuilder`/raster envelope at all, builds a real band
+    /// row directly.
+    #[test]
+    fn bare_band_array_builder_produces_expected_struct_array() {
+        let mut builder = BandArrayBuilder::new(2);
+        assert!(builder.is_empty());
+
+        builder
+            .start_band(StartBandArgs {
+                name: Some("first"),
+                nodata: Some(&[9u8]),
+                ..StartBandArgs::new(&["x"], &[3], BandDataType::UInt8)
+            })
+            .unwrap();
+        builder.band_data_writer().append_value(vec![1u8, 2, 3]);
+        builder.finish_band().unwrap();
+
+        builder
+            .start_band(StartBandArgs::new(&["x"], &[2], BandDataType::UInt8))
+            .unwrap();
+        builder.band_data_writer().append_value(vec![4u8, 5]);
+        builder.finish_band().unwrap();
+
+        assert_eq!(builder.len(), 2);
+        let bands = builder.finish().unwrap();
+        assert_eq!(bands.len(), 2);
+
+        let names = bands
+            .column(band_indices::NAME)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(names.value(0), "first");
+        assert!(names.is_null(1));
+
+        let datatype = bands
+            .column(band_indices::DATA_TYPE)
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .unwrap();
+        assert_eq!(datatype.value(0), BandDataType::UInt8 as u32);
+
+        let data = bands
+            .column(band_indices::DATA)
+            .as_any()
+            .downcast_ref::<BinaryViewArray>()
+            .unwrap();
+        assert_eq!(data.value(0), &[1u8, 2, 3]);
+        assert_eq!(data.value(1), &[4u8, 5]);
+    }
+
+    /// `copy_into` targets a `&mut dyn BandWriter` precisely so a derived
+    /// band can land in a bare `BandArrayBuilder` — no raster envelope, no
+    /// `RasterBuilder::finish_raster`/`finish` needed — which this proves
+    /// end to end: a real `BandRef` (read from a `RasterBuilder`-built
+    /// source) copied into a standalone `BandArrayBuilder`.
+    #[test]
+    fn copy_into_targets_a_bare_band_array_builder() {
+        let transform = [0.0, 1.0, 0.0, 0.0, 0.0, -1.0];
+        let mut source_builder = RasterBuilder::new(1);
+        source_builder
+            .start_raster_nd(&transform, &["x"], &[3], None)
+            .unwrap();
+        source_builder
+            .start_band(StartBandArgs {
+                nodata: Some(&[9u8]),
+                ..StartBandArgs::new(&["x"], &[3], BandDataType::UInt8)
+            })
+            .unwrap();
+        source_builder
+            .band_data_writer()
+            .append_value(vec![1u8, 2, 3]);
+        source_builder.finish_band().unwrap();
+        source_builder.finish_raster().unwrap();
+        let source_array = source_builder.finish().unwrap();
+        let source_rasters = RasterStructArray::try_new(&source_array).unwrap();
+        let source_raster = source_rasters.get(0).unwrap();
+        let source_band = source_raster.band(0).unwrap();
+
+        let mut target = BandArrayBuilder::new(1);
+        source_band
+            .copy_into(&mut target, BandOverrides::default())
+            .unwrap();
+        target.finish_band().unwrap();
+        assert_eq!(target.len(), 1);
+
+        let bands = target.finish().unwrap();
+        let nodata = bands.column(band_indices::NODATA);
+        assert_eq!(
+            nodata
+                .as_any()
+                .downcast_ref::<arrow_array::BinaryArray>()
+                .unwrap()
+                .value(0),
+            &[9u8]
+        );
+        let data = bands
+            .column(band_indices::DATA)
+            .as_any()
+            .downcast_ref::<BinaryViewArray>()
+            .unwrap();
+        assert_eq!(data.value(0), &[1u8, 2, 3]);
+    }
+}

--- a/rust/sedona-raster/src/builder.rs
+++ b/rust/sedona-raster/src/builder.rs
@@ -16,21 +16,18 @@
 // under the License.
 
 use arrow_array::{
-    builder::{
-        ArrayBuilder, BinaryBuilder, BinaryViewBuilder, BooleanBuilder, Float64Builder,
-        Int64Builder, StringBuilder, StringViewBuilder, UInt32Builder,
-    },
+    builder::{BinaryViewBuilder, BooleanBuilder, Float64Builder, Int64Builder, StringViewBuilder},
     Array, ArrayRef, BinaryViewArray, ListArray, StructArray,
 };
-use arrow_buffer::{Buffer, NullBuffer, OffsetBuffer, ScalarBuffer};
+use arrow_buffer::{Buffer, OffsetBuffer, ScalarBuffer};
 use arrow_schema::{ArrowError, DataType};
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use sedona_schema::raster::{BandDataType, RasterSchema};
 
+use crate::band_builder::{BandArrayBuilder, BandWriter};
 use crate::traits::{BandOverrides, BandRef, RasterRef};
-use crate::view_entries::{ViewEntries, ViewEntry};
+use crate::view_entries::ViewEntry;
 
 /// Raster-level metadata overrides for [`RasterBuilder::start_raster_from`] and
 /// [`RasterBuilder::copy_raster_from`]. A `None` field inherits the source
@@ -40,11 +37,6 @@ pub struct RasterOverrides {
     /// Override the 6-element GDAL geotransform; `None` inherits the source's.
     pub transform: Option<[f64; 6]>,
 }
-
-/// Maximum byte length of an inline `BinaryViewArray` view. Views this short
-/// store their bytes in the 16-byte view itself; longer views reference a data
-/// block by `(buffer_index, offset)`. Fixed by the Arrow columnar format spec.
-const MAX_INLINE_VIEW_LEN: u32 = 12;
 
 /// Builder for constructing raster arrays with zero-copy band data writing
 ///
@@ -92,29 +84,11 @@ pub struct RasterBuilder {
     spatial_shape_values: Int64Builder,
     spatial_shape_offsets: Vec<i32>,
 
-    // Band fields (flattened across all bands)
-    band_name: StringBuilder,
-    band_dim_names_values: StringBuilder,
-    band_dim_names_offsets: Vec<i32>,
-    band_shape_values: Int64Builder,
-    band_shape_offsets: Vec<i32>,
-    band_datatype: UInt32Builder,
-    band_nodata: BinaryBuilder,
-    // VIEW field — one entry per visible dimension per band. Stored as four
-    // parallel Int64 columns + a List offset vector; assembled into a
-    // `ListArray<StructArray<Int64,Int64,Int64,Int64>>` in `finish()`.
-    band_view_source_axis_values: Int64Builder,
-    band_view_start_values: Int64Builder,
-    band_view_step_values: Int64Builder,
-    band_view_steps_values: Int64Builder,
-    band_view_offsets: Vec<i32>,
-    // Per-band validity for the view list. `false` means the row is null —
-    // the canonical representation of an identity view. `true` means the row
-    // carries an explicit view in the four parallel value builders.
-    band_view_validity: Vec<bool>,
-    band_outdb_uri: StringBuilder,
-    band_outdb_format: StringViewBuilder,
-    band_data: BinaryViewBuilder,
+    // The flat, per-band columns — see [`BandArrayBuilder`]. Everything
+    // below is raster-envelope bookkeeping layered on top of it: grouping
+    // its rows into a per-raster list, and validating them against each
+    // raster's spatial grid.
+    bands: BandArrayBuilder,
 
     // List structure tracking
     band_offsets: Vec<i32>,  // Track where each raster's bands start/end
@@ -129,15 +103,6 @@ pub struct RasterBuilder {
     current_spatial_dims: Vec<String>,
     current_spatial_shape: Vec<i64>,
     current_raster_bands: Vec<(Vec<String>, Vec<i64>)>,
-
-    // Track band_data count at the start of each band for finish_band validation
-    band_data_count_at_start: usize,
-
-    // Zero-copy band-data dedup: maps an already-appended source `Buffer`'s
-    // data pointer to its block index in `band_data`, so the same backing
-    // buffer (e.g. many bands sharing one source column block) is attached
-    // once and referenced by multiple views. See `append_band_data_buffer`.
-    band_data_blocks: HashMap<usize, u32>,
 
     raster_validity: BooleanBuilder,
 }
@@ -205,22 +170,7 @@ impl RasterBuilder {
             spatial_shape_values: Int64Builder::with_capacity(capacity * 2),
             spatial_shape_offsets: vec![0],
 
-            band_name: StringBuilder::with_capacity(capacity, capacity),
-            band_dim_names_values: StringBuilder::with_capacity(capacity * 2, capacity * 4),
-            band_dim_names_offsets: vec![0],
-            band_shape_values: Int64Builder::with_capacity(capacity * 2),
-            band_shape_offsets: vec![0],
-            band_datatype: UInt32Builder::with_capacity(capacity),
-            band_nodata: BinaryBuilder::with_capacity(capacity, capacity),
-            band_view_source_axis_values: Int64Builder::with_capacity(capacity * 2),
-            band_view_start_values: Int64Builder::with_capacity(capacity * 2),
-            band_view_step_values: Int64Builder::with_capacity(capacity * 2),
-            band_view_steps_values: Int64Builder::with_capacity(capacity * 2),
-            band_view_offsets: vec![0],
-            band_view_validity: Vec::with_capacity(capacity),
-            band_outdb_uri: StringBuilder::with_capacity(capacity, capacity),
-            band_outdb_format: StringViewBuilder::with_capacity(capacity),
-            band_data: BinaryViewBuilder::with_capacity(capacity),
+            bands: BandArrayBuilder::new(capacity),
 
             band_offsets: vec![0],
             current_band_count: 0,
@@ -230,9 +180,6 @@ impl RasterBuilder {
             current_spatial_dims: Vec::new(),
             current_spatial_shape: Vec::new(),
             current_raster_bands: Vec::new(),
-
-            band_data_count_at_start: 0,
-            band_data_blocks: HashMap::new(),
 
             raster_validity: BooleanBuilder::with_capacity(capacity),
         }
@@ -391,176 +338,27 @@ impl RasterBuilder {
     /// the *source* shape and the visible shape is derived from the view on
     /// read; the source bytes are carried over unchanged.
     pub fn start_band(&mut self, args: StartBandArgs<'_>) -> Result<(), ArrowError> {
-        let StartBandArgs {
-            name,
-            dim_names,
-            source_shape,
-            view,
-            data_type,
-            nodata,
-            outdb_uri,
-            outdb_format,
-        } = args;
-
-        // A caller-supplied view is validated against source_shape. An identity
-        // view falls through to the null-sentinel storage path below (identical
-        // to `None`) so downstream readers agree on the canonical
-        // representation; a genuinely non-identity view is persisted explicitly
-        // into the band's four parallel view columns here.
-        if let Some(view) = view {
-            let ndim = dim_names.len();
-            if ndim == 0 {
-                return Err(ArrowError::InvalidArgumentError(
-                    "start_band: 0-dimensional bands are not supported".into(),
-                ));
-            }
-            if source_shape.len() != ndim || view.len() != ndim {
-                return Err(ArrowError::InvalidArgumentError(format!(
-                    "start_band: dim_names ({}), source_shape ({}), and view ({}) \
-                     must all have the same length",
-                    ndim,
-                    source_shape.len(),
-                    view.len()
-                )));
-            }
-            let view_entries = ViewEntries::new(view.to_vec());
-            view_entries.validate(source_shape)?;
-
-            if !view_entries.is_identity(source_shape) {
-                // -- Non-identity view: persist the explicit ViewEntry list. --
-                match name {
-                    Some(n) => self.band_name.append_value(n),
-                    None => self.band_name.append_null(),
-                }
-
-                for dn in dim_names {
-                    self.band_dim_names_values.append_value(dn);
-                }
-                let next = *self.band_dim_names_offsets.last().unwrap() + ndim as i32;
-                self.band_dim_names_offsets.push(next);
-
-                // The `shape` column stores the *source* shape; the visible
-                // shape is derived from the view at read time.
-                for &s in source_shape {
-                    self.band_shape_values.append_value(s);
-                }
-                let next = *self.band_shape_offsets.last().unwrap() + ndim as i32;
-                self.band_shape_offsets.push(next);
-
-                self.band_datatype.append_value(data_type as u32);
-
-                match nodata {
-                    Some(b) => self.band_nodata.append_value(b),
-                    None => self.band_nodata.append_null(),
-                }
-
-                // VIEW: one entry per visible axis written into the four
-                // parallel columns, offset advanced by the entry count,
-                // validity bit set — the mirror of the null-sentinel path below
-                // (validity false, offset unchanged).
-                for v in view {
-                    self.band_view_source_axis_values
-                        .append_value(v.source_axis);
-                    self.band_view_start_values.append_value(v.start);
-                    self.band_view_step_values.append_value(v.step);
-                    self.band_view_steps_values.append_value(v.steps);
-                }
-                let next = *self.band_view_offsets.last().unwrap() + ndim as i32;
-                self.band_view_offsets.push(next);
-                self.band_view_validity.push(true);
-
-                match outdb_uri {
-                    Some(uri) => self.band_outdb_uri.append_value(uri),
-                    None => self.band_outdb_uri.append_null(),
-                }
-                match outdb_format {
-                    Some(format) => self.band_outdb_format.append_value(format),
-                    None => self.band_outdb_format.append_null(),
-                }
-
-                self.current_band_count += 1;
-                self.band_data_count_at_start = self.band_data.len();
-
-                // finish_raster compares the band's *visible* shape against
-                // spatial_shape.
-                self.current_raster_bands.push((
-                    dim_names.iter().map(|s| s.to_string()).collect(),
-                    view_entries.visible_shape(),
-                ));
-
-                return Ok(());
-            }
-        }
-
-        if dim_names.is_empty() {
-            return Err(ArrowError::InvalidArgumentError(
-                "start_band: 0-dimensional bands are not supported".into(),
-            ));
-        }
-        if dim_names.len() != source_shape.len() {
-            return Err(ArrowError::InvalidArgumentError(format!(
-                "start_band: dim_names ({}) and shape ({}) must have the same length",
-                dim_names.len(),
-                source_shape.len(),
-            )));
-        }
-        // Name
-        match name {
-            Some(n) => self.band_name.append_value(n),
-            None => self.band_name.append_null(),
-        }
-
-        // Dim names
-        for dn in dim_names {
-            self.band_dim_names_values.append_value(dn);
-        }
-        let next = *self.band_dim_names_offsets.last().unwrap() + dim_names.len() as i32;
-        self.band_dim_names_offsets.push(next);
-
-        // Shape
-        for &s in source_shape {
-            self.band_shape_values.append_value(s);
-        }
-        let next = *self.band_shape_offsets.last().unwrap() + source_shape.len() as i32;
-        self.band_shape_offsets.push(next);
-
-        // Data type
-        self.band_datatype.append_value(data_type as u32);
-
-        // Nodata
-        match nodata {
-            Some(nodata_bytes) => self.band_nodata.append_value(nodata_bytes),
-            None => self.band_nodata.append_null(),
-        }
-
-        // VIEW: canonical identity is encoded as a null list entry — no
-        // values appended, offset unchanged, validity bit cleared.
-        let next = *self.band_view_offsets.last().unwrap();
-        self.band_view_offsets.push(next);
-        self.band_view_validity.push(false);
-
-        // OutDb URI
-        match outdb_uri {
-            Some(uri) => self.band_outdb_uri.append_value(uri),
-            None => self.band_outdb_uri.append_null(),
-        }
-
-        // OutDb format
-        match outdb_format {
-            Some(format) => self.band_outdb_format.append_value(format),
-            None => self.band_outdb_format.append_null(),
-        }
-
-        self.current_band_count += 1;
-        self.band_data_count_at_start = self.band_data.len();
-
-        // Record this band's dims/shape for strict validation at finish_raster.
-        self.current_raster_bands.push((
-            dim_names.iter().map(|s| s.to_string()).collect(),
-            source_shape.to_vec(),
-        ));
-
+        self.start_band_and_record(args)?;
         Ok(())
+    }
+
+    /// Shared by the inherent [`Self::start_band`] (used directly by ~20
+    /// call sites across the raster function crates, which don't need the
+    /// recorded `(dim_names, visible_shape)`) and `impl BandWriter for
+    /// RasterBuilder` (used by [`BandRef::copy_into`](crate::traits::
+    /// BandRef::copy_into), which does need it — see [`BandWriter::
+    /// start_band`]). Both delegate here rather than to each other, so
+    /// there's no same-type self-call to disambiguate between the inherent
+    /// method and the trait impl of the same name.
+    fn start_band_and_record(
+        &mut self,
+        args: StartBandArgs<'_>,
+    ) -> Result<(Vec<String>, Vec<i64>), ArrowError> {
+        let (dim_names, shape) = self.bands.start_band(args)?;
+        self.current_band_count += 1;
+        self.current_raster_bands
+            .push((dim_names.clone(), shape.clone()));
+        Ok((dim_names, shape))
     }
 
     /// Build a band that is a new view into an existing band.
@@ -641,23 +439,13 @@ impl RasterBuilder {
 
     /// Get direct access to the BinaryViewBuilder for writing the current band's data.
     pub fn band_data_writer(&mut self) -> &mut BinaryViewBuilder {
-        &mut self.band_data
+        self.bands.band_data_writer()
     }
 
     /// Append the current band's data as a **zero-copy** view into an existing
-    /// Arrow [`Buffer`], rather than copying bytes via `append_value`.
-    ///
-    /// `buffer` is attached to the output `BinaryViewArray` as a shared data
-    /// block (a refcount bump, never a copy) and a single view row referencing
-    /// `[offset, offset + len)` is appended. Buffers are de-duplicated by data
-    /// pointer, so handing the same backing buffer for many bands attaches it
-    /// once and points every view at it.
-    ///
-    /// Bytes at or under the inline threshold ([`MAX_INLINE_VIEW_LEN`]) are
-    /// stored inline (a tiny copy) instead, since the `BinaryViewArray` layout
-    /// requires such views to be inline and a block-referencing view of that
-    /// size is non-canonical (it fails array validation on roundtrip). Band
-    /// data is realistically always larger, so this is the degenerate path.
+    /// Arrow [`Buffer`], rather than copying bytes via `append_value`. See
+    /// [`crate::band_builder::BandArrayBuilder::append_band_data_buffer`] for
+    /// the full documentation — identical logic, delegated.
     ///
     /// Counts as the one data value for the current band (see [`finish_band`]).
     ///
@@ -668,28 +456,14 @@ impl RasterBuilder {
         offset: u32,
         len: u32,
     ) -> Result<(), ArrowError> {
-        if len <= MAX_INLINE_VIEW_LEN {
-            self.band_data
-                .append_value(&buffer.as_slice()[offset as usize..(offset + len) as usize]);
-            return Ok(());
-        }
-        let block = match self.band_data_blocks.get(&(buffer.as_ptr() as usize)) {
-            Some(&idx) => idx,
-            None => {
-                // `clone` bumps the buffer's refcount; the bytes are not copied.
-                let idx = self.band_data.append_block(buffer.clone());
-                self.band_data_blocks.insert(buffer.as_ptr() as usize, idx);
-                idx
-            }
-        };
-        self.band_data.try_append_view(block, offset, len)
+        self.bands.append_band_data_buffer(buffer, offset, len)
     }
 
     /// Append the current band's data by copying row `row` of `src` through —
     /// zero-copy when the row's bytes are block-backed (shares the backing
     /// `Buffer` via [`append_band_data_buffer`]), with a small copy only for
-    /// inline views (≤ [`MAX_INLINE_VIEW_LEN`] bytes, which live in the view
-    /// itself and have no backing buffer).
+    /// inline views (which live in the view itself and have no backing
+    /// buffer).
     ///
     /// Counts as the one data value for the current band (see [`finish_band`]).
     ///
@@ -699,40 +473,14 @@ impl RasterBuilder {
         src: &BinaryViewArray,
         row: usize,
     ) -> Result<(), ArrowError> {
-        // Arrow BYTE_VIEW layout (u128, little-endian fields), fixed by the
-        // columnar format spec:
-        //   bits   0..32  length
-        //   bits  32..64  prefix
-        //   bits  64..96  buffer_index
-        //   bits  96..128 offset
-        // A view of `length <= MAX_INLINE_VIEW_LEN` stores its bytes inline and
-        // has no backing buffer to share.
-        let view = src.views()[row];
-        let len = view as u32;
-        if len <= MAX_INLINE_VIEW_LEN {
-            self.band_data.append_value(src.value(row));
-            Ok(())
-        } else {
-            let buffer_index = (view >> 64) as u32;
-            let offset = (view >> 96) as u32;
-            self.append_band_data_buffer(&src.data_buffers()[buffer_index as usize], offset, len)
-        }
+        self.bands.append_band_data_from(src, row)
     }
 
     /// Finish writing the current band.
     ///
     /// Validates that exactly one data value was appended since `start_band()`.
     pub fn finish_band(&mut self) -> Result<(), ArrowError> {
-        let current_count = self.band_data.len();
-        if current_count != self.band_data_count_at_start + 1 {
-            return Err(ArrowError::InvalidArgumentError(
-                format!(
-                    "Expected exactly one band data value per band, but got {} appended since start_band()",
-                    current_count - self.band_data_count_at_start
-                ),
-            ));
-        }
-        Ok(())
+        self.bands.finish_band()
     }
 
     /// Finish all bands for the current raster.
@@ -848,95 +596,10 @@ impl RasterBuilder {
             None,
         );
 
-        // Build band dim_names nested list
-        let dim_names_values = self.band_dim_names_values.finish();
-        let dim_names_offsets = OffsetBuffer::new(ScalarBuffer::from(self.band_dim_names_offsets));
-        let DataType::List(dim_names_field) = RasterSchema::dim_names_type() else {
-            return Err(ArrowError::SchemaError(
-                "Expected list type for dim_names".to_string(),
-            ));
-        };
-        let dim_names_list = ListArray::new(
-            dim_names_field,
-            dim_names_offsets,
-            Arc::new(dim_names_values),
-            None,
-        );
-
-        // Build band source_shape nested list
-        let source_shape_values = self.band_shape_values.finish();
-        let source_shape_offsets = OffsetBuffer::new(ScalarBuffer::from(self.band_shape_offsets));
-        let DataType::List(source_shape_field) = RasterSchema::source_shape_type() else {
-            return Err(ArrowError::SchemaError(
-                "Expected list type for source_shape".to_string(),
-            ));
-        };
-        let source_shape_list = ListArray::new(
-            source_shape_field,
-            source_shape_offsets,
-            Arc::new(source_shape_values),
-            None,
-        );
-
-        // Build band view nested list (List<Struct<Int64×4>>).
-        let view_source_axis = self.band_view_source_axis_values.finish();
-        let view_start = self.band_view_start_values.finish();
-        let view_step = self.band_view_step_values.finish();
-        let view_steps = self.band_view_steps_values.finish();
-        let view_offsets = OffsetBuffer::new(ScalarBuffer::from(self.band_view_offsets));
-        let DataType::List(view_list_field) = RasterSchema::view_type() else {
-            return Err(ArrowError::SchemaError(
-                "Expected list type for view".to_string(),
-            ));
-        };
-        let DataType::Struct(view_struct_fields) = view_list_field.data_type().clone() else {
-            return Err(ArrowError::SchemaError(
-                "Expected struct type inside view list".to_string(),
-            ));
-        };
-        let view_struct = StructArray::new(
-            view_struct_fields,
-            vec![
-                Arc::new(view_source_axis) as ArrayRef,
-                Arc::new(view_start) as ArrayRef,
-                Arc::new(view_step) as ArrayRef,
-                Arc::new(view_steps) as ArrayRef,
-            ],
-            None,
-        );
-        let view_nulls = if self.band_view_validity.iter().all(|&b| b) {
-            None
-        } else {
-            Some(NullBuffer::from_iter(
-                self.band_view_validity.iter().copied(),
-            ))
-        };
-        let view_list = ListArray::new(
-            view_list_field,
-            view_offsets,
-            Arc::new(view_struct),
-            view_nulls,
-        );
-
-        // Build band struct
-        let DataType::Struct(band_fields) = RasterSchema::band_type() else {
-            return Err(ArrowError::SchemaError(
-                "Expected struct type for band".to_string(),
-            ));
-        };
-
-        let band_arrays: Vec<ArrayRef> = vec![
-            Arc::new(self.band_name.finish()),
-            Arc::new(dim_names_list),
-            Arc::new(source_shape_list),
-            Arc::new(self.band_datatype.finish()),
-            Arc::new(self.band_nodata.finish()),
-            Arc::new(view_list),
-            Arc::new(self.band_outdb_uri.finish()),
-            Arc::new(self.band_outdb_format.finish()),
-            Arc::new(self.band_data.finish()),
-        ];
-        let band_struct = StructArray::new(band_fields, band_arrays, None);
+        // Build the flat band struct — delegated to `BandArrayBuilder`,
+        // which owns all the per-band columns (name, dim_names, shape,
+        // datatype, nodata, view, outdb_uri/format, data).
+        let band_struct = self.bands.finish()?;
 
         // Build bands list
         let DataType::List(bands_field) = RasterSchema::bands_type() else {
@@ -962,6 +625,36 @@ impl RasterBuilder {
         let raster_nulls = raster_validity_array.nulls().cloned();
 
         Ok(StructArray::new(raster_fields, raster_arrays, raster_nulls))
+    }
+}
+
+/// Lets [`BandRef::copy_into`](crate::traits::BandRef::copy_into) and
+/// [`BandRef::append_data_into`](crate::traits::BandRef::append_data_into)
+/// target a `RasterBuilder` directly, same as before this trait existed:
+/// `start_band` here does the *same* per-raster bookkeeping as the inherent
+/// [`RasterBuilder::start_band`] (both delegate to
+/// [`Self::start_band_and_record`]) — deriving a band via `copy_into` into a
+/// `RasterBuilder` is still validated against that raster's spatial grid at
+/// `finish_raster`, exactly as it was when `copy_into` was hardcoded to this
+/// type.
+impl BandWriter for RasterBuilder {
+    fn start_band(
+        &mut self,
+        args: StartBandArgs<'_>,
+    ) -> Result<(Vec<String>, Vec<i64>), ArrowError> {
+        self.start_band_and_record(args)
+    }
+
+    fn band_data_writer(&mut self) -> &mut BinaryViewBuilder {
+        self.bands.band_data_writer()
+    }
+
+    fn append_band_data_from(
+        &mut self,
+        src: &BinaryViewArray,
+        row: usize,
+    ) -> Result<(), ArrowError> {
+        self.bands.append_band_data_from(src, row)
     }
 }
 

--- a/rust/sedona-raster/src/lib.rs
+++ b/rust/sedona-raster/src/lib.rs
@@ -17,6 +17,7 @@
 
 pub mod affine_transformation;
 pub mod array;
+pub mod band_builder;
 pub mod builder;
 pub mod display;
 pub mod geo_transform;

--- a/rust/sedona-raster/src/traits.rs
+++ b/rust/sedona-raster/src/traits.rs
@@ -18,7 +18,8 @@
 use arrow_schema::ArrowError;
 use sedona_schema::raster::BandDataType;
 
-use crate::builder::{RasterBuilder, StartBandArgs};
+use crate::band_builder::BandWriter;
+use crate::builder::StartBandArgs;
 use crate::view_entries::{ViewEntries, ViewEntry};
 
 /// Recognized spatial dimension-name pairs, in band C-order: the slower-
@@ -456,14 +457,22 @@ pub trait BandRef {
     /// inherits the source's view unchanged.
     ///
     /// The composition + persistence is delegated to
-    /// [`RasterBuilder::start_band`]: an identity effective view is
+    /// [`BandWriter::start_band`]: an identity effective view is
     /// stored as the canonical null sentinel, and a non-identity one (a slice,
     /// broadcast, permutation, or reverse) is persisted explicitly and decoded
     /// back by the reader. The source bytes are carried over unchanged — the
     /// view relocates the visible window over them, it does not repack them.
+    ///
+    /// `builder` is a [`BandWriter`] rather than a concrete
+    /// [`crate::builder::RasterBuilder`] so a derived band can be written
+    /// into a bare [`crate::band_builder::BandArrayBuilder`] (no enclosing
+    /// raster) too — `RasterBuilder` implements the trait by delegating to
+    /// its own internal `BandArrayBuilder` plus its own per-raster
+    /// bookkeeping, so calling this with a `&mut RasterBuilder` behaves
+    /// exactly as before.
     fn copy_into(
         &self,
-        builder: &mut RasterBuilder,
+        builder: &mut dyn BandWriter,
         overrides: BandOverrides<'_>,
     ) -> Result<(), ArrowError> {
         let inherited_dims = self.dim_names();
@@ -496,10 +505,10 @@ pub trait BandRef {
     /// The default copies the visible source bytes via `append_value`. Arrow-
     /// backed implementations override this to share the source row's backing
     /// `Buffer` zero-copy (a refcount bump via
-    /// [`RasterBuilder::append_band_data_from`]), keeping the buffer plumbing
+    /// [`BandWriter::append_band_data_from`]), keeping the buffer plumbing
     /// encapsulated rather than exposing a raw `Buffer` accessor. Call after the
     /// band's schema has been written (e.g. by [`Self::copy_into`]).
-    fn append_data_into(&self, builder: &mut RasterBuilder) -> Result<(), ArrowError> {
+    fn append_data_into(&self, builder: &mut dyn BandWriter) -> Result<(), ArrowError> {
         if self.is_indb() {
             let ndb = self.nd_buffer()?;
             builder.band_data_writer().append_value(ndb.buffer);
@@ -668,6 +677,7 @@ pub fn nodata_f64_to_bytes(value: f64, dt: &BandDataType) -> Result<Vec<u8>, Arr
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::builder::RasterBuilder;
 
     #[test]
     fn test_nodata_bytes_to_f64_uint8() {


### PR DESCRIPTION
## What

Extracts `RasterBuilder`'s per-band column state and writing methods into a standalone `BandArrayBuilder` (`band_builder.rs`) — one row per band, no raster envelope (`crs`, `transform`, `spatial_dims`/`spatial_shape`, per-raster band grouping). `RasterBuilder` now holds one internally and delegates, layering its per-raster bookkeeping on top.

`BandRef::copy_into`/`append_data_into` now target a new `BandWriter` trait object instead of `&mut RasterBuilder`. `RasterBuilder` implements it, so existing call sites are unaffected — but `copy_into` can now also target a bare `BandArrayBuilder`.

Pure internal refactor: no schema change, no new column, no behavior change. All of `RasterBuilder`'s public inherent signatures are unchanged.

## Why

A derived band with no enclosing raster can't currently reuse `copy_into`'s view-composition/override logic or the builder's column assembly without wrapping and unwrapping a throwaway single-band `Raster`. The read side (`ViewEntries::compose`, `BandRef` defaults) was already reusable; this closes the gap on the write side.

## Verification

- `sedona-raster`: 177 tests pass (175 existing unmodified, plus 2 new covering the bare-builder and `copy_into`-into-bare-builder paths).
- `sedona-raster-functions`, `-zarr`, `sedona-spatial-join{,-raster}`, `sedona-testing`: all pass, no regressions.
- `sedona-raster-gdal` unbuildable locally (pre-existing GDAL/`gdal-sys` mismatch, fails identically on clean `main`); its call sites use only unchanged inherent methods.
- clippy `-D warnings` + fmt clean.
