### PR TITLE
feat(rust/sedona-functions): add the Sedona Spark ST_Force3DZ alias for st_force3d

### DIFF
--- a/docs/reference/sql/st_force2d.qmd
+++ b/docs/reference/sql/st_force2d.qmd
@@ -29,6 +29,8 @@ kernels:
 
 Discards any Z and M values present (if any).
 
+Aliases: `ST_Force_2D`.
+
 ## Examples
 
 ```sql

--- a/docs/reference/sql/st_force2d.qmd
+++ b/docs/reference/sql/st_force2d.qmd
@@ -29,8 +29,6 @@ kernels:
 
 Discards any Z and M values present (if any).
 
-Aliases: `ST_Force_2D`.
-
 ## Examples
 
 ```sql

--- a/docs/reference/sql/st_force3d.qmd
+++ b/docs/reference/sql/st_force3d.qmd
@@ -39,6 +39,8 @@ kernels:
 
 If the geometry already has Z values they are preserved; otherwise the optional `z` argument (default 0) is used.
 
+Aliases: `ST_Force3DZ`.
+
 ## Examples
 
 ```sql

--- a/rust/sedona-functions/src/st_force_dim.rs
+++ b/rust/sedona-functions/src/st_force_dim.rs
@@ -72,7 +72,7 @@ fn build_return_matcher(is_geography: bool, num_optional_numeric_args: usize) ->
 
 /// ST_Force2D() scalar UDF
 pub fn st_force2d_udf() -> SedonaScalarUDF {
-    let udf = SedonaScalarUDF::new(
+    SedonaScalarUDF::new(
         "st_force2d",
         ItemCrsKernel::wrap_impl(vec![
             Arc::new(STForce2D {
@@ -81,9 +81,7 @@ pub fn st_force2d_udf() -> SedonaScalarUDF {
             Arc::new(STForce2D { is_geography: true }),
         ]),
         Volatility::Immutable,
-    );
-    // Sedona Spark registers this function as ST_Force_2D as well
-    udf.with_aliases(vec!["st_force_2d".to_string()])
+    )
 }
 
 #[derive(Debug)]
@@ -442,7 +440,6 @@ mod tests {
     fn udf_metadata() {
         let st_force2d: ScalarUDF = st_force2d_udf().into();
         assert_eq!(st_force2d.name(), "st_force2d");
-        assert!(st_force2d.aliases().contains(&"st_force_2d".to_string()));
 
         let st_force3d: ScalarUDF = st_force3d_udf().into();
         assert_eq!(st_force3d.name(), "st_force3d");

--- a/rust/sedona-functions/src/st_force_dim.rs
+++ b/rust/sedona-functions/src/st_force_dim.rs
@@ -72,7 +72,7 @@ fn build_return_matcher(is_geography: bool, num_optional_numeric_args: usize) ->
 
 /// ST_Force2D() scalar UDF
 pub fn st_force2d_udf() -> SedonaScalarUDF {
-    SedonaScalarUDF::new(
+    let udf = SedonaScalarUDF::new(
         "st_force2d",
         ItemCrsKernel::wrap_impl(vec![
             Arc::new(STForce2D {
@@ -81,7 +81,9 @@ pub fn st_force2d_udf() -> SedonaScalarUDF {
             Arc::new(STForce2D { is_geography: true }),
         ]),
         Volatility::Immutable,
-    )
+    );
+    // Sedona Spark registers this function as ST_Force_2D as well
+    udf.with_aliases(vec!["st_force_2d".to_string()])
 }
 
 #[derive(Debug)]
@@ -145,7 +147,7 @@ impl CrsTransform for Force2DTransform {
 
 /// ST_Force3D() scalar UDF
 pub fn st_force3d_udf() -> SedonaScalarUDF {
-    SedonaScalarUDF::new(
+    let udf = SedonaScalarUDF::new(
         "st_force3d",
         ItemCrsKernel::wrap_impl(vec![
             Arc::new(STForce3D {
@@ -154,7 +156,9 @@ pub fn st_force3d_udf() -> SedonaScalarUDF {
             Arc::new(STForce3D { is_geography: true }),
         ]),
         Volatility::Immutable,
-    )
+    );
+    // Sedona Spark registers this function as ST_Force3DZ as well
+    udf.with_aliases(vec!["st_force3dz".to_string()])
 }
 
 #[derive(Debug)]
@@ -438,9 +442,11 @@ mod tests {
     fn udf_metadata() {
         let st_force2d: ScalarUDF = st_force2d_udf().into();
         assert_eq!(st_force2d.name(), "st_force2d");
+        assert!(st_force2d.aliases().contains(&"st_force_2d".to_string()));
 
         let st_force3d: ScalarUDF = st_force3d_udf().into();
         assert_eq!(st_force3d.name(), "st_force3d");
+        assert!(st_force3d.aliases().contains(&"st_force3dz".to_string()));
 
         let st_force3dm: ScalarUDF = st_force3dm_udf().into();
         assert_eq!(st_force3dm.name(), "st_force3dm");


### PR DESCRIPTION
## What changes were proposed in this PR?

Register `st_force3dz` as an alias of `st_force3d`. It is both the name Sedona Spark registers (`ST_Force3DZ` as an alias of `ST_Force3D`) and the canonical name in current PostGIS (`ST_Force3D` is the alias there), so SQL written against either resolves unchanged on sedona-db.

Per review, the `st_force_2d` alias originally in this PR was **dropped**: it is the pre-2.1 PostGIS name that PostGIS itself deprecated, and rather than porting it here it is now being deprecated in Sedona Spark with a warning giving the canonical name (apache/sedona#3264).

This follows the existing alias pattern used by `st_geomfromwkt` (`st_geomfromtext`, `st_geometryfromtext`, ...).

## Why are the changes needed?

Spark SQL written against Sedona (e.g. pipelines using `ST_Force3DZ`) currently fails with an unknown-function error when run on sedona-db. The alias makes such SQL portable unchanged, and matches current PostGIS naming.

## How was this patch tested?

Extended the existing `udf_metadata` test in `st_force_dim.rs` to assert the alias; `cargo test -p sedona-functions st_force_dim` passes.

## Did this PR include necessary documentation updates?

Yes — the alias is listed on the `st_force3d` SQL reference page (kept in sync with the registered aliases, as required by the docs check).
