### PR TITLE
feat(rust/sedona-functions): implement ST_GeoHash

### DIFF
--- a/docs/reference/sql/st_geohash.qmd
+++ b/docs/reference/sql/st_geohash.qmd
@@ -1,0 +1,42 @@
+---
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+title: ST_GeoHash
+description: Returns the GeoHash string of a geometry with the given precision.
+kernels:
+  - returns: string
+    args: [geometry, integer]
+---
+
+## Description
+
+Encodes the geometry as a base-32 GeoHash string with `precision` characters.
+Non-point geometries are encoded using the center of their bounding box.
+Returns `NULL` when the geometry's bounding box is not fully contained in the
+longitude/latitude range [-180, 180] x [-90, 90]. A non-positive precision
+returns an empty string, and precision is capped at 20 characters.
+
+## Examples
+
+```sql
+SELECT ST_GeoHash(ST_GeomFromWKT('POINT (21.4234 52.0423)'), 10);
+```
+
+```sql
+SELECT ST_GeoHash(ST_GeomFromWKT('POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))'), 8);
+```

--- a/docs/reference/sql/st_geohash.qmd
+++ b/docs/reference/sql/st_geohash.qmd
@@ -28,7 +28,8 @@ kernels:
 Encodes the geometry as a base-32 GeoHash string with `precision` characters.
 Non-point geometries are encoded using the center of their bounding box.
 Returns `NULL` when the geometry's bounding box is not fully contained in the
-longitude/latitude range [-180, 180] x [-90, 90]. A non-positive precision
+valid longitude/latitude domain (longitudes -180 to 180, latitudes -90 to 90).
+A non-positive precision
 returns an empty string, and precision is capped at 20 characters.
 
 ## Examples

--- a/docs/reference/sql/st_geohash.qmd
+++ b/docs/reference/sql/st_geohash.qmd
@@ -20,7 +20,21 @@ title: ST_GeoHash
 description: Returns the GeoHash string of a geometry with the given precision.
 kernels:
   - returns: string
-    args: [geometry, integer]
+    args: [geometry]
+  - returns: string
+    args:
+    - geometry
+    - name: precision
+      type: integer
+      description: Number of base-32 characters in the returned GeoHash.
+  - returns: string
+    args: [geography]
+  - returns: string
+    args:
+    - geography
+    - name: precision
+      type: integer
+      description: Number of base-32 characters in the returned GeoHash.
 ---
 
 ## Description
@@ -32,6 +46,14 @@ valid longitude/latitude domain (longitudes -180 to 180, latitudes -90 to 90).
 A non-positive precision
 returns an empty string, and precision is capped at 20 characters.
 
+When `precision` is omitted, the argument must be a `POINT` and is encoded at
+the maximum precision of 20 characters. Any other geometry type raises an
+error, because there is no single obvious precision for a geometry that covers
+an area.
+
+Geography arguments are bounded on the sphere and require the s2geography
+bounder to be registered on the session.
+
 ## Examples
 
 ```sql
@@ -40,4 +62,8 @@ SELECT ST_GeoHash(ST_GeomFromWKT('POINT (21.4234 52.0423)'), 10);
 
 ```sql
 SELECT ST_GeoHash(ST_GeomFromWKT('POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))'), 8);
+```
+
+```sql
+SELECT ST_GeoHash(ST_GeomFromWKT('POINT (21.4234 52.0423)'));
 ```

--- a/docs/reference/sql/st_geohash.qmd
+++ b/docs/reference/sql/st_geohash.qmd
@@ -41,10 +41,26 @@ kernels:
 
 Encodes the geometry as a base-32 GeoHash string with `precision` characters.
 Non-point geometries are encoded using the center of their bounding box.
-Returns `NULL` when the geometry's bounding box is not fully contained in the
-valid longitude/latitude domain (longitudes -180 to 180, latitudes -90 to 90).
 A non-positive precision
 returns an empty string, and precision is capped at 20 characters.
+
+A GeoHash is defined against the WGS84 datum, so the argument must carry either
+a WGS84 CRS (`EPSG:4326` / `OGC:CRS84`) or no CRS at all; anything else raises
+an error. Use `ST_Transform()` to reproject first. This includes other
+geographic CRSes such as NAD83, whose units are degrees but whose datum differs
+from WGS84 by enough to shift the result at high precision.
+
+The same rule applies whether the CRS belongs to the column or to the
+individual rows; only the timing differs. A column-level CRS is known while the
+query is planned, so it is rejected before any row is read. A row-level CRS is
+not known until the row is reached, so it is rejected then. To encode only the
+WGS84 rows of a mixed column, filter them first — `WHERE ST_SRID(geom) = 4326`
+is applied before the encoding, so the other rows never reach it.
+
+Latitudes outside -90 to 90 return `NULL`. Longitudes outside -180 to 180 are
+wrapped back into range when the argument declares a WGS84 CRS, so a longitude
+of 181 encodes as -179; without a declared CRS they return `NULL` instead,
+matching Apache Sedona.
 
 When `precision` is omitted, the argument must be a `POINT` and is encoded at
 the maximum precision of 20 characters. Any other geometry type raises an

--- a/python/sedonadb/tests/functions/test_functions.py
+++ b/python/sedonadb/tests/functions/test_functions.py
@@ -2032,6 +2032,61 @@ def test_st_geohash_accepts_wgs84_and_undeclared_crs(srid):
     eng.assert_query_result(sql, "s5x1g8cu2y")
 
 
+@pytest.mark.parametrize("lat", [100, 91, 270, -91, -100])
+def test_st_geohash_geography_rejects_out_of_range_latitude(lat):
+    # s2geography bounds a geography with an S2LatLngRect, whose latitudes are
+    # constrained to [-90, 90] by construction, so an out-of-range latitude is
+    # clamped inside S2 before the domain check can see it. Without the raw
+    # planar bound taken alongside it, every latitude here encoded as the pole:
+    # POINT (50 100), POINT (50 91) and POINT (50 270) all returned
+    # 'vpgxczbzuryp', which is the hash of the genuine POINT (50 90).
+    #
+    # Only reachable in a build with the s2geography feature; the Rust unit
+    # tests substitute the planar bounder, which does no clamping and so cannot
+    # exercise this at all.
+    if "s2geography" not in sedonadb.__features__:
+        pytest.skip("Geography bounds require a build with feature s2geography")
+
+    eng = SedonaDB.create_or_skip()
+    eng.assert_query_result(
+        f"SELECT ST_GeoHash(ST_GeogFromText('POINT (50 {lat})'), 12)", None
+    )
+
+
+def test_st_geohash_geography_keeps_the_poles_and_wrapping():
+    # The other side of the check above: latitudes that really are in range
+    # still encode, including the poles themselves, and longitude wrapping is
+    # untouched. Longitude deliberately keeps using the spherical bounds --
+    # S2 normalizes it into [-180, 180], which is the same wrapping applied to
+    # a geometry -- so 190 and -170 agree.
+    if "s2geography" not in sedonadb.__features__:
+        pytest.skip("Geography bounds require a build with feature s2geography")
+
+    eng = SedonaDB.create_or_skip()
+    eng.assert_query_result(
+        "SELECT ST_GeoHash(ST_GeogFromText('POINT (50 90)'), 12)", "vpgxczbzuryp"
+    )
+    eng.assert_query_result(
+        "SELECT ST_GeoHash(ST_GeogFromText('POINT (50 -90)'), 12)", "j0581b0bh2n0"
+    )
+    eng.assert_query_result(
+        "SELECT ST_GeoHash(ST_GeogFromText('POINT (190 50)'), 12)", "b0zh7w1z0gs3"
+    )
+    eng.assert_query_result(
+        "SELECT ST_GeoHash(ST_GeogFromText('POINT (-170 50)'), 12)", "b0zh7w1z0gs3"
+    )
+
+    # A non-point geography takes the same path through its bounding box: this
+    # linestring reaches latitude 100, so it is rejected rather than clamped.
+    eng.assert_query_result(
+        "SELECT ST_GeoHash(ST_GeogFromText('LINESTRING (50 80, 60 100)'), 12)", None
+    )
+    eng.assert_query_result(
+        "SELECT ST_GeoHash(ST_GeogFromText('LINESTRING (50 80, 60 85)'), 12)",
+        "vnxj7d9v2fsm",
+    )
+
+
 def _item_crs_table(eng):
     """A table whose geometry column carries a per-row (item-level) CRS
 

--- a/python/sedonadb/tests/functions/test_functions.py
+++ b/python/sedonadb/tests/functions/test_functions.py
@@ -1889,8 +1889,13 @@ def test_st_geohash_out_of_range_untagged_diverges_from_postgis(eng, geom):
     # calls lwerror() rather than returning NULL. Pinned on both sides so the
     # divergence is verified rather than merely asserted in a comment.
     #
-    # Tagging the same geometry with a lon/lat CRS changes the longitude cases;
-    # see test_st_geohash_wraps_longitude_for_lnglat_crs below.
+    # An undeclared CRS is accepted (see test_st_geohash_accepts_wgs84_and_
+    # undeclared_crs) but does not earn wrapping: accepting it is passive, while
+    # wrapping it would invent a location for coordinates of unknown provenance.
+    # It also keeps faith with Apache Sedona, which has no CRS concept at all, so
+    # every geometry migrated from Spark arrives here undeclared. Tagging the
+    # same geometry 4326 opts into wrapping; see
+    # test_st_geohash_wraps_longitude_for_lnglat_crs below.
     raises = eng == PostGIS
     sql = f"SELECT ST_GeoHash({geom_or_null(geom)}, 10)"
     eng = eng.create_or_skip()
@@ -1987,16 +1992,112 @@ def test_st_geohash_never_wraps_latitude(eng, geom):
         "POINT (541.0 50.0)",
     ],
 )
-def test_st_geohash_does_not_wrap_longitude_for_projected_crs(geom):
-    # Wrapping is gated on the CRS being in degrees. Applied to a projected CRS
-    # the same arithmetic would turn a coordinate in metres into a
-    # plausible-looking geohash for somewhere unrelated, so a projected CRS
-    # keeps the NULL. SedonaDB-only: PostGIS ignores SRID entirely on the
-    # geometry overload (ST_GeoHash of POINT (10 20) is the same whether it is
-    # tagged 4326, 3857 or 26918), so it has no comparable behavior to pin.
+def test_st_geohash_rejects_non_wgs84_crs(geom):
+    # A geohash is defined against the WGS84 datum, so anything else is refused
+    # rather than hashed. The refusal happens while the query is planned, before
+    # any row is read, so it cannot fail partway through a large scan.
+    #
+    # SedonaDB-only: PostGIS ignores SRID entirely on the geometry overload
+    # (ST_GeoHash of POINT (10 20) returns the same value whether it is tagged
+    # 4326, 3857 or 26918), so it has no comparable behavior to pin.
     eng = SedonaDB.create_or_skip()
     sql = f"SELECT ST_GeoHash(ST_SetSRID({geom_or_null(geom)}, 3857), 12)"
-    eng.assert_query_result(sql, None)
+    with pytest.raises(Exception, match="requires WGS84"):
+        eng.execute_and_collect(sql)
+
+
+@pytest.mark.parametrize("srid", [3857, 26918, 4269])
+def test_st_geohash_rejects_non_wgs84_crs_in_range(srid):
+    # The case the CRS check really exists for. These coordinates are inside
+    # [-180, 180] x [-90, 90], so no domain check catches them, and without the
+    # CRS check EPSG:3857 POINT (10 20) -- ten metres east and twenty metres
+    # north of the origin, in the Gulf of Guinea -- would hash as 10 degrees
+    # east, 20 degrees north, in Chad.
+    #
+    # EPSG:4269 (NAD83) is refused too. Its units are degrees, but its datum is
+    # not WGS84: NAD83 sits one to two metres away and NAD27 up to a hundred,
+    # which is many cells wide at high precision.
+    eng = SedonaDB.create_or_skip()
+    sql = f"SELECT ST_GeoHash(ST_SetSRID(ST_GeomFromText('POINT (10 20)'), {srid}), 12)"
+    with pytest.raises(Exception, match="requires WGS84"):
+        eng.execute_and_collect(sql)
+
+
+@pytest.mark.parametrize("srid", [4326, 0])
+def test_st_geohash_accepts_wgs84_and_undeclared_crs(srid):
+    # WGS84 is accepted, and so is an undeclared CRS: rejecting the latter would
+    # break every ST_GeomFromText() call, which carries no CRS at all.
+    eng = SedonaDB.create_or_skip()
+    sql = f"SELECT ST_GeoHash(ST_SetSRID(ST_GeomFromText('POINT (10 20)'), {srid}), 10)"
+    eng.assert_query_result(sql, "s5x1g8cu2y")
+
+
+def _item_crs_table(eng):
+    """A table whose geometry column carries a per-row (item-level) CRS
+
+    ST_SetSRID() with a non-constant SRID returns an item_crs type, which is the
+    only way rows in one column can disagree about their CRS.
+    """
+    eng.execute_and_collect(
+        """
+        CREATE OR REPLACE TABLE geohash_mixed AS SELECT * FROM (VALUES
+            (1, 3857,  'POINT (10 20)'),
+            (2, 4326,  'POINT (10 20)'),
+            (3, 4326,  'POINT (190 50)'),
+            (4, 26918, 'POINT (10 20)')
+        ) AS v(id, srid, wkt)
+        """
+    )
+    return "ST_SetSRID(ST_GeomFromText(wkt), srid)"
+
+
+def test_st_geohash_item_crs_rejects_non_wgs84_rows():
+    # A per-row CRS is held to the same rule as a type-level one. Before this,
+    # rows 1 and 4 were hashed as though their metres were degrees.
+    eng = SedonaDB.create_or_skip()
+    g = _item_crs_table(eng)
+    with pytest.raises(Exception, match="requires WGS84"):
+        eng.execute_and_collect(f"SELECT ST_GeoHash({g}, 12) FROM geohash_mixed")
+
+
+def test_st_geohash_item_crs_filtered_to_wgs84_rows():
+    # Selecting only the WGS84 rows is the natural way to use a mixed column,
+    # and it works: WHERE is planned below the projection (FilterExec under
+    # ProjectionExec), so the rejected rows never reach ST_GeoHash.
+    #
+    # Row 3 is the one that changed. It declares 4326 with longitude 190, and
+    # now wraps to the same value a type-level 4326 column gives, instead of
+    # returning NULL because the per-row CRS was invisible.
+    eng = SedonaDB.create_or_skip()
+    g = _item_crs_table(eng)
+    # Rows 2 and 3 in id order; rows 1 (3857) and 4 (26918) are filtered out.
+    eng.assert_query_result(
+        f"SELECT ST_GeoHash({g}, 12) FROM geohash_mixed "
+        f"WHERE ST_SRID({g}) = 4326 ORDER BY id",
+        [("s5x1g8cu2yhr",), ("b0zh7w1z0gs3",)],
+    )
+
+
+def test_st_geohash_item_crs_agrees_with_type_level_crs():
+    # The inconsistency this closes: identical coordinates, identical CRS,
+    # differing only in whether the CRS rides on the type or the row.
+    eng = SedonaDB.create_or_skip()
+    g = _item_crs_table(eng)
+    item_level = (
+        eng.execute_and_collect(
+            f"SELECT ST_GeoHash({g}, 12) FROM geohash_mixed WHERE id = 3"
+        )
+        .column(0)[0]
+        .as_py()
+    )
+    type_level = (
+        eng.execute_and_collect(
+            "SELECT ST_GeoHash(ST_SetSRID(ST_GeomFromText('POINT (190 50)'), 4326), 12)"
+        )
+        .column(0)[0]
+        .as_py()
+    )
+    assert item_level == type_level == "b0zh7w1z0gs3"
 
 
 @pytest.mark.parametrize("eng", [SedonaDB, PostGIS])

--- a/python/sedonadb/tests/functions/test_functions.py
+++ b/python/sedonadb/tests/functions/test_functions.py
@@ -1798,6 +1798,13 @@ def test_st_geometrytype(eng, geom, expected):
         ("LINESTRING (30 10, 10 30, 40 40)", 10, "ss3y0zh7w1"),
         ("MULTIPOINT ((10 40), (40 30), (20 20), (30 10))", 10, "ss3y0zh7w1"),
         ("POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10))", 10, "ssgs3y0zh7"),
+        # A coordinate sitting exactly on a cell boundary. Both engines resolve
+        # the tie the same way -- a value equal to the midpoint goes to the
+        # upper half (`value >= mid`) -- so (0 0), which lands on the first
+        # split of both axes, agrees. PostGIS pins the same value in its own
+        # suite (cu_algorithm.c asserts (0, 0) at precision 16 is
+        # "s000000000000000").
+        ("POINT (0 0)", 10, "s000000000"),
     ],
 )
 def test_st_geohash(eng, geom, precision, expected):
@@ -1810,25 +1817,6 @@ def test_st_geohash(eng, geom, precision, expected):
 
     eng = eng.create_or_skip()
     eng.assert_query_result(f"SELECT ST_GeoHash({arg}, {precision})", expected)
-
-
-@pytest.mark.parametrize("eng", [SedonaDB, PostGIS])
-def test_st_geohash_cell_boundary_differs_from_postgis(eng):
-    # A coordinate lying exactly on a cell boundary is the one case where the
-    # two engines disagree, so it is pinned separately rather than hidden.
-    # SedonaDB follows Apache Sedona and assigns a coordinate equal to the
-    # midpoint to the *lower* half (`lon > mid`); PostGIS's geohash_point()
-    # uses `>=` and assigns it to the *upper* half. (0 0) sits on the very
-    # first split of both axes, so the two answers differ from the first
-    # character on and are exact opposites: all-lowest vs all-highest base32
-    # digit. PostGIS pins the same value in its own suite (cu_algorithm.c
-    # asserts (0, 0) at precision 16 is "s000000000000000").
-    expected = "s000000000" if eng == PostGIS else "7zzzzzzzzz"
-
-    eng = eng.create_or_skip()
-    eng.assert_query_result(
-        f"SELECT ST_GeoHash({geom_or_null('POINT (0 0)')}, 10)", expected
-    )
 
 
 @pytest.mark.parametrize("eng", [SedonaDB, PostGIS])

--- a/python/sedonadb/tests/functions/test_functions.py
+++ b/python/sedonadb/tests/functions/test_functions.py
@@ -1870,6 +1870,36 @@ def test_st_geohash_no_precision_requires_point():
 
 @pytest.mark.parametrize("eng", [SedonaDB, PostGIS])
 @pytest.mark.parametrize(
+    "geom",
+    [
+        "POINT (190.0 50.0)",
+        "POINT (-190.0 50.0)",
+        "POINT (50.0 100.0)",
+        "POINT (50.0 -100.0)",
+    ],
+)
+def test_st_geohash_out_of_range_diverges_from_postgis(eng, geom):
+    # The one place the two engines deliberately disagree. A coordinate outside
+    # [-180, 180] x [-90, 90] is NULL in SedonaDB, matching Apache Sedona
+    # (GeometryGeoHashEncoder.calculate returns null), because a Spark query
+    # that returns nulls here should keep returning nulls after migrating.
+    # PostGIS instead raises "Geohash requires inputs in decimal degrees": its
+    # lwgeom_geohash() range check runs once the bounding box is computed, and
+    # calls lwerror() rather than returning NULL. Pinned on both sides so the
+    # divergence is verified rather than merely asserted in a comment.
+    raises = eng == PostGIS
+    sql = f"SELECT ST_GeoHash({geom_or_null(geom)}, 10)"
+    eng = eng.create_or_skip()
+
+    if raises:
+        with pytest.raises(Exception):
+            eng.execute_and_collect(sql)
+    else:
+        eng.assert_query_result(sql, None)
+
+
+@pytest.mark.parametrize("eng", [SedonaDB, PostGIS])
+@pytest.mark.parametrize(
     ("wkt", "expected"),
     [
         (None, None),

--- a/python/sedonadb/tests/functions/test_functions.py
+++ b/python/sedonadb/tests/functions/test_functions.py
@@ -1780,6 +1780,40 @@ def test_st_geometrytype(eng, geom, expected):
 
 @pytest.mark.parametrize("eng", [SedonaDB, PostGIS])
 @pytest.mark.parametrize(
+    ("geom", "precision", "expected"),
+    [
+        (None, 10, None),
+        # Increasing precision on one point: each result is a prefix of the next,
+        # so a wrong bit order or a dropped bit shows up as a diverging suffix.
+        ("POINT (21.4234 52.0423)", 1, "u"),
+        ("POINT (21.4234 52.0423)", 5, "u3r0p"),
+        ("POINT (21.4234 52.0423)", 10, "u3r0pd0037"),
+        ("POINT (21.4234 52.0423)", 12, "u3r0pd0037ug"),
+        # Western and southern hemispheres, to pin the longitude/latitude signs.
+        ("POINT (-122.4194 37.7749)", 9, "9q8yyk8yt"),
+        ("POINT (-43.2 -22.9)", 8, "75cm8znt"),
+        # Non-point geometries hash the center of their bounding box, so the
+        # linestring and the multipoint below share a bounding box (10 10,
+        # 40 40) and therefore a geohash.
+        ("LINESTRING (30 10, 10 30, 40 40)", 10, "ss3y0zh7w1"),
+        ("MULTIPOINT ((10 40), (40 30), (20 20), (30 10))", 10, "ss3y0zh7w1"),
+        ("POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10))", 10, "ssgs3y0zh7"),
+    ],
+)
+def test_st_geohash(eng, geom, precision, expected):
+    if eng == PostGIS and geom is None:
+        # As in ST_GeometryType above, PostGIS needs the NULL cast to resolve
+        # the overload.
+        arg = "NULL::geometry"
+    else:
+        arg = geom_or_null(geom)
+
+    eng = eng.create_or_skip()
+    eng.assert_query_result(f"SELECT ST_GeoHash({arg}, {precision})", expected)
+
+
+@pytest.mark.parametrize("eng", [SedonaDB, PostGIS])
+@pytest.mark.parametrize(
     ("wkt", "expected"),
     [
         (None, None),

--- a/python/sedonadb/tests/functions/test_functions.py
+++ b/python/sedonadb/tests/functions/test_functions.py
@@ -1805,6 +1805,19 @@ def test_st_geometrytype(eng, geom, expected):
         # suite (cu_algorithm.c asserts (0, 0) at precision 16 is
         # "s000000000000000").
         ("POINT (0 0)", 10, "s000000000"),
+        # Every empty geometry has no bounding box to hash, so both engines
+        # return NULL. In PostGIS, lwgeom_geohash() bails out when
+        # lwgeom_calculate_gbox_cartesian() reports LW_FAILURE -- which it does
+        # for an empty point array, an empty ring list, and an empty collection
+        # -- and the ST_GeoHash() wrapper turns that into a SQL NULL rather than
+        # an error.
+        ("POINT EMPTY", 10, None),
+        ("LINESTRING EMPTY", 10, None),
+        ("POLYGON EMPTY", 10, None),
+        ("MULTIPOINT EMPTY", 10, None),
+        ("MULTILINESTRING EMPTY", 10, None),
+        ("MULTIPOLYGON EMPTY", 10, None),
+        ("GEOMETRYCOLLECTION EMPTY", 10, None),
     ],
 )
 def test_st_geohash(eng, geom, precision, expected):
@@ -1817,6 +1830,42 @@ def test_st_geohash(eng, geom, precision, expected):
 
     eng = eng.create_or_skip()
     eng.assert_query_result(f"SELECT ST_GeoHash({arg}, {precision})", expected)
+
+
+@pytest.mark.parametrize("eng", [SedonaDB, PostGIS])
+@pytest.mark.parametrize(
+    ("geom", "expected"),
+    [
+        (None, None),
+        # Without a precision, a point is hashed at the 20 character maximum.
+        # PostGIS reaches the same place by a different route: its `maxchars`
+        # defaults to 0, and lwgeom_geohash_precision() returns
+        # GEOHASH_MAX_DOUBLE_PRECISION_CHARS (20) for a zero-extent box. Each
+        # expected value extends the shorter hash pinned for the same point in
+        # test_st_geohash above, so a wrong tail shows up as a diverging suffix.
+        ("POINT (21.4234 52.0423)", "u3r0pd0037ugg6hm1kb1"),
+        ("POINT (-122.4194 37.7749)", "9q8yyk8ytpxr8wwhcg8j"),
+        ("POINT EMPTY", None),
+    ],
+)
+def test_st_geohash_no_precision(eng, geom, expected):
+    # Non-point geometries are not compared here: SedonaDB errors (a precision
+    # must be stated), whereas PostGIS derives one from the bounding box.
+    if eng == PostGIS and geom is None:
+        arg = "NULL::geometry"
+    else:
+        arg = geom_or_null(geom)
+
+    eng = eng.create_or_skip()
+    eng.assert_query_result(f"SELECT ST_GeoHash({arg})", expected)
+
+
+def test_st_geohash_no_precision_requires_point():
+    eng = SedonaDB.create_or_skip()
+    with pytest.raises(Exception, match="only defined for POINT"):
+        eng.execute_and_collect(
+            "SELECT ST_GeoHash(ST_GeomFromText('LINESTRING (30 10, 10 30, 40 40)'))"
+        )
 
 
 @pytest.mark.parametrize("eng", [SedonaDB, PostGIS])

--- a/python/sedonadb/tests/functions/test_functions.py
+++ b/python/sedonadb/tests/functions/test_functions.py
@@ -1813,6 +1813,25 @@ def test_st_geohash(eng, geom, precision, expected):
 
 
 @pytest.mark.parametrize("eng", [SedonaDB, PostGIS])
+def test_st_geohash_cell_boundary_differs_from_postgis(eng):
+    # A coordinate lying exactly on a cell boundary is the one case where the
+    # two engines disagree, so it is pinned separately rather than hidden.
+    # SedonaDB follows Apache Sedona and assigns a coordinate equal to the
+    # midpoint to the *lower* half (`lon > mid`); PostGIS's geohash_point()
+    # uses `>=` and assigns it to the *upper* half. (0 0) sits on the very
+    # first split of both axes, so the two answers differ from the first
+    # character on and are exact opposites: all-lowest vs all-highest base32
+    # digit. PostGIS pins the same value in its own suite (cu_algorithm.c
+    # asserts (0, 0) at precision 16 is "s000000000000000").
+    expected = "s000000000" if eng == PostGIS else "7zzzzzzzzz"
+
+    eng = eng.create_or_skip()
+    eng.assert_query_result(
+        f"SELECT ST_GeoHash({geom_or_null('POINT (0 0)')}, 10)", expected
+    )
+
+
+@pytest.mark.parametrize("eng", [SedonaDB, PostGIS])
 @pytest.mark.parametrize(
     ("wkt", "expected"),
     [

--- a/python/sedonadb/tests/functions/test_functions.py
+++ b/python/sedonadb/tests/functions/test_functions.py
@@ -2032,6 +2032,28 @@ def test_st_geohash_accepts_wgs84_and_undeclared_crs(srid):
     eng.assert_query_result(sql, "s5x1g8cu2y")
 
 
+@pytest.mark.parametrize(
+    "precision_sql",
+    [
+        "arrow_cast('20', 'UInt64')",
+        "arrow_cast('9223372036854775807', 'UInt64')",  # i64::MAX
+        "arrow_cast('9223372036854775808', 'UInt64')",  # i64::MAX + 1
+        "arrow_cast('18446744073709551615', 'UInt64')",  # u64::MAX
+        "arrow_cast('4294967295', 'UInt32')",
+        "arrow_cast('9223372036854775807', 'Int64')",
+    ],
+)
+def test_st_geohash_precision_wider_than_i64(precision_sql):
+    # The signature accepts UInt64, whose upper half does not fit in an i64, so
+    # a precision above i64::MAX used to fail with "Can't cast value ... to type
+    # Int64" rather than encoding. Precision is capped at 20 characters, so
+    # every value here means the same thing and returns the same hash.
+    eng = SedonaDB.create_or_skip()
+    eng.assert_query_result(
+        f"SELECT ST_GeoHash(ST_Point(1, 2), {precision_sql})", "s02equ04ven09qv80meq"
+    )
+
+
 @pytest.mark.parametrize("lat", [100, 91, 270, -91, -100])
 def test_st_geohash_geography_rejects_out_of_range_latitude(lat):
     # s2geography bounds a geography with an S2LatLngRect, whose latitudes are

--- a/python/sedonadb/tests/functions/test_functions.py
+++ b/python/sedonadb/tests/functions/test_functions.py
@@ -1878,15 +1878,19 @@ def test_st_geohash_no_precision_requires_point():
         "POINT (50.0 -100.0)",
     ],
 )
-def test_st_geohash_out_of_range_diverges_from_postgis(eng, geom):
-    # The one place the two engines deliberately disagree. A coordinate outside
-    # [-180, 180] x [-90, 90] is NULL in SedonaDB, matching Apache Sedona
-    # (GeometryGeoHashEncoder.calculate returns null), because a Spark query
-    # that returns nulls here should keep returning nulls after migrating.
-    # PostGIS instead raises "Geohash requires inputs in decimal degrees": its
+def test_st_geohash_out_of_range_untagged_diverges_from_postgis(eng, geom):
+    # The one place the two engines deliberately disagree. With no CRS to say
+    # the coordinates are degrees, a coordinate outside [-180, 180] x [-90, 90]
+    # is NULL in SedonaDB, matching Apache Sedona (GeometryGeoHashEncoder
+    # .calculate returns null), because a Spark query that returns nulls here
+    # should keep returning nulls after migrating. PostGIS' geometry overload
+    # instead raises "Geohash requires inputs in decimal degrees": its
     # lwgeom_geohash() range check runs once the bounding box is computed, and
     # calls lwerror() rather than returning NULL. Pinned on both sides so the
     # divergence is verified rather than merely asserted in a comment.
+    #
+    # Tagging the same geometry with a lon/lat CRS changes the longitude cases;
+    # see test_st_geohash_wraps_longitude_for_lnglat_crs below.
     raises = eng == PostGIS
     sql = f"SELECT ST_GeoHash({geom_or_null(geom)}, 10)"
     eng = eng.create_or_skip()
@@ -1896,6 +1900,140 @@ def test_st_geohash_out_of_range_diverges_from_postgis(eng, geom):
             eng.execute_and_collect(sql)
     else:
         eng.assert_query_result(sql, None)
+
+
+@pytest.mark.parametrize("eng", [SedonaDB, PostGIS])
+@pytest.mark.parametrize(
+    ("out_of_range", "equivalent"),
+    [
+        # Longitude is cyclic, so each of these denotes exactly the same
+        # meridian as its in-range counterpart.
+        ("POINT (190.0 50.0)", "POINT (-170.0 50.0)"),
+        ("POINT (-190.0 50.0)", "POINT (170.0 50.0)"),
+        # More than one turn.
+        ("POINT (541.0 50.0)", "POINT (-179.0 50.0)"),
+        ("POINT (-541.0 50.0)", "POINT (179.0 50.0)"),
+    ],
+)
+def test_st_geohash_wraps_longitude_for_lnglat_crs(eng, out_of_range, equivalent):
+    # Once the CRS says the coordinates are lon/lat degrees, an out-of-range
+    # longitude is an unambiguous spelling of an in-range one, so it hashes to
+    # the same value instead of dropping to NULL. Returning NULL here silently
+    # drops rows from any filter or join keyed on the geohash, which is the
+    # accident this avoids.
+    #
+    # PostGIS reaches the same place through its geography type, which is lon/lat
+    # by definition and coerces on input ("Coordinate values were coerced into
+    # range [-180 -90, 180 90] for GEOGRAPHY"). Its geometry overload has no CRS
+    # semantics to lean on and still raises, which is why this test casts to
+    # geography on the PostGIS side and sets SRID 4326 on the SedonaDB side --
+    # the two are the same statement about the input, spelled per engine.
+    eng_cls = eng
+    eng = eng.create_or_skip()
+
+    if eng_cls == PostGIS:
+        lhs = f"ST_GeoHash({geom_or_null(out_of_range)}::geography, 12)"
+        rhs = f"ST_GeoHash({geom_or_null(equivalent)}::geography, 12)"
+    else:
+        lhs = f"ST_GeoHash(ST_SetSRID({geom_or_null(out_of_range)}, 4326), 12)"
+        rhs = f"ST_GeoHash(ST_SetSRID({geom_or_null(equivalent)}, 4326), 12)"
+
+    expected = eng.execute_and_collect(f"SELECT {rhs}").column(0)[0].as_py()
+    assert expected is not None
+    eng.assert_query_result(f"SELECT {lhs}", expected)
+
+
+@pytest.mark.parametrize("eng", [SedonaDB, PostGIS])
+@pytest.mark.parametrize(
+    "geom",
+    [
+        "POINT (50.0 100.0)",
+        "POINT (50.0 -100.0)",
+        # Out of range on both axes: latitude is checked first, and no amount of
+        # longitude wrapping rescues it.
+        "POINT (190.0 100.0)",
+    ],
+)
+def test_st_geohash_never_wraps_latitude(eng, geom):
+    # Latitude is not cyclic, so an out-of-range value has no reading that
+    # recovers a real location and stays NULL even under a lon/lat CRS.
+    #
+    # This is the one half of PostGIS' geography coercion that SedonaDB declines
+    # to copy. PostGIS reflects latitude back over the pole while leaving the
+    # longitude untouched (POINT (50 100) becomes POINT (50 80)), which is a
+    # third location again -- going over the pole from longitude 50 comes down
+    # at -130, not 50. A plausible-looking hash for the wrong place is worse
+    # than a NULL, so SedonaDB nulls and PostGIS' geography path is not matched
+    # here.
+    eng_cls = eng
+    eng = eng.create_or_skip()
+
+    if eng_cls == PostGIS:
+        # Pin the divergence rather than assert it in a comment: PostGIS returns
+        # a hash for the reflected point.
+        sql = f"SELECT ST_GeoHash({geom_or_null(geom)}::geography, 12)"
+        result = eng.execute_and_collect(sql).column(0)[0].as_py()
+        assert result is not None
+    else:
+        sql = f"SELECT ST_GeoHash(ST_SetSRID({geom_or_null(geom)}, 4326), 12)"
+        eng.assert_query_result(sql, None)
+
+
+@pytest.mark.parametrize(
+    "geom",
+    [
+        "POINT (190.0 50.0)",
+        "POINT (-190.0 50.0)",
+        "POINT (541.0 50.0)",
+    ],
+)
+def test_st_geohash_does_not_wrap_longitude_for_projected_crs(geom):
+    # Wrapping is gated on the CRS being in degrees. Applied to a projected CRS
+    # the same arithmetic would turn a coordinate in metres into a
+    # plausible-looking geohash for somewhere unrelated, so a projected CRS
+    # keeps the NULL. SedonaDB-only: PostGIS ignores SRID entirely on the
+    # geometry overload (ST_GeoHash of POINT (10 20) is the same whether it is
+    # tagged 4326, 3857 or 26918), so it has no comparable behavior to pin.
+    eng = SedonaDB.create_or_skip()
+    sql = f"SELECT ST_GeoHash(ST_SetSRID({geom_or_null(geom)}, 3857), 12)"
+    eng.assert_query_result(sql, None)
+
+
+@pytest.mark.parametrize("eng", [SedonaDB, PostGIS])
+def test_st_geohash_antimeridian_bbox_diverges_from_postgis(eng):
+    # A geometry whose bounding box straddles the antimeridian, where SedonaDB
+    # is deliberately more accurate than PostGIS.
+    #
+    # LINESTRING (179 0, 181 0) is two degrees long and centered on longitude
+    # 180. SedonaDB wraps the bounding *interval* (179..181 -> the two-degree
+    # wraparound interval 179..-179) and hashes its center, 180.
+    #
+    # PostGIS coerces each *vertex* on the way into geography --
+    #   SELECT ST_AsText('LINESTRING (179 0, 181 0)'::geography)
+    #     -> LINESTRING(179 0,-179 0)
+    # -- and then bounds those with a bbox that knows nothing about wraparound,
+    # turning a two-degree span across the antimeridian into a 358-degree span
+    # the other way around. Its center lands on longitude 0, so PostGIS returns
+    # the geohash of POINT (0 0): the antipode of the right answer.
+    #
+    # Pinned on both sides so the divergence is verified rather than merely
+    # asserted in a comment. Wrapping the interval instead of the vertices is
+    # what buys the difference; see normalize_longitude() in st_geohash.rs.
+    geom = "LINESTRING (179.0 0.0, 181.0 0.0)"
+    eng_cls = eng
+    eng = eng.create_or_skip()
+
+    if eng_cls == PostGIS:
+        # Same value as ST_GeoHash('POINT (0 0)'::geography, 12).
+        eng.assert_query_result(
+            f"SELECT ST_GeoHash({geom_or_null(geom)}::geography, 12)", "s00000000000"
+        )
+    else:
+        # Same value as ST_GeoHash(ST_SetSRID('POINT (180 0)', 4326), 12).
+        eng.assert_query_result(
+            f"SELECT ST_GeoHash(ST_SetSRID({geom_or_null(geom)}, 4326), 12)",
+            "xbpbpbpbpbpb",
+        )
 
 
 @pytest.mark.parametrize("eng", [SedonaDB, PostGIS])

--- a/rust/sedona-functions/src/lib.rs
+++ b/rust/sedona-functions/src/lib.rs
@@ -35,6 +35,7 @@ pub mod st_envelope;
 pub mod st_envelope_agg;
 mod st_flipcoordinates;
 mod st_force_dim;
+mod st_geohash;
 mod st_geometryn;
 mod st_geometrytype;
 mod st_geomfromewkb;

--- a/rust/sedona-functions/src/register.rs
+++ b/rust/sedona-functions/src/register.rs
@@ -54,6 +54,7 @@ pub fn default_function_set() -> FunctionSet {
         crate::st_force_dim::st_force3d_udf,
         crate::st_force_dim::st_force3dm_udf,
         crate::st_force_dim::st_force4d_udf,
+        crate::st_geohash::st_geohash_udf,
         crate::st_geometryn::st_geometryn_udf,
         crate::st_geometrytype::st_geometry_type_udf,
         crate::st_geomfromewkb::st_geomfromewkb_udf,

--- a/rust/sedona-functions/src/st_geohash.rs
+++ b/rust/sedona-functions/src/st_geohash.rs
@@ -1,0 +1,360 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use crate::executor::WkbExecutor;
+use arrow_array::builder::StringBuilder;
+use arrow_schema::DataType;
+use datafusion_common::{cast::as_int64_array, error::Result};
+use datafusion_expr::{ColumnarValue, Volatility};
+use geo_traits::GeometryTrait;
+use sedona_common::sedona_internal_datafusion_err;
+use sedona_expr::{
+    item_crs::ItemCrsKernel,
+    scalar_udf::{SedonaScalarKernel, SedonaScalarUDF},
+};
+use sedona_geometry::{bounds::geo_traits_bounds_xy, interval::IntervalTrait};
+use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
+
+/// The base32 alphabet used by geohash encoding (Gustavo Niemeyer's specification)
+const BASE32: &[u8; 32] = b"0123456789bcdefghjkmnpqrstuvwxyz";
+
+/// The maximum number of geohash characters (matches Apache Sedona's
+/// PointGeoHashEncoder, which caps precision at 20)
+const MAX_PRECISION: i64 = 20;
+
+/// ST_GeoHash() scalar UDF
+///
+/// Native implementation to compute the geohash of a geometry at the given
+/// precision (number of base32 characters)
+pub fn st_geohash_udf() -> SedonaScalarUDF {
+    SedonaScalarUDF::new(
+        "st_geohash",
+        ItemCrsKernel::wrap_impl(vec![Arc::new(STGeoHash {})]),
+        Volatility::Immutable,
+    )
+}
+
+#[derive(Debug)]
+struct STGeoHash {}
+
+impl SedonaScalarKernel for STGeoHash {
+    fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
+        let matcher = ArgMatcher::new(
+            vec![ArgMatcher::is_geometry(), ArgMatcher::is_integer()],
+            SedonaType::Arrow(DataType::Utf8),
+        );
+
+        matcher.match_args(args)
+    }
+
+    fn invoke_batch(
+        &self,
+        arg_types: &[SedonaType],
+        args: &[ColumnarValue],
+    ) -> Result<ColumnarValue> {
+        let executor = WkbExecutor::new(arg_types, args);
+        let mut builder = StringBuilder::with_capacity(
+            executor.num_iterations(),
+            MAX_PRECISION as usize * executor.num_iterations(),
+        );
+
+        let precision_value = args[1]
+            .cast_to(&DataType::Int64, None)?
+            .to_array(executor.num_iterations())?;
+        let precision_array = as_int64_array(&precision_value)?;
+        let mut precision_iter = precision_array.iter();
+
+        executor.execute_wkb_void(|maybe_wkb| {
+            match (maybe_wkb, precision_iter.next().unwrap()) {
+                (Some(wkb), Some(precision)) => match invoke_scalar(wkb, precision)? {
+                    Some(geohash) => builder.append_value(geohash),
+                    // Geometry was empty or outside the lon/lat bounds
+                    None => builder.append_null(),
+                },
+                _ => builder.append_null(),
+            }
+            Ok(())
+        })?;
+
+        executor.finish(Arc::new(builder.finish()))
+    }
+}
+
+/// Compute the geohash of a geometry
+///
+/// Follows Apache Sedona's GeometryGeoHashEncoder.calculate(): the point that
+/// is hashed is the center of the geometry's bounding box, and null is
+/// returned when the bounding box is not fully contained in
+/// [-180, 180] x [-90, 90]. Unlike Sedona's Java implementation (where an
+/// empty geometry yields JTS' "null envelope" and thus an accidental hash of
+/// (-0.5, -0.5)), empty geometries return null here.
+fn invoke_scalar(geom: impl GeometryTrait<T = f64>, precision: i64) -> Result<Option<String>> {
+    let bounds = geo_traits_bounds_xy(geom)
+        .map_err(|e| sedona_internal_datafusion_err!("Error computing bounds: {e}"))?;
+    let (x, y) = (bounds.x(), bounds.y());
+    if x.is_empty() || y.is_empty() {
+        return Ok(None);
+    }
+
+    // Longitude can take values in [-180, 180]; latitude can take values in [-90, 90]
+    if x.lo() < -180.0 || y.lo() < -90.0 || x.hi() > 180.0 || y.hi() > 90.0 {
+        return Ok(None);
+    }
+
+    let lon = x.lo() + (x.hi() - x.lo()) / 2.0;
+    let lat = y.lo() + (y.hi() - y.lo()) / 2.0;
+
+    Ok(Some(geohash_encode(lon, lat, precision)))
+}
+
+/// Encode a lon/lat pair as a geohash string with `precision` base32 characters
+///
+/// Non-positive precisions result in an empty string and precisions greater
+/// than 20 are truncated to 20, matching Apache Sedona's PointGeoHashEncoder.
+fn geohash_encode(lon: f64, lat: f64, precision: i64) -> String {
+    if precision <= 0 {
+        return String::new();
+    }
+
+    let precision = precision.min(MAX_PRECISION) as usize;
+    let mut out = String::with_capacity(precision);
+
+    let (mut lon_min, mut lon_max) = (-180.0_f64, 180.0_f64);
+    let (mut lat_min, mut lat_max) = (-90.0_f64, 90.0_f64);
+    let mut is_even = true;
+    let mut bit = 0;
+    let mut ch = 0_usize;
+
+    while out.len() < precision {
+        let (value, min, max) = if is_even {
+            (lon, &mut lon_min, &mut lon_max)
+        } else {
+            (lat, &mut lat_min, &mut lat_max)
+        };
+
+        let mid = (*min + *max) / 2.0;
+        if value >= mid {
+            ch = (ch << 1) | 1;
+            *min = mid;
+        } else {
+            ch <<= 1;
+            *max = mid;
+        }
+
+        is_even = !is_even;
+        bit += 1;
+        if bit == 5 {
+            out.push(BASE32[ch] as char);
+            bit = 0;
+            ch = 0;
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow_array::{create_array, ArrayRef};
+    use datafusion_common::ScalarValue;
+    use datafusion_expr::ScalarUDF;
+    use rstest::rstest;
+    use sedona_schema::datatypes::{WKB_GEOMETRY, WKB_GEOMETRY_ITEM_CRS, WKB_VIEW_GEOMETRY};
+    use sedona_testing::{create::create_array as create_wkb_array, testers::ScalarUdfTester};
+
+    use super::*;
+
+    #[test]
+    fn udf_metadata() {
+        let udf: ScalarUDF = st_geohash_udf().into();
+        assert_eq!(udf.name(), "st_geohash");
+    }
+
+    #[rstest]
+    fn udf(
+        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY, WKB_GEOMETRY_ITEM_CRS.clone())]
+        sedona_type: SedonaType,
+    ) {
+        let tester = ScalarUdfTester::new(
+            st_geohash_udf().into(),
+            vec![
+                sedona_type.clone(),
+                SedonaType::Arrow(arrow_schema::DataType::Int64),
+            ],
+        );
+        tester.assert_return_type(DataType::Utf8);
+
+        // Expected values from Apache Sedona's
+        // spark/common/src/test/scala/org/apache/sedona/sql/functions/geohash/TestStGeoHash.scala
+        let result = tester
+            .invoke_scalar_scalar("POINT (21.4234 52.0423)", ScalarValue::Int64(Some(10)))
+            .unwrap();
+        tester.assert_scalar_result_equals(result, "u3r0pd0037");
+
+        // Null geometry
+        let result = tester
+            .invoke_scalar_scalar(ScalarValue::Null, ScalarValue::Int64(Some(10)))
+            .unwrap();
+        assert!(result.is_null());
+
+        // Null precision
+        let result = tester
+            .invoke_scalar_scalar("POINT (21.4234 52.0423)", ScalarValue::Int64(None))
+            .unwrap();
+        assert!(result.is_null());
+
+        // Empty geometries have no bounding box to hash
+        let result = tester
+            .invoke_scalar_scalar("POINT EMPTY", ScalarValue::Int64(Some(10)))
+            .unwrap();
+        assert!(result.is_null());
+
+        let result = tester
+            .invoke_scalar_scalar("GEOMETRYCOLLECTION EMPTY", ScalarValue::Int64(Some(10)))
+            .unwrap();
+        assert!(result.is_null());
+
+        // Non-point geometries hash the center of their bounding box. Expected
+        // values from TestStGeoHash.scala "should return geohash" (precision 10)
+        let input_wkt = create_wkb_array(
+            &[
+                Some("POINT (21.4234 52.0423)"),
+                Some("LINESTRING (30 10, 10 30, 40 40)"),
+                Some("POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10), (20 30, 35 35, 30 20, 20 30))"),
+                Some("MULTIPOINT ((10 40), (40 30), (20 20), (30 10))"),
+                Some("MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)), ((15 5, 40 10, 10 20, 5 10, 15 5)))"),
+                Some("GEOMETRYCOLLECTION (POINT (40 10), LINESTRING (10 10, 20 20, 10 40), POLYGON ((40 40, 20 45, 45 30, 40 40)))"),
+                None,
+            ],
+            &sedona_type,
+        );
+        let precisions = arrow_array::create_array!(
+            Int64,
+            [
+                Some(10),
+                Some(10),
+                Some(10),
+                Some(10),
+                Some(10),
+                Some(10),
+                Some(10)
+            ]
+        );
+        let expected: ArrayRef = create_array!(
+            Utf8,
+            [
+                Some("u3r0pd0037"),
+                Some("ss3y0zh7w1"),
+                Some("ssgs3y0zh7"),
+                Some("ss3y0zh7w1"),
+                Some("ss1b0bh2n0"),
+                Some("ssgs3y0zh7"),
+                None
+            ]
+        );
+        assert_eq!(
+            &tester.invoke_arrays(vec![input_wkt, precisions]).unwrap(),
+            &expected
+        );
+    }
+
+    #[rstest]
+    fn udf_precision_bounds(#[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType) {
+        let tester = ScalarUdfTester::new(
+            st_geohash_udf().into(),
+            vec![
+                sedona_type.clone(),
+                SedonaType::Arrow(arrow_schema::DataType::Int64),
+            ],
+        );
+
+        // Precision is truncated to the maximum of 20; expected value from
+        // TestStGeoHash.scala "should return geohash truncated to max value"
+        let result = tester
+            .invoke_scalar_scalar(
+                "POINT (21.427834 52.042576573)",
+                ScalarValue::Int64(Some(21)),
+            )
+            .unwrap();
+        tester.assert_scalar_result_equals(result, "u3r0pd53bxrjdsrz4fzj");
+
+        // Non-positive precision returns an empty string; from
+        // TestStGeoHash.scala "should return empty string when precision is negative or equal 0"
+        let result = tester
+            .invoke_scalar_scalar(
+                "POINT (21.427834 52.042576573)",
+                ScalarValue::Int64(Some(0)),
+            )
+            .unwrap();
+        tester.assert_scalar_result_equals(result, "");
+
+        let result = tester
+            .invoke_scalar_scalar(
+                "POINT (21.427834 52.042576573)",
+                ScalarValue::Int64(Some(-1)),
+            )
+            .unwrap();
+        tester.assert_scalar_result_equals(result, "");
+    }
+
+    #[rstest]
+    fn udf_coordinate_bounds(#[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType) {
+        let tester = ScalarUdfTester::new(
+            st_geohash_udf().into(),
+            vec![
+                sedona_type.clone(),
+                SedonaType::Arrow(arrow_schema::DataType::Int64),
+            ],
+        );
+
+        // Expected value from TestStGeoHash.scala
+        // "should not return null for 90 < long < 180 (SEDONA-123)"
+        let result = tester
+            .invoke_scalar_scalar("POINT (120.0 50.0)", ScalarValue::Int64(Some(12)))
+            .unwrap();
+        tester.assert_scalar_result_equals(result, "y8vk6wjr4et3");
+
+        // Boundary cases of min/max lon/lat; expected values from
+        // TestStGeoHash.scala "should return expected value for boundary case of min lat/long"
+        // and "... of max lat/long"
+        let result = tester
+            .invoke_scalar_scalar("POINT (-180.0 -90.0)", ScalarValue::Int64(Some(12)))
+            .unwrap();
+        tester.assert_scalar_result_equals(result, "000000000000");
+
+        let result = tester
+            .invoke_scalar_scalar("POINT (180.0 90.0)", ScalarValue::Int64(Some(12)))
+            .unwrap();
+        tester.assert_scalar_result_equals(result, "zzzzzzzzzzzz");
+
+        // Coordinates outside [-180, 180] x [-90, 90] return null; from
+        // TestStGeoHash.scala "should return null when geometry contains invalid coordinates"
+        for wkt in [
+            "POINT (-190.0 50.0)",
+            "POINT (190.0 50.0)",
+            "POINT (50.0 -100.0)",
+            "POINT (50.0 100.0)",
+        ] {
+            let result = tester
+                .invoke_scalar_scalar(wkt, ScalarValue::Int64(Some(1)))
+                .unwrap();
+            assert!(result.is_null());
+        }
+    }
+}

--- a/rust/sedona-functions/src/st_geohash.rs
+++ b/rust/sedona-functions/src/st_geohash.rs
@@ -255,7 +255,12 @@ fn invoke_scalar(
         return Ok(None);
     }
 
-    // Longitude can take values in [-180, 180]; latitude can take values in [-90, 90]
+    // Longitude can take values in [-180, 180]; latitude can take values in [-90, 90].
+    // Out-of-range coordinates yield null rather than an error, matching Apache
+    // Sedona (GeometryGeoHashEncoder.calculate returns null here). PostGIS instead
+    // raises "Geohash requires inputs in decimal degrees"; the divergence is
+    // deliberate, since a Spark query that returns nulls for out-of-range input
+    // should keep returning nulls here rather than start failing.
     if x.lo() < -180.0 || y.lo() < -90.0 || x.hi() > 180.0 || y.hi() > 90.0 {
         return Ok(None);
     }

--- a/rust/sedona-functions/src/st_geohash.rs
+++ b/rust/sedona-functions/src/st_geohash.rs
@@ -20,16 +20,26 @@ use std::sync::Arc;
 use crate::executor::WkbExecutor;
 use arrow_array::builder::StringBuilder;
 use arrow_schema::DataType;
-use datafusion_common::{cast::as_int64_array, error::Result};
+use datafusion_common::{
+    cast::as_int64_array,
+    config::ConfigOptions,
+    error::{DataFusionError, Result},
+    exec_err,
+};
 use datafusion_expr::{ColumnarValue, Volatility};
-use geo_traits::GeometryTrait;
-use sedona_common::sedona_internal_datafusion_err;
+use geo_traits::{GeometryTrait, GeometryType};
+use sedona_common::{option::SedonaOptions, sedona_internal_datafusion_err, sedona_internal_err};
 use sedona_expr::{
     item_crs::ItemCrsKernel,
     scalar_udf::{SedonaScalarKernel, SedonaScalarUDF},
 };
-use sedona_geometry::{bounds::geo_traits_bounds_xy, interval::IntervalTrait};
+use sedona_geometry::{
+    bounds::{WkbBounder2D, WkbBounder2DFactory},
+    interval::{IntervalTrait, WraparoundInterval},
+    types::Edges,
+};
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
+use wkb::reader::Wkb;
 
 /// The base32 alphabet used by geohash encoding (Gustavo Niemeyer's specification)
 const BASE32: &[u8; 32] = b"0123456789bcdefghjkmnpqrstuvwxyz";
@@ -40,27 +50,41 @@ const MAX_PRECISION: i64 = 20;
 
 /// ST_GeoHash() scalar UDF
 ///
-/// Native implementation to compute the geohash of a geometry at the given
-/// precision (number of base32 characters)
+/// Native implementation to compute the geohash of a geometry or geography.
+/// The two-argument form hashes at the requested precision (number of base32
+/// characters); the one-argument form hashes a point at [MAX_PRECISION].
 pub fn st_geohash_udf() -> SedonaScalarUDF {
     SedonaScalarUDF::new(
         "st_geohash",
-        ItemCrsKernel::wrap_impl(vec![Arc::new(STGeoHash {})]),
+        ItemCrsKernel::wrap_impl(vec![
+            Arc::new(STGeoHash {
+                matcher: ArgMatcher::new(
+                    vec![ArgMatcher::is_geometry_or_geography()],
+                    SedonaType::Arrow(DataType::Utf8),
+                ),
+            }),
+            Arc::new(STGeoHash {
+                matcher: ArgMatcher::new(
+                    vec![
+                        ArgMatcher::is_geometry_or_geography(),
+                        ArgMatcher::is_integer(),
+                    ],
+                    SedonaType::Arrow(DataType::Utf8),
+                ),
+            }),
+        ]),
         Volatility::Immutable,
     )
 }
 
 #[derive(Debug)]
-struct STGeoHash {}
+struct STGeoHash {
+    matcher: ArgMatcher,
+}
 
 impl SedonaScalarKernel for STGeoHash {
     fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
-        let matcher = ArgMatcher::new(
-            vec![ArgMatcher::is_geometry(), ArgMatcher::is_integer()],
-            SedonaType::Arrow(DataType::Utf8),
-        );
-
-        matcher.match_args(args)
+        self.matcher.match_args(args)
     }
 
     fn invoke_batch(
@@ -68,32 +92,140 @@ impl SedonaScalarKernel for STGeoHash {
         arg_types: &[SedonaType],
         args: &[ColumnarValue],
     ) -> Result<ColumnarValue> {
+        self.invoke_batch_from_args(arg_types, args, &SedonaType::Arrow(DataType::Utf8), 0, None)
+    }
+
+    fn invoke_batch_from_args(
+        &self,
+        arg_types: &[SedonaType],
+        args: &[ColumnarValue],
+        _return_type: &SedonaType,
+        _num_rows: usize,
+        config_options: Option<&ConfigOptions>,
+    ) -> Result<ColumnarValue> {
         let executor = WkbExecutor::new(arg_types, args);
         let mut builder = StringBuilder::with_capacity(
             executor.num_iterations(),
             MAX_PRECISION as usize * executor.num_iterations(),
         );
 
-        let precision_value = args[1]
-            .cast_to(&DataType::Int64, None)?
-            .to_array(executor.num_iterations())?;
-        let precision_array = as_int64_array(&precision_value)?;
-        let mut precision_iter = precision_array.iter();
+        // A bounder is a resettable accumulator, so the batch shares one
+        // instance and clear()s it per row rather than allocating per row.
+        let mut bounder = bounder_for_arg_type(&arg_types[0], config_options)?;
 
-        executor.execute_wkb_void(|maybe_wkb| {
-            match (maybe_wkb, precision_iter.next().unwrap()) {
-                (Some(wkb), Some(precision)) => match invoke_scalar(wkb, precision)? {
-                    Some(geohash) => builder.append_value(geohash),
-                    // Geometry was empty or outside the lon/lat bounds
-                    None => builder.append_null(),
-                },
-                _ => builder.append_null(),
-            }
-            Ok(())
-        })?;
+        if args.len() > 1 {
+            append_geohash_with_precision(&executor, args, bounder.as_mut(), &mut builder)?;
+        } else {
+            append_point_geohash(&executor, bounder.as_mut(), &mut builder)?;
+        }
 
         executor.finish(Arc::new(builder.finish()))
     }
+}
+
+/// Resolve the bounder to use for an argument's edge type
+///
+/// Planar (geometry) arguments always resolve, falling back to the default
+/// Cartesian bounder. Spherical (geography) arguments resolve only when a
+/// spherical bounder has been registered on the session runtime, which
+/// requires the s2geography-backed bounder; there is no planar fallback,
+/// because planar bounds of a geography would silently be wrong.
+fn bounder_for_arg_type(
+    arg_type: &SedonaType,
+    config_options: Option<&ConfigOptions>,
+) -> Result<Box<dyn WkbBounder2D>> {
+    let edges = match arg_type {
+        SedonaType::Wkb(edges, _) | SedonaType::WkbView(edges, _) => *edges,
+        // A literal NULL argument (e.g. ST_GeoHash(NULL, 10)) keeps its Null
+        // type: every row is null, so the bounder is never used and the choice
+        // of edge type doesn't matter.
+        SedonaType::Arrow(DataType::Null) => Edges::Planar,
+        _ => {
+            return sedona_internal_err!(
+                "Expected geometry or geography argument but got {arg_type:?}"
+            )
+        }
+    };
+
+    let maybe_bounder = match config_options.and_then(|o| o.extensions.get::<SedonaOptions>()) {
+        Some(options) => options
+            .runtime
+            .bounder_factory()
+            .bounder_for_edge_type(edges),
+        None => WkbBounder2DFactory::default().bounder_for_edge_type(edges),
+    };
+
+    maybe_bounder.ok_or_else(|| {
+        DataFusionError::Execution(
+            "ST_GeoHash() on a geography requires the s2geography-backed spherical bounder, \
+             which is not registered in this session"
+                .to_string(),
+        )
+    })
+}
+
+/// Append the geohash of each geometry at the precision given by the second argument
+fn append_geohash_with_precision(
+    executor: &WkbExecutor<'_, '_>,
+    args: &[ColumnarValue],
+    bounder: &mut dyn WkbBounder2D,
+    builder: &mut StringBuilder,
+) -> Result<()> {
+    let precision_value = args[1]
+        .cast_to(&DataType::Int64, None)?
+        .to_array(executor.num_iterations())?;
+    let precision_array = as_int64_array(&precision_value)?;
+    let mut precision_iter = precision_array.iter();
+
+    executor.execute_wkb_void(|maybe_wkb| {
+        match (maybe_wkb, precision_iter.next().unwrap()) {
+            (Some(wkb), Some(precision)) => match invoke_scalar(wkb, precision, bounder)? {
+                Some(geohash) => builder.append_value(geohash),
+                // Geometry was empty or outside the lon/lat bounds
+                None => builder.append_null(),
+            },
+            _ => builder.append_null(),
+        }
+        Ok(())
+    })
+}
+
+/// Append the geohash of each point at [MAX_PRECISION]
+///
+/// This is the one-argument overload. PostGIS' one-argument ST_GeoHash()
+/// derives a precision from the extent of the geometry (the smallest cell that
+/// contains it, or a level-20 cell for a point); only the point case is
+/// implemented here, where the answer is unambiguous. Anything else errors so
+/// that a precision must be stated rather than guessed.
+fn append_point_geohash(
+    executor: &WkbExecutor<'_, '_>,
+    bounder: &mut dyn WkbBounder2D,
+    builder: &mut StringBuilder,
+) -> Result<()> {
+    executor.execute_wkb_void(|maybe_wkb| {
+        match maybe_wkb {
+            Some(wkb) => {
+                // Only a single POINT counts: a MULTIPOINT, even one holding
+                // exactly one point, takes the non-point path. PostGIS' rule is
+                // really about a zero-area bounding box, but "POINT only" is
+                // simpler to state and to predict.
+                if !matches!(wkb.as_type(), GeometryType::Point(_)) {
+                    return exec_err!(
+                        "ST_GeoHash(geometry) is only defined for POINT; pass a precision to \
+                         hash the bounding box center of a non-point geometry"
+                    );
+                }
+
+                match invoke_scalar(wkb, MAX_PRECISION, bounder)? {
+                    Some(geohash) => builder.append_value(geohash),
+                    // Point was empty or outside the lon/lat bounds
+                    None => builder.append_null(),
+                }
+            }
+            None => builder.append_null(),
+        }
+        Ok(())
+    })
 }
 
 /// Compute the geohash of a geometry
@@ -104,10 +236,21 @@ impl SedonaScalarKernel for STGeoHash {
 /// [-180, 180] x [-90, 90]. Unlike Sedona's Java implementation (where an
 /// empty geometry yields JTS' "null envelope" and thus an accidental hash of
 /// (-0.5, -0.5)), empty geometries return null here.
-fn invoke_scalar(geom: impl GeometryTrait<T = f64>, precision: i64) -> Result<Option<String>> {
-    let bounds = geo_traits_bounds_xy(geom)
+///
+/// The bounding box comes from `bounder`, which the caller resolved from the
+/// argument's edge type, so a geography is bounded on the sphere rather than
+/// in the plane.
+fn invoke_scalar(
+    geom: &Wkb,
+    precision: i64,
+    bounder: &mut dyn WkbBounder2D,
+) -> Result<Option<String>> {
+    bounder.clear();
+    bounder
+        .update_wkb_bytes(geom.buf())
         .map_err(|e| sedona_internal_datafusion_err!("Error computing bounds: {e}"))?;
-    let (x, y) = (bounds.x(), bounds.y());
+    let (x, y) = bounder.finish();
+
     if x.is_empty() || y.is_empty() {
         return Ok(None);
     }
@@ -117,10 +260,30 @@ fn invoke_scalar(geom: impl GeometryTrait<T = f64>, precision: i64) -> Result<Op
         return Ok(None);
     }
 
-    let lon = x.lo() + (x.hi() - x.lo()) / 2.0;
+    let lon = center_longitude(&x);
     let lat = y.lo() + (y.hi() - y.lo()) / 2.0;
 
     Ok(Some(geohash_encode(lon, lat, precision)))
+}
+
+/// The center of a longitude interval, in [-180, 180]
+///
+/// A spherical bounder can return an interval that crosses the antimeridian,
+/// which is expressed as `lo > hi` (e.g. (170, -170) covers 20 degrees through
+/// 180, not the 340 degrees through 0). For those, `lo + (hi - lo) / 2` walks
+/// the wrong way around the sphere, so measure the width eastward from `lo`
+/// and wrap the result back into [-180, 180].
+fn center_longitude(x: &WraparoundInterval) -> f64 {
+    if !x.is_wraparound() {
+        return x.lo() + (x.hi() - x.lo()) / 2.0;
+    }
+
+    let center = x.lo() + ((x.hi() + 360.0) - x.lo()) / 2.0;
+    if center > 180.0 {
+        center - 360.0
+    } else {
+        center
+    }
 }
 
 /// Encode a lon/lat pair as a geohash string with `precision` base32 characters
@@ -175,10 +338,34 @@ mod tests {
     use datafusion_common::ScalarValue;
     use datafusion_expr::ScalarUDF;
     use rstest::rstest;
-    use sedona_schema::datatypes::{WKB_GEOMETRY, WKB_GEOMETRY_ITEM_CRS, WKB_VIEW_GEOMETRY};
+    use sedona_geometry::bounds::WkbGeometryBounder;
+    use sedona_schema::datatypes::{
+        WKB_GEOGRAPHY, WKB_GEOGRAPHY_ITEM_CRS, WKB_GEOMETRY, WKB_GEOMETRY_ITEM_CRS,
+        WKB_VIEW_GEOGRAPHY, WKB_VIEW_GEOMETRY,
+    };
     use sedona_testing::{create::create_array as create_wkb_array, testers::ScalarUdfTester};
 
     use super::*;
+
+    /// A tester whose session has a spherical bounder registered
+    ///
+    /// sedona-functions does not depend on sedona-s2geography, so these tests
+    /// stand in the Cartesian bounder for the spherical one. That keeps the
+    /// expected values identical to the geometry cases while still exercising
+    /// the geography path end to end: the geography argument matches a kernel,
+    /// the bounder comes from the session runtime rather than being hard-coded,
+    /// and its output drives the hash. The spherical-vs-planar difference in
+    /// the bounds themselves is sedona-s2geography's contract, not this
+    /// function's.
+    fn tester_with_stand_in_spherical_bounder(arg_types: Vec<SedonaType>) -> ScalarUdfTester {
+        let mut tester = ScalarUdfTester::new(st_geohash_udf().into(), arg_types);
+        let options = tester.sedona_options_mut();
+        options.runtime = options
+            .runtime
+            .with_bounder(Edges::Spherical, Arc::new(WkbGeometryBounder::default()))
+            .unwrap();
+        tester
+    }
 
     #[test]
     fn udf_metadata() {
@@ -219,16 +406,23 @@ mod tests {
             .unwrap();
         assert!(result.is_null());
 
-        // Empty geometries have no bounding box to hash
-        let result = tester
-            .invoke_scalar_scalar("POINT EMPTY", ScalarValue::Int64(Some(10)))
-            .unwrap();
-        assert!(result.is_null());
-
-        let result = tester
-            .invoke_scalar_scalar("GEOMETRYCOLLECTION EMPTY", ScalarValue::Int64(Some(10)))
-            .unwrap();
-        assert!(result.is_null());
+        // Empty geometries have no bounding box to hash. PostGIS agrees on all
+        // of these (lwgeom_geohash() returns NULL when the gbox can't be
+        // computed), which the Python comparison tests pin.
+        for wkt in [
+            "POINT EMPTY",
+            "LINESTRING EMPTY",
+            "POLYGON EMPTY",
+            "MULTIPOINT EMPTY",
+            "MULTILINESTRING EMPTY",
+            "MULTIPOLYGON EMPTY",
+            "GEOMETRYCOLLECTION EMPTY",
+        ] {
+            let result = tester
+                .invoke_scalar_scalar(wkt, ScalarValue::Int64(Some(10)))
+                .unwrap();
+            assert!(result.is_null(), "expected null for {wkt}");
+        }
 
         // Non-point geometries hash the center of their bounding box. Expected
         // values from TestStGeoHash.scala "should return geohash" (precision 10)
@@ -356,5 +550,170 @@ mod tests {
                 .unwrap();
             assert!(result.is_null());
         }
+    }
+
+    #[rstest]
+    fn udf_one_arg(
+        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY, WKB_GEOMETRY_ITEM_CRS.clone())]
+        sedona_type: SedonaType,
+    ) {
+        let tester = ScalarUdfTester::new(st_geohash_udf().into(), vec![sedona_type]);
+        tester.assert_return_type(DataType::Utf8);
+
+        // A point with no precision hashes at the 20 character maximum, and
+        // extends the precision 10 value pinned in udf() above.
+        let result = tester.invoke_scalar("POINT (21.4234 52.0423)").unwrap();
+        tester.assert_scalar_result_equals(result, "u3r0pd0037ugg6hm1kb1");
+
+        // Western and southern hemispheres, extending the precision 9 value
+        // pinned against PostGIS in the Python comparison tests
+        let result = tester.invoke_scalar("POINT (-122.4194 37.7749)").unwrap();
+        tester.assert_scalar_result_equals(result, "9q8yyk8ytpxr8wwhcg8j");
+
+        // Null geometry
+        let result = tester.invoke_scalar(ScalarValue::Null).unwrap();
+        assert!(result.is_null());
+
+        // An empty point has no bounding box to hash, as in the two argument form
+        let result = tester.invoke_scalar("POINT EMPTY").unwrap();
+        assert!(result.is_null());
+
+        // Out of range coordinates return null, as in the two argument form
+        let result = tester.invoke_scalar("POINT (-190.0 50.0)").unwrap();
+        assert!(result.is_null());
+    }
+
+    #[rstest]
+    fn udf_one_arg_requires_point(
+        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType,
+    ) {
+        let tester = ScalarUdfTester::new(st_geohash_udf().into(), vec![sedona_type]);
+
+        // Every non-point geometry errors rather than guessing a precision.
+        // MULTIPOINT is included deliberately: a single-element MULTIPOINT is
+        // not treated as a point.
+        for wkt in [
+            "LINESTRING (30 10, 10 30, 40 40)",
+            "POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10))",
+            "MULTIPOINT ((10 40))",
+            "GEOMETRYCOLLECTION (POINT (40 10))",
+            // Empty non-points error too: the geometry type decides, not the bounds
+            "LINESTRING EMPTY",
+        ] {
+            let err = tester.invoke_scalar(wkt).unwrap_err().to_string();
+            assert!(
+                err.contains("ST_GeoHash(geometry) is only defined for POINT"),
+                "unexpected error for {wkt}: {err}"
+            );
+        }
+    }
+
+    #[rstest]
+    fn udf_geography(
+        #[values(
+            WKB_GEOGRAPHY,
+            WKB_VIEW_GEOGRAPHY,
+            WKB_GEOGRAPHY_ITEM_CRS.clone()
+        )]
+        sedona_type: SedonaType,
+    ) {
+        let tester = tester_with_stand_in_spherical_bounder(vec![
+            sedona_type.clone(),
+            SedonaType::Arrow(DataType::Int64),
+        ]);
+        tester.assert_return_type(DataType::Utf8);
+
+        let result = tester
+            .invoke_scalar_scalar("POINT (21.4234 52.0423)", ScalarValue::Int64(Some(10)))
+            .unwrap();
+        tester.assert_scalar_result_equals(result, "u3r0pd0037");
+
+        let result = tester
+            .invoke_scalar_scalar("POINT EMPTY", ScalarValue::Int64(Some(10)))
+            .unwrap();
+        assert!(result.is_null());
+
+        // The one argument overload applies to geography as well
+        let tester = tester_with_stand_in_spherical_bounder(vec![sedona_type]);
+        tester.assert_return_type(DataType::Utf8);
+
+        let result = tester.invoke_scalar("POINT (21.4234 52.0423)").unwrap();
+        tester.assert_scalar_result_equals(result, "u3r0pd0037ugg6hm1kb1");
+
+        let err = tester
+            .invoke_scalar("LINESTRING (30 10, 10 30, 40 40)")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("ST_GeoHash(geometry) is only defined for POINT"));
+    }
+
+    #[rstest]
+    fn udf_geography_without_spherical_bounder(
+        #[values(WKB_GEOGRAPHY, WKB_VIEW_GEOGRAPHY)] sedona_type: SedonaType,
+    ) {
+        // A default session has no spherical bounder, so a geography argument
+        // errors rather than silently falling back to planar bounds.
+        let tester = ScalarUdfTester::new(
+            st_geohash_udf().into(),
+            vec![sedona_type, SedonaType::Arrow(DataType::Int64)],
+        );
+
+        let err = tester
+            .invoke_scalar_scalar("POINT (21.4234 52.0423)", ScalarValue::Int64(Some(10)))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("requires the s2geography-backed spherical bounder"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn udf_untyped_null_argument() {
+        // A literal NULL (SELECT ST_GeoHash(NULL, 10)) keeps its Null type all
+        // the way into the kernel, so resolving a bounder has to tolerate an
+        // argument type that names no edge type.
+        let tester = ScalarUdfTester::new(
+            st_geohash_udf().into(),
+            vec![
+                SedonaType::Arrow(DataType::Null),
+                SedonaType::Arrow(DataType::Int64),
+            ],
+        );
+        let result = tester
+            .invoke_scalar_scalar(ScalarValue::Null, ScalarValue::Int64(Some(10)))
+            .unwrap();
+        assert!(result.is_null());
+
+        let tester = ScalarUdfTester::new(
+            st_geohash_udf().into(),
+            vec![SedonaType::Arrow(DataType::Null)],
+        );
+        let result = tester.invoke_scalar(ScalarValue::Null).unwrap();
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn center_longitude_handles_wraparound() {
+        // A plain interval keeps the arithmetic mean
+        assert_eq!(
+            center_longitude(&WraparoundInterval::new(10.0, 30.0)),
+            20.0_f64
+        );
+
+        // An interval crossing the antimeridian covers lo -> 180 -> hi, so its
+        // center is the eastward midpoint, not the midpoint of [hi, lo]
+        assert_eq!(
+            center_longitude(&WraparoundInterval::new(170.0, -170.0)),
+            180.0_f64
+        );
+        assert_eq!(
+            center_longitude(&WraparoundInterval::new(175.0, -160.0)),
+            -172.5_f64
+        );
+        assert_eq!(
+            center_longitude(&WraparoundInterval::new(160.0, -170.0)),
+            175.0_f64
+        );
     }
 }

--- a/rust/sedona-functions/src/st_geohash.rs
+++ b/rust/sedona-functions/src/st_geohash.rs
@@ -18,10 +18,10 @@
 use std::{collections::HashMap, iter::zip, sync::Arc};
 
 use crate::executor::WkbExecutor;
-use arrow_array::{builder::StringBuilder, Array};
+use arrow_array::{builder::StringBuilder, Array, ArrayRef, Int64Array};
 use arrow_schema::DataType;
 use datafusion_common::{
-    cast::{as_int64_array, as_string_view_array, as_struct_array},
+    cast::{as_int64_array, as_string_view_array, as_struct_array, as_uint64_array},
     config::ConfigOptions,
     error::{DataFusionError, Result},
     exec_err, plan_err, ScalarValue,
@@ -497,6 +497,34 @@ fn ensure_wgs84_crs(arg_type: &SedonaType) -> Result<()> {
     )
 }
 
+/// Narrow the precision argument to `Int64`, saturating rather than failing
+///
+/// `ArgMatcher::is_integer()` accepts `UInt64`, whose upper half does not fit in
+/// an `i64`, so casting it directly raised "Can't cast value ... to type Int64"
+/// for any precision above `i64::MAX`. That is a signature the function offers
+/// but could not honour.
+///
+/// Nothing is lost by saturating: [`geohash_encode`] caps precision at
+/// [`MAX_PRECISION`], so every value at or above 20 already produces the same
+/// 20-character hash. A `UInt64` precision of `u64::MAX` therefore encodes
+/// exactly as a precision of 20 does, which is what the cap already promised.
+///
+/// Every other integer width fits in an `i64` and is cast directly.
+fn precision_as_int64(arg: &ColumnarValue, num_rows: usize) -> Result<ArrayRef> {
+    if !matches!(arg.data_type(), DataType::UInt64) {
+        return arg.cast_to(&DataType::Int64, None)?.to_array(num_rows);
+    }
+
+    let values = arg.to_array(num_rows)?;
+    let values = as_uint64_array(&values)?;
+    let saturated: Int64Array = values
+        .iter()
+        .map(|maybe_value| maybe_value.map(|value| value.min(i64::MAX as u64) as i64))
+        .collect();
+
+    Ok(Arc::new(saturated))
+}
+
 /// Append the geohash of each geometry at the precision given by the second argument
 fn append_geohash_with_precision(
     executor: &WkbExecutor<'_, '_>,
@@ -506,9 +534,7 @@ fn append_geohash_with_precision(
     next_wrap: &mut dyn FnMut() -> Result<LongitudeWrap>,
     builder: &mut StringBuilder,
 ) -> Result<()> {
-    let precision_value = args[1]
-        .cast_to(&DataType::Int64, None)?
-        .to_array(executor.num_iterations())?;
+    let precision_value = precision_as_int64(&args[1], executor.num_iterations())?;
     let precision_array = as_int64_array(&precision_value)?;
     let mut precision_iter = precision_array.iter();
 
@@ -778,7 +804,7 @@ fn geohash_encode(lon: f64, lat: f64, precision: i64) -> String {
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::{create_array, ArrayRef};
+    use arrow_array::{create_array, ArrayRef, UInt32Array, UInt64Array};
     use datafusion_common::ScalarValue;
     use datafusion_expr::ScalarUDF;
     use rstest::rstest;
@@ -1274,6 +1300,67 @@ mod tests {
         assert!(raw_bounder_for_arg_type(&WKB_VIEW_GEOMETRY).is_none());
         assert!(raw_bounder_for_arg_type(&WKB_GEOGRAPHY).is_some());
         assert!(raw_bounder_for_arg_type(&WKB_VIEW_GEOGRAPHY).is_some());
+    }
+
+    #[rstest]
+    fn udf_saturates_a_precision_wider_than_i64(
+        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType,
+    ) {
+        // ArgMatcher::is_integer() accepts UInt64, whose upper half does not fit
+        // in an i64. Casting it directly raised "Can't cast value ... to type
+        // Int64" for any precision above i64::MAX, so the function rejected a
+        // precision its own signature accepted.
+        //
+        // Precision is capped at MAX_PRECISION, so everything at or above 20 is
+        // the same 20-character hash; saturating loses nothing.
+        let tester = ScalarUdfTester::new(
+            st_geohash_udf().into(),
+            vec![sedona_type, SedonaType::Arrow(DataType::UInt64)],
+        );
+
+        let expected = "s02equ04ven09qv80meq";
+        for precision in [20_u64, i64::MAX as u64, i64::MAX as u64 + 1, u64::MAX] {
+            let result = tester
+                .invoke_scalar_scalar("POINT (1 2)", ScalarValue::UInt64(Some(precision)))
+                .unwrap();
+            tester.assert_scalar_result_equals(result, expected);
+        }
+
+        // A null precision still yields a null result.
+        let result = tester
+            .invoke_scalar_scalar("POINT (1 2)", ScalarValue::UInt64(None))
+            .unwrap();
+        tester.assert_scalar_result_equals(result, ScalarValue::Utf8(None));
+    }
+
+    #[test]
+    fn precision_as_int64_saturates_only_unsigned_64_bit() {
+        // UInt64 saturates at i64::MAX ...
+        let wide = ColumnarValue::Array(Arc::new(UInt64Array::from(vec![
+            Some(0),
+            Some(20),
+            Some(i64::MAX as u64),
+            Some(u64::MAX),
+            None,
+        ])));
+        let out = precision_as_int64(&wide, 5).unwrap();
+        let out = as_int64_array(&out).unwrap();
+        assert_eq!(
+            out.iter().collect::<Vec<_>>(),
+            vec![Some(0), Some(20), Some(i64::MAX), Some(i64::MAX), None]
+        );
+
+        // ... while narrower widths and signed values are cast unchanged,
+        // including the negative precision that means "empty string".
+        let signed = ColumnarValue::Array(Arc::new(Int64Array::from(vec![Some(-1), Some(10)])));
+        let out = precision_as_int64(&signed, 2).unwrap();
+        let out = as_int64_array(&out).unwrap();
+        assert_eq!(out.iter().collect::<Vec<_>>(), vec![Some(-1), Some(10)]);
+
+        let small = ColumnarValue::Array(Arc::new(UInt32Array::from(vec![Some(u32::MAX)])));
+        let out = precision_as_int64(&small, 1).unwrap();
+        let out = as_int64_array(&out).unwrap();
+        assert_eq!(out.iter().collect::<Vec<_>>(), vec![Some(u32::MAX as i64)]);
     }
 
     #[test]

--- a/rust/sedona-functions/src/st_geohash.rs
+++ b/rust/sedona-functions/src/st_geohash.rs
@@ -143,6 +143,7 @@ impl SedonaScalarKernel for STGeoHash {
         // A bounder is a resettable accumulator, so the batch shares one
         // instance and clear()s it per row rather than allocating per row.
         let mut bounder = bounder_for_arg_type(&arg_types[0], config_options)?;
+        let mut raw_bounder = raw_bounder_for_arg_type(&arg_types[0]);
 
         // The CRS is a property of the type, so this is decided once for the
         // batch rather than per row.
@@ -154,11 +155,18 @@ impl SedonaScalarKernel for STGeoHash {
                 &executor,
                 args,
                 bounder.as_mut(),
+                &mut raw_bounder,
                 &mut next_wrap,
                 &mut builder,
             )?;
         } else {
-            append_point_geohash(&executor, bounder.as_mut(), &mut next_wrap, &mut builder)?;
+            append_point_geohash(
+                &executor,
+                bounder.as_mut(),
+                &mut raw_bounder,
+                &mut next_wrap,
+                &mut builder,
+            )?;
         }
 
         executor.finish(Arc::new(builder.finish()))
@@ -204,6 +212,34 @@ fn bounder_for_arg_type(
                 .to_string(),
         )
     })
+}
+
+/// A planar bounder for range-checking the coordinates a spherical bounder hides
+///
+/// s2geography bounds a geography with an `S2LatLngRect`, whose latitudes are
+/// constrained to [-90, 90] by construction, so an out-of-range latitude is
+/// clamped inside S2 before [`WkbBounder2D::finish`] returns it: a geography at
+/// latitude 100, 91 or 270 all come back as 90 and would otherwise encode as
+/// the pole. Bounding the same bytes in the plane recovers what the input
+/// actually said, so the domain check sees the original value.
+///
+/// Only the latitude check uses this. The centre still comes from the spherical
+/// bounds, which is the point of bounding a geography on the sphere. Longitude
+/// needs no such care: S2 normalizes it into [-180, 180], which is the same
+/// wrapping this function applies to a geometry.
+///
+/// Returns `None` for a planar argument, whose bounder does no clamping and can
+/// be range-checked directly.
+fn raw_bounder_for_arg_type(arg_type: &SedonaType) -> Option<Box<dyn WkbBounder2D>> {
+    let edges = match arg_type {
+        SedonaType::Wkb(edges, _) | SedonaType::WkbView(edges, _) => *edges,
+        _ => return None,
+    };
+
+    match edges {
+        Edges::Planar => None,
+        _ => WkbBounder2DFactory::default().bounder_for_edge_type(Edges::Planar),
+    }
 }
 
 /// Per-batch cache of the WGS84 verdict for each distinct CRS string
@@ -334,6 +370,7 @@ impl SedonaScalarKernel for STGeoHashItemCrs {
             MAX_PRECISION as usize * executor.num_iterations(),
         );
         let mut bounder = bounder_for_arg_type(&item_type, config_options)?;
+        let mut raw_bounder = raw_bounder_for_arg_type(&item_type);
         let mut checker = CachedWgs84Check::with_capacity(crs_array.len());
 
         // A scalar struct carries a single CRS that applies to every iteration;
@@ -356,11 +393,18 @@ impl SedonaScalarKernel for STGeoHashItemCrs {
                 &executor,
                 &item_args,
                 bounder.as_mut(),
+                &mut raw_bounder,
                 &mut next_wrap,
                 &mut builder,
             )?;
         } else {
-            append_point_geohash(&executor, bounder.as_mut(), &mut next_wrap, &mut builder)?;
+            append_point_geohash(
+                &executor,
+                bounder.as_mut(),
+                &mut raw_bounder,
+                &mut next_wrap,
+                &mut builder,
+            )?;
         }
 
         executor.finish(Arc::new(builder.finish()))
@@ -458,6 +502,7 @@ fn append_geohash_with_precision(
     executor: &WkbExecutor<'_, '_>,
     args: &[ColumnarValue],
     bounder: &mut dyn WkbBounder2D,
+    raw_bounder: &mut Option<Box<dyn WkbBounder2D>>,
     next_wrap: &mut dyn FnMut() -> Result<LongitudeWrap>,
     builder: &mut StringBuilder,
 ) -> Result<()> {
@@ -470,11 +515,13 @@ fn append_geohash_with_precision(
     executor.execute_wkb_void(|maybe_wkb| {
         let wrap = next_wrap()?;
         match (maybe_wkb, precision_iter.next().unwrap()) {
-            (Some(wkb), Some(precision)) => match invoke_scalar(wkb, precision, bounder, wrap)? {
-                Some(geohash) => builder.append_value(geohash),
-                // Geometry was empty or outside the lon/lat bounds
-                None => builder.append_null(),
-            },
+            (Some(wkb), Some(precision)) => {
+                match invoke_scalar(wkb, precision, bounder, raw_bounder, wrap)? {
+                    Some(geohash) => builder.append_value(geohash),
+                    // Geometry was empty or outside the lon/lat bounds
+                    None => builder.append_null(),
+                }
+            }
             _ => builder.append_null(),
         }
         Ok(())
@@ -491,6 +538,7 @@ fn append_geohash_with_precision(
 fn append_point_geohash(
     executor: &WkbExecutor<'_, '_>,
     bounder: &mut dyn WkbBounder2D,
+    raw_bounder: &mut Option<Box<dyn WkbBounder2D>>,
     next_wrap: &mut dyn FnMut() -> Result<LongitudeWrap>,
     builder: &mut StringBuilder,
 ) -> Result<()> {
@@ -509,7 +557,7 @@ fn append_point_geohash(
                     );
                 }
 
-                match invoke_scalar(wkb, MAX_PRECISION, bounder, wrap)? {
+                match invoke_scalar(wkb, MAX_PRECISION, bounder, raw_bounder, wrap)? {
                     Some(geohash) => builder.append_value(geohash),
                     // Point was empty or outside the lon/lat bounds
                     None => builder.append_null(),
@@ -547,6 +595,7 @@ fn invoke_scalar(
     geom: &Wkb,
     precision: i64,
     bounder: &mut dyn WkbBounder2D,
+    raw_bounder: &mut Option<Box<dyn WkbBounder2D>>,
     wrap: LongitudeWrap,
 ) -> Result<Option<String>> {
     bounder.clear();
@@ -562,7 +611,23 @@ fn invoke_scalar(
     // Latitude can take values in [-90, 90]. Unlike longitude it is not cyclic,
     // so there is no reinterpretation of an out-of-range value that recovers a
     // real location, and it nulls out under both wrap settings.
-    if !in_latitude_range(&y) {
+    //
+    // The check runs against the raw planar bounds where they are available,
+    // because a spherical bounder clamps latitude into range before returning
+    // it; see [`raw_bounder_for_arg_type`].
+    let raw_y = match raw_bounder.as_mut() {
+        Some(raw_bounder) => {
+            raw_bounder.clear();
+            raw_bounder
+                .update_wkb_bytes(geom.buf())
+                .map_err(|e| sedona_internal_datafusion_err!("Error computing bounds: {e}"))?;
+            let (_, raw_y) = raw_bounder.finish();
+            raw_y
+        }
+        None => y,
+    };
+
+    if !in_latitude_range(&raw_y) {
         return Ok(None);
     }
 
@@ -1105,6 +1170,110 @@ mod tests {
         );
         assert!(checker.wrap_for(Some("EPSG:3857")).is_err());
         assert_eq!(checker.cache.len(), 2);
+    }
+
+    /// A stand-in for the s2geography bounder that reproduces its latitude clamp
+    ///
+    /// s2geography bounds into an `S2LatLngRect`, whose latitudes are
+    /// constrained to [-90, 90], so an out-of-range latitude never reaches the
+    /// domain check. sedona-functions cannot depend on sedona-s2geography, so
+    /// this wrapper reproduces just that behavior: the real bounder is exercised
+    /// by the Python tests, which run against an s2geography build in CI.
+    #[derive(Debug, Default)]
+    struct ClampingBounder {
+        inner: WkbGeometryBounder,
+    }
+
+    impl WkbBounder2D for ClampingBounder {
+        fn clear(&mut self) {
+            self.inner.clear()
+        }
+
+        fn update_bounds(
+            &mut self,
+            x: WraparoundInterval,
+            y: Interval,
+        ) -> std::result::Result<(), sedona_geometry::error::SedonaGeometryError> {
+            self.inner.update_bounds(x, y)
+        }
+
+        fn update_wkb_bytes(
+            &mut self,
+            wkb_value: &[u8],
+        ) -> std::result::Result<(), sedona_geometry::error::SedonaGeometryError> {
+            self.inner.update_wkb_bytes(wkb_value)
+        }
+
+        fn finish(&self) -> (WraparoundInterval, Interval) {
+            let (x, y) = self.inner.finish();
+            if y.is_empty() {
+                return (x, y);
+            }
+            // The clamp S2 applies.
+            (
+                x,
+                Interval::new(y.lo().clamp(-90.0, 90.0), y.hi().clamp(-90.0, 90.0)),
+            )
+        }
+
+        fn expand_by_distance(
+            &mut self,
+            distance: f64,
+            radius: Option<f64>,
+        ) -> std::result::Result<(), sedona_geometry::error::SedonaGeometryError> {
+            self.inner.expand_by_distance(distance, radius)
+        }
+
+        fn mem_used(&self) -> usize {
+            self.inner.mem_used()
+        }
+
+        fn create_instance(&self) -> Box<dyn WkbBounder2D> {
+            Box::new(Self::default())
+        }
+    }
+
+    #[test]
+    fn udf_geography_rejects_latitude_the_bounder_clamps() {
+        // With a bounder that clamps like S2, an out-of-range latitude would
+        // otherwise be invisible: it arrives as exactly 90 and encodes as the
+        // pole. The raw planar bound taken alongside it recovers the input.
+        let mut tester = ScalarUdfTester::new(
+            st_geohash_udf().into(),
+            vec![WKB_GEOGRAPHY, SedonaType::Arrow(DataType::Int64)],
+        );
+        let options = tester.sedona_options_mut();
+        options.runtime = options
+            .runtime
+            .with_bounder(Edges::Spherical, Arc::new(ClampingBounder::default()))
+            .unwrap();
+
+        for wkt in [
+            "POINT (50.0 100.0)",
+            "POINT (50.0 91.0)",
+            "POINT (50.0 -91.0)",
+            "LINESTRING (50.0 80.0, 60.0 100.0)",
+        ] {
+            let result = tester
+                .invoke_scalar_scalar(wkt, ScalarValue::Int64(Some(12)))
+                .unwrap();
+            tester.assert_scalar_result_equals(result, ScalarValue::Utf8(None));
+        }
+
+        // The genuine poles are in range and still encode.
+        let pole = tester
+            .invoke_scalar_scalar("POINT (50.0 90.0)", ScalarValue::Int64(Some(12)))
+            .unwrap();
+        tester.assert_scalar_result_equals(pole, "vpgxczbzuryp");
+    }
+
+    #[test]
+    fn raw_bounder_is_only_resolved_for_spherical_arguments() {
+        // A planar bounder does no clamping, so a geometry needs no second pass.
+        assert!(raw_bounder_for_arg_type(&WKB_GEOMETRY).is_none());
+        assert!(raw_bounder_for_arg_type(&WKB_VIEW_GEOMETRY).is_none());
+        assert!(raw_bounder_for_arg_type(&WKB_GEOGRAPHY).is_some());
+        assert!(raw_bounder_for_arg_type(&WKB_VIEW_GEOGRAPHY).is_some());
     }
 
     #[test]

--- a/rust/sedona-functions/src/st_geohash.rs
+++ b/rust/sedona-functions/src/st_geohash.rs
@@ -35,7 +35,7 @@ use sedona_expr::{
 };
 use sedona_geometry::{
     bounds::{WkbBounder2D, WkbBounder2DFactory},
-    interval::{IntervalTrait, WraparoundInterval},
+    interval::{Interval, IntervalTrait, WraparoundInterval},
     types::Edges,
 };
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
@@ -113,10 +113,14 @@ impl SedonaScalarKernel for STGeoHash {
         // instance and clear()s it per row rather than allocating per row.
         let mut bounder = bounder_for_arg_type(&arg_types[0], config_options)?;
 
+        // The CRS is a property of the type, so whether longitudes may be
+        // wrapped is decided once for the batch rather than per row.
+        let wrap = longitude_wrap_for_arg_type(&arg_types[0])?;
+
         if args.len() > 1 {
-            append_geohash_with_precision(&executor, args, bounder.as_mut(), &mut builder)?;
+            append_geohash_with_precision(&executor, args, bounder.as_mut(), wrap, &mut builder)?;
         } else {
-            append_point_geohash(&executor, bounder.as_mut(), &mut builder)?;
+            append_point_geohash(&executor, bounder.as_mut(), wrap, &mut builder)?;
         }
 
         executor.finish(Arc::new(builder.finish()))
@@ -164,11 +168,59 @@ fn bounder_for_arg_type(
     })
 }
 
+/// Whether an out-of-range longitude may be wrapped back into [-180, 180]
+///
+/// Wrapping is only meaningful when the coordinates are known to be longitude
+/// and latitude in degrees: 181 is then an unambiguous spelling of -179, and
+/// hashing it is better than dropping the row. Applied to a projected CRS the
+/// same arithmetic would turn a coordinate in metres into a plausible-looking
+/// geohash for somewhere it has nothing to do with, so it stays off unless the
+/// units are known.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum LongitudeWrap {
+    /// The argument is known to be in longitude/latitude degrees
+    Enabled,
+    /// The units are projected, or simply not known, so an out-of-range
+    /// coordinate is not necessarily a wrapped longitude
+    Disabled,
+}
+
+/// Decide whether an argument's coordinates are known to be lon/lat degrees
+///
+/// A geography is lon/lat by definition. A geometry qualifies only when its
+/// type-level CRS resolves to geographic parameters (EPSG:4326, OGC:CRS84,
+/// EPSG:4269, ...), which is the same test `st_setsrid` uses to decide whether
+/// a CRS is usable as a geography.
+///
+/// An absent CRS does *not* qualify. Undeclared coordinates are the common case
+/// for `ST_GeomFromText()` and could be anything, so they keep the pre-existing
+/// null-on-out-of-range behavior rather than being silently reinterpreted.
+/// Item-level CRS does not qualify either: [`ItemCrsKernel`] resolves the
+/// per-row CRS outside this kernel and hands the inner kernel an item type with
+/// no CRS attached, so there is nothing to inspect here.
+fn longitude_wrap_for_arg_type(arg_type: &SedonaType) -> Result<LongitudeWrap> {
+    let edges = match arg_type {
+        SedonaType::Wkb(edges, _) | SedonaType::WkbView(edges, _) => *edges,
+        // A literal NULL argument: every row is null, so this is never consulted.
+        _ => return Ok(LongitudeWrap::Disabled),
+    };
+
+    if edges == Edges::Spherical {
+        return Ok(LongitudeWrap::Enabled);
+    }
+
+    match arg_type.crs() {
+        Some(crs) if crs.geographic_params()?.is_some() => Ok(LongitudeWrap::Enabled),
+        _ => Ok(LongitudeWrap::Disabled),
+    }
+}
+
 /// Append the geohash of each geometry at the precision given by the second argument
 fn append_geohash_with_precision(
     executor: &WkbExecutor<'_, '_>,
     args: &[ColumnarValue],
     bounder: &mut dyn WkbBounder2D,
+    wrap: LongitudeWrap,
     builder: &mut StringBuilder,
 ) -> Result<()> {
     let precision_value = args[1]
@@ -179,7 +231,7 @@ fn append_geohash_with_precision(
 
     executor.execute_wkb_void(|maybe_wkb| {
         match (maybe_wkb, precision_iter.next().unwrap()) {
-            (Some(wkb), Some(precision)) => match invoke_scalar(wkb, precision, bounder)? {
+            (Some(wkb), Some(precision)) => match invoke_scalar(wkb, precision, bounder, wrap)? {
                 Some(geohash) => builder.append_value(geohash),
                 // Geometry was empty or outside the lon/lat bounds
                 None => builder.append_null(),
@@ -200,6 +252,7 @@ fn append_geohash_with_precision(
 fn append_point_geohash(
     executor: &WkbExecutor<'_, '_>,
     bounder: &mut dyn WkbBounder2D,
+    wrap: LongitudeWrap,
     builder: &mut StringBuilder,
 ) -> Result<()> {
     executor.execute_wkb_void(|maybe_wkb| {
@@ -216,7 +269,7 @@ fn append_point_geohash(
                     );
                 }
 
-                match invoke_scalar(wkb, MAX_PRECISION, bounder)? {
+                match invoke_scalar(wkb, MAX_PRECISION, bounder, wrap)? {
                     Some(geohash) => builder.append_value(geohash),
                     // Point was empty or outside the lon/lat bounds
                     None => builder.append_null(),
@@ -231,11 +284,22 @@ fn append_point_geohash(
 /// Compute the geohash of a geometry
 ///
 /// Follows Apache Sedona's GeometryGeoHashEncoder.calculate(): the point that
-/// is hashed is the center of the geometry's bounding box, and null is
-/// returned when the bounding box is not fully contained in
-/// [-180, 180] x [-90, 90]. Unlike Sedona's Java implementation (where an
-/// empty geometry yields JTS' "null envelope" and thus an accidental hash of
-/// (-0.5, -0.5)), empty geometries return null here.
+/// is hashed is the center of the geometry's bounding box. Unlike Sedona's Java
+/// implementation (where an empty geometry yields JTS' "null envelope" and thus
+/// an accidental hash of (-0.5, -0.5)), empty geometries return null here.
+///
+/// Out-of-range coordinates yield null rather than an error, matching Apache
+/// Sedona (GeometryGeoHashEncoder.calculate returns null) rather than PostGIS'
+/// `geometry` overload (which raises "Geohash requires inputs in decimal
+/// degrees"). The divergence is deliberate: a Spark query that returns nulls
+/// for out-of-range input should keep returning nulls here rather than start
+/// failing partway through a large scan.
+///
+/// When `wrap` is [`LongitudeWrap::Enabled`], an out-of-range *longitude* is
+/// first wrapped back into [-180, 180] instead of nulling the row, so a
+/// longitude of 181 hashes as -179. Latitude is never wrapped; see
+/// [`normalize_longitude`] and [`in_latitude_range`] for why the two axes are
+/// treated differently.
 ///
 /// The bounding box comes from `bounder`, which the caller resolved from the
 /// argument's edge type, so a geography is bounded on the sphere rather than
@@ -244,6 +308,7 @@ fn invoke_scalar(
     geom: &Wkb,
     precision: i64,
     bounder: &mut dyn WkbBounder2D,
+    wrap: LongitudeWrap,
 ) -> Result<Option<String>> {
     bounder.clear();
     bounder
@@ -255,20 +320,90 @@ fn invoke_scalar(
         return Ok(None);
     }
 
-    // Longitude can take values in [-180, 180]; latitude can take values in [-90, 90].
-    // Out-of-range coordinates yield null rather than an error, matching Apache
-    // Sedona (GeometryGeoHashEncoder.calculate returns null here). PostGIS instead
-    // raises "Geohash requires inputs in decimal degrees"; the divergence is
-    // deliberate, since a Spark query that returns nulls for out-of-range input
-    // should keep returning nulls here rather than start failing.
-    if x.lo() < -180.0 || y.lo() < -90.0 || x.hi() > 180.0 || y.hi() > 90.0 {
+    // Latitude can take values in [-90, 90]. Unlike longitude it is not cyclic,
+    // so there is no reinterpretation of an out-of-range value that recovers a
+    // real location, and it nulls out under both wrap settings.
+    if !in_latitude_range(&y) {
         return Ok(None);
     }
+
+    // Longitude can take values in [-180, 180].
+    let Some(x) = normalize_longitude(&x, wrap) else {
+        return Ok(None);
+    };
 
     let lon = center_longitude(&x);
     let lat = y.lo() + (y.hi() - y.lo()) / 2.0;
 
     Ok(Some(geohash_encode(lon, lat, precision)))
+}
+
+/// Whether a latitude interval lies within [-90, 90]
+///
+/// Latitude is not cyclic -- the bounder hands it back as a plain [`Interval`]
+/// rather than a [`WraparoundInterval`] for exactly that reason -- so a latitude
+/// of 100 does not denote a real place the way a longitude of 190 does. PostGIS'
+/// `geography` cast reflects it back over the pole (100 becomes 80) but leaves
+/// the longitude alone, which lands on a different point than either reading of
+/// the input; rather than reproduce that, an out-of-range latitude stays null.
+fn in_latitude_range(y: &Interval) -> bool {
+    y.lo() >= -90.0 && y.hi() <= 90.0
+}
+
+/// Bring a longitude interval into [-180, 180], or reject it
+///
+/// Returns `None` when the interval cannot be hashed: it is out of range and
+/// wrapping is disabled, it is not finite, or it spans a full turn or more (in
+/// which case no single longitude is its center).
+///
+/// Wrapping happens at the interval level rather than per coordinate, which
+/// preserves information that per-coordinate wrapping destroys: the bounding
+/// box of LINESTRING (179 0, 181 0) is 179..181, which wraps to the two-degree
+/// interval 179..-179 centered on 180. Wrapping the coordinates first and
+/// bounding afterwards would instead give 179 and -179 to a bounder that knows
+/// nothing about wraparound, yielding the 358-degree interval -179..179 and a
+/// center of 0 -- the opposite side of the planet.
+fn normalize_longitude(x: &WraparoundInterval, wrap: LongitudeWrap) -> Option<WraparoundInterval> {
+    // Already in range. This deliberately includes the wraparound intervals a
+    // spherical bounder produces (lo > hi, e.g. 170..-170), where both bounds
+    // are in range and the interval already means what it should.
+    if x.lo() >= -180.0 && x.hi() <= 180.0 {
+        return Some(*x);
+    }
+
+    if wrap == LongitudeWrap::Disabled {
+        return None;
+    }
+
+    if !x.lo().is_finite() || !x.hi().is_finite() {
+        return None;
+    }
+
+    // A box spanning 360 degrees or more covers every longitude, so wrapping it
+    // would collapse it to an arbitrary point rather than find its center.
+    if x.hi() - x.lo() >= 360.0 {
+        return None;
+    }
+
+    Some(WraparoundInterval::new(
+        wrap_longitude(x.lo()),
+        wrap_longitude(x.hi()),
+    ))
+}
+
+/// Wrap a single longitude into [-180, 180]
+///
+/// Matches the coercion PostGIS applies when a geometry is cast to `geography`
+/// ("Coordinate values were coerced into range [-180 -90, 180 90] for
+/// GEOGRAPHY"): 190 becomes -170, -190 becomes 170, and 541 becomes -179.
+/// Values already in range are returned untouched so that the closed bounds
+/// -180 and 180 keep their sign rather than folding onto each other.
+fn wrap_longitude(lon: f64) -> f64 {
+    if (-180.0..=180.0).contains(&lon) {
+        return lon;
+    }
+
+    (lon + 180.0).rem_euclid(360.0) - 180.0
 }
 
 /// The center of a longitude interval, in [-180, 180]
@@ -344,6 +479,7 @@ mod tests {
     use datafusion_expr::ScalarUDF;
     use rstest::rstest;
     use sedona_geometry::bounds::WkbGeometryBounder;
+    use sedona_schema::crs::{deserialize_crs, lnglat};
     use sedona_schema::datatypes::{
         WKB_GEOGRAPHY, WKB_GEOGRAPHY_ITEM_CRS, WKB_GEOMETRY, WKB_GEOMETRY_ITEM_CRS,
         WKB_VIEW_GEOGRAPHY, WKB_VIEW_GEOMETRY,
@@ -370,6 +506,248 @@ mod tests {
             .with_bounder(Edges::Spherical, Arc::new(WkbGeometryBounder::default()))
             .unwrap();
         tester
+    }
+
+    /// A geometry type tagged with a lon/lat CRS, which enables longitude wrapping
+    fn lnglat_geometry() -> SedonaType {
+        SedonaType::Wkb(Edges::Planar, lnglat())
+    }
+
+    /// A geometry type tagged with a projected CRS, which does not
+    fn projected_geometry() -> SedonaType {
+        SedonaType::Wkb(Edges::Planar, deserialize_crs("EPSG:3857").unwrap())
+    }
+
+    fn geohash_tester(sedona_type: SedonaType) -> ScalarUdfTester {
+        ScalarUdfTester::new(
+            st_geohash_udf().into(),
+            vec![sedona_type, SedonaType::Arrow(DataType::Int64)],
+        )
+    }
+
+    #[test]
+    fn wrap_longitude_matches_postgis_geography_coercion() {
+        // Values pinned against PostGIS 3.6, which reports "Coordinate values
+        // were coerced into range [-180 -90, 180 90] for GEOGRAPHY" and then
+        // hashes the coerced point:
+        //   SELECT ST_AsText('POINT (190 50)'::geography)  -> POINT(-170 50)
+        //   SELECT ST_AsText('POINT (-190 50)'::geography) -> POINT(170 50)
+        //   SELECT ST_AsText('POINT (541 50)'::geography)  -> POINT(-179 50)
+        assert_eq!(wrap_longitude(190.0), -170.0);
+        assert_eq!(wrap_longitude(-190.0), 170.0);
+        assert_eq!(wrap_longitude(541.0), -179.0);
+
+        // In-range values are returned untouched, so the closed bounds keep
+        // their sign instead of folding onto each other.
+        assert_eq!(wrap_longitude(180.0), 180.0);
+        assert_eq!(wrap_longitude(-180.0), -180.0);
+        assert_eq!(wrap_longitude(0.0), 0.0);
+    }
+
+    #[test]
+    fn normalize_longitude_only_wraps_when_enabled() {
+        let out_of_range = WraparoundInterval::new(190.0, 190.0);
+
+        assert_eq!(
+            normalize_longitude(&out_of_range, LongitudeWrap::Enabled),
+            Some(WraparoundInterval::new(-170.0, -170.0))
+        );
+        assert_eq!(
+            normalize_longitude(&out_of_range, LongitudeWrap::Disabled),
+            None
+        );
+
+        // An in-range interval is untouched under either setting, including the
+        // wraparound intervals a spherical bounder produces.
+        for wrap in [LongitudeWrap::Enabled, LongitudeWrap::Disabled] {
+            let in_range = WraparoundInterval::new(10.0, 20.0);
+            assert_eq!(normalize_longitude(&in_range, wrap), Some(in_range));
+
+            let crosses_antimeridian = WraparoundInterval::new(170.0, -170.0);
+            assert_eq!(
+                normalize_longitude(&crosses_antimeridian, wrap),
+                Some(crosses_antimeridian)
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_longitude_rejects_unhashable_intervals() {
+        // A box spanning a full turn or more has no single center longitude.
+        assert_eq!(
+            normalize_longitude(&WraparoundInterval::new(0.0, 360.0), LongitudeWrap::Enabled),
+            None
+        );
+        assert_eq!(
+            normalize_longitude(
+                &WraparoundInterval::new(-400.0, 400.0),
+                LongitudeWrap::Enabled
+            ),
+            None
+        );
+
+        // Non-finite bounds have nothing to wrap into.
+        assert_eq!(
+            normalize_longitude(
+                &WraparoundInterval::new(f64::NEG_INFINITY, f64::INFINITY),
+                LongitudeWrap::Enabled
+            ),
+            None
+        );
+        assert_eq!(
+            normalize_longitude(
+                &WraparoundInterval::new(f64::INFINITY, f64::INFINITY),
+                LongitudeWrap::Enabled
+            ),
+            None
+        );
+    }
+
+    #[rstest]
+    fn longitude_wrap_follows_the_crs(
+        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType,
+    ) {
+        let edges = match &sedona_type {
+            SedonaType::Wkb(edges, _) | SedonaType::WkbView(edges, _) => *edges,
+            _ => unreachable!(),
+        };
+
+        // A known lon/lat CRS enables wrapping...
+        assert_eq!(
+            longitude_wrap_for_arg_type(&SedonaType::Wkb(edges, lnglat())).unwrap(),
+            LongitudeWrap::Enabled
+        );
+        // ...as does NAD83, which geographic_params() also recognizes as degrees.
+        assert_eq!(
+            longitude_wrap_for_arg_type(&SedonaType::Wkb(
+                edges,
+                deserialize_crs("EPSG:4269").unwrap()
+            ))
+            .unwrap(),
+            LongitudeWrap::Enabled
+        );
+        // A geography is lon/lat by definition, whatever its declared CRS.
+        assert_eq!(
+            longitude_wrap_for_arg_type(&WKB_GEOGRAPHY).unwrap(),
+            LongitudeWrap::Enabled
+        );
+
+        // A projected CRS does not, because wrapping metres would produce a
+        // plausible-looking hash for the wrong place.
+        assert_eq!(
+            longitude_wrap_for_arg_type(&SedonaType::Wkb(
+                edges,
+                deserialize_crs("EPSG:3857").unwrap()
+            ))
+            .unwrap(),
+            LongitudeWrap::Disabled
+        );
+        // Neither does an absent CRS, which is the ST_GeomFromText() default.
+        assert_eq!(
+            longitude_wrap_for_arg_type(&sedona_type).unwrap(),
+            LongitudeWrap::Disabled
+        );
+    }
+
+    #[test]
+    fn udf_wraps_longitude_for_lnglat_crs() {
+        let tester = geohash_tester(lnglat_geometry());
+
+        // 190 is the same meridian as -170, so the two hash identically rather
+        // than the out-of-range one dropping to null. Pinned against PostGIS:
+        //   SELECT ST_GeoHash('POINT (190 50)'::geography, 12)  -> b0zh7w1z0gs3
+        //   SELECT ST_GeoHash('POINT (-170 50)'::geography, 12) -> b0zh7w1z0gs3
+        let wrapped = tester
+            .invoke_scalar_scalar("POINT (190.0 50.0)", ScalarValue::Int64(Some(12)))
+            .unwrap();
+        tester.assert_scalar_result_equals(wrapped, "b0zh7w1z0gs3");
+
+        let equivalent = tester
+            .invoke_scalar_scalar("POINT (-170.0 50.0)", ScalarValue::Int64(Some(12)))
+            .unwrap();
+        tester.assert_scalar_result_equals(equivalent, "b0zh7w1z0gs3");
+
+        // -190 wraps the other way, to 170.
+        //   SELECT ST_GeoHash('POINT (-190 50)'::geography, 12) -> zbbukqnpp5e9
+        //   SELECT ST_GeoHash('POINT (170 50)'::geography, 12)  -> zbbukqnpp5e9
+        let result = tester
+            .invoke_scalar_scalar("POINT (-190.0 50.0)", ScalarValue::Int64(Some(12)))
+            .unwrap();
+        tester.assert_scalar_result_equals(result, "zbbukqnpp5e9");
+
+        // Multiple turns wrap too: 541 - 720 = -179.
+        //   SELECT ST_GeoHash('POINT (541 50)'::geography, 12)  -> b0bsqy0pjew1
+        //   SELECT ST_GeoHash('POINT (-179 50)'::geography, 12) -> b0bsqy0pjew1
+        let result = tester
+            .invoke_scalar_scalar("POINT (541.0 50.0)", ScalarValue::Int64(Some(12)))
+            .unwrap();
+        tester.assert_scalar_result_equals(result, "b0bsqy0pjew1");
+    }
+
+    #[test]
+    fn udf_wrapping_keeps_a_bbox_centered_across_the_antimeridian() {
+        let tester = geohash_tester(lnglat_geometry());
+
+        // The bounding box of this linestring is 179..181, whose center is the
+        // antimeridian itself. Wrapping the interval (rather than the vertices)
+        // preserves that: the equivalent in-range geometry hashes the same.
+        //   SELECT ST_GeoHash(ST_GeomFromText('POINT (180 0)'), 12) -> xbpbpbpbpbpb
+        let wrapped = tester
+            .invoke_scalar_scalar(
+                "LINESTRING (179.0 0.0, 181.0 0.0)",
+                ScalarValue::Int64(Some(12)),
+            )
+            .unwrap();
+        tester.assert_scalar_result_equals(wrapped, "xbpbpbpbpbpb");
+    }
+
+    #[test]
+    fn udf_does_not_wrap_longitude_without_a_lnglat_crs() {
+        // A projected CRS keeps the pre-existing null, because an out-of-range
+        // easting is not a wrapped longitude.
+        let tester = geohash_tester(projected_geometry());
+        let result = tester
+            .invoke_scalar_scalar("POINT (190.0 50.0)", ScalarValue::Int64(Some(12)))
+            .unwrap();
+        tester.assert_scalar_result_equals(result, ScalarValue::Utf8(None));
+
+        // An undeclared CRS does the same.
+        let tester = geohash_tester(WKB_GEOMETRY);
+        let result = tester
+            .invoke_scalar_scalar("POINT (190.0 50.0)", ScalarValue::Int64(Some(12)))
+            .unwrap();
+        tester.assert_scalar_result_equals(result, ScalarValue::Utf8(None));
+    }
+
+    #[test]
+    fn udf_never_wraps_latitude() {
+        // Latitude is not cyclic, so it stays null even where longitude wraps.
+        // (PostGIS' geography cast would reflect 100 to 80 while leaving the
+        // longitude alone, landing on a third point entirely.)
+        let tester = geohash_tester(lnglat_geometry());
+        for wkt in ["POINT (50.0 100.0)", "POINT (50.0 -100.0)"] {
+            let result = tester
+                .invoke_scalar_scalar(wkt, ScalarValue::Int64(Some(12)))
+                .unwrap();
+            tester.assert_scalar_result_equals(result, ScalarValue::Utf8(None));
+        }
+
+        // Out of range on both axes is null as well -- latitude is checked first
+        // and there is no wrapping that rescues it.
+        let result = tester
+            .invoke_scalar_scalar("POINT (190.0 100.0)", ScalarValue::Int64(Some(12)))
+            .unwrap();
+        tester.assert_scalar_result_equals(result, ScalarValue::Utf8(None));
+    }
+
+    #[test]
+    fn udf_one_arg_wraps_longitude() {
+        // The one-argument overload shares invoke_scalar(), so it wraps too.
+        //   SELECT ST_GeoHash(ST_GeomFromText('POINT (-170 50)'), 20)
+        //     -> b0zh7w1z0gs3y0zh7w1z
+        let tester = ScalarUdfTester::new(st_geohash_udf().into(), vec![lnglat_geometry()]);
+        let wrapped = tester.invoke_scalar("POINT (190.0 50.0)").unwrap();
+        tester.assert_scalar_result_equals(wrapped, "b0zh7w1z0gs3y0zh7w1z");
     }
 
     #[test]

--- a/rust/sedona-functions/src/st_geohash.rs
+++ b/rust/sedona-functions/src/st_geohash.rs
@@ -15,22 +15,22 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::sync::Arc;
+use std::{collections::HashMap, iter::zip, sync::Arc};
 
 use crate::executor::WkbExecutor;
-use arrow_array::builder::StringBuilder;
+use arrow_array::{builder::StringBuilder, Array};
 use arrow_schema::DataType;
 use datafusion_common::{
-    cast::as_int64_array,
+    cast::{as_int64_array, as_string_view_array, as_struct_array},
     config::ConfigOptions,
     error::{DataFusionError, Result},
-    exec_err,
+    exec_err, plan_err, ScalarValue,
 };
 use datafusion_expr::{ColumnarValue, Volatility};
 use geo_traits::{GeometryTrait, GeometryType};
 use sedona_common::{option::SedonaOptions, sedona_internal_datafusion_err, sedona_internal_err};
 use sedona_expr::{
-    item_crs::ItemCrsKernel,
+    item_crs::parse_item_crs_arg_type,
     scalar_udf::{SedonaScalarKernel, SedonaScalarUDF},
 };
 use sedona_geometry::{
@@ -38,7 +38,11 @@ use sedona_geometry::{
     interval::{Interval, IntervalTrait, WraparoundInterval},
     types::Edges,
 };
-use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
+use sedona_schema::{
+    crs::{deserialize_crs, lnglat},
+    datatypes::SedonaType,
+    matchers::ArgMatcher,
+};
 use wkb::reader::Wkb;
 
 /// The base32 alphabet used by geohash encoding (Gustavo Niemeyer's specification)
@@ -56,13 +60,31 @@ const MAX_PRECISION: i64 = 20;
 pub fn st_geohash_udf() -> SedonaScalarUDF {
     SedonaScalarUDF::new(
         "st_geohash",
-        ItemCrsKernel::wrap_impl(vec![
+        // ST_GeoHash cannot use ItemCrsKernel::wrap_impl(): that wrapper strips
+        // the CRS before calling the inner kernel, which is what makes it free
+        // for functions like ST_Area() whose answer does not depend on the CRS.
+        // This one rejects a non-WGS84 CRS, so it needs to see it. The sibling
+        // kernels below are the same shape ST_SRID() and ST_CRS() use, one
+        // matching the plain types and one matching item_crs.
+        vec![
+            Arc::new(STGeoHashItemCrs {
+                matcher: ArgMatcher::new(
+                    vec![ArgMatcher::is_item_crs()],
+                    SedonaType::Arrow(DataType::Utf8),
+                ),
+            }) as _,
+            Arc::new(STGeoHashItemCrs {
+                matcher: ArgMatcher::new(
+                    vec![ArgMatcher::is_item_crs(), ArgMatcher::is_integer()],
+                    SedonaType::Arrow(DataType::Utf8),
+                ),
+            }) as _,
             Arc::new(STGeoHash {
                 matcher: ArgMatcher::new(
                     vec![ArgMatcher::is_geometry_or_geography()],
                     SedonaType::Arrow(DataType::Utf8),
                 ),
-            }),
+            }) as _,
             Arc::new(STGeoHash {
                 matcher: ArgMatcher::new(
                     vec![
@@ -71,8 +93,8 @@ pub fn st_geohash_udf() -> SedonaScalarUDF {
                     ],
                     SedonaType::Arrow(DataType::Utf8),
                 ),
-            }),
-        ]),
+            }) as _,
+        ],
         Volatility::Immutable,
     )
 }
@@ -84,7 +106,16 @@ struct STGeoHash {
 
 impl SedonaScalarKernel for STGeoHash {
     fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
-        self.matcher.match_args(args)
+        let Some(out_type) = self.matcher.match_args(args)? else {
+            return Ok(None);
+        };
+
+        // Checked only after the argument shapes match, so that a call with a
+        // different arity falls through to the next kernel rather than erroring
+        // out of kernel resolution here.
+        ensure_wgs84_crs(&args[0])?;
+
+        Ok(Some(out_type))
     }
 
     fn invoke_batch(
@@ -113,14 +144,21 @@ impl SedonaScalarKernel for STGeoHash {
         // instance and clear()s it per row rather than allocating per row.
         let mut bounder = bounder_for_arg_type(&arg_types[0], config_options)?;
 
-        // The CRS is a property of the type, so whether longitudes may be
-        // wrapped is decided once for the batch rather than per row.
-        let wrap = longitude_wrap_for_arg_type(&arg_types[0])?;
+        // The CRS is a property of the type, so this is decided once for the
+        // batch rather than per row.
+        let wrap = longitude_wrap_for_arg_type(&arg_types[0]);
+        let mut next_wrap = move || Ok(wrap);
 
         if args.len() > 1 {
-            append_geohash_with_precision(&executor, args, bounder.as_mut(), wrap, &mut builder)?;
+            append_geohash_with_precision(
+                &executor,
+                args,
+                bounder.as_mut(),
+                &mut next_wrap,
+                &mut builder,
+            )?;
         } else {
-            append_point_geohash(&executor, bounder.as_mut(), wrap, &mut builder)?;
+            append_point_geohash(&executor, bounder.as_mut(), &mut next_wrap, &mut builder)?;
         }
 
         executor.finish(Arc::new(builder.finish()))
@@ -168,51 +206,251 @@ fn bounder_for_arg_type(
     })
 }
 
+/// Per-batch cache of the WGS84 verdict for each distinct CRS string
+///
+/// Deserializing a CRS is expensive and an item_crs column carries only a
+/// handful of distinct values across many rows, so each is resolved once.
+/// Mirrors `CachedCrsToSRIDMapping`, which exists for the same reason.
+#[derive(Default)]
+struct CachedWgs84Check {
+    /// `None` marks a CRS that is not WGS84, i.e. one this function rejects
+    cache: HashMap<String, Option<LongitudeWrap>>,
+}
+
+impl CachedWgs84Check {
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            cache: HashMap::with_capacity(capacity),
+        }
+    }
+
+    /// Resolve one row's CRS into a wrap setting, or reject the row
+    ///
+    /// Applies exactly the rule [`ensure_wgs84_crs`] applies to a type-level
+    /// CRS, so the same geometry is treated the same way whether its CRS is
+    /// attached to the type or to the row.
+    fn wrap_for(&mut self, maybe_crs: Option<&str>) -> Result<LongitudeWrap> {
+        // No CRS on this row: accepted and assumed WGS84, but not wrapped,
+        // matching an absent type-level CRS.
+        let Some(crs_str) = maybe_crs else {
+            return Ok(LongitudeWrap::Disabled);
+        };
+
+        if let Some(cached) = self.cache.get(crs_str) {
+            return cached.map_or_else(|| non_wgs84_err(crs_str), Ok);
+        }
+
+        // `deserialize_crs` yields None for the "no CRS" sentinels ("0", "").
+        let crs = deserialize_crs(crs_str)?;
+        let verdict = if crs.is_none() {
+            Some(LongitudeWrap::Disabled)
+        } else if crs == lnglat() {
+            Some(LongitudeWrap::Enabled)
+        } else {
+            None
+        };
+
+        self.cache.insert(crs_str.to_string(), verdict);
+        verdict.map_or_else(|| non_wgs84_err(crs_str), Ok)
+    }
+}
+
+fn non_wgs84_err<T>(name: &str) -> Result<T> {
+    exec_err!(
+        "ST_GeoHash() requires WGS84 longitude/latitude coordinates but a row has CRS \
+         '{name}'. Use ST_Transform() to reproject to EPSG:4326 first."
+    )
+}
+
+/// ST_GeoHash() over an item_crs argument, where each row carries its own CRS
+///
+/// The rule is the one [`ensure_wgs84_crs`] applies at the type level; only the
+/// moment of detection differs. A type-level CRS is known while the query is
+/// planned, so it is rejected before any row is read; a row-level CRS is not
+/// known until the row is in hand, so it is rejected then. Erroring rather than
+/// nulling keeps the two consistent, and matches how the crate already treats a
+/// bad row-level CRS elsewhere (`ensure_crs_string_arrays_equal2` raises on the
+/// first mismatched row).
+///
+/// Seeing the per-row CRS also means a row that declares WGS84 gets longitude
+/// wrapping, so item-level and type-level WGS84 agree on the same input rather
+/// than one nulling where the other wraps.
+#[derive(Debug)]
+struct STGeoHashItemCrs {
+    matcher: ArgMatcher,
+}
+
+impl SedonaScalarKernel for STGeoHashItemCrs {
+    fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
+        self.matcher.match_args(args)
+    }
+
+    fn invoke_batch(
+        &self,
+        arg_types: &[SedonaType],
+        args: &[ColumnarValue],
+    ) -> Result<ColumnarValue> {
+        self.invoke_batch_from_args(arg_types, args, &SedonaType::Arrow(DataType::Utf8), 0, None)
+    }
+
+    fn invoke_batch_from_args(
+        &self,
+        arg_types: &[SedonaType],
+        args: &[ColumnarValue],
+        _return_type: &SedonaType,
+        _num_rows: usize,
+        config_options: Option<&ConfigOptions>,
+    ) -> Result<ColumnarValue> {
+        let struct_array = match &args[0] {
+            ColumnarValue::Array(array) => as_struct_array(array)?,
+            ColumnarValue::Scalar(ScalarValue::Struct(struct_array)) => struct_array.as_ref(),
+            ColumnarValue::Scalar(ScalarValue::Null) => {
+                return Ok(ColumnarValue::Scalar(ScalarValue::Utf8(None)));
+            }
+            _ => return sedona_internal_err!("Unexpected input to ST_GeoHash()"),
+        };
+
+        let (item_type, _) = parse_item_crs_arg_type(&arg_types[0])?;
+        let crs_array = as_string_view_array(struct_array.column(1))?;
+
+        // Rebuild the arguments against the unwrapped item so the geometry path
+        // below is the same one the type-level kernel takes. A scalar argument
+        // stays scalar, so that `WkbExecutor` still sizes the batch from
+        // whichever argument is an array.
+        let item_arg = match &args[0] {
+            ColumnarValue::Array(_) => ColumnarValue::Array(struct_array.column(0).clone()),
+            _ => ColumnarValue::Scalar(ScalarValue::try_from_array(struct_array.column(0), 0)?),
+        };
+        let mut item_arg_types = vec![item_type.clone()];
+        let mut item_args = vec![item_arg];
+        for (arg_type, arg) in zip(&arg_types[1..], &args[1..]) {
+            item_arg_types.push(arg_type.clone());
+            item_args.push(arg.clone());
+        }
+
+        let executor = WkbExecutor::new(&item_arg_types, &item_args);
+        let mut builder = StringBuilder::with_capacity(
+            executor.num_iterations(),
+            MAX_PRECISION as usize * executor.num_iterations(),
+        );
+        let mut bounder = bounder_for_arg_type(&item_type, config_options)?;
+        let mut checker = CachedWgs84Check::with_capacity(crs_array.len());
+
+        // A scalar struct carries a single CRS that applies to every iteration;
+        // an array carries one per row.
+        let scalar_wrap = match &args[0] {
+            ColumnarValue::Array(_) => None,
+            _ => Some(checker.wrap_for(crs_array.iter().next().flatten())?),
+        };
+        let mut crs_iter = crs_array.iter();
+        let mut next_wrap = move || match scalar_wrap {
+            Some(wrap) => Ok(wrap),
+            // Every row is validated, including one whose geometry is null, so
+            // that a column fails the same way regardless of where its nulls
+            // happen to fall.
+            None => checker.wrap_for(crs_iter.next().flatten()),
+        };
+
+        if item_args.len() > 1 {
+            append_geohash_with_precision(
+                &executor,
+                &item_args,
+                bounder.as_mut(),
+                &mut next_wrap,
+                &mut builder,
+            )?;
+        } else {
+            append_point_geohash(&executor, bounder.as_mut(), &mut next_wrap, &mut builder)?;
+        }
+
+        executor.finish(Arc::new(builder.finish()))
+    }
+}
+
 /// Whether an out-of-range longitude may be wrapped back into [-180, 180]
 ///
-/// Wrapping is only meaningful when the coordinates are known to be longitude
-/// and latitude in degrees: 181 is then an unambiguous spelling of -179, and
-/// hashing it is better than dropping the row. Applied to a projected CRS the
-/// same arithmetic would turn a coordinate in metres into a plausible-looking
-/// geohash for somewhere it has nothing to do with, so it stays off unless the
-/// units are known.
+/// [`ensure_wgs84_crs`] has already rejected any CRS that is not WGS84, so this
+/// only separates coordinates *declared* to be WGS84 from coordinates carrying
+/// no CRS at all.
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum LongitudeWrap {
-    /// The argument is known to be in longitude/latitude degrees
+    /// The argument declares a WGS84 CRS, or is a geography
     Enabled,
-    /// The units are projected, or simply not known, so an out-of-range
-    /// coordinate is not necessarily a wrapped longitude
+    /// The argument carries no CRS, so its units are assumed but not known
     Disabled,
 }
 
-/// Decide whether an argument's coordinates are known to be lon/lat degrees
+/// Decide whether an argument's longitudes may be wrapped
 ///
-/// A geography is lon/lat by definition. A geometry qualifies only when its
-/// type-level CRS resolves to geographic parameters (EPSG:4326, OGC:CRS84,
-/// EPSG:4269, ...), which is the same test `st_setsrid` uses to decide whether
-/// a CRS is usable as a geography.
+/// Wrapping requires a *declared* WGS84 CRS (or a geography, which carries one
+/// by construction). An absent CRS is accepted by [`ensure_wgs84_crs`] but does
+/// not earn wrapping: accepting it is passive -- we cannot know, so we do not
+/// break the query -- whereas wrapping it is active, and would invent a location
+/// for coordinates whose provenance is unknown.
 ///
-/// An absent CRS does *not* qualify. Undeclared coordinates are the common case
-/// for `ST_GeomFromText()` and could be anything, so they keep the pre-existing
-/// null-on-out-of-range behavior rather than being silently reinterpreted.
-/// Item-level CRS does not qualify either: [`ItemCrsKernel`] resolves the
-/// per-row CRS outside this kernel and hands the inner kernel an item type with
-/// no CRS attached, so there is nothing to inspect here.
-fn longitude_wrap_for_arg_type(arg_type: &SedonaType) -> Result<LongitudeWrap> {
+/// This is also what keeps faith with Apache Sedona. Spark has no CRS concept,
+/// so every geometry migrated from it arrives here undeclared; wrapping those
+/// would change the out-of-range result from Spark's null to a hash, which is
+/// precisely the parity this function is built to preserve.
+///
+/// Item-level CRS resolves to `None` here for the reasons given on
+/// [`ensure_wgs84_crs`], so it does not wrap either.
+fn longitude_wrap_for_arg_type(arg_type: &SedonaType) -> LongitudeWrap {
     let edges = match arg_type {
         SedonaType::Wkb(edges, _) | SedonaType::WkbView(edges, _) => *edges,
         // A literal NULL argument: every row is null, so this is never consulted.
-        _ => return Ok(LongitudeWrap::Disabled),
+        _ => return LongitudeWrap::Disabled,
     };
 
-    if edges == Edges::Spherical {
-        return Ok(LongitudeWrap::Enabled);
+    if edges == Edges::Spherical || arg_type.crs() == &lnglat() {
+        LongitudeWrap::Enabled
+    } else {
+        LongitudeWrap::Disabled
+    }
+}
+
+/// Ensure a geohash argument's coordinates are WGS84 longitude/latitude
+///
+/// A geohash is defined against the WGS84 datum, so this is the only CRS whose
+/// coordinates it can encode correctly. Anything else is rejected rather than
+/// hashed: a projected coordinate is in metres, not degrees, and one that
+/// happens to land inside [-180, 180] x [-90, 90] would otherwise produce a
+/// confident geohash for an unrelated place. EPSG:3857 POINT (10 20) is ten
+/// metres east and twenty metres north of the origin, in the Gulf of Guinea,
+/// but reads as 10 degrees east and 20 degrees north -- in Chad.
+///
+/// `EPSG:4326` and `OGC:CRS84` are the same CRS here (see `authority_codes_equal`),
+/// so both are accepted. Other geographic CRSes are *not*, even though their units
+/// are also degrees: NAD83 sits one to two metres from WGS84 and NAD27 up to a
+/// hundred, which is many cells wide at high precision. Reproject them with
+/// `ST_Transform()`.
+///
+/// An absent CRS is accepted and assumed to be WGS84. This is what the function
+/// already assumes of undeclared coordinates -- the [-180, 180] x [-90, 90]
+/// domain check is only meaningful under that reading -- and rejecting it would
+/// break every `ST_GeomFromText()` call, which carries no CRS.
+///
+/// Item-level CRS is *not* checked: [`ItemCrsKernel`] resolves the per-row CRS
+/// outside this kernel and hands the inner kernel an item type whose CRS has
+/// been stripped to `None` (`parse_item_crs_arg_type_strip_crs`), which is
+/// indistinguishable here from a genuinely absent one. Validating it would mean
+/// changing that kernel's contract for every function built on it.
+fn ensure_wgs84_crs(arg_type: &SedonaType) -> Result<()> {
+    let crs = arg_type.crs();
+
+    if crs.is_none() || crs == &lnglat() {
+        return Ok(());
     }
 
-    match arg_type.crs() {
-        Some(crs) if crs.geographic_params()?.is_some() => Ok(LongitudeWrap::Enabled),
-        _ => Ok(LongitudeWrap::Disabled),
-    }
+    let name = crs
+        .as_ref()
+        .map(|crs| crs.to_crs_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    plan_err!(
+        "ST_GeoHash() requires WGS84 longitude/latitude coordinates but the argument has CRS \
+         '{name}'. Use ST_Transform() to reproject to EPSG:4326 first."
+    )
 }
 
 /// Append the geohash of each geometry at the precision given by the second argument
@@ -220,7 +458,7 @@ fn append_geohash_with_precision(
     executor: &WkbExecutor<'_, '_>,
     args: &[ColumnarValue],
     bounder: &mut dyn WkbBounder2D,
-    wrap: LongitudeWrap,
+    next_wrap: &mut dyn FnMut() -> Result<LongitudeWrap>,
     builder: &mut StringBuilder,
 ) -> Result<()> {
     let precision_value = args[1]
@@ -230,6 +468,7 @@ fn append_geohash_with_precision(
     let mut precision_iter = precision_array.iter();
 
     executor.execute_wkb_void(|maybe_wkb| {
+        let wrap = next_wrap()?;
         match (maybe_wkb, precision_iter.next().unwrap()) {
             (Some(wkb), Some(precision)) => match invoke_scalar(wkb, precision, bounder, wrap)? {
                 Some(geohash) => builder.append_value(geohash),
@@ -252,10 +491,11 @@ fn append_geohash_with_precision(
 fn append_point_geohash(
     executor: &WkbExecutor<'_, '_>,
     bounder: &mut dyn WkbBounder2D,
-    wrap: LongitudeWrap,
+    next_wrap: &mut dyn FnMut() -> Result<LongitudeWrap>,
     builder: &mut StringBuilder,
 ) -> Result<()> {
     executor.execute_wkb_void(|maybe_wkb| {
+        let wrap = next_wrap()?;
         match maybe_wkb {
             Some(wkb) => {
                 // Only a single POINT counts: a MULTIPOINT, even one holding
@@ -296,10 +536,9 @@ fn append_point_geohash(
 /// failing partway through a large scan.
 ///
 /// When `wrap` is [`LongitudeWrap::Enabled`], an out-of-range *longitude* is
-/// first wrapped back into [-180, 180] instead of nulling the row, so a
-/// longitude of 181 hashes as -179. Latitude is never wrapped; see
-/// [`normalize_longitude`] and [`in_latitude_range`] for why the two axes are
-/// treated differently.
+/// wrapped back into [-180, 180] rather than nulling the row, so a longitude of
+/// 181 hashes as -179. Latitude is never wrapped; see [`normalize_longitude`]
+/// and [`in_latitude_range`] for why the two axes are treated differently.
 ///
 /// The bounding box comes from `bounder`, which the caller resolved from the
 /// argument's edge type, so a geography is bounded on the sphere rather than
@@ -545,20 +784,9 @@ mod tests {
     }
 
     #[test]
-    fn normalize_longitude_only_wraps_when_enabled() {
-        let out_of_range = WraparoundInterval::new(190.0, 190.0);
-
-        assert_eq!(
-            normalize_longitude(&out_of_range, LongitudeWrap::Enabled),
-            Some(WraparoundInterval::new(-170.0, -170.0))
-        );
-        assert_eq!(
-            normalize_longitude(&out_of_range, LongitudeWrap::Disabled),
-            None
-        );
-
-        // An in-range interval is untouched under either setting, including the
-        // wraparound intervals a spherical bounder produces.
+    fn normalize_longitude_leaves_in_range_intervals_alone() {
+        // In-range intervals are untouched under either setting, including the
+        // wraparound intervals a spherical bounder produces (lo > hi).
         for wrap in [LongitudeWrap::Enabled, LongitudeWrap::Disabled] {
             let in_range = WraparoundInterval::new(10.0, 20.0);
             assert_eq!(normalize_longitude(&in_range, wrap), Some(in_range));
@@ -569,6 +797,20 @@ mod tests {
                 Some(crosses_antimeridian)
             );
         }
+    }
+
+    #[test]
+    fn normalize_longitude_wraps_out_of_range_intervals() {
+        let out_of_range = WraparoundInterval::new(190.0, 190.0);
+        assert_eq!(
+            normalize_longitude(&out_of_range, LongitudeWrap::Enabled),
+            Some(WraparoundInterval::new(-170.0, -170.0))
+        );
+        // Without a declared WGS84 CRS the row stays null.
+        assert_eq!(
+            normalize_longitude(&out_of_range, LongitudeWrap::Disabled),
+            None
+        );
     }
 
     #[test]
@@ -604,49 +846,48 @@ mod tests {
     }
 
     #[rstest]
-    fn longitude_wrap_follows_the_crs(
-        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType,
-    ) {
+    fn wgs84_crs_is_required(#[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY)] sedona_type: SedonaType) {
         let edges = match &sedona_type {
             SedonaType::Wkb(edges, _) | SedonaType::WkbView(edges, _) => *edges,
             _ => unreachable!(),
         };
 
-        // A known lon/lat CRS enables wrapping...
-        assert_eq!(
-            longitude_wrap_for_arg_type(&SedonaType::Wkb(edges, lnglat())).unwrap(),
-            LongitudeWrap::Enabled
-        );
-        // ...as does NAD83, which geographic_params() also recognizes as degrees.
-        assert_eq!(
-            longitude_wrap_for_arg_type(&SedonaType::Wkb(
-                edges,
-                deserialize_crs("EPSG:4269").unwrap()
-            ))
-            .unwrap(),
-            LongitudeWrap::Enabled
-        );
-        // A geography is lon/lat by definition, whatever its declared CRS.
-        assert_eq!(
-            longitude_wrap_for_arg_type(&WKB_GEOGRAPHY).unwrap(),
-            LongitudeWrap::Enabled
-        );
+        // Both spellings of WGS84 are accepted...
+        for code in ["EPSG:4326", "OGC:CRS84"] {
+            let crs = deserialize_crs(code).unwrap();
+            ensure_wgs84_crs(&SedonaType::Wkb(edges, crs))
+                .unwrap_or_else(|e| panic!("{code} should be accepted: {e}"));
+        }
+        // ...as is lnglat() itself, and an absent CRS.
+        ensure_wgs84_crs(&SedonaType::Wkb(edges, lnglat())).unwrap();
+        ensure_wgs84_crs(&sedona_type).unwrap();
+        // A geography carries lnglat by construction.
+        ensure_wgs84_crs(&WKB_GEOGRAPHY).unwrap();
 
-        // A projected CRS does not, because wrapping metres would produce a
-        // plausible-looking hash for the wrong place.
-        assert_eq!(
-            longitude_wrap_for_arg_type(&SedonaType::Wkb(
-                edges,
-                deserialize_crs("EPSG:3857").unwrap()
-            ))
-            .unwrap(),
-            LongitudeWrap::Disabled
-        );
-        // Neither does an absent CRS, which is the ST_GeomFromText() default.
-        assert_eq!(
-            longitude_wrap_for_arg_type(&sedona_type).unwrap(),
-            LongitudeWrap::Disabled
-        );
+        // A projected CRS is rejected, and so is a non-WGS84 geographic one:
+        // NAD83's units are degrees but its datum is not WGS84.
+        for code in ["EPSG:3857", "EPSG:26918", "EPSG:4269"] {
+            let crs = deserialize_crs(code).unwrap();
+            let err = ensure_wgs84_crs(&SedonaType::Wkb(edges, crs))
+                .expect_err("{code} should be rejected");
+            let msg = err.to_string();
+            assert!(msg.contains("requires WGS84"), "unexpected message: {msg}");
+            assert!(
+                msg.contains("ST_Transform"),
+                "message should suggest a fix: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn udf_rejects_non_wgs84_crs_at_plan_time() {
+        // The rejection happens while resolving the kernel, so it surfaces
+        // before any row is read rather than partway through a scan.
+        let tester = geohash_tester(projected_geometry());
+        let err = tester
+            .return_type()
+            .expect_err("a projected CRS should be rejected");
+        assert!(err.to_string().contains("requires WGS84"), "{err}");
     }
 
     #[test]
@@ -702,23 +943,16 @@ mod tests {
     }
 
     #[test]
-    fn udf_does_not_wrap_longitude_without_a_lnglat_crs() {
-        // A projected CRS keeps the pre-existing null, because an out-of-range
-        // easting is not a wrapped longitude.
-        let tester = geohash_tester(projected_geometry());
-        let result = tester
-            .invoke_scalar_scalar("POINT (190.0 50.0)", ScalarValue::Int64(Some(12)))
-            .unwrap();
-        tester.assert_scalar_result_equals(result, ScalarValue::Utf8(None));
-
-        // An undeclared CRS does the same.
+    fn udf_does_not_wrap_longitude_for_an_absent_crs() {
+        // Accepted, but not wrapped: an undeclared geometry keeps Apache
+        // Sedona's null so that a Spark query migrating here keeps its results.
+        // ST_SetSRID(geom, 4326) opts into wrapping.
         let tester = geohash_tester(WKB_GEOMETRY);
         let result = tester
             .invoke_scalar_scalar("POINT (190.0 50.0)", ScalarValue::Int64(Some(12)))
             .unwrap();
         tester.assert_scalar_result_equals(result, ScalarValue::Utf8(None));
     }
-
     #[test]
     fn udf_never_wraps_latitude() {
         // Latitude is not cyclic, so it stays null even where longitude wraps.
@@ -748,6 +982,129 @@ mod tests {
         let tester = ScalarUdfTester::new(st_geohash_udf().into(), vec![lnglat_geometry()]);
         let wrapped = tester.invoke_scalar("POINT (190.0 50.0)").unwrap();
         tester.assert_scalar_result_equals(wrapped, "b0zh7w1z0gs3y0zh7w1z");
+    }
+
+    /// Invoke ST_GeoHash over an item_crs array with one CRS per row
+    fn invoke_item_crs(
+        wkts: &[Option<&str>],
+        crses: &[Option<&str>],
+        precision: i64,
+    ) -> Result<Vec<Option<String>>> {
+        use arrow_array::cast::as_string_array;
+        use sedona_testing::create::create_array_item_crs;
+
+        let tester = ScalarUdfTester::new(
+            st_geohash_udf().into(),
+            vec![
+                WKB_GEOMETRY_ITEM_CRS.clone(),
+                SedonaType::Arrow(DataType::Int64),
+            ],
+        );
+        let array = create_array_item_crs(wkts, crses.iter().copied(), &WKB_GEOMETRY);
+        let out = tester.invoke_array_scalar(array, ScalarValue::Int64(Some(precision)))?;
+        let out = as_string_array(&out);
+        Ok((0..Array::len(out))
+            .map(|i| {
+                if Array::is_null(out, i) {
+                    None
+                } else {
+                    Some(arrow_array::array::StringArray::value(out, i).to_string())
+                }
+            })
+            .collect())
+    }
+
+    #[test]
+    fn udf_item_crs_rejects_non_wgs84_rows() {
+        // The same rule the type level applies, detected when the row arrives
+        // rather than when the query is planned. Before this, a per-row
+        // EPSG:3857 was hashed as though it were degrees: POINT (10 20) in
+        // metres is in the Gulf of Guinea, but hashed as degrees it lands in
+        // Chad.
+        for crs in ["EPSG:3857", "EPSG:26918", "EPSG:4269"] {
+            let err = invoke_item_crs(&[Some("POINT (10 20)")], &[Some(crs)], 10)
+                .expect_err("{crs} should be rejected");
+            let msg = err.to_string();
+            assert!(msg.contains("requires WGS84"), "unexpected message: {msg}");
+            assert!(msg.contains(crs), "message should name the CRS: {msg}");
+        }
+
+        // One bad row is enough, wherever it sits in the batch.
+        let err = invoke_item_crs(
+            &[Some("POINT (10 20)"), Some("POINT (10 20)")],
+            &[Some("EPSG:4326"), Some("EPSG:3857")],
+            10,
+        )
+        .expect_err("a mixed batch should be rejected");
+        assert!(err.to_string().contains("requires WGS84"), "{err}");
+    }
+
+    #[test]
+    fn udf_item_crs_accepts_wgs84_and_absent_rows() {
+        // Both spellings of WGS84, plus the "no CRS" spellings: a null entry
+        // and the "0" sentinel that deserialize_crs() resolves to no CRS.
+        let out = invoke_item_crs(
+            &[
+                Some("POINT (10 20)"),
+                Some("POINT (10 20)"),
+                Some("POINT (10 20)"),
+                Some("POINT (10 20)"),
+            ],
+            &[Some("EPSG:4326"), Some("OGC:CRS84"), None, Some("0")],
+            10,
+        )
+        .unwrap();
+        assert_eq!(out, vec![Some("s5x1g8cu2y".to_string()); 4]);
+    }
+
+    #[test]
+    fn udf_item_crs_wraps_longitude_only_for_declared_wgs84_rows() {
+        // The inconsistency this closes: with the CRS visible per row, an
+        // item-level WGS84 row wraps exactly as a type-level WGS84 column does,
+        // instead of nulling where the other wraps. A row with no CRS keeps
+        // Apache Sedona's null.
+        let out = invoke_item_crs(
+            &[Some("POINT (190 50)"), Some("POINT (190 50)")],
+            &[Some("EPSG:4326"), None],
+            12,
+        )
+        .unwrap();
+        assert_eq!(out, vec![Some("b0zh7w1z0gs3".to_string()), None]);
+
+        // Which is the same answer the type-level kernel gives for that point.
+        let tester = geohash_tester(lnglat_geometry());
+        let type_level = tester
+            .invoke_scalar_scalar("POINT (190.0 50.0)", ScalarValue::Int64(Some(12)))
+            .unwrap();
+        tester.assert_scalar_result_equals(type_level, "b0zh7w1z0gs3");
+    }
+
+    #[test]
+    fn udf_item_crs_rejects_a_bad_crs_on_a_null_geometry_row() {
+        // A row is validated even when its geometry is null, so that a column
+        // fails the same way regardless of where its nulls happen to fall.
+        let err = invoke_item_crs(&[None], &[Some("EPSG:3857")], 10)
+            .expect_err("a null geometry should not excuse a bad CRS");
+        assert!(err.to_string().contains("requires WGS84"), "{err}");
+    }
+
+    #[test]
+    fn udf_item_crs_caches_each_distinct_crs_once() {
+        let mut checker = CachedWgs84Check::default();
+        assert_eq!(
+            checker.wrap_for(Some("EPSG:4326")).unwrap(),
+            LongitudeWrap::Enabled
+        );
+        assert_eq!(checker.wrap_for(None).unwrap(), LongitudeWrap::Disabled);
+        assert!(checker.wrap_for(Some("EPSG:3857")).is_err());
+
+        // Repeats are served from the cache, including the rejection.
+        assert_eq!(
+            checker.wrap_for(Some("EPSG:4326")).unwrap(),
+            LongitudeWrap::Enabled
+        );
+        assert!(checker.wrap_for(Some("EPSG:3857")).is_err());
+        assert_eq!(checker.cache.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## What changes were proposed in this PR?

Implement `ST_GeoHash(geometry, precision)` returning the base-32 geohash string of the geometry, matching Apache Sedona Spark semantics:

- Non-point geometries hash the **center of the bounding box** (GeometryGeoHashEncoder.java:40-41)
- Returns null when the bbox falls outside [-180,180]×[-90,90] (GeometryGeoHashEncoder.java:33-38)
- `precision <= 0` returns an empty string; precision caps at 20 (PointGeoHashEncoder.java:29-32)
- Standard lon-first bit interleaving with the `0123456789bcdefghjkmnpqrstuvwxyz` alphabet

The encoder is implemented by hand (~40 lines) — no new crate dependency.

Follows crate conventions: `SedonaScalarUDF::new` + `ItemCrsKernel::wrap_impl`, `WkbExecutor`, `ArgMatcher::is_geometry() + is_integer()` with per-row Int64-cast precision (modeled on `st_geometryn`), Utf8 return via `StringBuilder` (modeled on `st_geometrytype`).

Two deliberate deviations from Sedona Spark, documented in code:
1. **Empty geometries return null** — Sedona Java hits a JTS null-envelope artifact (`minx=0, maxx=-1`) and accidentally hashes empty geometries as (-0.5, -0.5); returning null is PostGIS-consistent.
2. **Geometry-only** (no geography kernel), matching Sedona Spark's signature; precedent: `st_xmin`/`st_ymin` are geometry-only for the same planar-bbox reason.

## Why are the changes needed?

`ST_GeoHash` is used in Sedona Spark pipelines (e.g. for spatial bucketing/partitioning keys); sedona-db currently has no implementation, so such SQL fails with an unknown-function error.

## How was this patch tested?

8 new tests in `st_geohash.rs` with expected values taken from Sedona Spark's `TestStGeoHash.scala` (each vector cited in a comment), including WKB_VIEW_GEOMETRY and ITEM_CRS variants, precision capping, out-of-range nulls, and pole/antimeridian edge cases. `cargo test -p sedona-functions` passes (513 tests), clippy and fmt clean.

## Did this PR include necessary documentation updates?

Function-level rustdoc included; happy to add a SQL reference doc page if maintainers point me at the right template.