### PR TITLE
fix(rust): return zero distance for crossing linestrings

### DIFF
--- a/python/sedonadb/tests/functions/test_distance.py
+++ b/python/sedonadb/tests/functions/test_distance.py
@@ -36,6 +36,11 @@ from sedonadb.testing import geom_or_null, PostGIS, SedonaDB
             "POLYGON ((5 5, 6 5, 6 6, 5 6, 5 5))",
             5.656854249492381,
         ),
+        (
+            "LINESTRING (0 0, 2 2)",
+            "LINESTRING (0 2, 2 0)",
+            0,
+        ),
     ],
 )
 def test_st_distance(eng, geom1, geom2, expected):

--- a/python/sedonadb/tests/functions/test_predicates.py
+++ b/python/sedonadb/tests/functions/test_predicates.py
@@ -212,6 +212,7 @@ def test_st_disjoint(eng, geom1, geom2, expected):
         (None, None, None, None),
         ("POINT (0 0)", "POINT (0 0)", 1.0, True),
         ("POINT (0 0)", "POINT (5 0)", 2.0, False),
+        ("LINESTRING (0 0, 2 2)", "LINESTRING (0 2, 2 0)", 0.0, True),
         ("LINESTRING (0 0, 1 1)", "LINESTRING (2 2, 3 3)", 1.0, False),
         ("LINESTRING (0 0, 1 1)", "LINESTRING (10 0, 11 1)", 2.0, False),
         (

--- a/rust/sedona-geo-generic-alg/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
+++ b/rust/sedona-geo-generic-alg/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
@@ -491,12 +491,10 @@ where
         let mut min_dist: F = Float::max_value();
         for line1 in self.lines() {
             for line2 in rhs.lines() {
-                // Line-to-line distance using endpoints
-                let d1 = distance_coord_to_line_generic(&line1.start_coord(), &line2);
-                let d2 = distance_coord_to_line_generic(&line1.end_coord(), &line2);
-                let d3 = distance_coord_to_line_generic(&line2.start_coord(), &line1);
-                let d4 = distance_coord_to_line_generic(&line2.end_coord(), &line1);
-                let line_dist = d1.min(d2).min(d3).min(d4);
+                let line_dist = distance_line_to_line_generic(&line1, &line2);
+                if line_dist == F::zero() {
+                    return F::zero();
+                }
                 min_dist = min_dist.min(line_dist);
             }
         }
@@ -1858,6 +1856,36 @@ mod tests {
             // Ensure both implementations agree
             assert_relative_eq!(distance, generic_distance);
         }
+
+        #[test]
+        fn test_crossing_linestring_distance() {
+            let issue_left = LineString::from(vec![(0.0, 0.0), (2.0, 2.0)]);
+            let issue_right = LineString::from(vec![(0.0, 2.0), (2.0, 0.0)]);
+            let later_segment_left = LineString::from(vec![(-2.0, -2.0), (-1.0, -1.0), (2.0, 2.0)]);
+            let later_segment_right = LineString::from(vec![(-2.0, 2.0), (-1.0, 1.0), (2.0, -2.0)]);
+
+            for (left, right) in [
+                (&issue_left, &issue_right),
+                (&later_segment_left, &later_segment_right),
+            ] {
+                let distance = Euclidean.distance(left, right);
+                assert_relative_eq!(distance, 0.0);
+                assert_relative_eq!(left.distance_ext(right), distance);
+                assert_relative_eq!(right.distance_ext(left), distance);
+            }
+
+            // Multi-geometries and collections delegate to the same public
+            // LineString-to-LineString dispatch.
+            let multi = MultiLineString::new(vec![
+                LineString::from(vec![(10.0, 10.0), (11.0, 11.0)]),
+                issue_left.clone(),
+            ]);
+            assert_relative_eq!(multi.distance_ext(&issue_right), 0.0);
+
+            let collection = GeometryCollection(vec![Geometry::LineString(issue_left.clone())]);
+            assert_relative_eq!(collection.distance_ext(&issue_right), 0.0);
+        }
+
         #[test]
         // Line-Polygon test: closest point on Polygon is NOT nearest to a Line end-point
         fn test_line_polygon_simple() {

--- a/rust/sedona-geo/src/st_distance.rs
+++ b/rust/sedona-geo/src/st_distance.rs
@@ -202,4 +202,21 @@ mod tests {
         let expected: ArrayRef = Arc::new(Float64Array::from(vec![Some(5.0), Some(0.0)]));
         assert_array_equal(&tester.invoke_array_array(arg0, arg1).unwrap(), &expected);
     }
+
+    #[rstest]
+    fn crossing_linestrings_have_zero_distance(
+        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY, WKB_GEOMETRY_ITEM_CRS.clone())] left: SedonaType,
+        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY, WKB_GEOMETRY_ITEM_CRS.clone())] right: SedonaType,
+    ) {
+        let udf = SedonaScalarUDF::from_impl("st_distance", st_distance_impl());
+        let tester = ScalarUdfTester::new(udf.into(), vec![left.clone(), right.clone()]);
+        let result = tester
+            .invoke_scalar_scalar(
+                create_scalar(Some("LINESTRING (0 0, 2 2)"), &left),
+                create_scalar(Some("LINESTRING (0 2, 2 0)"), &right),
+            )
+            .unwrap();
+
+        assert_eq!(result, ScalarValue::Float64(Some(0.0)));
+    }
 }

--- a/rust/sedona-geo/src/st_dwithin.rs
+++ b/rust/sedona-geo/src/st_dwithin.rs
@@ -174,4 +174,29 @@ mod tests {
             &expected,
         );
     }
+
+    #[rstest]
+    fn crossing_linestrings_are_dwithin_zero(
+        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY, WKB_GEOMETRY_ITEM_CRS.clone())] left: SedonaType,
+        #[values(WKB_GEOMETRY, WKB_VIEW_GEOMETRY, WKB_GEOMETRY_ITEM_CRS.clone())] right: SedonaType,
+    ) {
+        let udf = SedonaScalarUDF::from_impl("st_dwithin", st_dwithin_impl());
+        let tester = ScalarUdfTester::new(
+            udf.into(),
+            vec![
+                left.clone(),
+                right.clone(),
+                SedonaType::Arrow(DataType::Float64),
+            ],
+        );
+        let result = tester
+            .invoke_scalar_scalar_scalar(
+                create_scalar(Some("LINESTRING (0 0, 2 2)"), &left),
+                create_scalar(Some("LINESTRING (0 2, 2 0)"), &right),
+                0.0,
+            )
+            .unwrap();
+
+        assert_eq!(result, ScalarValue::Boolean(Some(true)));
+    }
 }


### PR DESCRIPTION
Fixes #1156.

## Summary

- route each LineString segment pair through the existing intersection-aware distance helper
- return immediately when the distance reaches zero
- add regressions at the generic algorithm, Rust UDF, and SedonaDB/PostGIS conformance layers

## Root cause

The native `geo` kernel routes non-Point distance calculations through `sedona-geo-generic-alg::DistanceExt`. Its specialized LineString-to-LineString branch visited every segment pair, but calculated only the four endpoint-to-opposite-segment distances.

That formula is valid only after ruling out a segment intersection. For the two crossing lines from #1156, none of the endpoints lies on the other segment, so all four projections have a positive distance even though the segment interiors cross. The result was `sqrt(2)` instead of zero.

The same crate already had the correct `distance_line_to_line_generic()` primitive: it tests segment intersection first and then, only for disjoint segments, takes the same four endpoint distances. The public LineString dispatch duplicated the endpoint portion and bypassed that helper.

This affected more than the direct `ST_Distance` example:

- `ST_DWithin` shares the same distance backend, so a zero bound was also wrong.
- MultiLineString and GeometryCollection distance calculations delegate to the same LineString branch.
- Callers of the generic distance trait, including native distance refinement paths, inherited the same result.

The concrete upstream `geo` LineString implementation does not have this defect; it checks for intersection before searching for a positive minimum distance. The bug was specific to the generic adaptation in this repository.

## History

The generic distance work originated in [`wherobots/geo#7`](https://github.com/wherobots/geo/pull/7) and was first consumed by SedonaDB in [`apache/sedona-db#73`](https://github.com/apache/sedona-db/pull/73). A broader generic rewrite in [`wherobots/geo#9`](https://github.com/wherobots/geo/pull/9) introduced the endpoint-only LineString specialization. That source was imported into this repository by [`apache/sedona-db#195`](https://github.com/apache/sedona-db/pull/195) in commit [`91f1b7e`](https://github.com/apache/sedona-db/commit/91f1b7e70d656ab136ea6037488f190b0c88b014), then integrated into the workspace by [`apache/sedona-db#203`](https://github.com/apache/sedona-db/pull/203).

The existing tests did exercise crossing segments, but only through the correct helper. The randomized LineString cross-validation also compared upstream `geo` with `nearest_neighbour_distance()` rather than the public `DistanceExt` LineString dispatch. Existing benchmarks used disjoint LineStrings. Consequently, all of those checks bypassed the duplicated faulty branch.

## Fix

The LineString specialization now calls `distance_line_to_line_generic()` inside its existing segment-pair traversal and stops as soon as any pair returns zero. This keeps intersection detection and positive-distance calculation in one traversal: disjoint inputs are not subjected to a separate whole-LineString intersection pass followed by a second distance pass. Complexity remains O(n*m) with O(1) additional memory, and the existing empty/no-segment behavior is preserved.

For valid LineStrings, this makes the implementation mathematically equivalent to upstream `geo`, but deliberately not line-for-line identical. [`geo` 0.31](https://github.com/georust/geo/blob/geo-0.31.0/geo/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs#L175-L181) first checks the complete LineStrings for intersection and then uses [two R-trees](https://github.com/georust/geo/blob/geo-0.31.0/geo/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs#L364-L380) to find a positive minimum. `geo-generic-alg` rewrites those algorithms against geometry traits so SedonaDB can operate directly on its internal geometry representations without first materializing concrete `geo_types` geometries. This patch restores the upstream correctness invariant—intersecting segments have zero distance—while retaining that generic, allocation-free segment traversal. Porting upstream's indexed search strategy would be a separate optimization requiring representative benchmarks.

This is intentionally a localized correction to `geo-generic-alg`; it does not switch `ST_Distance` or `ST_DWithin` to another backend.

## Performance investigation

The benchmark terminology below distinguishes the input representation from the implementation: both paths execute the native `geo-generic-alg::DistanceExt` algorithm. "geo-types" uses a materialized `geo_types::LineString`; "WKB view" reads the same serialized geometries through the zero-copy WKB reader used by SedonaDB. The WKB measurement includes `read_wkb()` inside the timed iteration, but excludes serialization and the surrounding Arrow/DataFusion UDF machinery, so it is the closer proxy for the production kernel path rather than a whole-query benchmark.

The existing LineString benchmark is a fixed asymmetric, disjoint case: an 8,853-segment Norway geometry against a 2-segment LineString, for 17,706 segment pairs. Indicative Criterion results on the same machine with isolated build directories were:

| Input representation | Previous endpoint-only implementation | This PR | Change |
| --- | ---: | ---: | ---: |
| geo-types | ~260 us | ~417 us | ~+60% |
| WKB view | ~292 us | ~417 us | ~+43% |

This is the expected worst-side tradeoff of restoring the missing robust intersection test: a disjoint input still examines every segment pair. The previous implementation is a meaningful timing baseline for disjoint inputs only; for crossing inputs it returned the wrong result.

A controlled geo-types-only matrix also varied both LineStrings over 4, 16, 64, and 256 segments and covered widely separated lines, disjoint lines with overlapping global bounding boxes, a crossing in the first segment pair, and a crossing in the last pair. At the larger full-scan sizes, the corrected unguarded traversal added roughly 20-27% over the endpoint-only traversal. For a first-pair crossing, the corrected implementation returned zero immediately in roughly constant time, while the old implementation scanned all segment pairs and returned an incorrect positive value. A WKB-view complexity matrix has not yet been run, so these matrix results should not be treated as production-path measurements.

I also evaluated a cheap, direct segment-AABB rejection before invoking the robust intersection predicate. On the existing fixture it reduced the corrected geo-types result from ~417 us to ~270 us, but reduced the production-relevant WKB-view result only from ~417 us to ~383 us (about 8%). In the 256-by-256 geo-types matrix it improved highly prunable full-scan cases by about 33-36%, but regressed an adversarial case in which every segment AABB overlapped by about 25%; an early crossing also paid about 1.7 ns of additional fixed overhead. The existing Norway fixture is especially favorable to this guard because its segment pairs are AABB-separable.

Based on these results, I decided to hold back the AABB optimization from this PR. Its benefit is workload-dependent, its measured gain on the representative WKB-view path is modest even on a favorable fixture, and it would add a Sedona-specific implementation detail. This PR therefore remains a localized correctness fix. The optimization can be reconsidered separately after running a representative WKB-view complexity and workload matrix.


## Validation

- `cargo test --offline -p sedona-geo-generic-alg` (323 tests and 30 doctests passed)
- `cargo test --offline -p sedona-geo` (159 tests passed)
- `cargo clippy --offline -p sedona-geo-generic-alg --all-targets --no-deps -- -D warnings`
- `cargo clippy --offline -p sedona-geo --all-targets --no-deps -- -D warnings`
- targeted Python `ST_Distance` and `ST_DWithin` conformance tests (18 passed; 18 PostGIS parameterizations skipped because PostGIS was unavailable locally)
- `ruff format --check` and `ruff check` for the modified Python tests

The new coverage includes both operand orders, a crossing that occurs on a later segment, MultiLineString and GeometryCollection delegation, all supported WKB/WKB-view/item-CRS UDF type pairs, and `ST_DWithin(..., 0)`.

