### PR TITLE
fix(rust/sedona-spatial-join): Handle empty left join build side

### DIFF
--- a/python/sedonadb/tests/test_sjoin.py
+++ b/python/sedonadb/tests/test_sjoin.py
@@ -68,6 +68,21 @@ def test_spatial_join(join_type, on):
         eng_postgis.assert_query_result(sql, sedonadb_results)
 
 
+def test_spatial_left_join_with_empty_left_side(con):
+    left = con.sql("SELECT ST_Point(0.0, 0.0) AS g, 1 AS x").alias("l")
+    left_empty = left.filter(left["x"] > 99)
+    right = con.sql("SELECT ST_Point(0.0, 0.0) AS g2, 2 AS y").alias("r")
+
+    result = left_empty.join(
+        right,
+        on=left_empty["g"].geo.intersects(right["g2"]),
+        how="left",
+    ).to_arrow_table()
+
+    assert result.num_rows == 0
+    assert result.schema.names == ["g", "x", "g2", "y"]
+
+
 def _plan_text(df):
     query_plan = df.to_pandas()
     return "\n".join(query_plan.iloc[:, 1].astype(str).tolist())

--- a/rust/sedona-spatial-join/src/index/default_spatial_index.rs
+++ b/rust/sedona-spatial-join/src/index/default_spatial_index.rs
@@ -116,6 +116,7 @@ impl DefaultSpatialIndex {
         schema: SchemaRef,
         options: SpatialJoinOptions,
         refiner: Arc<dyn IndexQueryResultRefiner>,
+        visited_build_side: Option<Mutex<Vec<BooleanBufferBuilder>>>,
         probe_threads_counter: AtomicUsize,
     ) -> Self {
         let rtree = RTreeBuilder::<f32>::new(0).finish::<HilbertSort>();
@@ -131,7 +132,7 @@ impl DefaultSpatialIndex {
                 data_id_to_batch_pos: Vec::new(),
                 indexed_batches: Vec::new(),
                 geom_idx_vec: Vec::new(),
-                visited_build_side: None,
+                visited_build_side,
                 probe_threads_counter,
                 knn_components,
             }),
@@ -755,20 +756,31 @@ mod tests {
             SpatialRelationType::Intersects,
         ));
 
-        let mut builder = DefaultSpatialIndexBuilder::new(
-            schema.clone(),
-            spatial_predicate,
-            options,
-            JoinType::Inner,
-            4,
-            metrics,
-        )
-        .unwrap();
+        for (join_type, needs_visited_build_side) in
+            [(JoinType::Inner, false), (JoinType::Left, true)]
+        {
+            let mut builder = DefaultSpatialIndexBuilder::new(
+                schema.clone(),
+                spatial_predicate.clone(),
+                options.clone(),
+                join_type,
+                4,
+                metrics.clone(),
+            )
+            .unwrap();
 
-        // Test finishing with empty data
-        let index = builder.finish().unwrap();
-        assert_eq!(index.schema(), schema);
-        assert_eq!(index.num_indexed_batches(), 0);
+            // Test finishing with empty data
+            let index = builder.finish().unwrap();
+            assert_eq!(index.schema(), schema);
+            assert_eq!(index.num_indexed_batches(), 0);
+            assert_eq!(
+                index.visited_build_side().is_some(),
+                needs_visited_build_side
+            );
+            if let Some(visited_build_side) = index.visited_build_side() {
+                assert!(visited_build_side.lock().is_empty());
+            }
+        }
     }
 
     #[tokio::test]

--- a/rust/sedona-spatial-join/src/index/default_spatial_index_builder.rs
+++ b/rust/sedona-spatial-join/src/index/default_spatial_index_builder.rs
@@ -306,6 +306,9 @@ impl DefaultSpatialIndexBuilder {
 impl SpatialIndexBuilder for DefaultSpatialIndexBuilder {
     fn finish(&mut self) -> Result<SpatialIndexRef> {
         if self.indexed_batches.is_empty() {
+            // Match GPUSpatialIndexBuilder's empty-index path: outer joins still need a
+            // configured (empty) visited-build bitmap.
+            let visited_build_side = self.build_visited_bitmaps()?;
             let empty_refiner = self.refiner_factory.create_refiner(
                 &self.spatial_predicate,
                 self.options.clone(),
@@ -318,6 +321,7 @@ impl SpatialIndexBuilder for DefaultSpatialIndexBuilder {
                 self.schema.clone(),
                 self.options.clone(),
                 empty_refiner,
+                visited_build_side,
                 AtomicUsize::new(self.probe_threads_count),
             )));
         }

--- a/rust/sedona-spatial-join/tests/spatial_join_integration.rs
+++ b/rust/sedona-spatial-join/tests/spatial_join_integration.rs
@@ -840,6 +840,45 @@ async fn test_range_join_with_empty_partitions() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_left_join_with_empty_left_side() -> Result<()> {
+    let ((left_schema, _), (right_schema, right_partitions)) = create_default_test_data()?;
+    let left_partitions = vec![vec![]];
+    let sql =
+        "SELECT L.id l_id, R.id r_id FROM L LEFT JOIN R ON ST_Intersects(L.geometry, R.geometry)";
+
+    // Keep the empty left relation on the indexed build side so this exercises the
+    // empty-index outer-join finalization path.
+    let options = SpatialJoinOptions {
+        spatial_join_reordering: false,
+        ..Default::default()
+    };
+    let actual = run_spatial_join_query(
+        &left_schema,
+        &right_schema,
+        left_partitions.clone(),
+        right_partitions.clone(),
+        Some(options),
+        30,
+        sql,
+    )
+    .await?;
+    let expected = run_spatial_join_query(
+        &left_schema,
+        &right_schema,
+        left_partitions,
+        right_partitions,
+        None,
+        30,
+        sql,
+    )
+    .await?;
+
+    assert_eq!(actual.num_rows(), 0);
+    assert_eq!(actual, expected);
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_inner_join() -> Result<()> {
     let options = SpatialJoinOptions::default();
     test_with_join_types(JoinType::Inner, options, 30).await?;


### PR DESCRIPTION
## What changes were proposed in this PR?

Initialize the default spatial index's visited build-side bitmap when the build side produces no batches. The empty-index path now follows `GPUSpatialIndexBuilder`: outer joins receive a configured but empty bitmap list (`Some(empty)`), while join types that do not need final build-side output continue to use `None`.

The empty index constructor now accepts that bitmap state instead of hard-coding `None`.

This PR also adds:

- unit coverage verifying that an empty inner-join index has no visited bitmap and an empty left-join index has an empty visited bitmap
- an integration regression comparing an optimized spatial left join with a completely empty left side against `NestedLoopJoinExec`

## Why are the changes needed?

When a spatial left join's preserved left side was empty, `DefaultSpatialIndexBuilder` returned through its empty-index path before creating the visited build-side bitmap. Outer-join finalization interpreted the resulting `None` as an unconfigured invariant and raised an internal error instead of returning an empty, schema-correct result.

This made filter-then-left-join pipelines fail whenever the filter happened to produce no rows.

Fixes #1166.

## How was this patch tested?

- `cargo fmt --all -- --check`
- `cargo test -p sedona-spatial-join`
  - 302 unit tests passed; 1 ignored
  - 180 integration tests passed
  - 3 doc tests passed

The new integration test exercises the complete empty-left relation and confirms that the optimized spatial join matches the nested-loop reference result.

## Did this PR include necessary documentation updates?

No. This is a correctness fix for existing spatial left-join behavior and does not change the public API or documented semantics.
