### PR TITLE
chore(r/sedonadb): Print row count as ?? rather than NA

### DIFF
--- a/r/sdplyr/README.md
+++ b/r/sdplyr/README.md
@@ -85,7 +85,7 @@ cities |>
   ) |>
   arrange(country) |>
   head(10)
-#> <sedonab_dataframe: NA x 3>
+#> <sedonab_dataframe: ?? x 3>
 #> ┌──────────────┬─────────────┬───────────────┐
 #> │     city     ┆   country   ┆   continent   │
 #> │     utf8     ┆     utf8    ┆      utf8     │
@@ -117,7 +117,7 @@ cities |>
       wk::rct(-80, 40, -60, 60, wk::wk_crs_longlat())
     )
   )
-#> <sedonab_dataframe: NA x 2>
+#> <sedonab_dataframe: ?? x 2>
 #> ┌──────────┬─────────────────────────────────────────────┐
 #> │   name   ┆                   geometry                  │
 #> │   utf8   ┆                   geometry                  │

--- a/r/sdplyr/tests/testthat/_snaps/summarise.md
+++ b/r/sdplyr/tests/testthat/_snaps/summarise.md
@@ -22,3 +22,4 @@
       |     6.0 |
       +---------+
       Preview of up to 6 row(s)
+

--- a/r/sdplyr/tests/testthat/_snaps/summarise.md
+++ b/r/sdplyr/tests/testthat/_snaps/summarise.md
@@ -14,7 +14,7 @@
       In sdplyr, groups are dropped by default on summarise
       i Use .groups = "drop" to suppress this message
     Output
-      <sedonab_dataframe: NA x 1>
+      <sedonab_dataframe: ?? x 1>
       +---------+
       |  total  |
       | float64 |
@@ -22,4 +22,3 @@
       |     6.0 |
       +---------+
       Preview of up to 6 row(s)
-

--- a/r/sedonadb/R/dataframe.R
+++ b/r/sedonadb/R/dataframe.R
@@ -269,7 +269,7 @@ sd_preview <- function(.data, n = NULL, ascii = NULL, width = NULL) {
 
   cat(
     sprintf(
-      "<%ssedonab_dataframe: NA x %d%s>\n",
+      "<%ssedonab_dataframe: ?? x %d%s>\n",
       grouped_label,
       length(schema$children),
       grouped_vars

--- a/r/sedonadb/tests/testthat/_snaps/dataframe.md
+++ b/r/sedonadb/tests/testthat/_snaps/dataframe.md
@@ -15,7 +15,7 @@
     Code
       print(df)
     Output
-      <sedonab_dataframe: NA x 1>
+      <sedonab_dataframe: ?? x 1>
       +------------+
       |     pt     |
       |  geometry  |
@@ -29,7 +29,7 @@
     Code
       print(grouped)
     Output
-      <grouped sedonab_dataframe: NA x 1 | [`x`]>
+      <grouped sedonab_dataframe: ?? x 1 | [`x`]>
       +------------+
       |     pt     |
       |  geometry  |
@@ -49,4 +49,3 @@
 ---
 
     All option values must be named
-

--- a/r/sedonadb/tests/testthat/_snaps/dataframe.md
+++ b/r/sedonadb/tests/testthat/_snaps/dataframe.md
@@ -49,3 +49,4 @@
 ---
 
     All option values must be named
+

--- a/r/sedonafns/README.md
+++ b/r/sedonafns/README.md
@@ -59,7 +59,7 @@ sd_read_sf(system.file("shape/nc.shp", package = "sf")) |>
     NAME,
     area = sd_area(wkb_geometry)
   )
-#> <sedonab_dataframe: NA x 2>
+#> <sedonab_dataframe: ?? x 2>
 #> ┌─────────────┬─────────────────────┐
 #> │     NAME    ┆         area        │
 #> │     utf8    ┆       float64       │


### PR DESCRIPTION
Currently, the row count of `sedonadb_dataframe` is printed as `NA`. This might be just my preference, but I feel `??` is better.

```r
#> <sedonab_dataframe: NA x 2>
#> ┌──────────────┬───────────────────────────────┐
#> │     name     ┆            geometry           │
#> │     utf8     ┆            geometry           │
#> ╞══════════════╪═══════════════════════════════╡
#> │ Vatican City ┆ POINT(12.4533865 41.9032822)  │
#> ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
#> │ San Marino   ┆ POINT(12.4417702 43.9360958)  │
#> ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
#> │ Vaduz        ┆ POINT(9.5166695 47.1337238)   │
#> ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
#> │ Lobamba      ┆ POINT(31.1999971 -26.4666675) │
#> ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
#> │ Luxembourg   ┆ POINT(6.1300028 49.6116604)   │
#> ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
#> │ Palikir      ┆ POINT(158.1499743 6.9166437)  │
#> └──────────────┴───────────────────────────────┘
#> Preview of up to 6 row(s)
```

cf. dbplyr shows `??`

<https://dbplyr.tidyverse.org/#usage>:
```r
#> # A query:  ?? x 11
#> # Database: sqlite 3.52.0 [:memory:]
#>      mpg   cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb
#>    <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
#>  1  21       6  160    110  3.9   2.62  16.5     0     1     4     4
#>  2  21       6  160    110  3.9   2.88  17.0     0     1     4     4
#>  3  22.8     4  108     93  3.85  2.32  18.6     1     1     4     1
#>  4  21.4     6  258    110  3.08  3.22  19.4     1     0     3     1
#>  5  18.7     8  360    175  3.15  3.44  17.0     0     0     3     2
#>  6  18.1     6  225    105  2.76  3.46  20.2     1     0     3     1
#>  7  14.3     8  360    245  3.21  3.57  15.8     0     0     3     4
#>  8  24.4     4  147.    62  3.69  3.19  20       1     0     4     2
#>  9  22.8     4  141.    95  3.92  3.15  22.9     1     0     4     2
#> 10  19.2     6  168.   123  3.92  3.44  18.3     1     0     4     4
#> # ℹ more rows
```