### PR TITLE
 feat(r/sedonadb): Add SQL translation for nested field 

### DIFF
--- a/r/sdplyr/tests/testthat/test-filter.R
+++ b/r/sdplyr/tests/testthat/test-filter.R
@@ -83,6 +83,20 @@ test_that("filter() handles NA values", {
   )
 })
 
+test_that("filter() supports nested struct fields", {
+  df <- sedonadb::sd_sql(
+    "SELECT named_struct('bar', named_struct('baz', 1)) AS foo"
+  )
+
+  expect_identical(
+    df |>
+      filter(foo$bar$baz > 0) |>
+      transmute(value = foo$bar$baz) |>
+      collect(),
+    tibble(value = 1)
+  )
+})
+
 test_that("filter(..., .by) is unsupported", {
   df <- tibble(x = 1:3, g = c("a", "a", "b"))
   expect_snapshot_error(

--- a/r/sedonadb/R/expression.R
+++ b/r/sedonadb/R/expression.R
@@ -110,6 +110,23 @@ sd_expr_scalar_function <- function(function_name, args, factory = sd_expr_facto
   factory$scalar_function(function_name, args_as_expr)
 }
 
+# Construct access to a named field of a nested expression.
+sd_expr_get_field <- function(expr, field_name, factory) {
+  if (!is_sd_expr(expr)) {
+    rlang::abort("`expr` must be a SedonaDB expression")
+  }
+
+  if (!is.character(field_name) || length(field_name) != 1L || is.na(field_name)) {
+    rlang::abort("`field_name` must be a single non-missing string")
+  }
+
+  field_name_expr <- sd_expr_literal(field_name, factory = factory)
+  factory$scalar_function(
+    "get_field",
+    list(expr, field_name_expr)
+  )
+}
+
 #' @rdname sd_expr_column
 #' @export
 sd_expr_aggregate_function <- function(
@@ -242,11 +259,30 @@ sd_eval_expr <- function(expr, expr_ctx = sd_expr_ctx(env = env), env = parent.f
 
 sd_eval_expr_inner <- function(expr, expr_ctx) {
   if (rlang::is_call(expr)) {
-    # Special syntax for the escape hatch of "just call a DataFusion function" is
-    # the expression .fns$datafusion_fn_name(arg1, arg2)
+    # .fns$fn() is special syntax for the escape hatch of "just call a
+    # DataFusion function". In this case, expr is the function invocation and
+    # expr[[1]] is the `$` call `.fns$fn`. This is distinct from struct field
+    # access below, where expr itself is the `$` call.
     if (rlang::is_call(expr[[1]], "$") && rlang::is_symbol(expr[[1]][[2]], ".fns")) {
       fn_key <- as.character(expr[[1]][[3]])
       return(sd_eval_datafusion_fn(fn_key, expr, expr_ctx))
+    }
+
+    # For foo$bar, expr itself is a `$` call: expr[[1]] is the symbol `$`,
+    # expr[[2]] is foo, and expr[[3]] is bar. Evaluate the left-hand side
+    # recursively so the top-level column is resolved through the data mask
+    # and chained field access such as foo$bar$baz works.
+    if (rlang::is_call(expr, "$")) {
+      lhs <- sd_eval_expr_inner(expr[[2]], expr_ctx)
+      if (is_sd_expr(lhs)) {
+        return(
+          sd_expr_get_field(
+            lhs,
+            as.character(expr[[3]]),
+            factory = expr_ctx$factory
+          )
+        )
+      }
     }
 
     # Extract `pkg::fun` or `fun` if this is a usual call (e.g., not

--- a/r/sedonadb/R/expression.R
+++ b/r/sedonadb/R/expression.R
@@ -112,10 +112,6 @@ sd_expr_scalar_function <- function(function_name, args, factory = sd_expr_facto
 
 # Construct access to a named field of a nested expression.
 sd_expr_get_field <- function(expr, field_name, factory) {
-  if (!is_sd_expr(expr)) {
-    rlang::abort("`expr` must be a SedonaDB expression")
-  }
-
   if (!is.character(field_name) || length(field_name) != 1L || is.na(field_name)) {
     rlang::abort("`field_name` must be a single non-missing string")
   }

--- a/r/sedonadb/tests/testthat/test-dataframe.R
+++ b/r/sedonadb/tests/testthat/test-dataframe.R
@@ -486,6 +486,27 @@ test_that("sd_filter() works with dplyr-like filter syntax", {
   )
 })
 
+test_that("dataframe expressions support nested struct fields", {
+  df <- sd_sql(
+    "SELECT named_struct('bar', named_struct('baz', 1)) AS foo"
+  )
+
+  expect_identical(
+    df |>
+      sd_filter(foo$bar$baz > 0) |>
+      sd_transmute(value = foo$bar$baz) |>
+      sd_collect(),
+    data.frame(value = 1)
+  )
+
+  expect_identical(
+    df |>
+      sd_transmute(value = .data$foo$bar$baz) |>
+      sd_collect(),
+    data.frame(value = 1)
+  )
+})
+
 test_that("sd_arrange() works with dplyr-like arrange syntax", {
   df_in <- data.frame(x = 1:10, y = letters[10:1])
 

--- a/r/sedonadb/tests/testthat/test-expression.R
+++ b/r/sedonadb/tests/testthat/test-expression.R
@@ -80,6 +80,42 @@ test_that("column expressions can be translated", {
   )
 })
 
+test_that("nested struct field expressions can be translated", {
+  schema <- nanoarrow::na_struct(list(
+    foo = nanoarrow::na_struct(list(
+      bar = nanoarrow::na_struct(list(baz = nanoarrow::na_int32()))
+    ))
+  ))
+  expr_ctx <- sd_expr_ctx(schema)
+
+  bar <- sd_expr_scalar_function(
+    "get_field",
+    list(sd_expr_column("foo", factory = expr_ctx$factory), "bar"),
+    factory = expr_ctx$factory
+  )
+  expected <- sd_expr_scalar_function(
+    "get_field",
+    list(bar, "baz"),
+    factory = expr_ctx$factory
+  )
+
+  actual <- sd_eval_expr(quote(foo$bar$baz), expr_ctx)
+  expect_identical(actual$debug_string(), expected$debug_string())
+
+  actual_data_pronoun <- sd_eval_expr(quote(.data$foo$bar$baz), expr_ctx)
+  expect_identical(actual_data_pronoun$debug_string(), expected$debug_string())
+
+  local_object <- list(value = 1L)
+  actual_local <- sd_eval_expr(quote(local_object$value), expr_ctx)
+  expected_local <- sd_expr_literal(1L, factory = expr_ctx$factory)
+  expect_identical(actual_local$debug_string(), expected_local$debug_string())
+
+  expect_error(
+    sd_eval_expr(quote(not_a_column$bar$baz), expr_ctx),
+    "object 'not_a_column' not found"
+  )
+})
+
 test_that("function calls with a translation become function calls", {
   # Should work for the qualified or unqualified versions
   expect_snapshot(sd_eval_expr(quote(abs(-1L))))

--- a/r/sedonadb/tests/testthat/test-expression.R
+++ b/r/sedonadb/tests/testthat/test-expression.R
@@ -105,6 +105,25 @@ test_that("nested struct field expressions can be translated", {
   actual_data_pronoun <- sd_eval_expr(quote(.data$foo$bar$baz), expr_ctx)
   expect_identical(actual_data_pronoun$debug_string(), expected$debug_string())
 
+  struct_expr <- sd_expr_scalar_function(
+    "named_struct",
+    list("value", 1L),
+    factory = expr_ctx$factory
+  )
+  expected_function_field <- sd_expr_get_field(
+    struct_expr,
+    "value",
+    factory = expr_ctx$factory
+  )
+  actual_function_field <- sd_eval_expr(
+    quote(.fns$named_struct("value", 1L)$value),
+    expr_ctx
+  )
+  expect_identical(
+    actual_function_field$debug_string(),
+    expected_function_field$debug_string()
+  )
+
   local_object <- list(value = 1L)
   actual_local <- sd_eval_expr(quote(local_object$value), expr_ctx)
   expected_local <- sd_expr_literal(1L, factory = expr_ctx$factory)


### PR DESCRIPTION
Fix #1169 

Translate an R expression `a$b` as SQL `get_field(a, 'b')`. 

``` r
library(sdplyr)
#> ── Attaching sdplyr packages ───────────────────────────────────── 0.4.0.9000 ──
#> ✔ sedonadb  0.4.0.9000
#> ✔ sedonafns 0.4.0.9000
#> ✔ dplyr     1.2.0

df <- sedonadb::sd_sql(
  "SELECT named_struct('bar', named_struct('baz', 1)) AS foo"
)

df |> 
  filter(foo$bar$baz > 0) |>
  transmute(value = foo$bar$baz) |>
  collect()
#> # A tibble: 1 × 1
#>   value
#>   <dbl>
#> 1     1
```

<sup>Created on 2026-08-16 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

I was thinking the implementation would be simpler than this, but it seems `sd_eval_expr_inner()` needs to be executed recursively in order to support a mixed case like this.

```r
df |> 
  transmute(value = .fns$get_field(foo, 'bar')$baz)
```
