### PR TITLE
fix(ci): unbreak wheel tests and stop linux silently passing them

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -293,10 +293,14 @@ jobs:
         env:
           CIBW_SKIP: "*musllinux*"
           VCPKG_BINARY_CACHE_HOST: ${{ github.workspace }}/vcpkg-bincache
+          HOST_WORKSPACE: ${{ github.workspace }}
           CIBW_TEST_REQUIRES: pytest adbc_driver_manager geoarrow-pyarrow geopandas duckdb
           # Test command exits 0 even on failure so CIBW continues building all wheels;
-          # failures are recorded in .test_failed and checked after upload.
-          CIBW_TEST_COMMAND: "pytest {package}/tests -vv -o faulthandler_timeout=600 || touch {project}/.test_failed"
+          # failures are recorded in .test_failed and checked after upload. The
+          # marker goes to the bind-mounted /host-workspace rather than {project}:
+          # cibuildwheel copies the project into the container, so a marker
+          # written there would be discarded and the gate would pass silently.
+          CIBW_TEST_COMMAND: "pytest {package}/tests -vv -o faulthandler_timeout=600 || touch /host-workspace/.test_failed"
 
       - name: Save vcpkg binaries
         if: always() && steps.vcpkg-cache.outputs.cache-hit != 'true'

--- a/ci/scripts/wheels-build-linux.sh
+++ b/ci/scripts/wheels-build-linux.sh
@@ -50,14 +50,31 @@ BEFORE_ALL_MANYLINUX="yum install -y curl zip unzip tar clang perl"
 # cached between Python versions (just not between invocations of this script).
 export CIBW_ENVIRONMENT_LINUX="VCPKG_ROOT=/vcpkg VCPKG_REF=$VCPKG_REF VCPKG_DEFAULT_TRIPLET=$VCPKG_DEFAULT_TRIPLET CMAKE_TOOLCHAIN_FILE=/vcpkg/scripts/buildsystems/vcpkg.cmake PKG_CONFIG_PATH=/vcpkg/installed/$VCPKG_DEFAULT_TRIPLET/lib/pkgconfig LD_LIBRARY_PATH=/vcpkg/installed/$VCPKG_DEFAULT_TRIPLET/lib MATURIN_PEP517_ARGS='--features s2geography,pyo3/extension-module'"
 
+# Host directories to bind-mount into the build container. cibuildwheel copies
+# the project into the container rather than bind-mounting it, so anything the
+# build or test writes under {project} is discarded when the container exits;
+# only these mounts survive back to the host.
+CONTAINER_VOLUMES=""
+
 # When a persistent vcpkg binary cache is provided (CI), bind-mount it into the
 # build container and point vcpkg at it, so `vcpkg install` restores prebuilt
 # binaries instead of rebuilding from source. Left unset for local builds, which
 # fall back to vcpkg's in-container default cache and mount nothing.
 if [ -n "${VCPKG_BINARY_CACHE_HOST}" ]; then
     mkdir -p "${VCPKG_BINARY_CACHE_HOST}"
-    export CIBW_CONTAINER_ENGINE="docker; create_args: --volume ${VCPKG_BINARY_CACHE_HOST}:/vcpkg-bincache"
+    CONTAINER_VOLUMES="${CONTAINER_VOLUMES} --volume ${VCPKG_BINARY_CACHE_HOST}:/vcpkg-bincache"
     export CIBW_ENVIRONMENT_LINUX="$CIBW_ENVIRONMENT_LINUX VCPKG_DEFAULT_BINARY_CACHE=/vcpkg-bincache"
+fi
+
+# The test-failure marker has to outlive the container for the job's final gate
+# to see it (see CIBW_TEST_COMMAND in python-wheels.yml). Mount the workspace so
+# the marker lands on the host, at the same path the macOS and Windows jobs use.
+if [ -n "${HOST_WORKSPACE}" ]; then
+    CONTAINER_VOLUMES="${CONTAINER_VOLUMES} --volume ${HOST_WORKSPACE}:/host-workspace"
+fi
+
+if [ -n "${CONTAINER_VOLUMES}" ]; then
+    export CIBW_CONTAINER_ENGINE="docker; create_args:${CONTAINER_VOLUMES}"
 fi
 
 export CIBW_BEFORE_ALL="$BEFORE_ALL_MANYLINUX && git clone https://github.com/microsoft/vcpkg.git /vcpkg && bash {package}/../../ci/scripts/wheels-bootstrap-vcpkg.sh"

--- a/python/sedonadb/tests/test_sjoin.py
+++ b/python/sedonadb/tests/test_sjoin.py
@@ -75,7 +75,7 @@ def test_spatial_left_join_with_empty_left_side(con):
 
     result = left_empty.join(
         right,
-        on=left_empty["g"].geo.intersects(right["g2"]),
+        on=left_empty["g"].funcs.st_intersects(right["g2"]),
         how="left",
     ).to_arrow_table()
 


### PR DESCRIPTION
Wheel tests have been failing on main since #1167: `test_sjoin.py` reaches the `.geo` accessor, which imports `sedonadb_expr` — not in `CIBW_TEST_REQUIRES`. Switched to the `funcs` accessor so the test keeps covering the #1167 regression without the extra dependency.

Linux was failing the same test but reporting success: cibuildwheel copies the project into the container, so the `.test_failed` marker written to `{project}` was discarded and the gate saw nothing. Bind-mounts the workspace so the marker lands on the host, alongside the existing vcpkg cache mount.