### PR TITLE
chore(r): Bump development versions to 0.4.1.9000

### DIFF
--- a/r/sdplyr/DESCRIPTION
+++ b/r/sdplyr/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sdplyr
 Title: Apache SedonaDB 'dplyr' Interface
-Version: 0.4.0.9000
+Version: 0.4.1.9000
 Authors@R:
     person("Dewey", "Dunnington", , "dewey@dunnington.ca", role = c("aut", "cre"))
 Description: Provides a 'dplyr' backend implemented using 'SedonaDB'.

--- a/r/sedonadb/DESCRIPTION
+++ b/r/sedonadb/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sedonadb
 Title: Bindings for Apache SedonaDB
-Version: 0.4.0.9000
+Version: 0.4.1.9000
 Authors@R:
     person("Dewey", "Dunnington", , "dewey@dunnington.ca", role = c("aut", "cre"))
 Description: Provides bindings for Apache SedonaDB, a lightweight

--- a/r/sedonafns/DESCRIPTION
+++ b/r/sedonafns/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sedonafns
 Title: Apache SedonaDB Function Definitions and Documentation
-Version: 0.4.0.9000
+Version: 0.4.1.9000
 Authors@R:
     person("Dewey", "Dunnington", , "dewey@dunnington.ca", role = c("aut", "cre"))
 Description: Provides function definitions and documentation for use in 'SedonaDB'.


### PR DESCRIPTION
## What changes are included in this PR?

Updates the three R package `DESCRIPTION` files from `0.4.0.9000` to `0.4.1.9000` following the 0.4.1 release, per the R development-version convention described in `dev/release/README.md`.

## Are these changes tested?

Version-only change.

## Are there any user-facing changes?

No.
