### PR TITLE
feat(python/sedonadb-geopandas): add column assignment, arithmetic, and dissolve

### DIFF
--- a/python/sedonadb-geopandas/README.md
+++ b/python/sedonadb-geopandas/README.md
@@ -67,12 +67,12 @@ deliberately *not* identical to GeoPandas:
 Division follows pandas rather than SQL: `/` is true division, so integer
 columns do not silently truncate. `//` is not implemented, since SQL division
 truncates toward zero where Python floors. Duration arithmetic whose row
-results overflow the 64-bit tick range produces missing values (`NaT`) rather
-than raising the way pandas does — a lazy expression cannot raise for
-individual rows. (pandas clamps finite positive float overflow to
-`Timedelta.max`, a casting artifact this layer treats as overflow instead. An
-integer operand that itself exceeds the 64-bit range raises `OverflowError`,
-as in pandas.)
+results overflow the 64-bit tick range produces missing values (`NaT`) — a
+lazy expression cannot raise for individual rows the way pandas 3 does, and
+pandas 2 silently wraps integer overflow instead. (pandas also clamps finite
+positive float overflow to `Timedelta.max`, a casting artifact this layer
+treats as overflow. An integer operand that itself exceeds the 64-bit range
+raises `OverflowError`, as in every pandas version.)
 
 `dissolve()` aggregates non-geometry columns with `"first"`, which is an
 unordered aggregate: it returns *some* value from the group rather than the one

--- a/python/sedonadb-geopandas/README.md
+++ b/python/sedonadb-geopandas/README.md
@@ -31,9 +31,13 @@ import sedonadb_geopandas as sgpd
 
 gdf = sgpd.from_geopandas(geopandas.read_file("cities.geojson"))
 big = gdf[gdf["pop"] > 1_000_000]          # boolean-mask filter
+gdf["density"] = gdf["pop"] / gdf["area"]  # assign a computed column
 buffered = gdf.geometry.buffer(0.5)        # element-wise .geo operation
 web = gdf.to_crs("EPSG:3857")              # reproject (CRS tracked through)
-result = web.to_geopandas()                # back to a real GeoDataFrame
+
+zones = gdf.dissolve(by="region")          # group and union geometry
+
+result = zones.to_geopandas()               # back to a real GeoDataFrame
 ```
 
 ## Intentional differences from GeoPandas
@@ -44,10 +48,34 @@ deliberately *not* identical to GeoPandas:
 - **Lazy, not eager**: operations build a query; data materializes on
   `to_geopandas()` / `to_pandas()` / display.
 - **No row index / alignment**: there is no pandas `Index`; joins and filters
-  are positional/relational, not index-aligned.
+  are positional/relational, not index-aligned. Consequently `dissolve()`
+  leaves the group keys as ordinary columns instead of moving them into the
+  index.
 - **Immutable under the hood**: "in-place" style operations return a new frame.
+  Assigning a column with `gdf["x"] = ...` rebinds the frame, so a `Series` read
+  before the assignment is stale and cannot be combined with later reads.
+- **Columns cannot be mixed across frames**: without row alignment, combining
+  columns from two different frames raises rather than guessing. Join first.
 - **Plotting and arbitrary `apply`**: use the `to_geopandas()` escape hatch and
   operate on the materialized result.
+- **Assignment takes a column or a scalar, not a bare expression**: a SedonaDB
+  expression records no origin, so one built from another frame would resolve
+  against the destination and silently write the wrong values. Assign a `Series`
+  read from the same frame, or a scalar (a geometry included). For anything the
+  wrapper does not cover, drop to the SedonaDB `DataFrame` API directly.
+
+Division follows pandas rather than SQL: `/` is true division, so integer
+columns do not silently truncate. `//` is not implemented, since SQL division
+truncates toward zero where Python floors.
+
+`dissolve()` aggregates non-geometry columns with `"first"`, which is an
+unordered aggregate: it returns *some* value from the group rather than the one
+from the first row, and unlike GeoPandas it does not skip missing values, so a
+group containing a null or NaN may aggregate to that. Dissolving an empty frame
+without a group key returns one row — empty geometry collection, null attribute
+values — rather than zero rows, because that is what a grouping-free SQL
+aggregate produces, and a group mixing 2D and 3D geometries raises rather than
+being promoted to 3D.
 
 See the SedonaDB "Migrating from GeoPandas" guide for the relational model that
 underlies each method.

--- a/python/sedonadb-geopandas/README.md
+++ b/python/sedonadb-geopandas/README.md
@@ -66,7 +66,10 @@ deliberately *not* identical to GeoPandas:
 
 Division follows pandas rather than SQL: `/` is true division, so integer
 columns do not silently truncate. `//` is not implemented, since SQL division
-truncates toward zero where Python floors.
+truncates toward zero where Python floors. Duration arithmetic whose result
+overflows the 64-bit tick range produces missing values (`NaT`) rather than
+raising the way pandas does — a lazy expression cannot raise for individual
+rows.
 
 `dissolve()` aggregates non-geometry columns with `"first"`, which is an
 unordered aggregate: it returns *some* value from the group rather than the one

--- a/python/sedonadb-geopandas/README.md
+++ b/python/sedonadb-geopandas/README.md
@@ -75,7 +75,10 @@ group containing a null or NaN may aggregate to that. Dissolving an empty frame
 without a group key returns one row — empty geometry collection, null attribute
 values — rather than zero rows, because that is what a grouping-free SQL
 aggregate produces, and a group mixing 2D and 3D geometries raises rather than
-being promoted to 3D.
+being promoted to 3D. Grouping is observed-only: unused categories of a
+categorical key do not produce empty groups the way GeoPandas' default
+`observed=False` does, because the category domain does not survive a relational
+aggregation.
 
 See the SedonaDB "Migrating from GeoPandas" guide for the relational model that
 underlies each method.

--- a/python/sedonadb-geopandas/README.md
+++ b/python/sedonadb-geopandas/README.md
@@ -66,10 +66,13 @@ deliberately *not* identical to GeoPandas:
 
 Division follows pandas rather than SQL: `/` is true division, so integer
 columns do not silently truncate. `//` is not implemented, since SQL division
-truncates toward zero where Python floors. Duration arithmetic whose result
-overflows the 64-bit tick range produces missing values (`NaT`) rather than
-raising the way pandas does — a lazy expression cannot raise for individual
-rows.
+truncates toward zero where Python floors. Duration arithmetic whose row
+results overflow the 64-bit tick range produces missing values (`NaT`) rather
+than raising the way pandas does — a lazy expression cannot raise for
+individual rows. (pandas clamps finite positive float overflow to
+`Timedelta.max`, a casting artifact this layer treats as overflow instead. An
+integer operand that itself exceeds the 64-bit range raises `OverflowError`,
+as in pandas.)
 
 `dissolve()` aggregates non-geometry columns with `"first"`, which is an
 unordered aggregate: it returns *some* value from the group rather than the one

--- a/python/sedonadb-geopandas/pyproject.toml
+++ b/python/sedonadb-geopandas/pyproject.toml
@@ -26,13 +26,12 @@ readme = "README.md"
 requires-python = ">=3.9"
 dynamic = ["version"]
 dependencies = [
-    # `DataFrame.mutate`, which `to_crs()` and column assignment are built on, is
-    # not in 0.4.0 — it first ships in 0.5.0. The floor is written as the
-    # prerelease `0.5.0a0` rather than `0.5.0` because nightlies version as
-    # `0.5.0aN`, which PEP 440 orders *below* `0.5.0`; a plain `>=0.5.0` would
-    # reject exactly the nightly wheels this is developed against.
-    "sedonadb>=0.5.0a0",
-    "sedonadb-expr>=0.5.0a0",
+    # `DataFrame.mutate`, which `to_crs()` and column assignment are built on,
+    # first shipped in the released 0.4.1 (it is absent from 0.4.0). Nightlies
+    # version as `0.5.0aN`, which PEP 440 orders above `0.4.1`, so they satisfy
+    # this floor naturally. sedonadb-expr is unchanged since 0.4.0.
+    "sedonadb>=0.4.1",
+    "sedonadb-expr>=0.4.0",
     "pyarrow",
 ]
 classifiers = [

--- a/python/sedonadb-geopandas/pyproject.toml
+++ b/python/sedonadb-geopandas/pyproject.toml
@@ -26,13 +26,13 @@ readme = "README.md"
 requires-python = ">=3.9"
 dynamic = ["version"]
 dependencies = [
-    # The `.geo` accessor and `DataFrame.unnest` this package builds on landed in
-    # 0.4.0. Keep this floor at a *released* version rather than raising it to
-    # the current development version: nightlies are versioned `X.Y.ZaN`, which
-    # PEP 440 orders *below* `X.Y.Z`, so a floor equal to the version being
-    # developed would reject the matching nightly wheels.
-    "sedonadb>=0.4.0",
-    "sedonadb-expr>=0.4.0",
+    # `DataFrame.mutate`, which `to_crs()` and column assignment are built on, is
+    # not in 0.4.0 — it first ships in 0.5.0. The floor is written as the
+    # prerelease `0.5.0a0` rather than `0.5.0` because nightlies version as
+    # `0.5.0aN`, which PEP 440 orders *below* `0.5.0`; a plain `>=0.5.0` would
+    # reject exactly the nightly wheels this is developed against.
+    "sedonadb>=0.5.0a0",
+    "sedonadb-expr>=0.5.0a0",
     "pyarrow",
 ]
 classifiers = [

--- a/python/sedonadb-geopandas/pyproject.toml
+++ b/python/sedonadb-geopandas/pyproject.toml
@@ -29,7 +29,8 @@ dependencies = [
     # `DataFrame.mutate`, which `to_crs()` and column assignment are built on,
     # first shipped in the released 0.4.1 (it is absent from 0.4.0). Nightlies
     # version as `0.5.0aN`, which PEP 440 orders above `0.4.1`, so they satisfy
-    # this floor naturally. sedonadb-expr is unchanged since 0.4.0.
+    # this floor naturally. The APIs this wrapper needs from sedonadb-expr (the
+    # generated .geo accessor methods it calls) are all available in 0.4.0.
     "sedonadb>=0.4.1",
     "sedonadb-expr>=0.4.0",
     "pyarrow",

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
@@ -227,15 +227,23 @@ class GeoDataFrame:
         else:
             expr = self._scalar_expr(key, value)
 
+        geometry_before = _geometry_column_names(self._df)
         self._df = self._df.mutate(**{key: expr})
 
         # Assignment can change whether the active geometry column is still a
         # geometry: replacing it with a number leaves nothing to be active, and
-        # giving a frame without geometry one makes that column active.
-        geometry_columns = _geometry_column_names(self._df)
-        if key == self._geometry_name and key not in geometry_columns:
+        # *creating* a geometry column on a frame without one activates it. The
+        # created-not-preexisting distinction matters: a frame whose geometry was
+        # explicitly deactivated (geometry=None) must not be reactivated by a
+        # no-op reassignment of a column that was already geometry.
+        geometry_after = _geometry_column_names(self._df)
+        if key == self._geometry_name and key not in geometry_after:
             self._geometry_name = None
-        elif self._geometry_name is None and key in geometry_columns:
+        elif (
+            self._geometry_name is None
+            and key in geometry_after
+            and key not in geometry_before
+        ):
             self._geometry_name = key
 
     def _scalar_expr(self, key, value):
@@ -260,12 +268,18 @@ class GeoDataFrame:
 
         # Only geometry values inherit the column's type and CRS. Assigning a number
         # over a geometry column is a legitimate way to turn it into an ordinary
-        # column, and must not be dressed up as geometry.
+        # column, and must not be dressed up as geometry. Geometry-ness is decided
+        # from the resolved literal's schema rather than by duck-typing the Python
+        # value: a GeoArrow scalar carries no __geo_interface__ yet is geometry.
         missing = _is_missing(raw)
-        is_geometry_value = missing or hasattr(raw, "__geo_interface__")
         replacing_geometry = key in _geometry_column_names(self._df)
-        if not (replacing_geometry and is_geometry_value):
+        if not replacing_geometry:
             return lit(raw)
+        if not missing:
+            candidate = lit(raw)
+            projected = self._df.select(candidate.alias("x")).schema
+            if not projected.geometry_column_indices:
+                return candidate
 
         crs = self._df.schema.field(key).type.crs
         # A context-bound literal is needed to call functions on it.
@@ -327,6 +341,11 @@ class GeoDataFrame:
         - A group mixing 2D and 3D geometries raises, because the collect step
           rejects mixed coordinate dimensions; GeoPandas promotes to 3D with NaN.
           Normalize the dimension first if a group can contain both.
+        - Grouping is observed-only: a categorical key contributes one group per
+          value actually present. GeoPandas defaults to `observed=False` and also
+          emits empty groups for unused categories, but the category domain does
+          not survive a relational aggregation, so those groups cannot be
+          reconstructed here.
         """
         if self._geometry_name is None:
             raise ValueError("dissolve() requires an active geometry column")
@@ -343,6 +362,10 @@ class GeoDataFrame:
             keys = [by]
         else:
             keys = list(by)
+            if not keys:
+                # Matches GeoPandas: an explicit empty iterable is almost
+                # certainly a bug, unlike by=None which means dissolve-all.
+                raise ValueError("No group keys passed!")
 
         unknown = [k for k in keys if k not in self.columns]
         if unknown:

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
@@ -26,6 +26,28 @@ _REPR_HTML_ROWS = 10
 _DERIVE = object()
 
 
+def _sanitize_temporal(df, expr, name):
+    """Null out the pandas missing-value sentinel in temporal columns.
+
+    INT64_MIN is a representable Arrow duration/timestamp tick, but it is what
+    numpy-backed pandas stores for NaT, so data arriving through Arrow can
+    carry it as a real value. Treated as data it corrupts every operator:
+    self-subtraction returns zero instead of missing, negation wraps back onto
+    the sentinel, subtracting a tick aborts the query on arithmetic overflow,
+    and equality matches, so a filter retains rows that materialize as NaT.
+    It becomes SQL null here, where columns are read, so every downstream
+    operator sees it as missing.
+    """
+    import pyarrow as pa
+
+    from sedonadb.expr import lit
+
+    dtype = pa.schema(df.schema).field(name).type
+    if pa.types.is_duration(dtype) or pa.types.is_timestamp(dtype):
+        return expr.cast(pa.int64()).funcs.nullif(lit(-(2**63))).cast(dtype)
+    return expr
+
+
 def _geometry_column_names(df):
     names = df.schema.names
     return {names[i] for i in df.schema.geometry_column_indices}
@@ -149,7 +171,7 @@ class GeoDataFrame:
             expr = self._df[key]
             if key == self._geometry_name:
                 return GeoSeries(self._df, expr, key)
-            return Series(self._df, expr, key)
+            return Series(self._df, _sanitize_temporal(self._df, expr, key), key)
 
         if isinstance(key, slice):
             raise TypeError(

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
@@ -16,7 +16,7 @@
 # under the License.
 """GeoPandas-style GeoDataFrame backed by a lazy SedonaDB frame."""
 
-from sedonadb_geopandas._series import GeoSeries, Series
+from sedonadb_geopandas._series import GeoSeries, Series, is_scalar
 
 # Rows to collect for the Jupyter rich-text (`_repr_html_`) preview.
 _REPR_HTML_ROWS = 10
@@ -29,6 +29,49 @@ _DERIVE = object()
 def _geometry_column_names(df):
     names = df.schema.names
     return {names[i] for i in df.schema.geometry_column_indices}
+
+
+def _is_floating(df, name):
+    """Whether column `name` holds scalar floating-point values, so it can hold NaN.
+
+    The Arrow datatype is checked rather than its string form: a rendered type such
+    as `list<item: double>` or `struct<x: double>` contains "float"/"double" while
+    being nothing `isnan()` can be applied to, and passing one to `isnan()` fails
+    at planning time. Dictionary encoding is unwrapped — a
+    `dictionary<values=double>` column is floating for NaN purposes, and `isnan()`
+    handles it.
+    """
+    import pyarrow as pa
+
+    dtype = pa.schema(df.schema).field(name).type
+    if pa.types.is_dictionary(dtype):
+        dtype = dtype.value_type
+    return pa.types.is_floating(dtype)
+
+
+def _expr_crs(df, expr):
+    """The CRS carried by `expr`, read from a projected schema (a plan build)."""
+    field = df.select(expr.alias("x")).schema.field("x")
+    return getattr(field.type, "crs", None)
+
+
+def _is_missing(value):
+    """Whether `value` is one of the missing-value sentinels.
+
+    `None`, NaN, and `pandas.NA` all mean "no value" to GeoPandas, and a geometry
+    column assigned any of them keeps its type and CRS rather than becoming an
+    ordinary column of nulls.
+    """
+    if value is None:
+        return True
+    try:
+        import pandas as pd
+
+        # Safe for scalars; geometries and numbers simply return False.
+        return bool(pd.isna(value))
+    except Exception:
+        # Without pandas, catch NaN via its self-inequality.
+        return isinstance(value, float) and value != value
 
 
 class GeoDataFrame:
@@ -77,6 +120,18 @@ class GeoDataFrame:
     def __getitem__(self, key):
         # Boolean mask -> row filter (gdf[gdf["pop"] > 1000]).
         if isinstance(key, Series):
+            if key._df is not self._df:
+                # Same check assignment makes. Without it a mask captured before an
+                # assignment is silently reused against the rebound frame: it
+                # happens to resolve while the referenced column still exists, and
+                # fails obscurely at collection when it does not.
+                raise ValueError(
+                    "Cannot filter with a mask built from a different DataFrame: "
+                    "there is no row alignment, so the result would be silently "
+                    "wrong. Note that assigning a column rebinds this frame, so a "
+                    "mask taken beforehand is stale; re-read it as gdf[...] > ... "
+                    "and try again."
+                )
             return GeoDataFrame(self._df.filter(key._expr), self._geometry_name)
 
         # Column subset -> GeoDataFrame. Matching GeoPandas, the active geometry
@@ -115,6 +170,118 @@ class GeoDataFrame:
             f"boolean mask, not {type(key).__name__}"
         )
 
+    def __setitem__(self, key, value):
+        """Add or replace a column, as in `gdf["buffered"] = gdf.geometry.buffer(1)`.
+
+        The underlying frame is immutable, so this rebinds this object to a new
+        frame rather than mutating data in place. A consequence worth knowing:
+        `Series` objects taken from this frame *before* the assignment still
+        refer to the previous frame, so combining one with a column read
+        afterwards raises rather than silently mixing two frames.
+
+        Args:
+            key: Column name to add or replace.
+            value: A `Series`/`GeoSeries` from this same frame, or a scalar (which
+                may be a geometry) to broadcast to every row.
+
+        A bare SedonaDB expression is deliberately not accepted. An expression
+        carries no record of the frame it was built from, so a column reference
+        taken from another frame would resolve against this one and silently
+        produce this frame's values instead of the intended ones.
+        """
+        if not isinstance(key, str):
+            raise TypeError(f"Column name must be a string, not {type(key).__name__}")
+
+        from sedonadb.expr import Expr, Literal
+
+        if isinstance(value, Series):
+            if value._df is not self._df:
+                raise ValueError(
+                    "Cannot assign a Series that comes from a different "
+                    "DataFrame: there is no row alignment, so the result would "
+                    "be silently wrong. Note that assigning to this frame "
+                    "rebinds it, so a Series read before an earlier assignment "
+                    "is already stale; re-read it as gdf[...] and try again."
+                )
+            expr = value._expr
+        elif isinstance(value, Literal):
+            # A literal holds a value rather than a column reference, so there is
+            # no frame for it to be misattributed to. It still goes through the
+            # scalar path so that a literal geometry gets the same CRS treatment as
+            # a plain one.
+            expr = self._scalar_expr(key, value)
+        elif isinstance(value, Expr):
+            raise TypeError(
+                "Assigning a bare expression isn't supported: an expression does "
+                "not record which frame its columns came from, so one built "
+                "against another frame would silently resolve against this one. "
+                "Assign a Series read from this frame, or a literal."
+            )
+        elif not is_scalar(value):
+            raise TypeError(
+                f"Assigning a {type(value).__name__} isn't supported (there is no "
+                f"row alignment, so the values could not be matched to rows). "
+                f"Build the column from this frame's own columns, or load the "
+                f"data as a frame and join it."
+            )
+        else:
+            expr = self._scalar_expr(key, value)
+
+        self._df = self._df.mutate(**{key: expr})
+
+        # Assignment can change whether the active geometry column is still a
+        # geometry: replacing it with a number leaves nothing to be active, and
+        # giving a frame without geometry one makes that column active.
+        geometry_columns = _geometry_column_names(self._df)
+        if key == self._geometry_name and key not in geometry_columns:
+            self._geometry_name = None
+        elif self._geometry_name is None and key in geometry_columns:
+            self._geometry_name = key
+
+    def _scalar_expr(self, key, value):
+        """Build the expression for broadcasting `value` into column `key`.
+
+        Replacing an existing geometry column keeps that column's type and CRS, as
+        GeoPandas does. A bare Shapely geometry carries no CRS of its own, and any
+        missing-value sentinel (`None`, NaN, `pandas.NA`) means "no geometry" rather
+        than "no longer a geometry column", so neither should silently reset what
+        the frame already knew.
+
+        A `Literal` is unwrapped and rebuilt on this frame's context: a literal
+        constructed by the bare `lit()` has no context, so functions cannot be
+        applied to it, and passing it straight through would skip the CRS handling.
+        """
+        from sedonadb.expr import Literal, lit
+
+        from sedonadb_geopandas._series import normalize_scalar
+
+        raw = value._value if isinstance(value, Literal) else value
+        raw = normalize_scalar(raw)
+
+        # Only geometry values inherit the column's type and CRS. Assigning a number
+        # over a geometry column is a legitimate way to turn it into an ordinary
+        # column, and must not be dressed up as geometry.
+        missing = _is_missing(raw)
+        is_geometry_value = missing or hasattr(raw, "__geo_interface__")
+        replacing_geometry = key in _geometry_column_names(self._df)
+        if not (replacing_geometry and is_geometry_value):
+            return lit(raw)
+
+        crs = self._df.schema.field(key).type.crs
+        # A context-bound literal is needed to call functions on it.
+        ctx = self._df._ctx
+        if missing:
+            expr = ctx.lit(None).funcs.st_geomfromwkt()
+        else:
+            expr = ctx.lit(raw)
+        # The destination CRS is inherited only by genuinely CRS-less geometry.
+        # A value that carries its own CRS (a GeoSeries literal, say) keeps it:
+        # stamping the destination CRS over it would relabel the coordinates
+        # without transforming them, which is silently wrong data.
+        if crs is not None and _expr_crs(self._df, expr) is None:
+            expr = expr.funcs.st_setcrs(ctx.lit(crs.to_json()))
+        return expr
+
     def head(self, n=5):
         """Return a `GeoDataFrame` of at most `n` rows.
 
@@ -132,6 +299,107 @@ class GeoDataFrame:
         transformed = self._df[self._geometry_name].geo.transform(lit(crs))
         new_df = self._df.mutate(**{self._geometry_name: transformed})
         return GeoDataFrame(new_df, self._geometry_name)
+
+    def dissolve(self, by=None, aggfunc="first", dropna=True):
+        """Group rows and union each group's geometry.
+
+        Args:
+            by: Column name, or list of names, to group on. With `None`, every
+                row is dissolved into one.
+            aggfunc: How to aggregate the remaining non-geometry columns.
+                Only `"first"` is currently supported.
+            dropna: Drop rows whose group key is missing, as GeoPandas does.
+
+        Returns:
+            A `GeoDataFrame` with one row per group. Unlike GeoPandas, the group
+            keys stay ordinary columns rather than becoming the index.
+
+        Three remaining differences from GeoPandas:
+
+        - `aggfunc="first"` is an unordered aggregate: it returns *some* value from
+          the group, not necessarily the one from the first row, and it does not
+          skip missing values the way GeoPandas' `first` does. A group containing a
+          null or NaN may therefore aggregate to that value.
+        - Dissolving an empty frame with `by=None` yields one row — empty geometry
+          collection, null attribute values — rather than zero rows, because that
+          is what a grouping-free SQL aggregate returns. Detecting emptiness would
+          require executing the query first.
+        - A group mixing 2D and 3D geometries raises, because the collect step
+          rejects mixed coordinate dimensions; GeoPandas promotes to 3D with NaN.
+          Normalize the dimension first if a group can contain both.
+        """
+        if self._geometry_name is None:
+            raise ValueError("dissolve() requires an active geometry column")
+        if aggfunc != "first":
+            raise NotImplementedError(
+                f"dissolve() currently supports aggfunc='first' only, got "
+                f"{aggfunc!r}. Aggregate explicitly with group_by/agg on the "
+                f"underlying SedonaDB DataFrame if you need something else."
+            )
+
+        if by is None:
+            keys = []
+        elif isinstance(by, str):
+            keys = [by]
+        else:
+            keys = list(by)
+
+        unknown = [k for k in keys if k not in self.columns]
+        if unknown:
+            raise KeyError(f"Column(s) {unknown} not found. Columns: {self.columns}")
+
+        source = self._df
+        if keys and dropna:
+            # GeoPandas drops rows with a missing group key by default. "Missing"
+            # has to cover IEEE NaN as well as SQL null: a float column read from
+            # pandas carries NaN, and grouping treats it as an ordinary value, so
+            # filtering nulls alone would leave it as its own group.
+            for key in keys:
+                column = source[key]
+                keep = column.is_not_null()
+                if _is_floating(source, key):
+                    keep = keep & ~column.funcs.isnan()
+                source = source.filter(keep)
+
+        # Collect each group into one geometry and union it afterwards, rather than
+        # using ST_Union_Agg: that aggregate only initializes for polygonal input,
+        # so a group of points or linestrings dissolves to NULL
+        # (apache/sedona-db#1093). Collect-then-unary-union is geometry-general and
+        # also produces the geometry types GeoPandas produces.
+        #
+        # The union is a separate projection because a scalar function wrapped
+        # around an aggregate is not a valid aggregate expression.
+        aggregates = [
+            source[self._geometry_name].geo.collect_agg().alias(self._geometry_name)
+        ]
+        for name in self.columns:
+            if name == self._geometry_name or name in keys:
+                continue
+            aggregates.append(source[name].funcs.first_value().alias(name))
+
+        if keys:
+            collected = source.group_by(*keys).agg(*aggregates)
+        else:
+            collected = source.agg(*aggregates)
+
+        # A group whose geometries are all null unions to null; GeoPandas yields an
+        # empty geometry collection, which behaves differently for isna, is_empty,
+        # predicates, and serialization. Coalescing loses the geometry type, so the
+        # result is re-typed and the source column's CRS re-applied.
+        ctx = self._df._ctx
+        crs = self._df.schema.field(self._geometry_name).type.crs
+        empty = ctx.lit("GEOMETRYCOLLECTION EMPTY").funcs.st_geomfromwkt()
+        geometry_expr = (
+            collected[self._geometry_name]
+            .geo.unary_union()
+            .funcs.coalesce(empty)
+            .funcs.st_geomfromwkb()
+        )
+        if crs is not None:
+            geometry_expr = geometry_expr.funcs.st_setcrs(ctx.lit(crs.to_json()))
+
+        unioned = collected.mutate(**{self._geometry_name: geometry_expr})
+        return GeoDataFrame(unioned, self._geometry_name)
 
     def to_geopandas(self):
         """Execute and return a `geopandas.GeoDataFrame` (or plain DataFrame).

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
@@ -74,18 +74,40 @@ def normalize_scalar(value):
         ):
             value = value[()]
         # NumPy temporal scalars are rebuilt as typed Arrow scalars: .item()
-        # would flatten them to integer ticks, lit() rejects non-nanosecond
-        # units, and NaT needs to become a typed null rather than an error.
+        # would flatten them to integer ticks and lit() rejects most NumPy
+        # units directly. The Arrow unit is chosen losslessly rather than
+        # forcing nanoseconds: the ns range covers only 1677-2262, so an
+        # unchecked astype silently wraps coarse-unit values centuries away.
         if isinstance(value, (np.datetime64, np.timedelta64)):
             import pyarrow as pa
 
-            kind = "datetime64" if isinstance(value, np.datetime64) else "timedelta64"
-            arrow_null = (
-                pa.timestamp("ns") if kind == "datetime64" else pa.duration("ns")
-            )
+            is_datetime = isinstance(value, np.datetime64)
+            kind = "datetime64" if is_datetime else "timedelta64"
             if np.isnat(value):
-                return pa.scalar(None, arrow_null)
-            return pa.scalar(value.astype(f"{kind}[ns]"))
+                null_type = pa.timestamp("ns") if is_datetime else pa.duration("ns")
+                return pa.scalar(None, null_type)
+
+            unit = np.datetime_data(value.dtype)[0]
+            if unit in ("s", "ms", "us", "ns"):
+                # Arrow-native resolution: keep it exactly.
+                target = unit
+            elif unit in ("W", "D", "h", "m") or (is_datetime and unit in ("Y", "M")):
+                # Whole multiples of seconds — and for datetimes, calendar
+                # year/month positions — convert exactly to seconds.
+                target = "s"
+            else:
+                # timedelta64 in months/years is ambiguous (pandas rejects it
+                # too), and sub-nanosecond units cannot be represented.
+                raise TypeError(
+                    f"Cannot represent a {kind}[{unit}] value exactly; use an "
+                    f"unambiguous unit no finer than nanoseconds"
+                )
+            converted = value.astype(f"{kind}[{target}]")
+            if converted.astype(value.dtype) != value:
+                raise OverflowError(
+                    f"{value!r} does not fit the Arrow {target!r} resolution"
+                )
+            return pa.scalar(converted)
     except ImportError:
         pass
     if hasattr(value, "__array__") and getattr(value, "ndim", None) == 0:
@@ -114,7 +136,20 @@ def _numeric_value(other):
 
     value = other
     if isinstance(value, Literal):
-        value = value._value
+        # Resolve through the literal's Arrow value rather than its raw Python
+        # payload: SedonaDB accepts one-element containers (an Arrow array, a
+        # pandas Series or one-cell frame) as single-value literals, and the
+        # payload alone does not reveal that.
+        try:
+            import pyarrow as pa
+
+            arr = pa.array(value)
+            if len(arr) == 1:
+                value = arr[0].as_py()
+            else:
+                value = value._value
+        except Exception:
+            value = value._value
     if is_scalar(value):
         value = normalize_scalar(value)
     try:
@@ -344,9 +379,17 @@ class Series:
 
         dtype = self._dtype()
 
-        # Division by zero and non-finite operands have no integer form to cast
-        # back to. Pandas yields NaT for a Series in these cases, and a scalar
-        # operand makes every row NaT, so the result is a typed null broadcast.
+        # Non-finite operands have no integer form to cast back to, so they are
+        # resolved up front the way pandas resolves them. Division by infinity
+        # is zero for every valid row — computed as ticks * 0 so source nulls
+        # stay null — while division by zero or NaN, and multiplication by a
+        # non-finite value, make every row NaT.
+        if op == "/" and math.isinf(value):
+            return Series(
+                self._df,
+                (self._expr.cast(pa.int64()) * 0).cast(dtype),
+                self._name,
+            )
         if not math.isfinite(value) or (op == "/" and value == 0):
             return Series(self._df, lit(pa.scalar(None, dtype)), self._name)
 

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
@@ -64,15 +64,28 @@ def normalize_scalar(value):
         # a missing value into a real number; masked means missing.
         if value is np.ma.masked or np.ma.is_masked(value):
             return None
-        # NumPy temporal scalars must not be unwrapped: .item() yields integer
-        # ticks. datetime64 is accepted by lit() directly; timedelta64 is not,
-        # so it goes through pandas, which lit() understands.
-        if isinstance(value, np.datetime64):
-            return value
-        if isinstance(value, np.timedelta64):
-            import pandas as pd
+        # A 0-D array wrapping a temporal must be unwrapped to its NumPy scalar
+        # (not .item(), which yields integer ticks) so it reaches the temporal
+        # handling below.
+        if (
+            isinstance(value, np.ndarray)
+            and value.ndim == 0
+            and value.dtype.kind in "mM"
+        ):
+            value = value[()]
+        # NumPy temporal scalars are rebuilt as typed Arrow scalars: .item()
+        # would flatten them to integer ticks, lit() rejects non-nanosecond
+        # units, and NaT needs to become a typed null rather than an error.
+        if isinstance(value, (np.datetime64, np.timedelta64)):
+            import pyarrow as pa
 
-            return pd.Timedelta(value)
+            kind = "datetime64" if isinstance(value, np.datetime64) else "timedelta64"
+            arrow_null = (
+                pa.timestamp("ns") if kind == "datetime64" else pa.duration("ns")
+            )
+            if np.isnat(value):
+                return pa.scalar(None, arrow_null)
+            return pa.scalar(value.astype(f"{kind}[ns]"))
     except ImportError:
         pass
     if hasattr(value, "__array__") and getattr(value, "ndim", None) == 0:
@@ -84,6 +97,31 @@ def normalize_scalar(value):
         # the NA sentinel becomes SQL null.
         if value is pd.NA:
             return None
+    except ImportError:
+        pass
+    return value
+
+
+def _numeric_value(other):
+    """Resolve an operand to its numeric payload, unwrapping supported wrappers.
+
+    A `Literal` or Arrow scalar is one value by the shared scalar contract, so a
+    type decision (is this integer division? is this a numeric duration operand?)
+    must look through the wrapper at the payload rather than judging the wrapper
+    itself.
+    """
+    from sedonadb.expr import Literal
+
+    value = other
+    if isinstance(value, Literal):
+        value = value._value
+    if is_scalar(value):
+        value = normalize_scalar(value)
+    try:
+        import pyarrow as pa
+
+        if isinstance(value, pa.Scalar):
+            value = value.as_py()
     except ImportError:
         pass
     return value
@@ -269,14 +307,12 @@ class Series:
         if isinstance(other, Series):
             other_integer = pa.types.is_integer(other._dtype())
         else:
-            from decimal import Decimal
-
-            normalized = normalize_scalar(other) if is_scalar(other) else other
-            other_integer = isinstance(normalized, numbers.Integral) and not isinstance(
-                normalized, bool
+            # Look through Literal / Arrow-scalar wrappers: `series / lit(2)` is
+            # integer division just as much as `series / 2` is.
+            resolved = _numeric_value(other)
+            other_integer = isinstance(resolved, numbers.Integral) and not isinstance(
+                resolved, bool
             )
-            if isinstance(normalized, Decimal):
-                other_integer = False
         if other_integer:
             return self._expr.cast(pa.float64())
         return self._expr
@@ -292,19 +328,40 @@ class Series:
         microseconds. Only numeric scalars are supported; anything else keeps the
         engine's own error.
         """
+        import math
         import numbers
 
         import pyarrow as pa
 
-        value = normalize_scalar(other) if is_scalar(other) else other
+        from sedonadb.expr import lit
+
+        value = _numeric_value(other)
         if not isinstance(value, numbers.Real) or isinstance(value, bool):
             raise TypeError(
                 f"Duration arithmetic supports numeric scalars only, got "
                 f"{type(other).__name__}"
             )
+
         dtype = self._dtype()
+
+        # Division by zero and non-finite operands have no integer form to cast
+        # back to. Pandas yields NaT for a Series in these cases, and a scalar
+        # operand makes every row NaT, so the result is a typed null broadcast.
+        if not math.isfinite(value) or (op == "/" and value == 0):
+            return Series(self._df, lit(pa.scalar(None, dtype)), self._name)
+
         ticks = self._expr.cast(pa.int64())
-        result = ticks * value if op == "*" else ticks.cast(pa.float64()) / value
+        integral = isinstance(value, numbers.Integral)
+        if op == "*":
+            result = (
+                ticks * int(value) if integral else ticks.cast(pa.float64()) * value
+            )
+        elif integral:
+            # Exact integer tick division: routing an integral divisor through
+            # float64 loses precision above 2**53 ticks.
+            result = ticks / int(value)
+        else:
+            result = ticks.cast(pa.float64()) / value
         return Series(
             self._df,
             result.cast(pa.int64()).cast(dtype),

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
@@ -64,15 +64,13 @@ def normalize_scalar(value):
         # a missing value into a real number; masked means missing.
         if value is np.ma.masked or np.ma.is_masked(value):
             return None
-        # A 0-D array wrapping a temporal must be unwrapped to its NumPy scalar
-        # (not .item(), which yields integer ticks) so it reaches the temporal
-        # handling below.
-        if (
-            isinstance(value, np.ndarray)
-            and value.ndim == 0
-            and value.dtype.kind in "mM"
-        ):
-            value = value[()]
+        # A 0-D array is unwrapped first and the result re-normalized: the
+        # wrapped value may itself need handling below (an object-dtype 0-d
+        # array can hold a NumPy temporal). Temporal dtypes unwrap via [()]
+        # because .item() would flatten them to integer ticks.
+        if isinstance(value, np.ndarray) and value.ndim == 0:
+            unwrapped = value[()] if value.dtype.kind in "mM" else value.item()
+            return normalize_scalar(unwrapped)
         # NumPy temporal scalars are rebuilt as typed Arrow scalars: .item()
         # would flatten them to integer ticks and lit() rejects most NumPy
         # units directly. The Arrow unit is chosen losslessly rather than
@@ -95,15 +93,29 @@ def normalize_scalar(value):
                 # Whole multiples of seconds — and for datetimes, calendar
                 # year/month positions — convert exactly to seconds.
                 target = "s"
+            elif is_datetime:
+                # Sub-nanosecond datetimes narrow to nanoseconds; the
+                # round-trip check below rejects only the values that
+                # actually lose precision (GeoPandas silently truncates
+                # these instead, which this layer deliberately does not do).
+                target = "ns"
             else:
-                # timedelta64 in months/years is ambiguous (pandas rejects it
-                # too), and sub-nanosecond units cannot be represented.
-                raise TypeError(
+                # timedelta64 in months/years is ambiguous, and pandas
+                # rejects sub-nanosecond timedeltas outright, exactly
+                # representable or not.
+                raise ValueError(
                     f"Cannot represent a {kind}[{unit}] value exactly; use an "
                     f"unambiguous unit no finer than nanoseconds"
                 )
             converted = value.astype(f"{kind}[{target}]")
             if converted.astype(value.dtype) != value:
+                # A same-unit conversion is the identity, so a mismatch means
+                # either a sub-nanosecond value that has no exact ns form or
+                # a coarse value whose seconds form overflows int64.
+                if unit not in ("s", "ms", "us", "ns", "W", "D", "h", "m", "Y", "M"):
+                    raise ValueError(
+                        f"{value!r} loses precision at the Arrow 'ns' resolution"
+                    )
                 raise OverflowError(
                     f"{value!r} does not fit the Arrow {target!r} resolution"
                 )
@@ -139,17 +151,17 @@ def _numeric_value(other):
         # Resolve through the literal's Arrow value rather than its raw Python
         # payload: SedonaDB accepts one-element containers (an Arrow array, a
         # pandas Series or one-cell frame) as single-value literals, and the
-        # payload alone does not reveal that.
-        try:
-            import pyarrow as pa
+        # payload alone does not reveal that. Conversion and validation errors
+        # propagate as-is — the resolver's own message (a Series of length
+        # != 1, say) is more precise than any downstream type-check error.
+        import pyarrow as pa
 
-            arr = pa.array(value)
-            if len(arr) == 1:
-                value = arr[0].as_py()
-            else:
-                value = value._value
-        except Exception:
-            value = value._value
+        arr = pa.array(value)
+        if len(arr) != 1:
+            raise ValueError(
+                f"Can't use a Literal resolving to {len(arr)} values as a single value"
+            )
+        value = arr[0].as_py()
     if is_scalar(value):
         value = normalize_scalar(value)
     try:
@@ -396,9 +408,24 @@ class Series:
         ticks = self._expr.cast(pa.int64())
         integral = isinstance(value, numbers.Integral)
         if op == "*":
-            result = (
-                ticks * int(value) if integral else ticks.cast(pa.float64()) * value
-            )
+            if integral:
+                factor = int(value)
+                result = ticks * factor
+                if factor not in (-1, 0, 1):
+                    # Integer tick multiplication wraps on int64 overflow.
+                    # pandas raises there (silently wrapped before pandas 3);
+                    # a lazy expression cannot raise per row, so rows whose
+                    # product would overflow become null instead: the gate is
+                    # 1 in range and null past the (conservatively symmetric)
+                    # bound, and multiplying by it preserves in-range values.
+                    bound = (2**63 - 1) // abs(factor)
+                    in_range = (ticks <= lit(bound)) & (ticks >= lit(-bound))
+                    gate = in_range.funcs.nullif(lit(False)).cast(pa.int64())
+                    result = result * gate
+            else:
+                # Float products past int64 fail the cast back to ticks at
+                # materialization, so they raise rather than wrap.
+                result = ticks.cast(pa.float64()) * value
         elif integral:
             # Exact integer tick division: routing an integral divisor through
             # float64 loses precision above 2**53 ticks.

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
@@ -58,6 +58,21 @@ def normalize_scalar(value):
     after `is_scalar` has accepted the value.
     """
     try:
+        import pyarrow as pa
+
+        # An Arrow temporal scalar holding INT64_MIN carries the pandas NaT
+        # sentinel, not a value (see _frame._sanitize_temporal for the column
+        # side of the same invariant).
+        if (
+            isinstance(value, pa.Scalar)
+            and (pa.types.is_duration(value.type) or pa.types.is_timestamp(value.type))
+            and value.is_valid
+            and value.value == -(2**63)
+        ):
+            return pa.scalar(None, value.type)
+    except ImportError:
+        pass
+    try:
         import numpy as np
 
         # A masked value's .item() would expose the hidden data, silently turning
@@ -127,6 +142,14 @@ def normalize_scalar(value):
     try:
         import pandas as pd
 
+        # pandas temporal scalars resolve to microsecond literals downstream,
+        # silently zeroing nanoseconds; their numpy form routes through the
+        # lossless unit handling above instead. (A timezone-aware Timestamp
+        # keeps the current path — asm8 would drop its zone.)
+        if isinstance(value, pd.Timedelta) or (
+            isinstance(value, pd.Timestamp) and value.tz is None
+        ):
+            return normalize_scalar(value.asm8)
         # NaN is deliberately left as-is — pandas keeps NaN a float value; only
         # the NA sentinel becomes SQL null.
         if value is pd.NA:
@@ -399,13 +422,10 @@ class Series:
 
         dtype = self._dtype()
 
-        # INT64_MIN is a representable Arrow duration tick, but it is the
-        # missing-value sentinel in the pandas model this layer implements
-        # (Timedelta.min is one tick above it). Treating it as a value breaks
-        # every path — division by -1 aborts on arithmetic overflow, negation
-        # wraps back onto the sentinel, other divisors produce real-looking
-        # results pandas would call NaT — so it becomes null at the source.
-        ticks = self._expr.cast(pa.int64()).funcs.nullif(lit(-(2**63)))
+        # Column reads null out the INT64_MIN missing-value sentinel at the
+        # frame boundary (see _frame._sanitize_temporal), so the ticks here
+        # never carry it as data.
+        ticks = self._expr.cast(pa.int64())
 
         # Non-finite operands have no integer form to cast back to, so they are
         # resolved up front the way pandas resolves them. Division by infinity

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
@@ -17,17 +17,62 @@
 """pandas/GeoPandas-style Series backed by a SedonaDB expression."""
 
 
+def is_scalar(value):
+    """Whether `value` is a single value that can be broadcast to every row.
+
+    Checking for `__array__` alone is not enough in either direction: a list or
+    tuple has no `__array__` yet is a sequence, while a NumPy scalar has one and
+    *is* a single value. So sequences are rejected explicitly, and anything
+    array-like is judged by its dimensionality — 0-d is a scalar, anything else
+    holds multiple values and has no defined row alignment here.
+
+    Shared by operators and assignment so the two cannot disagree about what
+    counts as a scalar.
+    """
+    if isinstance(value, (str, bytes, bytearray)):
+        return True
+    if isinstance(value, (list, tuple, set, frozenset, dict, range)):
+        return False
+    if hasattr(value, "__array__"):
+        return getattr(value, "ndim", None) == 0
+    # Non-sequence objects (numbers, shapely geometries, None, ...) broadcast.
+    return not hasattr(value, "__len__")
+
+
+def normalize_scalar(value):
+    """Normalize an accepted scalar into something a literal can hold.
+
+    Passing the classifier is not the same as being constructible: a 0-d NumPy
+    array is a scalar but `lit()` cannot take it, and `pandas.NA` is a missing
+    sentinel `lit()` does not recognize. Unwrap the former to its Python value
+    and convert missing sentinels to `None` (SQL null). Callers apply this only
+    after `is_scalar` has accepted the value.
+    """
+    if hasattr(value, "__array__") and getattr(value, "ndim", None) == 0:
+        value = value.item()
+    try:
+        import pandas as pd
+
+        # NaN is deliberately left as-is — pandas keeps NaN a float value; only
+        # the NA sentinel becomes SQL null.
+        if value is pd.NA:
+            return None
+    except ImportError:
+        pass
+    return value
+
+
 def _operand(df, other):
     """Coerce the right-hand side of an operator into something usable.
 
     A `Series` is unwrapped to its expression, but only if it came from the same
     source frame as `df`: combining columns from two different frames has no
     defined meaning here (there is no row alignment) and would otherwise build a
-    plan that silently returns wrong rows. A raw SedonaDB `Expr` or `Literal` is
-    passed through as-is (`lit()` is a useful escape hatch for specifying a
-    literal that carries a CRS); other scalars pass through unchanged. A
-    pandas/numpy array-like is rejected with a clear message, since it would
-    otherwise fail obscurely as a multi-element literal.
+    plan that silently returns wrong rows. A `Literal` passes through, since it
+    holds a value rather than a column reference (`lit()` is a useful escape hatch
+    for specifying a literal that carries a CRS). Other scalars pass through
+    unchanged. A pandas/numpy array-like is rejected with a clear message, since it
+    would otherwise fail obscurely as a multi-element literal.
     """
     from sedonadb.expr import Expr, Literal
 
@@ -40,15 +85,28 @@ def _operand(df, other):
                 "frames first."
             )
         return other._expr
-    if isinstance(other, (Expr, Literal)):
+    if isinstance(other, Literal):
         return other
-    if hasattr(other, "__array__"):
+    if isinstance(other, Expr):
+        # A bare expression records no origin, so a column reference built against
+        # another frame would resolve against this one and quietly contribute this
+        # frame's values. Same reasoning as assignment, which also refuses these.
         raise TypeError(
-            "Operating against a pandas/numpy array-like isn't supported "
-            "(there is no row alignment). Operate within this frame, or collect "
-            "with to_pandas() first."
+            "Cannot combine with a bare expression: an expression does not "
+            "record which frame its columns came from, so one built against "
+            "another frame would silently resolve against this one. Use a "
+            "Series read from the same frame, or a literal."
         )
-    return other
+    if not is_scalar(other):
+        raise TypeError(
+            f"Operating against a {type(other).__name__} isn't supported (there "
+            f"is no row alignment). Operate within this frame, or collect with "
+            f"to_pandas() first."
+        )
+    # A 0-d value such as a NumPy scalar reaches here and broadcasts, matching
+    # what assignment accepts; normalization unwraps it into something a
+    # literal can actually hold.
+    return normalize_scalar(other)
 
 
 class Series:
@@ -59,6 +117,13 @@ class Series:
     as a filter mask (`gdf[gdf["pop"] > 1000]`). Nothing is computed until
     `to_pandas()`.
     """
+
+    # Without this, `np.array([...]) + series` never reaches our reflected
+    # operator: NumPy broadcasts element-by-element and returns an object array
+    # of lazy Series. Opting out of ufunc dispatch makes NumPy defer, so the
+    # whole array reaches `__radd__` and is rejected by `_operand` like any
+    # other multi-element operand.
+    __array_ufunc__ = None
 
     def __init__(self, df, expr, name):
         self._df = df
@@ -93,6 +158,62 @@ class Series:
 
     def __invert__(self):
         return Series(self._df, ~self._expr, self._name)
+
+    # -- arithmetic --------------------------------------------------------
+    # The reflected forms build `other <op> self._expr`; for a scalar left
+    # operand Python falls through to the underlying expression's reflected
+    # operator, so no special-casing is needed here.
+    def __add__(self, other):
+        return Series(self._df, self._expr + _operand(self._df, other), self._name)
+
+    def __radd__(self, other):
+        return Series(self._df, _operand(self._df, other) + self._expr, self._name)
+
+    def __sub__(self, other):
+        return Series(self._df, self._expr - _operand(self._df, other), self._name)
+
+    def __rsub__(self, other):
+        return Series(self._df, _operand(self._df, other) - self._expr, self._name)
+
+    def __mul__(self, other):
+        return Series(self._df, self._expr * _operand(self._df, other), self._name)
+
+    def __rmul__(self, other):
+        return Series(self._df, _operand(self._df, other) * self._expr, self._name)
+
+    # `/` is true division here, as in pandas. The engine follows SQL, where
+    # dividing two integers truncates (`1 / 2` is 0), so an *integer* numerator is
+    # cast to double first. The cast is restricted to integers because it is
+    # lossy elsewhere: a decimal forced through double picks up binary rounding
+    # (1.23/0.1 -> 12.299999...), and a duration would become a float nanosecond
+    # count instead of staying a duration. `//` is deliberately not implemented
+    # rather than mapped onto SQL division, which truncates toward zero where
+    # Python floors.
+    def __truediv__(self, other):
+        return Series(
+            self._df, self._for_division() / _operand(self._df, other), self._name
+        )
+
+    def __rtruediv__(self, other):
+        return Series(
+            self._df, _operand(self._df, other) / self._for_division(), self._name
+        )
+
+    def __neg__(self):
+        return Series(self._df, -self._expr, self._name)
+
+    def _for_division(self):
+        """This expression, cast to double only when it is integer-typed.
+
+        The type is read from the projected schema, which is a plan build, not an
+        execution.
+        """
+        import pyarrow as pa
+
+        projected = pa.schema(self._df.select(self._expr.alias("x")).schema)
+        if pa.types.is_integer(projected.field("x").type):
+            return self._expr.cast(pa.float64())
+        return self._expr
 
     __hash__ = None
 

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
@@ -31,6 +31,15 @@ def is_scalar(value):
     """
     if isinstance(value, (str, bytes, bytearray)):
         return True
+    try:
+        import pyarrow as pa
+
+        # An Arrow scalar is one value even when it implements __len__ (a
+        # ListScalar's length is its element count, not a row count).
+        if isinstance(value, pa.Scalar):
+            return True
+    except ImportError:
+        pass
     if isinstance(value, (list, tuple, set, frozenset, dict, range)):
         return False
     if hasattr(value, "__array__"):
@@ -48,6 +57,24 @@ def normalize_scalar(value):
     and convert missing sentinels to `None` (SQL null). Callers apply this only
     after `is_scalar` has accepted the value.
     """
+    try:
+        import numpy as np
+
+        # A masked value's .item() would expose the hidden data, silently turning
+        # a missing value into a real number; masked means missing.
+        if value is np.ma.masked or np.ma.is_masked(value):
+            return None
+        # NumPy temporal scalars must not be unwrapped: .item() yields integer
+        # ticks. datetime64 is accepted by lit() directly; timedelta64 is not,
+        # so it goes through pandas, which lit() understands.
+        if isinstance(value, np.datetime64):
+            return value
+        if isinstance(value, np.timedelta64):
+            import pandas as pd
+
+            return pd.Timedelta(value)
+    except ImportError:
+        pass
     if hasattr(value, "__array__") and getattr(value, "ndim", None) == 0:
         value = value.item()
     try:
@@ -176,44 +203,113 @@ class Series:
         return Series(self._df, _operand(self._df, other) - self._expr, self._name)
 
     def __mul__(self, other):
+        if self._is_duration():
+            return self._duration_arith("*", other)
         return Series(self._df, self._expr * _operand(self._df, other), self._name)
 
     def __rmul__(self, other):
+        if self._is_duration():
+            return self._duration_arith("*", other)
         return Series(self._df, _operand(self._df, other) * self._expr, self._name)
 
     # `/` is true division here, as in pandas. The engine follows SQL, where
-    # dividing two integers truncates (`1 / 2` is 0), so an *integer* numerator is
-    # cast to double first. The cast is restricted to integers because it is
-    # lossy elsewhere: a decimal forced through double picks up binary rounding
-    # (1.23/0.1 -> 12.299999...), and a duration would become a float nanosecond
-    # count instead of staying a duration. `//` is deliberately not implemented
-    # rather than mapped onto SQL division, which truncates toward zero where
-    # Python floors.
+    # dividing two integers truncates (`1 / 2` is 0), so an integer expression is
+    # cast to double first — but only when the *other* operand is also
+    # integer-like. The cast is scoped that tightly because it is lossy
+    # elsewhere: an integer divided by a Decimal must stay in decimal arithmetic
+    # (forcing double gives 1/Decimal("0.1") -> binary rounding), and durations
+    # are handled separately below. Dictionary encoding is unwrapped before
+    # deciding, so a dictionary<int64> column does not silently truncate.
+    # `//` is deliberately not implemented rather than mapped onto SQL division,
+    # which truncates toward zero where Python floors.
     def __truediv__(self, other):
+        if self._is_duration():
+            return self._duration_arith("/", other)
         return Series(
-            self._df, self._for_division() / _operand(self._df, other), self._name
+            self._df,
+            self._for_division(other) / _operand(self._df, other),
+            self._name,
         )
 
     def __rtruediv__(self, other):
         return Series(
-            self._df, _operand(self._df, other) / self._for_division(), self._name
+            self._df,
+            _operand(self._df, other) / self._for_division(other),
+            self._name,
         )
 
     def __neg__(self):
         return Series(self._df, -self._expr, self._name)
 
-    def _for_division(self):
-        """This expression, cast to double only when it is integer-typed.
+    def _dtype(self):
+        """This expression's Arrow type, dictionary-unwrapped.
 
-        The type is read from the projected schema, which is a plan build, not an
-        execution.
+        Read from the projected schema, which is a plan build, not an execution.
         """
         import pyarrow as pa
 
-        projected = pa.schema(self._df.select(self._expr.alias("x")).schema)
-        if pa.types.is_integer(projected.field("x").type):
+        dtype = pa.schema(self._df.select(self._expr.alias("x")).schema).field("x").type
+        if pa.types.is_dictionary(dtype):
+            dtype = dtype.value_type
+        return dtype
+
+    def _is_duration(self):
+        import pyarrow as pa
+
+        return pa.types.is_duration(self._dtype())
+
+    def _for_division(self, other):
+        """This expression, cast to double only for integer/integer division."""
+        import numbers
+
+        import pyarrow as pa
+
+        if not pa.types.is_integer(self._dtype()):
+            return self._expr
+        if isinstance(other, Series):
+            other_integer = pa.types.is_integer(other._dtype())
+        else:
+            from decimal import Decimal
+
+            normalized = normalize_scalar(other) if is_scalar(other) else other
+            other_integer = isinstance(normalized, numbers.Integral) and not isinstance(
+                normalized, bool
+            )
+            if isinstance(normalized, Decimal):
+                other_integer = False
+        if other_integer:
             return self._expr.cast(pa.float64())
         return self._expr
+
+    def _duration_arith(self, op, other):
+        """Duration * number and duration / number, as in pandas.
+
+        The engine cannot coerce Duration arithmetic directly, so the value is
+        taken through int64 ticks and cast back to the column's *own* duration
+        type. Reusing the source type matters: the tick count means whatever the
+        column's unit says it means, and assuming nanoseconds silently scales the
+        result by the unit ratio on engines that ingest durations as
+        microseconds. Only numeric scalars are supported; anything else keeps the
+        engine's own error.
+        """
+        import numbers
+
+        import pyarrow as pa
+
+        value = normalize_scalar(other) if is_scalar(other) else other
+        if not isinstance(value, numbers.Real) or isinstance(value, bool):
+            raise TypeError(
+                f"Duration arithmetic supports numeric scalars only, got "
+                f"{type(other).__name__}"
+            )
+        dtype = self._dtype()
+        ticks = self._expr.cast(pa.int64())
+        result = ticks * value if op == "*" else ticks.cast(pa.float64()) / value
+        return Series(
+            self._df,
+            result.cast(pa.int64()).cast(dtype),
+            self._name,
+        )
 
     __hash__ = None
 

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
@@ -154,8 +154,16 @@ def _numeric_value(other):
         # payload alone does not reveal that. Conversion and validation errors
         # propagate as-is — the resolver's own message (a Series of length
         # != 1, say) is more precise than any downstream type-check error.
+        # The exception is a plain integer past int64: the resolver's failure
+        # for it names the wrong problem, so it is reported as the overflow
+        # it is, matching the unwrapped-integer behavior.
+        import numbers
+
         import pyarrow as pa
 
+        raw = value._value
+        if isinstance(raw, numbers.Integral) and not -(2**63) <= int(raw) < 2**63:
+            raise OverflowError(f"{raw} overflows the signed 64-bit range")
         arr = pa.array(value)
         if len(arr) != 1:
             raise ValueError(
@@ -391,17 +399,21 @@ class Series:
 
         dtype = self._dtype()
 
+        # INT64_MIN is a representable Arrow duration tick, but it is the
+        # missing-value sentinel in the pandas model this layer implements
+        # (Timedelta.min is one tick above it). Treating it as a value breaks
+        # every path — division by -1 aborts on arithmetic overflow, negation
+        # wraps back onto the sentinel, other divisors produce real-looking
+        # results pandas would call NaT — so it becomes null at the source.
+        ticks = self._expr.cast(pa.int64()).funcs.nullif(lit(-(2**63)))
+
         # Non-finite operands have no integer form to cast back to, so they are
         # resolved up front the way pandas resolves them. Division by infinity
         # is zero for every valid row — computed as ticks * 0 so source nulls
         # stay null — while division by zero or NaN, and multiplication by a
         # non-finite value, make every row NaT.
         if op == "/" and math.isinf(value):
-            return Series(
-                self._df,
-                (self._expr.cast(pa.int64()) * 0).cast(dtype),
-                self._name,
-            )
+            return Series(self._df, (ticks * 0).cast(dtype), self._name)
         if not math.isfinite(value) or (op == "/" and value == 0):
             return Series(self._df, lit(pa.scalar(None, dtype)), self._name)
 
@@ -412,16 +424,14 @@ class Series:
         if is_int and not -(2**63) <= int(value) < 2**63:
             raise OverflowError(f"{value} overflows the signed 64-bit tick range")
 
-        ticks = self._expr.cast(pa.int64())
-        # Integral-valued floats take the exact integer path too: pandas keeps
-        # identity operations like `* 1.0` exact, and float64 cannot represent
-        # every int64 tick. Floats past the int64 range stay on the float path
-        # (pandas computes those in float as well rather than raising).
-        exact = is_int or (
-            isinstance(value, float)
-            and value.is_integer()
-            and -(2**63) <= int(value) < 2**63
-        )
+        # Among floats, only the identities ±1.0 take the exact integer path:
+        # float64 cannot represent every int64 tick, so the float round trip
+        # would corrupt (or, at the extremes, null) a value the operation was
+        # supposed to return unchanged. Every other float stays on the float
+        # path — pandas computes those in float too, losing sub-tick precision
+        # above 2**53, and matching those in-range results matters more than
+        # improving on them.
+        exact = is_int or value in (1.0, -1.0)
         if exact:
             factor = int(value)
             if op == "*":

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
@@ -405,11 +405,26 @@ class Series:
         if not math.isfinite(value) or (op == "/" and value == 0):
             return Series(self._df, lit(pa.scalar(None, dtype)), self._name)
 
+        # An integer operand that itself exceeds the signed 64-bit tick range
+        # cannot become a literal; pandas raises OverflowError for it on both
+        # multiplication and division, before any row is touched.
+        is_int = isinstance(value, numbers.Integral)
+        if is_int and not -(2**63) <= int(value) < 2**63:
+            raise OverflowError(f"{value} overflows the signed 64-bit tick range")
+
         ticks = self._expr.cast(pa.int64())
-        integral = isinstance(value, numbers.Integral)
-        if op == "*":
-            if integral:
-                factor = int(value)
+        # Integral-valued floats take the exact integer path too: pandas keeps
+        # identity operations like `* 1.0` exact, and float64 cannot represent
+        # every int64 tick. Floats past the int64 range stay on the float path
+        # (pandas computes those in float as well rather than raising).
+        exact = is_int or (
+            isinstance(value, float)
+            and value.is_integer()
+            and -(2**63) <= int(value) < 2**63
+        )
+        if exact:
+            factor = int(value)
+            if op == "*":
                 result = ticks * factor
                 if factor not in (-1, 0, 1):
                     # Integer tick multiplication wraps on int64 overflow.
@@ -423,15 +438,29 @@ class Series:
                     gate = in_range.funcs.nullif(lit(False)).cast(pa.int64())
                     result = result * gate
             else:
-                # Float products past int64 fail the cast back to ticks at
-                # materialization, so they raise rather than wrap.
-                result = ticks.cast(pa.float64()) * value
-        elif integral:
-            # Exact integer tick division: routing an integral divisor through
-            # float64 loses precision above 2**53 ticks.
-            result = ticks / int(value)
+                # Exact integer tick division: routing an integral divisor
+                # through float64 loses precision above 2**53 ticks, and the
+                # result magnitude never exceeds the ticks, so it cannot
+                # overflow.
+                result = ticks / factor
         else:
-            result = ticks.cast(pa.float64()) / value
+            fresult = (
+                ticks.cast(pa.float64()) * value
+                if op == "*"
+                else ticks.cast(pa.float64()) / value
+            )
+            # Range-gate before casting back to ticks: an out-of-range or
+            # non-finite float result would abort the whole query at the
+            # int64 cast, losing the in-range rows with it. The bound is the
+            # largest float64 that fits the tick range. Rows past it become
+            # null; pandas instead clamps finite positive overflow to
+            # Timedelta.max while negative overflow lands on the NaT
+            # sentinel — an asymmetric casting artifact this layer does not
+            # copy.
+            fbound = float(2**63 - 1024)
+            in_range = (fresult <= lit(fbound)) & (fresult >= lit(-fbound))
+            fgate = in_range.funcs.nullif(lit(False)).cast(pa.float64())
+            result = fresult * fgate
         return Series(
             self._df,
             result.cast(pa.int64()).cast(dtype),

--- a/python/sedonadb-geopandas/tests/test_geopandas_compat.py
+++ b/python/sedonadb-geopandas/tests/test_geopandas_compat.py
@@ -32,6 +32,32 @@ def cities():
 
 
 @pytest.fixture
+def points():
+    """A small frame in a projected CRS, shared across the tests."""
+    return gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.GeoSeries.from_wkt(["POINT (0 0)", "POINT (5 5)", "POINT (9 9)"]),
+        crs="EPSG:3857",
+    )
+
+
+@pytest.fixture
+def parcels():
+    """Overlapping polygons per zone, so a dissolve has something to union."""
+    return gpd.GeoDataFrame(
+        {"zone": ["A", "A", "B"], "v": [1, 2, 3]},
+        geometry=gpd.GeoSeries.from_wkt(
+            [
+                "POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))",
+                "POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1))",
+                "POLYGON ((5 5, 7 5, 7 7, 5 7, 5 5))",
+            ]
+        ),
+        crs="EPSG:3857",
+    )
+
+
+@pytest.fixture
 def con_free_geom_frame():
     """A frame whose active geometry column is *not* the heuristic's pick.
 
@@ -179,7 +205,7 @@ def test_repr_is_lazy(cities):
 
 def test_operand_rejects_arraylike(cities):
     gdf = sgpd.from_geopandas(cities)
-    with pytest.raises(TypeError, match="array-like"):
+    with pytest.raises(TypeError, match="isn't supported"):
         gdf["pop"] > cities["pop"]  # a real pandas Series
 
 
@@ -242,3 +268,463 @@ def test_head(cities):
     assert len(gdf.head(2)) == 2
     # head() keeps the active geometry column.
     assert isinstance(gdf.head(2).geometry, GeoSeries)
+
+
+# -- sjoin -------------------------------------------------------------------
+
+
+def test_dissolve_matches_geopandas(parcels):
+    got = (
+        sgpd.from_geopandas(parcels)
+        .dissolve(by="zone")
+        .to_geopandas()
+        .sort_values("zone")
+    )
+    expected = parcels.dissolve(by="zone")
+    # Unioned geometry per group, and non-geometry columns aggregated as "first",
+    # both matching GeoPandas.
+    assert got.area.round(6).tolist() == expected.area.round(6).tolist()
+    assert got["v"].tolist() == expected["v"].tolist()
+    # The group key stays a column here rather than becoming the index.
+    assert "zone" in got.columns
+
+
+def test_dissolve_without_by(parcels):
+    got = sgpd.from_geopandas(parcels).dissolve().to_geopandas()
+    assert len(got) == len(parcels.dissolve()) == 1
+
+
+def test_dissolve_multiple_keys(parcels):
+    got = sgpd.from_geopandas(parcels).dissolve(by=["zone"]).to_geopandas()
+    assert sorted(got["zone"]) == ["A", "B"]
+
+
+def test_dissolve_validation(parcels):
+    gdf = sgpd.from_geopandas(parcels)
+    with pytest.raises(NotImplementedError, match="aggfunc"):
+        gdf.dissolve(by="zone", aggfunc="sum")
+    with pytest.raises(KeyError, match="not found"):
+        gdf.dissolve(by="nope")
+    with pytest.raises(ValueError, match="active geometry"):
+        gdf[["zone", "v"]].dissolve(by="zone")
+
+
+# -- __setitem__ and arithmetic ---------------------------------------------
+
+
+def test_setitem_from_series(points):
+    gdf = sgpd.from_geopandas(points)
+    gdf["v2"] = gdf["v"] * 10 - 1
+    got = gdf.to_geopandas().sort_values("name")
+    assert got["v2"].tolist() == (points["v"] * 10 - 1).tolist()
+
+
+def test_setitem_scalar_broadcasts(points):
+    gdf = sgpd.from_geopandas(points)
+    gdf["k"] = 7
+    assert gdf.to_geopandas()["k"].tolist() == [7, 7, 7]
+
+
+def test_setitem_geometry_column(points):
+    gdf = sgpd.from_geopandas(points)
+    gdf["buffered"] = gdf.geometry.buffer(0.5)
+    assert "buffered" in gdf.columns
+    # The active geometry column is unchanged by adding another one.
+    assert gdf.geometry._name == "geometry"
+
+
+def test_setitem_replaces_existing_column(points):
+    gdf = sgpd.from_geopandas(points)
+    gdf["v"] = gdf["v"] + 100
+    assert sorted(gdf.to_geopandas()["v"]) == [101, 102, 103]
+    assert gdf.columns.count("v") == 1
+
+
+def test_setitem_makes_geometry_active_when_frame_had_none():
+    # A frame that starts without geometry gains an active geometry column when
+    # one is assigned.
+    from shapely.geometry import Point
+
+    plain = GeoDataFrame(sgpd.default_context().sql("SELECT 1 AS a"))
+    assert plain._geometry_name is None
+
+    plain["geometry"] = Point(1, 2)
+    assert plain._geometry_name == "geometry"
+    assert plain.to_geopandas().geometry.to_wkt().tolist() == ["POINT (1 2)"]
+
+
+def test_setitem_non_geometry_leaves_frame_without_geometry():
+    plain = GeoDataFrame(sgpd.default_context().sql("SELECT 1.0 AS x"))
+    plain["doubled"] = plain["x"] * 2
+    assert plain._geometry_name is None
+
+
+def test_setitem_rejects_bad_inputs(points):
+    gdf = sgpd.from_geopandas(points)
+    with pytest.raises(TypeError, match="must be a string"):
+        gdf[0] = 1
+    with pytest.raises(TypeError, match="isn't supported"):
+        gdf["x"] = points["v"]
+    # A Series from a different frame has no row alignment.
+    other = sgpd.from_geopandas(points)
+    with pytest.raises(ValueError, match="different"):
+        gdf["y"] = other["v"]
+
+
+def test_setitem_stale_series_raises(points):
+    # Assignment rebinds the frame, so a Series read beforehand is stale.
+    gdf = sgpd.from_geopandas(points)
+    before = gdf["v"]
+    gdf["k"] = 1
+    with pytest.raises(ValueError, match="different"):
+        gdf["z"] = before
+
+
+def test_series_arithmetic(points):
+    gdf = sgpd.from_geopandas(points)
+    for label, series, expected in [
+        ("add", gdf["v"] + 1, (points["v"] + 1).tolist()),
+        ("radd", 1 + gdf["v"], (1 + points["v"]).tolist()),
+        ("sub", gdf["v"] - 1, (points["v"] - 1).tolist()),
+        ("rsub", 10 - gdf["v"], (10 - points["v"]).tolist()),
+        ("mul", gdf["v"] * 2, (points["v"] * 2).tolist()),
+        ("truediv", gdf["v"] / 2, (points["v"] / 2).tolist()),
+        ("neg", -gdf["v"], (-points["v"]).tolist()),
+    ]:
+        assert sorted(series.to_pandas().tolist()) == sorted(expected), label
+
+
+def test_series_arithmetic_between_columns(points):
+    gdf = sgpd.from_geopandas(points)
+    got = (gdf["v"] + gdf["v"]).to_pandas().tolist()
+    assert sorted(got) == sorted((points["v"] + points["v"]).tolist())
+
+
+# -- regressions from review -------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "wkts",
+    [
+        ["POINT (0 0)", "POINT (1 1)"],
+        ["LINESTRING (0 0, 1 1)", "LINESTRING (1 1, 2 2)"],
+        ["POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))", "POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1))"],
+    ],
+    ids=["points", "lines", "polygons"],
+)
+def test_dissolve_handles_every_geometry_type(wkts):
+    # ST_Union_Agg only initializes for polygonal input, so points and linestrings
+    # used to dissolve to NULL geometry.
+    g = gpd.GeoDataFrame(
+        {"zone": ["A", "A"]},
+        geometry=gpd.GeoSeries.from_wkt(wkts),
+        crs="EPSG:3857",
+    )
+    got = sgpd.from_geopandas(g).dissolve(by="zone").to_geopandas()
+    expected = g.dissolve(by="zone")
+    assert got.geometry.iloc[0] is not None
+    assert got.geometry.iloc[0].geom_type == expected.geometry.iloc[0].geom_type
+    assert got.geometry.iloc[0].equals(expected.geometry.iloc[0])
+
+
+def test_dissolve_dropna_matches_geopandas():
+    g = gpd.GeoDataFrame(
+        {"zone": ["A", None], "v": [1, 2]},
+        geometry=gpd.GeoSeries.from_wkt(
+            [
+                "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))",
+                "POLYGON ((2 2, 3 2, 3 3, 2 3, 2 2))",
+            ]
+        ),
+        crs="EPSG:3857",
+    )
+    gdf = sgpd.from_geopandas(g)
+    # GeoPandas drops the missing key by default; dropna=False keeps it.
+    assert len(gdf.dissolve(by="zone").to_geopandas()) == len(g.dissolve(by="zone"))
+    assert len(gdf.dissolve(by="zone", dropna=False).to_geopandas()) == 2
+
+
+def test_setitem_rejects_bare_expression(points):
+    # A bare expression carries no origin, so one built from another frame would
+    # resolve against this frame and silently write this frame's values.
+    left = sgpd.from_geopandas(points)
+    right = sgpd.from_geopandas(points)
+    with pytest.raises(TypeError, match="bare expression"):
+        left["copied"] = right["v"]._expr
+
+
+def test_series_has_no_unguarded_expr_escape_hatch(points):
+    assert not hasattr(sgpd.from_geopandas(points)["v"], "expr")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [[10, 20, 30], (10, 20, 30), {10, 20}],
+    ids=["list", "tuple", "set"],
+)
+def test_setitem_rejects_sequences(points, value):
+    # Sequences have no __array__, so they used to be broadcast whole into every
+    # row rather than rejected.
+    gdf = sgpd.from_geopandas(points)
+    with pytest.raises(TypeError, match="isn't supported"):
+        gdf["x"] = value
+
+
+def test_setitem_accepts_numpy_scalar(points):
+    # NumPy scalars do have __array__ but are single values, so they used to be
+    # rejected as array-likes.
+    import numpy as np
+
+    gdf = sgpd.from_geopandas(points)
+    gdf["x"] = np.int64(5)
+    assert gdf.to_geopandas()["x"].tolist() == [5, 5, 5]
+
+
+def test_setitem_rejects_numpy_array(points):
+    import numpy as np
+
+    gdf = sgpd.from_geopandas(points)
+    with pytest.raises(TypeError, match="isn't supported"):
+        gdf["x"] = np.array([1, 2, 3])
+
+
+def test_setitem_over_active_geometry_clears_it(points):
+    # Replacing the active geometry with a number used to leave the name pointing
+    # at an integer column, so .geometry still returned a GeoSeries and .area
+    # failed later with a kernel error.
+    gdf = sgpd.from_geopandas(points)
+    gdf["geometry"] = 7
+    assert gdf._geometry_name is None
+    assert gdf.crs is None
+    with pytest.raises(AttributeError, match="no active geometry"):
+        gdf.geometry
+
+
+def test_operators_reject_bare_expression(points):
+    # Same provenance hole as assignment: a bare expression built from another
+    # frame resolved against this one and silently contributed this frame's values.
+    gdf = sgpd.from_geopandas(points)
+    other_raw = sgpd.default_context().create_data_frame(points)
+    with pytest.raises(TypeError, match="bare expression"):
+        gdf["v"] + other_raw["v"]
+
+
+def test_operators_still_accept_literals(points):
+    from sedonadb.expr import lit
+
+    gdf = sgpd.from_geopandas(points)
+    assert sorted((gdf["v"] > lit(1)).to_pandas().tolist()) == [False, True, True]
+
+
+def test_getitem_rejects_stale_mask(points):
+    # Assignment rebinds the frame, so a mask captured beforehand belongs to the
+    # previous one. It used to be accepted and quietly resolve against the new
+    # frame while the referenced column happened to still exist.
+    gdf = sgpd.from_geopandas(points)
+    mask = gdf["v"] > 1
+    gdf["k"] = 1
+    with pytest.raises(ValueError, match="different DataFrame"):
+        gdf[mask]
+
+
+def test_dissolve_drops_nan_group_keys():
+    # dropna has to cover IEEE NaN as well as SQL null: a float key read from
+    # pandas carries NaN, which grouping otherwise treats as its own group.
+    df = sgpd.default_context().sql(
+        "SELECT CAST('NaN' AS DOUBLE) k, ST_Point(0.0, 0.0) geometry "
+        "UNION ALL SELECT 1.0, ST_Point(1.0, 1.0)"
+    )
+    assert len(GeoDataFrame(df).dissolve(by="k").to_geopandas()) == 1
+    assert len(GeoDataFrame(df).dissolve(by="k", dropna=False).to_geopandas()) == 2
+
+
+def test_setitem_scalar_geometry_keeps_crs(points):
+    # A bare Shapely geometry carries no CRS; GeoPandas keeps the column's.
+    from shapely.geometry import Point
+
+    gdf = sgpd.from_geopandas(points)
+    before = str(gdf.crs)
+    gdf["geometry"] = Point(5, 5)
+    assert gdf._geometry_name == "geometry"
+    assert "3857" in str(gdf.crs)
+    assert "3857" in before
+
+
+def test_setitem_none_keeps_geometry_column(points):
+    # Assigning None used to turn the column untyped and clear the active geometry;
+    # GeoPandas keeps a geometry column with its CRS.
+    gdf = sgpd.from_geopandas(points)
+    gdf["geometry"] = None
+    assert gdf._geometry_name == "geometry"
+    assert "3857" in str(gdf.crs)
+    assert gdf.to_geopandas().geometry.isna().all()
+
+
+def test_setitem_non_geometry_over_geometry_still_clears(points):
+    # The CRS-preserving path must not dress a number up as geometry.
+    gdf = sgpd.from_geopandas(points)
+    gdf["geometry"] = 7
+    assert gdf._geometry_name is None
+    assert gdf.to_geopandas()["geometry"].tolist() == [7, 7, 7]
+
+
+# -- regressions from the third review pass ---------------------------------
+
+
+def test_dissolve_by_nested_float_column():
+    # _is_floating used to match the rendered type string, so `list<item: double>`
+    # looked like a float column and dropna called isnan() on it, failing at
+    # planning time.
+    df = sgpd.default_context().sql(
+        "SELECT [1.0, 2.0] AS k, ST_Point(0.0, 0.0) AS geometry"
+    )
+    got = GeoDataFrame(df).dissolve(by="k").to_geopandas()
+    assert len(got) == 1
+
+
+@pytest.mark.parametrize(
+    "value_name",
+    ["none", "nan", "pandas_na", "geometry", "literal_geometry", "literal_none"],
+)
+def test_setitem_geometry_scalars_keep_type_and_crs(points, value_name):
+    # Every supported scalar path has to go through the CRS-preserving branch:
+    # GeoPandas treats None, NaN and pd.NA as missing geometry and keeps the typed
+    # column and its CRS.
+    import numpy as np
+    import pandas as pd
+    from shapely.geometry import Point
+
+    from sedonadb.expr import lit
+
+    values = {
+        "none": None,
+        "nan": np.nan,
+        "pandas_na": pd.NA,
+        "geometry": Point(5, 5),
+        "literal_geometry": lit(Point(5, 5)),
+        "literal_none": lit(None),
+    }
+    gdf = sgpd.from_geopandas(points)
+    gdf["geometry"] = values[value_name]
+    assert gdf._geometry_name == "geometry"
+    assert "3857" in str(gdf.crs)
+
+
+def test_dissolve_all_null_group_is_empty_geometry(points):
+    # GeoPandas returns GEOMETRYCOLLECTION EMPTY rather than None, which behaves
+    # differently for isna, is_empty, predicates and serialization.
+    df = sgpd.default_context().sql(
+        "SELECT 'A' AS z, "
+        "ST_SetSRID(ST_GeomFromText(CAST(NULL AS VARCHAR)), 3857) AS geometry "
+        "UNION ALL SELECT 'A', "
+        "ST_SetSRID(ST_GeomFromText(CAST(NULL AS VARCHAR)), 3857)"
+    )
+    got = GeoDataFrame(df).dissolve(by="z").to_geopandas()
+    expected = gpd.GeoDataFrame(
+        {"z": ["A", "A"]},
+        geometry=gpd.GeoSeries.from_wkt([None, None]),
+        crs="EPSG:3857",
+    ).dissolve(by="z")
+    assert got.geometry.iloc[0].equals(expected.geometry.iloc[0])
+    assert got.geometry.iloc[0].is_empty
+    assert not got.geometry.isna().any()
+
+
+def test_operators_accept_numpy_scalars(points):
+    # Operators rejected anything with __array__, including NumPy scalars, even
+    # though assignment already accepted them.
+    import numpy as np
+
+    gdf = sgpd.from_geopandas(points)
+    assert sorted((gdf["v"] + np.int64(1)).to_pandas().tolist()) == [2, 3, 4]
+    assert sorted((gdf["v"] > np.float64(1)).to_pandas().tolist()) == [
+        False,
+        True,
+        True,
+    ]
+
+
+def test_operators_still_reject_arrays(points):
+    import numpy as np
+
+    gdf = sgpd.from_geopandas(points)
+    with pytest.raises(TypeError, match="isn't supported"):
+        gdf["v"] + np.array([1, 2, 3])
+
+
+# -- regressions from the fourth review pass --------------------------------
+
+
+def test_setitem_crs_carrying_literal_keeps_its_crs(points):
+    # A literal that carries its own CRS must not be relabeled with the
+    # destination column's CRS — that changes what the coordinates mean without
+    # transforming them.
+    from sedonadb.expr import lit
+
+    src = gpd.GeoSeries.from_wkt(["POINT (10 10)"], crs="EPSG:4326")
+    gdf = sgpd.from_geopandas(points)  # column is EPSG:3857
+    gdf["geometry"] = lit(src)
+    assert "4326" in str(gdf.crs)
+
+
+def test_division_preserves_decimal_exactness():
+    from decimal import Decimal
+
+    import pandas as pd
+
+    df = sgpd.default_context().create_data_frame(
+        pd.DataFrame({"d": [Decimal("1.23")]})
+    )
+    got = (GeoDataFrame(df)["d"] / Decimal("0.1")).to_pandas().tolist()
+    # Forced through double this would be 12.299999999999999.
+    assert got == [Decimal("12.300000")]
+
+
+def test_division_still_true_for_integers():
+    df = sgpd.default_context().sql("SELECT 1 AS n UNION ALL SELECT 3")
+    assert sorted((GeoDataFrame(df)["n"] / 2).to_pandas().tolist()) == [0.5, 1.5]
+
+
+def test_numpy_array_plus_series_is_rejected_whole(points):
+    # Without opting out of ufunc dispatch, NumPy broadcasts element-by-element
+    # and returns an object array of lazy Series instead of an error.
+    import numpy as np
+
+    gdf = sgpd.from_geopandas(points)
+    with pytest.raises(TypeError):
+        np.array([10, 20, 30]) + gdf["v"]
+    with pytest.raises(TypeError):
+        gdf["v"] + np.array([10, 20, 30])
+
+
+def test_zero_dimensional_array_normalizes(points):
+    import numpy as np
+
+    gdf = sgpd.from_geopandas(points)
+    gdf["z"] = np.array(5)  # 0-d: scalar by classification, unwrapped on use
+    assert gdf.to_geopandas()["z"].tolist() == [5, 5, 5]
+
+
+def test_pandas_na_assigns_as_null_to_ordinary_column(points):
+    import pandas as pd
+
+    gdf = sgpd.from_geopandas(points)
+    gdf["z"] = pd.NA
+    assert gdf.to_geopandas()["z"].isna().all()
+
+
+def test_is_floating_unwraps_dictionary_encoding():
+    import pyarrow as pa
+
+    from sedonadb_geopandas._frame import _is_floating
+
+    tbl = pa.table(
+        {
+            "k": pa.DictionaryArray.from_arrays(
+                pa.array([0, 1], type=pa.int8()), pa.array([1.0, float("nan")])
+            ),
+            "x": [1, 2],
+        }
+    )
+    df = sgpd.default_context().create_data_frame(tbl)
+    assert _is_floating(df, "k")

--- a/python/sedonadb-geopandas/tests/test_geopandas_compat.py
+++ b/python/sedonadb-geopandas/tests/test_geopandas_compat.py
@@ -944,6 +944,10 @@ def test_ambiguous_and_subnano_temporal_units_are_rejected(points):
     for unit in ("M", "Y", "ps"):
         with pytest.raises(ValueError, match="exactly"):
             gdf["t"] = np.timedelta64(1, unit)
+    # 1000 ps is exactly one nanosecond, and both pandas and GeoPandas still
+    # reject it — the rejection is per unit, not per value.
+    with pytest.raises(ValueError, match="exactly"):
+        gdf["t"] = np.timedelta64(1000, "ps")
 
 
 def test_duration_division_by_infinity_is_zero_preserving_nulls():
@@ -1025,6 +1029,73 @@ def test_duration_multiplication_overflow_is_null_not_wrapped():
     got = (gdf["t"] * 3).to_pandas()
     assert pd.isna(got.tolist()[0])
     assert got.tolist()[1] == pd.Timedelta(boundary * 3)
+    assert pd.isna(got.tolist()[2])
+
+
+# -- regressions from the ninth review pass ---------------------------------
+
+
+def _duration_frame(values):
+    import pandas as pd
+
+    return GeoDataFrame(
+        sgpd.default_context().create_data_frame(pd.DataFrame({"t": values}))
+    )
+
+
+def test_oversized_integer_duration_operand_raises_overflow():
+    # An integer operand past the signed 64-bit tick range failed literal
+    # construction with an unrelated ValueError, aborting even the rows whose
+    # result is representable. pandas raises OverflowError for the operand
+    # itself, on multiplication and division alike; so does this layer now.
+    import pandas as pd
+    import pyarrow as pa
+
+    gdf = _duration_frame([pd.Timedelta(0), pd.Timedelta(1)])
+    for operand in (2**63, pa.scalar(2**63, pa.uint64())):
+        with pytest.raises(OverflowError):
+            gdf["t"] * operand
+        with pytest.raises(OverflowError):
+            gdf["t"] / operand
+
+
+def test_integral_float_duration_arithmetic_is_exact():
+    # `* 1.0` and `/ 1.0` are identities in pandas even at the largest tick,
+    # but the float64 round trip cannot represent every int64 tick and the
+    # cast back aborted. Integral-valued floats use the exact integer path.
+    import pandas as pd
+
+    gdf = _duration_frame([pd.Timedelta(2**63 - 1)])
+    assert (gdf["t"] * 1.0).to_pandas().tolist()[0] == pd.Timedelta(2**63 - 1)
+    assert (gdf["t"] / 1.0).to_pandas().tolist()[0] == pd.Timedelta(2**63 - 1)
+    got = (gdf["t"] * 3.0).to_pandas()
+    assert got.isna().all()  # routed through the gated integer path
+
+
+def test_float_duration_overflow_is_null_not_abort():
+    # A finite float result past the tick range aborted the whole query at
+    # the int64 cast. Out-of-range rows become NaT while in-range rows and
+    # source nulls are unaffected. pandas clamps positive finite overflow to
+    # Timedelta.max and sends negative overflow to NaT — an asymmetric
+    # casting artifact this layer does not copy: both directions are NaT.
+    import pandas as pd
+
+    gdf = _duration_frame(
+        [pd.Timedelta(2**62), pd.Timedelta(-(2**62)), pd.Timedelta(5), pd.NaT]
+    )
+    got = (gdf["t"] / 0.5).to_pandas()
+    assert pd.isna(got.tolist()[0])
+    assert pd.isna(got.tolist()[1])
+    assert got.tolist()[2] == pd.Timedelta(10)
+    assert pd.isna(got.tolist()[3])
+
+    # A float operand past int64 stays on the float path the way pandas keeps
+    # it in float arithmetic (it must not raise the integer-operand
+    # OverflowError): zero ticks survive, everything else overflows to NaT.
+    gdf = _duration_frame([pd.Timedelta(0), pd.Timedelta(5), pd.NaT])
+    got = (gdf["t"] * 1e300).to_pandas()
+    assert got.tolist()[0] == pd.Timedelta(0)
+    assert pd.isna(got.tolist()[1])
     assert pd.isna(got.tolist()[2])
 
 

--- a/python/sedonadb-geopandas/tests/test_geopandas_compat.py
+++ b/python/sedonadb-geopandas/tests/test_geopandas_compat.py
@@ -915,32 +915,35 @@ def test_duration_non_finite_results_are_nat():
 def test_coarse_unit_temporals_are_exact(points):
     # Forcing every temporal through nanoseconds silently wrapped values
     # outside the ns range (1677-2262): 2500-01-01 materialized as 1915-06-14.
-    # Coarse units convert exactly to seconds instead. Comparisons are done as
-    # numpy values because 200000 days exceeds the ns-backed scalar Timedelta.
+    # Coarse units convert exactly to seconds instead. Expectations are
+    # independent second-resolution constants — deriving them from the
+    # materialized dtype would repeat the conversion under test and wrap
+    # identically against a broken implementation.
     import numpy as np
 
     cases = [
-        np.datetime64("2500-01-01", "D"),
-        np.timedelta64(200000, "D"),
-        np.datetime64("2500", "Y"),
+        (np.datetime64("2500-01-01", "D"), np.datetime64("2500-01-01T00:00:00", "s")),
+        (np.timedelta64(200000, "D"), np.timedelta64(200000 * 86400, "s")),
+        (np.datetime64("2500", "Y"), np.datetime64("2500-01-01T00:00:00", "s")),
     ]
-    for value in cases:
+    for value, expected in cases:
         gdf = sgpd.from_geopandas(points)
         gdf["t"] = value
         got = gdf.to_geopandas()["t"].values[0]
-        assert got == value.astype(got.dtype)
+        assert got.dtype == expected.dtype
+        assert got == expected
 
 
 def test_ambiguous_and_subnano_temporal_units_are_rejected(points):
-    # Matches pandas: timedelta months/years have no fixed length, and
-    # sub-nanosecond units cannot be represented.
+    # Matches pandas, exception type included: timedelta months/years have no
+    # fixed length, and pandas raises ValueError for sub-nanosecond timedeltas
+    # even when the value is exactly representable.
     import numpy as np
 
     gdf = sgpd.from_geopandas(points)
-    with pytest.raises(TypeError, match="exactly"):
-        gdf["t"] = np.timedelta64(1, "M")
-    with pytest.raises(TypeError, match="exactly"):
-        gdf["t"] = np.timedelta64(1, "ps")
+    for unit in ("M", "Y", "ps"):
+        with pytest.raises(ValueError, match="exactly"):
+            gdf["t"] = np.timedelta64(1, unit)
 
 
 def test_duration_division_by_infinity_is_zero_preserving_nulls():
@@ -956,6 +959,73 @@ def test_duration_division_by_infinity_is_zero_preserving_nulls():
     got = (gdf["t"] / float("inf")).to_pandas()
     assert got.tolist()[0] == pd.Timedelta(0)
     assert pd.isna(got.tolist()[1])
+
+
+# -- regressions from the eighth review pass --------------------------------
+
+
+def test_exact_subnanosecond_datetimes_are_accepted(points):
+    # 10**6 fs and 10**9 as are exactly one nanosecond and GeoPandas accepts
+    # them, so rejecting every sub-ns datetime unit up front was too broad.
+    # Lossy values are still rejected — GeoPandas silently truncates those to
+    # nanoseconds instead, which this layer deliberately does not do.
+    import numpy as np
+
+    for value in (np.datetime64(10**6, "fs"), np.datetime64(10**9, "as")):
+        gdf = sgpd.from_geopandas(points)
+        gdf["t"] = value
+        assert gdf.to_geopandas()["t"].values[0] == np.datetime64(1, "ns")
+
+    gdf = sgpd.from_geopandas(points)
+    with pytest.raises(ValueError, match="precision"):
+        gdf["t"] = np.datetime64(1, "fs")
+
+
+def test_zero_dim_object_array_holding_temporal(points):
+    # A 0-d object array classifies as a broadcastable scalar, but its .item()
+    # returns the wrapped numpy temporal, which bypassed temporal
+    # normalization and failed assignment for non-Arrow-native units.
+    import numpy as np
+
+    gdf = sgpd.from_geopandas(points)
+    gdf["t"] = np.array(np.datetime64("2500-01-01", "D"), dtype=object)
+    got = gdf.to_geopandas()["t"].values[0]
+    assert got == np.datetime64("2500-01-01T00:00:00", "s")
+
+
+def test_multi_value_literal_errors_propagate():
+    # The Literal resolver's precise error (a Series of length != 1) was
+    # swallowed and replaced by a generic duration-arithmetic TypeError.
+    import pandas as pd
+    import pyarrow as pa
+    from sedonadb.expr import lit
+
+    gdf = GeoDataFrame(
+        sgpd.default_context().create_data_frame(
+            pd.DataFrame({"t": [pd.Timedelta(days=2)]})
+        )
+    )
+    with pytest.raises(ValueError, match="length != 1"):
+        gdf["t"] * lit(pd.Series([2, 3]))
+    with pytest.raises(ValueError, match="single value"):
+        gdf["t"] * lit(pa.array([2, 3]))
+
+
+def test_duration_multiplication_overflow_is_null_not_wrapped():
+    # Integer tick multiplication silently wrapped on int64 overflow:
+    # 2**62 ticks * 3 came back as a large negative duration. pandas 3 raises
+    # OverflowError there; a lazy expression cannot raise per row, so rows
+    # whose product would overflow become NaT instead, while in-range rows —
+    # the largest exactly-representable product included — are unaffected.
+    import pandas as pd
+
+    boundary = (2**63 - 1) // 3
+    pdf = pd.DataFrame({"t": [pd.Timedelta(2**62), pd.Timedelta(boundary), pd.NaT]})
+    gdf = GeoDataFrame(sgpd.default_context().create_data_frame(pdf))
+    got = (gdf["t"] * 3).to_pandas()
+    assert pd.isna(got.tolist()[0])
+    assert got.tolist()[1] == pd.Timedelta(boundary * 3)
+    assert pd.isna(got.tolist()[2])
 
 
 def test_singleton_container_literals_resolve_as_numbers():

--- a/python/sedonadb-geopandas/tests/test_geopandas_compat.py
+++ b/python/sedonadb-geopandas/tests/test_geopandas_compat.py
@@ -833,8 +833,8 @@ def test_numpy_temporals_materialize_correctly(points, value_name, expected_kind
         "zero_d_ns_datetime": np.array(np.datetime64("2026-01-01", "ns")),
         "day_unit_datetime": np.datetime64("2026-01-01"),
         "day_unit_timedelta": np.timedelta64(2, "D"),
-        "datetime_nat": np.datetime64("NaT"),
-        "timedelta_nat": np.timedelta64("NaT"),
+        "datetime_nat": np.datetime64("NaT", "ns"),
+        "timedelta_nat": np.timedelta64("NaT", "ns"),
     }
     gdf = sgpd.from_geopandas(points)
     gdf["t"] = values[value_name]
@@ -907,3 +907,73 @@ def test_duration_non_finite_results_are_nat():
     )
     assert (gdf["t"] / 0).to_pandas().isna().all()
     assert (gdf["t"] * float("nan")).to_pandas().isna().all()
+
+
+# -- regressions from the seventh review pass -------------------------------
+
+
+def test_coarse_unit_temporals_are_exact(points):
+    # Forcing every temporal through nanoseconds silently wrapped values
+    # outside the ns range (1677-2262): 2500-01-01 materialized as 1915-06-14.
+    # Coarse units convert exactly to seconds instead. Comparisons are done as
+    # numpy values because 200000 days exceeds the ns-backed scalar Timedelta.
+    import numpy as np
+
+    cases = [
+        np.datetime64("2500-01-01", "D"),
+        np.timedelta64(200000, "D"),
+        np.datetime64("2500", "Y"),
+    ]
+    for value in cases:
+        gdf = sgpd.from_geopandas(points)
+        gdf["t"] = value
+        got = gdf.to_geopandas()["t"].values[0]
+        assert got == value.astype(got.dtype)
+
+
+def test_ambiguous_and_subnano_temporal_units_are_rejected(points):
+    # Matches pandas: timedelta months/years have no fixed length, and
+    # sub-nanosecond units cannot be represented.
+    import numpy as np
+
+    gdf = sgpd.from_geopandas(points)
+    with pytest.raises(TypeError, match="exactly"):
+        gdf["t"] = np.timedelta64(1, "M")
+    with pytest.raises(TypeError, match="exactly"):
+        gdf["t"] = np.timedelta64(1, "ps")
+
+
+def test_duration_division_by_infinity_is_zero_preserving_nulls():
+    # Blanket NaT for non-finite operands regressed /inf, which pandas defines
+    # as zero for valid rows while keeping source nulls null.
+    import pandas as pd
+
+    gdf = GeoDataFrame(
+        sgpd.default_context().create_data_frame(
+            pd.DataFrame({"t": [pd.Timedelta(days=2), pd.NaT]})
+        )
+    )
+    got = (gdf["t"] / float("inf")).to_pandas()
+    assert got.tolist()[0] == pd.Timedelta(0)
+    assert pd.isna(got.tolist()[1])
+
+
+def test_singleton_container_literals_resolve_as_numbers():
+    # SedonaDB accepts one-element containers as single-value literals; the
+    # numeric resolver must look through them like any other wrapper.
+    import pandas as pd
+    import pyarrow as pa
+
+    from sedonadb.expr import lit
+
+    gdf = GeoDataFrame(sgpd.default_context().sql("SELECT 1 AS n UNION ALL SELECT 3"))
+    assert sorted((gdf["n"] / lit(pa.array([2]))).to_pandas().tolist()) == [0.5, 1.5]
+    assert sorted((gdf["n"] / lit(pd.Series([2]))).to_pandas().tolist()) == [0.5, 1.5]
+    tdf = GeoDataFrame(
+        sgpd.default_context().create_data_frame(
+            pd.DataFrame({"t": [pd.Timedelta(days=2)]})
+        )
+    )
+    assert (tdf["t"] * lit(pd.Series([2]))).to_pandas().tolist() == [
+        pd.Timedelta(days=4)
+    ]

--- a/python/sedonadb-geopandas/tests/test_geopandas_compat.py
+++ b/python/sedonadb-geopandas/tests/test_geopandas_compat.py
@@ -751,20 +751,6 @@ def test_duration_arithmetic_matches_pandas():
         gdf["t"] * "2"
 
 
-def test_normalize_preserves_temporals_and_masks():
-    import numpy as np
-
-    from sedonadb_geopandas._series import normalize_scalar
-
-    # Temporal scalars must not become integer ticks.
-    assert isinstance(normalize_scalar(np.datetime64("2026-01-01")), np.datetime64)
-    import pandas as pd
-
-    assert normalize_scalar(np.timedelta64(1, "D")) == pd.Timedelta(days=1)
-    # A masked value means missing, not its hidden payload.
-    assert normalize_scalar(np.ma.masked) is None
-
-
 def test_pyarrow_scalars_broadcast(points):
     # Arrow scalars implement __len__ but are single values.
     import pyarrow as pa
@@ -819,3 +805,105 @@ def test_dissolve_categorical_is_observed_only():
     )
     assert len(cat.dissolve(by="z")) == 2  # GeoPandas observed=False default
     assert len(sgpd.from_geopandas(cat).dissolve(by="z").to_geopandas()) == 1
+
+
+# -- regressions from the sixth review pass ---------------------------------
+
+
+@pytest.mark.parametrize(
+    "value_name,expected_kind",
+    [
+        ("ns_datetime", "datetime"),
+        ("zero_d_ns_datetime", "datetime"),
+        ("day_unit_datetime", "datetime"),
+        ("day_unit_timedelta", "timedelta"),
+        ("datetime_nat", "datetime_nat"),
+        ("timedelta_nat", "timedelta_nat"),
+    ],
+)
+def test_numpy_temporals_materialize_correctly(points, value_name, expected_kind):
+    # Asserted end to end (assignment then collection), not on the normalization
+    # helper: .item() flattening, unit rejection, and zeroed durations were all
+    # invisible to helper-level equality checks.
+    import numpy as np
+    import pandas as pd
+
+    values = {
+        "ns_datetime": np.datetime64("2026-01-01", "ns"),
+        "zero_d_ns_datetime": np.array(np.datetime64("2026-01-01", "ns")),
+        "day_unit_datetime": np.datetime64("2026-01-01"),
+        "day_unit_timedelta": np.timedelta64(2, "D"),
+        "datetime_nat": np.datetime64("NaT"),
+        "timedelta_nat": np.timedelta64("NaT"),
+    }
+    gdf = sgpd.from_geopandas(points)
+    gdf["t"] = values[value_name]
+    out = gdf.to_geopandas()["t"]
+    if expected_kind == "datetime":
+        assert out.tolist() == [pd.Timestamp("2026-01-01")] * 3
+    elif expected_kind == "timedelta":
+        assert out.tolist() == [pd.Timedelta(days=2)] * 3
+    else:
+        # NaT stays a typed null of the right family.
+        assert out.isna().all()
+        expected_dtype = "datetime64" if "datetime" in expected_kind else "timedelta64"
+        assert expected_dtype in str(out.dtype)
+
+
+def test_masked_scalar_assigns_as_missing(points):
+    import numpy as np
+
+    gdf = sgpd.from_geopandas(points)
+    gdf["m"] = np.ma.masked
+    assert gdf.to_geopandas()["m"].isna().all()
+
+
+def test_duration_division_is_exact_for_integral_divisors():
+    # Routing an integral divisor through float64 rounded 2**53 + 1 ticks.
+    import pandas as pd
+
+    gdf = GeoDataFrame(
+        sgpd.default_context().create_data_frame(
+            pd.DataFrame({"t": [pd.Timedelta(2**53 + 1)]})
+        )
+    )
+    assert (gdf["t"] / 1).to_pandas().tolist()[0].value == 2**53 + 1
+
+
+def test_division_by_wrapped_integers_is_true_division():
+    # lit(2) and pa.scalar(2) are integer operands just as 2 is.
+    import pyarrow as pa
+
+    from sedonadb.expr import lit
+
+    gdf = GeoDataFrame(sgpd.default_context().sql("SELECT 1 AS n UNION ALL SELECT 3"))
+    assert sorted((gdf["n"] / lit(2)).to_pandas().tolist()) == [0.5, 1.5]
+    assert sorted((gdf["n"] / pa.scalar(2)).to_pandas().tolist()) == [0.5, 1.5]
+
+
+def test_duration_arithmetic_accepts_wrapped_numbers():
+    import pandas as pd
+    import pyarrow as pa
+
+    from sedonadb.expr import lit
+
+    gdf = GeoDataFrame(
+        sgpd.default_context().create_data_frame(
+            pd.DataFrame({"t": [pd.Timedelta(days=2)]})
+        )
+    )
+    assert (gdf["t"] * lit(2)).to_pandas().tolist() == [pd.Timedelta(days=4)]
+    assert (gdf["t"] / pa.scalar(2)).to_pandas().tolist() == [pd.Timedelta(days=1)]
+
+
+def test_duration_non_finite_results_are_nat():
+    # Pandas yields NaT for these; the int64 cast-back used to fail on inf/NaN.
+    import pandas as pd
+
+    gdf = GeoDataFrame(
+        sgpd.default_context().create_data_frame(
+            pd.DataFrame({"t": [pd.Timedelta(days=2)]})
+        )
+    )
+    assert (gdf["t"] / 0).to_pandas().isna().all()
+    assert (gdf["t"] * float("nan")).to_pandas().isna().all()

--- a/python/sedonadb-geopandas/tests/test_geopandas_compat.py
+++ b/python/sedonadb-geopandas/tests/test_geopandas_compat.py
@@ -1178,6 +1178,68 @@ def test_negative_float_overflow_and_exact_boundary():
     assert got.tolist()[1] == pd.Timedelta(2**63 - 1024)
 
 
+# -- regressions from the eleventh review pass ------------------------------
+
+
+def test_sentinel_ticks_are_missing_for_every_operator():
+    # The sentinel fix covered only * and /. Addition, subtraction, and
+    # comparisons still treated INT64_MIN as data: self-subtraction returned
+    # zero, adding one tick produced a finite Timedelta.min, subtracting one
+    # tick aborted the query on arithmetic overflow, and equality matched, so
+    # a filter retained a row that materializes as NaT. The sentinel becomes
+    # null where columns are read, covering every operator at once.
+    import numpy as np
+    import pandas as pd
+    import pyarrow as pa
+
+    tbl = pa.table({"t": pa.array([-(2**63), 5], pa.duration("ns"))})
+    gdf = GeoDataFrame(sgpd.default_context().create_data_frame(tbl))
+    got = (gdf["t"] - gdf["t"]).to_pandas()
+    assert pd.isna(got.tolist()[0])
+    assert got.tolist()[1] == pd.Timedelta(0)
+    got = (gdf["t"] + pd.Timedelta(1)).to_pandas()
+    assert pd.isna(got.tolist()[0])
+    assert got.tolist()[1] == pd.Timedelta(6)
+    got = (gdf["t"] - np.timedelta64(1, "ns")).to_pandas()
+    assert pd.isna(got.tolist()[0])
+    assert got.tolist()[1] == pd.Timedelta(4)
+    kept = gdf[gdf["t"] == gdf["t"]].to_pandas()["t"]
+    assert kept.tolist() == [pd.Timedelta(5)]
+
+
+def test_sentinel_timestamp_ticks_are_missing():
+    # Timestamps share the sentinel: numpy-backed pandas stores datetime NaT
+    # as INT64_MIN too, so the column boundary treats both temporal kinds the
+    # same way.
+    import pandas as pd
+    import pyarrow as pa
+
+    tbl = pa.table({"ts": pa.array([-(2**63), 10**18], pa.timestamp("ns"))})
+    gdf = GeoDataFrame(sgpd.default_context().create_data_frame(tbl))
+    got = (gdf["ts"] - gdf["ts"]).to_pandas()
+    assert pd.isna(got.tolist()[0])
+    assert got.tolist()[1] == pd.Timedelta(0)
+    kept = gdf[gdf["ts"] == gdf["ts"]].to_pandas()["ts"]
+    assert kept.tolist() == [pd.Timestamp(10**18)]
+
+
+def test_pandas_temporal_scalars_keep_nanoseconds(points):
+    # pandas Timestamp/Timedelta scalars resolved to microsecond literals:
+    # assignment silently zeroed nanoseconds, and duration arithmetic lost
+    # them behind an interval coercion (`t + pd.Timedelta(1)` came back as
+    # DateOffset objects with the tick dropped). They route through their
+    # numpy form and its lossless unit handling instead.
+    import pandas as pd
+
+    gdf = sgpd.from_geopandas(points)
+    gdf["t"] = pd.Timedelta(1)
+    got = gdf.to_geopandas()["t"]
+    assert got.tolist() == [pd.Timedelta(1)] * len(got)
+    gdf["ts"] = pd.Timestamp("2026-01-01 00:00:00.000000001")
+    got = gdf.to_geopandas()["ts"]
+    assert got.tolist() == [pd.Timestamp("2026-01-01 00:00:00.000000001")] * len(got)
+
+
 def test_singleton_container_literals_resolve_as_numbers():
     # SedonaDB accepts one-element containers as single-value literals; the
     # numeric resolver must look through them like any other wrapper.

--- a/python/sedonadb-geopandas/tests/test_geopandas_compat.py
+++ b/python/sedonadb-geopandas/tests/test_geopandas_compat.py
@@ -1059,17 +1059,18 @@ def test_oversized_integer_duration_operand_raises_overflow():
             gdf["t"] / operand
 
 
-def test_integral_float_duration_arithmetic_is_exact():
-    # `* 1.0` and `/ 1.0` are identities in pandas even at the largest tick,
-    # but the float64 round trip cannot represent every int64 tick and the
-    # cast back aborted. Integral-valued floats use the exact integer path.
+def test_identity_float_duration_arithmetic_is_exact():
+    # `* 1.0` and `/ 1.0` return the input unchanged even at the largest
+    # tick, where the float64 round trip cannot represent the value and the
+    # cast back aborted. Only the identities ±1.0 take the exact integer
+    # path; other floats keep pandas' float64 semantics.
     import pandas as pd
 
     gdf = _duration_frame([pd.Timedelta(2**63 - 1)])
     assert (gdf["t"] * 1.0).to_pandas().tolist()[0] == pd.Timedelta(2**63 - 1)
     assert (gdf["t"] / 1.0).to_pandas().tolist()[0] == pd.Timedelta(2**63 - 1)
     got = (gdf["t"] * 3.0).to_pandas()
-    assert got.isna().all()  # routed through the gated integer path
+    assert got.isna().all()  # float path: past the tick range, so null
 
 
 def test_float_duration_overflow_is_null_not_abort():
@@ -1097,6 +1098,84 @@ def test_float_duration_overflow_is_null_not_abort():
     assert got.tolist()[0] == pd.Timedelta(0)
     assert pd.isna(got.tolist()[1])
     assert pd.isna(got.tolist()[2])
+
+
+# -- regressions from the tenth review pass ---------------------------------
+
+
+def test_int64_min_duration_tick_is_missing():
+    # INT64_MIN is a representable Arrow duration tick but the pandas missing
+    # sentinel (Timedelta.min sits one tick above it). Treated as a value it
+    # aborted `/ -1` on arithmetic overflow, survived `* -1.0` internally by
+    # wrapping back onto the sentinel (so a chained `* 0` resurrected it as
+    # zero), and divided into real-looking results. It is null at the source.
+    import pandas as pd
+    import pyarrow as pa
+
+    tbl = pa.table({"t": pa.array([-(2**63), 5], pa.duration("ns"))})
+    gdf = GeoDataFrame(sgpd.default_context().create_data_frame(tbl))
+    got = (gdf["t"] / -1).to_pandas()
+    assert pd.isna(got.tolist()[0])
+    assert got.tolist()[1] == pd.Timedelta(-5)
+    chained = ((gdf["t"] * -1.0) * 0).to_pandas()
+    assert pd.isna(chained.tolist()[0])
+    assert chained.tolist()[1] == pd.Timedelta(0)
+    divided = (gdf["t"] / 3).to_pandas()
+    assert pd.isna(divided.tolist()[0])
+
+
+def test_non_identity_float_duration_arithmetic_matches_pandas():
+    # Routing every integral-valued float through exact integer arithmetic
+    # silently changed in-range results: pandas computes `* 3.0` in float64,
+    # losing sub-tick precision above 2**53, and matching pandas there
+    # matters more than improving on it. The identities ±1.0 stay exact —
+    # pandas loses precision even on those above 2**53, a corruption of an
+    # operation that should return its input; that one this layer does not
+    # reproduce.
+    import pandas as pd
+
+    pdf = pd.DataFrame({"t": [pd.Timedelta(2**53 + 1)]})
+    gdf = GeoDataFrame(sgpd.default_context().create_data_frame(pdf))
+    for operand in (3.0, 1 / 3):
+        assert (gdf["t"] * operand).to_pandas().tolist()[0] == (
+            pdf["t"] * operand
+        ).tolist()[0]
+        assert (gdf["t"] / operand).to_pandas().tolist()[0] == (
+            pdf["t"] / operand
+        ).tolist()[0]
+    assert (gdf["t"] * 1.0).to_pandas().tolist()[0] == pd.Timedelta(2**53 + 1)
+    assert (gdf["t"] * -1.0).to_pandas().tolist()[0] == pd.Timedelta(-(2**53) - 1)
+
+
+def test_oversized_integer_literal_raises_overflow():
+    # lit(2**63) failed Arrow conversion inside the operand resolver with a
+    # misleading ValueError before the range check could run; the payload is
+    # inspected first and reported as the overflow it is.
+    import pandas as pd
+    from sedonadb.expr import lit
+
+    gdf = _duration_frame([pd.Timedelta(0), pd.Timedelta(1)])
+    with pytest.raises(OverflowError):
+        gdf["t"] * lit(2**63)
+    with pytest.raises(OverflowError):
+        gdf["t"] / lit(2**63)
+
+
+def test_negative_float_overflow_and_exact_boundary():
+    # The earlier negative case computed exactly -2**63, which lands on the
+    # pandas NaT sentinel even without the lower-bound gate, so it could not
+    # prove the gate exists. -2**64 is a genuine negative overflow — it
+    # aborts the cast without the gate — and (2**62 - 512) / 0.5 lands
+    # exactly on the largest float64 inside the tick range, proving the gate
+    # keeps the boundary itself.
+    import pandas as pd
+
+    gdf = _duration_frame([pd.Timedelta(-(2**62)), pd.Timedelta(2**62 - 512)])
+    got = (gdf["t"] / 0.25).to_pandas()
+    assert pd.isna(got.tolist()[0])
+    got = (gdf["t"] / 0.5).to_pandas()
+    assert pd.isna(got.tolist()[0])
+    assert got.tolist()[1] == pd.Timedelta(2**63 - 1024)
 
 
 def test_singleton_container_literals_resolve_as_numbers():

--- a/python/sedonadb-geopandas/tests/test_geopandas_compat.py
+++ b/python/sedonadb-geopandas/tests/test_geopandas_compat.py
@@ -488,18 +488,6 @@ def test_setitem_rejects_numpy_array(points):
         gdf["x"] = np.array([1, 2, 3])
 
 
-def test_setitem_over_active_geometry_clears_it(points):
-    # Replacing the active geometry with a number used to leave the name pointing
-    # at an integer column, so .geometry still returned a GeoSeries and .area
-    # failed later with a kernel error.
-    gdf = sgpd.from_geopandas(points)
-    gdf["geometry"] = 7
-    assert gdf._geometry_name is None
-    assert gdf.crs is None
-    with pytest.raises(AttributeError, match="no active geometry"):
-        gdf.geometry
-
-
 def test_operators_reject_bare_expression(points):
     # Same provenance hole as assignment: a bare expression built from another
     # frame resolved against this one and silently contributed this frame's values.
@@ -536,18 +524,6 @@ def test_dissolve_drops_nan_group_keys():
     )
     assert len(GeoDataFrame(df).dissolve(by="k").to_geopandas()) == 1
     assert len(GeoDataFrame(df).dissolve(by="k", dropna=False).to_geopandas()) == 2
-
-
-def test_setitem_scalar_geometry_keeps_crs(points):
-    # A bare Shapely geometry carries no CRS; GeoPandas keeps the column's.
-    from shapely.geometry import Point
-
-    gdf = sgpd.from_geopandas(points)
-    before = str(gdf.crs)
-    gdf["geometry"] = Point(5, 5)
-    assert gdf._geometry_name == "geometry"
-    assert "3857" in str(gdf.crs)
-    assert "3857" in before
 
 
 def test_setitem_none_keeps_geometry_column(points):
@@ -728,3 +704,118 @@ def test_is_floating_unwraps_dictionary_encoding():
     )
     df = sgpd.default_context().create_data_frame(tbl)
     assert _is_floating(df, "k")
+
+
+# -- regressions from the fifth review pass ---------------------------------
+
+
+def test_division_unwraps_dictionary_int():
+    # A dictionary<int64> column is integer for division purposes; it used to
+    # skip the double cast and truncate.
+    import pyarrow as pa
+
+    tbl = pa.table(
+        {
+            "k": pa.DictionaryArray.from_arrays(
+                pa.array([0, 1], type=pa.int8()), pa.array([1, 3], type=pa.int64())
+            ),
+            "x": [1, 2],
+        }
+    )
+    gdf = GeoDataFrame(sgpd.default_context().create_data_frame(tbl))
+    assert sorted((gdf["k"] / 2).to_pandas().tolist()) == [0.5, 1.5]
+
+
+def test_division_by_decimal_stays_decimal():
+    # An integer divided by a Decimal must stay in decimal arithmetic; the
+    # unconditional double cast used to force a float result.
+    from decimal import Decimal
+
+    gdf = GeoDataFrame(sgpd.default_context().sql("SELECT 1 AS n"))
+    got = (gdf["n"] / Decimal("0.5")).to_pandas().tolist()
+    assert isinstance(got[0], Decimal)
+
+
+def test_duration_arithmetic_matches_pandas():
+    import pandas as pd
+
+    gdf = GeoDataFrame(
+        sgpd.default_context().create_data_frame(
+            pd.DataFrame({"t": [pd.Timedelta(days=2)]})
+        )
+    )
+    assert (gdf["t"] * 2).to_pandas().tolist() == [pd.Timedelta(days=4)]
+    assert (2 * gdf["t"]).to_pandas().tolist() == [pd.Timedelta(days=4)]
+    assert (gdf["t"] / 2).to_pandas().tolist() == [pd.Timedelta(days=1)]
+    with pytest.raises(TypeError, match="numeric scalars"):
+        gdf["t"] * "2"
+
+
+def test_normalize_preserves_temporals_and_masks():
+    import numpy as np
+
+    from sedonadb_geopandas._series import normalize_scalar
+
+    # Temporal scalars must not become integer ticks.
+    assert isinstance(normalize_scalar(np.datetime64("2026-01-01")), np.datetime64)
+    import pandas as pd
+
+    assert normalize_scalar(np.timedelta64(1, "D")) == pd.Timedelta(days=1)
+    # A masked value means missing, not its hidden payload.
+    assert normalize_scalar(np.ma.masked) is None
+
+
+def test_pyarrow_scalars_broadcast(points):
+    # Arrow scalars implement __len__ but are single values.
+    import pyarrow as pa
+
+    from sedonadb_geopandas._series import is_scalar
+
+    assert is_scalar(pa.scalar([1, 2]))
+    assert is_scalar(pa.scalar({"a": 1}))
+    gdf = sgpd.from_geopandas(points)
+    gdf["tags"] = pa.scalar([1, 2])
+    assert len(gdf.to_geopandas()["tags"]) == 3
+
+
+def test_geoarrow_scalar_inherits_crs(points):
+    # A GeoArrow WKB scalar has no __geo_interface__, so geometry-ness must come
+    # from the resolved schema; it is CRS-less and inherits the column's CRS.
+    import geoarrow.pyarrow as ga
+
+    w = ga.as_wkb(ga.array(["POINT (5 5)"]))[0]
+    gdf = sgpd.from_geopandas(points)
+    gdf["geometry"] = w
+    assert gdf._geometry_name == "geometry"
+    assert "3857" in str(gdf.crs)
+
+
+def test_explicitly_inactive_geometry_stays_inactive(points):
+    # geometry=None is a choice; a no-op reassignment of an existing geometry
+    # column must not silently reactivate it.
+    df = sgpd.default_context().create_data_frame(points)
+    gdf = GeoDataFrame(df, geometry=None)
+    gdf["geometry"] = gdf["geometry"]
+    assert gdf._geometry_name is None
+
+
+def test_dissolve_rejects_empty_key_list(points):
+    # Matches GeoPandas: an explicit empty iterable is an error, unlike by=None.
+    gdf = sgpd.from_geopandas(points)
+    with pytest.raises(ValueError, match="No group keys"):
+        gdf.dissolve(by=[])
+    assert len(gdf.dissolve().to_geopandas()) == 1
+
+
+def test_dissolve_categorical_is_observed_only():
+    # Documented divergence: unused categories do not produce empty groups (the
+    # category domain does not survive a relational aggregation).
+    import pandas as pd
+
+    cat = gpd.GeoDataFrame(
+        {"z": pd.Categorical(["A"], categories=["A", "B"])},
+        geometry=gpd.GeoSeries.from_wkt(["POINT (0 0)"]),
+        crs="EPSG:3857",
+    )
+    assert len(cat.dissolve(by="z")) == 2  # GeoPandas observed=False default
+    assert len(sgpd.from_geopandas(cat).dissolve(by="z").to_geopandas()) == 1


### PR DESCRIPTION
The unblocked half of #1142, split out so it can move forward while the spatial-join engine issues are being fixed. `sjoin` stays in #1142, which is blocked on #1165 (`ST_Touches`/`ST_Within` boundary misclassification) and #1166 (empty preserved side fails in the spatial join executor); nothing here touches those code paths.

```python
gdf = sgpd.from_geopandas(points)
gdf["density"] = gdf["pop"] / gdf["area"]   # assignment + true division
zones = gdf.dissolve(by="region")           # group and union geometry
```

## What is added

- **`__setitem__`** — assign a `Series` from the same frame, or a scalar (a geometry included). Frame provenance is enforced: a `Series` from another frame, a bare expression (which records no origin), and multi-element values are rejected with focused errors. Replacing the active geometry with a non-geometry clears it; assigning geometry to a frame without one activates it; a geometry scalar or missing sentinel (`None`, NaN, `pandas.NA`) keeps the column's type and CRS, and a literal carrying its own CRS keeps that rather than being relabeled.
- **Arithmetic on `Series`** — `+`, `-`, `*`, `/` and the reflected forms. `/` is true division as in pandas: integer-typed expressions are cast to double (decided from the projected schema, a plan build) so SQL integer division does not truncate, while decimals stay exact and durations stay durations. `//` is deliberately not implemented, since SQL division truncates toward zero where Python floors. `Series` opts out of NumPy ufunc dispatch so an array operand is rejected whole instead of being broadcast element-by-element into an object array.
- **`dissolve(by, aggfunc="first", dropna=True)`** — unions each group's geometry via collect + unary union, which handles every geometry type (`ST_Union_Agg` only initializes for polygonal input, #1093). `dropna` covers IEEE NaN as well as SQL null, including dictionary-encoded float keys. A group whose geometries are all null yields an empty geometry collection carrying the source CRS, matching GeoPandas.
- **Shared scalar machinery** — one classification used by operators and assignment so they cannot disagree, with normalization: 0-d NumPy arrays unwrap to their value, `pandas.NA` becomes SQL null, NaN stays a float value.
- **Stale-mask guard** — boolean indexing rejects a mask built from another frame, including a mask captured before an assignment rebound this one; previously that could silently filter against the wrong frame state.

## Documented differences from GeoPandas

- `aggfunc="first"` is an unordered aggregate: it returns some value from the group and does not skip missing values.
- Dissolving an empty frame without a key returns one row (empty geometry collection, null attributes) rather than zero rows — a grouping-free SQL aggregate's shape.
- A group mixing 2D and 3D geometries raises rather than being promoted to 3D.

## Tests

73 tests, asserted against GeoPandas where a comparison exists (dissolve geometry equality across point/line/polygon groups, aggregation values, CRS propagation, division exactness for decimals, and the full assignment matrix including every missing-value sentinel). `ruff format` and `ruff check` clean.
