### PR TITLE
chore(deps): Bump aws-lc-sys to 0.44.0 to fix jitterentropy build under conda-forge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88aab2464f1f25453baa7a07c84c5b7684e274054ba06817f382357f77a288"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -713,14 +713,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.35.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45afffdee1e7c9126814751f88dddc747f41d91da16c9551a0f1e8a11e788a1"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]


### PR DESCRIPTION
## What

`cargo update -p aws-lc-rs` — moves `aws-lc-rs 1.15.2 → 1.18.0` and `aws-lc-sys 0.35.0 → 0.44.0` in `Cargo.lock`. Nothing else changes.

## Why

The conda-forge 0.4.1 builds (conda-forge/sedonadb-feedstock#14) fail on every Linux and macOS job while compiling `aws-lc-sys 0.35.0`:

```
jitterentropy-base.c:47:3: error: "The CPU Jitter random number generator must not be compiled with optimizations. See documentation. Use the compiler switch -O0 for compiling jitterentropy.c."
```

The same recipe built 0.4.0 fine eight days earlier; the difference is in our lockfile, where `cc` went from 1.2.51 (0.4.0) to 1.4.0 (0.4.1).

`aws-lc-sys 0.35` forces `-O0` for jitterentropy by temporarily appending it to `CFLAGS_<target>`, calling `cc::Build::get_compiler()`, then restoring the variable. That only worked because `cc <= 1.2.51` cached env lookups. Newer `cc` re-reads the env when it actually compiles, so the restored conda `CFLAGS` (`-O2`) get appended after `-O0` and win. conda-forge's rust activation exports `CFLAGS_<target>="${CFLAGS}"`, which is why it bites there and not in our own CI.

`aws-lc-sys >= 0.40` fixes this properly: it holds the override for the whole compile and strips any `-O*` from the inherited CFLAGS.

## Verification

Reproduced with a minimal crate and with this workspace's lockfile: `cargo build --locked --release -p aws-lc-sys` with `CFLAGS="-O2 -fPIC"` and `CFLAGS_<target>="-O2 -fPIC"`:

| lock | result |
|---|---|
| aws-lc-sys 0.35.0 + cc 1.4.0 (before) | fails with the `#error` above |
| aws-lc-sys 0.44.0 + cc 1.4.0 (this PR) | builds |

The feedstock carries a temporary `cargo update -p aws-lc-rs --precise 1.18.0` in its build script to unblock 0.4.1; it can be dropped once a release ships with this lockfile.
