### PR TITLE
fix(rust): address Rust 1.98 Clippy lints

### DIFF
--- a/c/sedona-s2geography/build.rs
+++ b/c/sedona-s2geography/build.rs
@@ -192,12 +192,14 @@ fn read_file_maybe_utf16(path: &PathBuf) -> String {
         // Skip the BOM and convert the rest
         let u16_bytes = &linker_flags_bytes[2..];
         let u16_vec: Vec<u16> = u16_bytes
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|chunk| {
                 if is_le {
-                    u16::from_le_bytes([chunk[0], chunk[1]])
+                    u16::from_le_bytes(*chunk)
                 } else {
-                    u16::from_be_bytes([chunk[0], chunk[1]])
+                    u16::from_be_bytes(*chunk)
                 }
             })
             .collect();

--- a/rust/sedona-functions/src/st_reverse.rs
+++ b/rust/sedona-functions/src/st_reverse.rs
@@ -198,7 +198,7 @@ fn write_reversed_coords(
     if needs_byteswap {
         let mut ord_reversed = [0u8; size_of::<f64>()];
         for coord in coords.rchunks_exact(coord_bytes) {
-            for ord in coord.chunks_exact(size_of::<f64>()) {
+            for ord in coord.as_chunks::<{ size_of::<f64>() }>().0 {
                 ord_reversed.copy_from_slice(ord);
                 ord_reversed.reverse();
                 writer.write_all(&ord_reversed)?;

--- a/rust/sedona-raster-gdal/src/utils.rs
+++ b/rust/sedona-raster-gdal/src/utils.rs
@@ -1028,8 +1028,10 @@ mod tests {
             .unwrap()
             .as_contiguous()
             .unwrap()
-            .chunks_exact(8)
-            .map(|chunk| u64::from_le_bytes(chunk.try_into().unwrap()))
+            .as_chunks::<8>()
+            .0
+            .iter()
+            .map(|chunk| u64::from_le_bytes(*chunk))
             .collect();
         assert_eq!(pixels, vec![1, 2, 3, 4]);
     }
@@ -1060,8 +1062,10 @@ mod tests {
             .unwrap()
             .as_contiguous()
             .unwrap()
-            .chunks_exact(8)
-            .map(|chunk| i64::from_le_bytes(chunk.try_into().unwrap()))
+            .as_chunks::<8>()
+            .0
+            .iter()
+            .map(|chunk| i64::from_le_bytes(*chunk))
             .collect();
         assert_eq!(pixels, vec![-1, -2, -3, -4]);
     }
@@ -1092,8 +1096,10 @@ mod tests {
             .unwrap()
             .as_contiguous()
             .unwrap()
-            .chunks_exact(2)
-            .map(|chunk| u16::from_le_bytes(chunk.try_into().unwrap()))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|chunk| u16::from_le_bytes(*chunk))
             .collect();
         assert_eq!(pixels, vec![1, 256, 511, 1024]);
     }

--- a/rust/sedona-testing/src/raster_spec.rs
+++ b/rust/sedona-testing/src/raster_spec.rs
@@ -505,6 +505,9 @@ pub fn list_i64_row(result: &ArrayRef, row: usize) -> Option<Vec<i64>> {
 
 /// Decode the pixel values of one band (1-based `band_number`) of one row of
 /// a raster `StructArray`. `T` must match the band's data type.
+// `as_chunks` requires a const chunk size, but generic const expressions cannot
+// use `size_of::<T>()` on stable Rust.
+#[allow(clippy::chunks_exact_to_as_chunks)]
 pub fn band_pixels<T: PixelValue>(rasters: &StructArray, row: usize, band_number: usize) -> Vec<T> {
     use sedona_raster::traits::RasterRef;
 

--- a/rust/sedona-testing/src/rasters.rs
+++ b/rust/sedona-testing/src/rasters.rs
@@ -536,8 +536,8 @@ mod tests {
 
             // Convert raw bytes back to u16 values for comparison
             let mut actual_pixel_values = Vec::new();
-            for chunk in band_data.chunks_exact(2) {
-                let value = u16::from_le_bytes([chunk[0], chunk[1]]);
+            for chunk in band_data.as_chunks::<2>().0 {
+                let value = u16::from_le_bytes(*chunk);
                 actual_pixel_values.push(value);
             }
             let expected_pixel_values: Vec<u16> = (0..expected_pixel_count as u16).collect();


### PR DESCRIPTION
## Summary

- replace fixed-size byte chunk decoding with `slice::as_chunks`
- retain `chunks_exact` in the generic pixel helper with a documented, targeted allowance because stable Rust cannot use `size_of::<T>()` as a const-generic argument
- restore Clippy compatibility with Rust 1.98

## Context

The stable toolchain moved from Rust 1.97.1 to 1.98.0. The new `chunks_exact_to_as_chunks` lint is promoted to an error by the workspace CI's `-Dwarnings` setting, which caused the `clippy` job on `main` to fail.

Failed job: https://github.com/apache/sedona-db/actions/runs/32623972713/job/97156348746

## Testing

- `cargo +1.98.0 clippy --workspace --all-targets --all-features -- -Dwarnings`
- `cargo +1.98.0 test -p sedona-testing -p sedona-functions --all-features`
- `cargo fmt --all -- --check`
