### PR TITLE
fix(python/sedonadb): serialize pyogrio reader lifecycles

### DIFF
--- a/python/sedonadb/python/sedonadb/datasource.py
+++ b/python/sedonadb/python/sedonadb/datasource.py
@@ -65,6 +65,16 @@ class ExternalFormatSpec:
         """
         return False
 
+    @property
+    def supports_concurrent_file_reads(self) -> bool:
+        """Whether file readers within one scan may be consumed concurrently
+
+        Return ``False`` when the underlying library cannot safely keep multiple
+        file readers active for one DataFusion scan. SedonaDB will then serialize
+        each file's full reader lifecycle, including consumption and cleanup.
+        """
+        return True
+
     def with_options(self, options: Mapping[str, Any]):
         """Clone this instance and return a new instance with options applied
 
@@ -140,6 +150,12 @@ class PyogrioFormatSpec(ExternalFormatSpec):
     def extension(self) -> str:
         return self._extension
 
+    @property
+    def supports_concurrent_file_reads(self) -> bool:
+        # Concurrent GDAL Arrow streams opened through pyogrio can abort the
+        # process. Keep each stream exclusive until its native reader is closed.
+        return False
+
     def open_reader(self, args):
         try:
             import pyogrio.raw
@@ -208,12 +224,10 @@ class PyogrioReaderShelter:
     is no longer required).
     """
 
-    # Serializes dataset open/close. pyogrio releases the GIL around the
-    # GDAL open, so a multi-file scan otherwise opens datasets from several
-    # threads at once, which can crash the process (SIGABRT) depending on
-    # the GDAL build and driver. Reentrant because a garbage-collected
-    # shelter's __del__ may run on a thread that is already holding the
-    # lock in __init__.
+    # Also serialize direct construction and destruction of shelter instances.
+    # File readers within an ExternalFormatSpec scan are protected for their
+    # whole lifetime by supports_concurrent_file_reads=False; this lock remains
+    # a safeguard for callers that construct a shelter directly.
     _open_close_lock = threading.RLock()
 
     def __init__(self, inner, output_names=None):

--- a/python/sedonadb/src/datasource.rs
+++ b/python/sedonadb/src/datasource.rs
@@ -52,6 +52,9 @@ pub struct PyExternalFormat {
     /// `False`); we snapshot it once to avoid GIL traffic in
     /// `list_single_object()`, which is called on hot paths.
     list_single_object: bool,
+    /// Cached from the Python spec so physical scan planning does not need the
+    /// GIL merely to decide whether file readers may overlap.
+    supports_concurrent_file_reads: bool,
     py_spec: Py<PyAny>,
 }
 
@@ -60,6 +63,7 @@ impl Clone for PyExternalFormat {
         Python::attach(|py| Self {
             extension: self.extension.clone(),
             list_single_object: self.list_single_object,
+            supports_concurrent_file_reads: self.supports_concurrent_file_reads,
             py_spec: self.py_spec.clone_ref(py),
         })
     }
@@ -78,9 +82,12 @@ impl PyExternalFormat {
             .getattr(py, "extension")?
             .extract::<String>(py)?;
         let new_list_single_object = read_list_single_object(py, &new_py_spec)?;
+        let new_supports_concurrent_file_reads =
+            read_supports_concurrent_file_reads(py, &new_py_spec)?;
         Ok(Self {
             extension: new_extension,
             list_single_object: new_list_single_object,
+            supports_concurrent_file_reads: new_supports_concurrent_file_reads,
             py_spec: new_py_spec,
         })
     }
@@ -138,8 +145,10 @@ impl PyExternalFormat {
         )?;
 
         let reader = import_arrow_array_stream(py, reader_obj.bind(py), None)?;
+        let schema = reader.schema();
         let wrapped_reader = WrappedRecordBatchReader {
-            inner: reader,
+            inner: Some(reader),
+            schema,
             shelter: Some(reader_obj),
         };
         Ok(Box::new(wrapped_reader))
@@ -152,9 +161,11 @@ impl PyExternalFormat {
     fn new<'py>(py: Python<'py>, py_spec: Py<PyAny>) -> Result<Self, PySedonaError> {
         let extension = py_spec.getattr(py, "extension")?.extract::<String>(py)?;
         let list_single_object = read_list_single_object(py, &py_spec)?;
+        let supports_concurrent_file_reads = read_supports_concurrent_file_reads(py, &py_spec)?;
         Ok(Self {
             extension,
             list_single_object,
+            supports_concurrent_file_reads,
             py_spec,
         })
     }
@@ -175,6 +186,18 @@ fn read_list_single_object<'py>(
         .extract::<bool>(py)?)
 }
 
+/// Read the `supports_concurrent_file_reads` attribute on a Python spec.
+///
+/// The [`ExternalFormatSpec`] Python base class defaults this to `True`.
+fn read_supports_concurrent_file_reads<'py>(
+    py: Python<'py>,
+    py_spec: &Py<PyAny>,
+) -> Result<bool, PySedonaError> {
+    Ok(py_spec
+        .getattr(py, "supports_concurrent_file_reads")?
+        .extract::<bool>(py)?)
+}
+
 #[async_trait]
 impl ExternalFormatSpec for PyExternalFormat {
     fn extension(&self) -> &str {
@@ -183,6 +206,10 @@ impl ExternalFormatSpec for PyExternalFormat {
 
     fn list_single_object(&self) -> bool {
         self.list_single_object
+    }
+
+    fn supports_concurrent_file_reads(&self) -> bool {
+        self.supports_concurrent_file_reads
     }
 
     fn with_options(
@@ -400,13 +427,30 @@ impl PyProjectedRecordBatchReader {
 /// ArrowArrayStream/RecordBatchReader (e.g., the pyogrio context manager, or
 /// an ADBC statement/cursor).
 struct WrappedRecordBatchReader {
-    pub inner: Box<dyn RecordBatchReader + Send>,
+    pub inner: Option<Box<dyn RecordBatchReader + Send>>,
+    pub schema: SchemaRef,
     pub shelter: Option<Py<PyAny>>,
+}
+
+impl WrappedRecordBatchReader {
+    /// Release resources in dependency order: the Arrow FFI stream first and
+    /// its owning Python context second. Explicitly dropping the shelter while
+    /// attached avoids PyO3 deferring its decref until a later Python callback.
+    fn finish(&mut self) {
+        self.inner = None;
+
+        if let Some(shelter) = self.shelter.take() {
+            if Python::try_attach(|_| drop(shelter)).is_none() {
+                // During interpreter shutdown PyO3 cannot safely decref the
+                // object. Let PyO3's normal deferred-drop path handle it.
+            }
+        }
+    }
 }
 
 impl RecordBatchReader for WrappedRecordBatchReader {
     fn schema(&self) -> SchemaRef {
-        self.inner.schema()
+        self.schema.clone()
     }
 }
 
@@ -414,11 +458,68 @@ impl Iterator for WrappedRecordBatchReader {
     type Item = Result<RecordBatch, ArrowError>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(item) = self.inner.next() {
+        if let Some(item) = self.inner.as_mut().and_then(|inner| inner.next()) {
             Some(item)
         } else {
-            self.shelter = None;
+            self.finish();
             None
         }
+    }
+}
+
+impl Drop for WrappedRecordBatchReader {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::RecordBatchIterator;
+    use pyo3::types::{PyAnyMethods, PyModule};
+
+    #[test]
+    fn wrapped_reader_drops_python_shelter_at_eof() {
+        let (shelter, shelter_class) = Python::attach(|py| {
+            let module = PyModule::from_code(
+                py,
+                cr#"
+class Shelter:
+    destroyed = 0
+
+    def __del__(self):
+        type(self).destroyed += 1
+"#,
+                cr"wrapped_reader_test.py",
+                cr"wrapped_reader_test",
+            )
+            .unwrap();
+            let shelter_class = module.getattr("Shelter").unwrap();
+            let shelter = shelter_class.call0().unwrap().unbind();
+            (shelter, shelter_class.unbind())
+        });
+
+        let schema = Arc::new(Schema::empty());
+        let inner = RecordBatchIterator::new(
+            std::iter::empty::<std::result::Result<RecordBatch, ArrowError>>(),
+            schema.clone(),
+        );
+        let mut reader = WrappedRecordBatchReader {
+            inner: Some(Box::new(inner)),
+            schema,
+            shelter: Some(shelter),
+        };
+
+        assert!(reader.next().is_none());
+        Python::attach(|py| {
+            let destroyed = shelter_class
+                .bind(py)
+                .getattr("destroyed")
+                .unwrap()
+                .extract::<usize>()
+                .unwrap();
+            assert_eq!(destroyed, 1);
+        });
     }
 }

--- a/python/sedonadb/src/datasource.rs
+++ b/python/sedonadb/src/datasource.rs
@@ -476,50 +476,105 @@ impl Drop for WrappedRecordBatchReader {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_array::RecordBatchIterator;
-    use pyo3::types::{PyAnyMethods, PyModule};
+    use pyo3::types::{PyAnyMethods, PyList, PyModule};
 
-    #[test]
-    fn wrapped_reader_drops_python_shelter_at_eof() {
-        let (shelter, shelter_class) = Python::attach(|py| {
+    struct DropTrackingReader {
+        log: Py<PyAny>,
+        batch: Option<RecordBatch>,
+        schema: SchemaRef,
+    }
+
+    impl Iterator for DropTrackingReader {
+        type Item = std::result::Result<RecordBatch, ArrowError>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            self.batch.take().map(Ok)
+        }
+    }
+
+    impl RecordBatchReader for DropTrackingReader {
+        fn schema(&self) -> SchemaRef {
+            self.schema.clone()
+        }
+    }
+
+    impl Drop for DropTrackingReader {
+        fn drop(&mut self) {
+            Python::attach(|py| {
+                self.log
+                    .bind(py)
+                    .call_method1("append", ("inner",))
+                    .unwrap();
+            });
+        }
+    }
+
+    fn shelter_and_log() -> (Py<PyAny>, Py<PyAny>) {
+        Python::attach(|py| {
+            let log = PyList::empty(py).unbind();
             let module = PyModule::from_code(
                 py,
                 cr#"
 class Shelter:
-    destroyed = 0
+    def __init__(self, log):
+        self.log = log
 
     def __del__(self):
-        type(self).destroyed += 1
+        self.log.append("shelter")
 "#,
                 cr"wrapped_reader_test.py",
                 cr"wrapped_reader_test",
             )
             .unwrap();
-            let shelter_class = module.getattr("Shelter").unwrap();
-            let shelter = shelter_class.call0().unwrap().unbind();
-            (shelter, shelter_class.unbind())
-        });
+            let shelter = module
+                .getattr("Shelter")
+                .unwrap()
+                .call1((log.bind(py),))
+                .unwrap()
+                .unbind();
+            (log.into_any(), shelter)
+        })
+    }
 
+    #[test]
+    fn wrapped_reader_drops_inner_before_python_shelter_at_eof() {
+        let (log, shelter) = shelter_and_log();
         let schema = Arc::new(Schema::empty());
-        let inner = RecordBatchIterator::new(
-            std::iter::empty::<std::result::Result<RecordBatch, ArrowError>>(),
-            schema.clone(),
-        );
         let mut reader = WrappedRecordBatchReader {
-            inner: Some(Box::new(inner)),
+            inner: Some(Box::new(DropTrackingReader {
+                log: Python::attach(|py| log.clone_ref(py)),
+                batch: None,
+                schema: schema.clone(),
+            })),
             schema,
             shelter: Some(shelter),
         };
 
         assert!(reader.next().is_none());
         Python::attach(|py| {
-            let destroyed = shelter_class
-                .bind(py)
-                .getattr("destroyed")
-                .unwrap()
-                .extract::<usize>()
-                .unwrap();
-            assert_eq!(destroyed, 1);
+            let observed = log.bind(py).extract::<Vec<String>>().unwrap();
+            assert_eq!(observed, vec!["inner", "shelter"]);
+        });
+    }
+
+    #[test]
+    fn wrapped_reader_drops_inner_before_python_shelter_before_eof() {
+        let (log, shelter) = shelter_and_log();
+        let schema = Arc::new(Schema::empty());
+        let reader = WrappedRecordBatchReader {
+            inner: Some(Box::new(DropTrackingReader {
+                log: Python::attach(|py| log.clone_ref(py)),
+                batch: Some(RecordBatch::new_empty(schema.clone())),
+                schema: schema.clone(),
+            })),
+            schema,
+            shelter: Some(shelter),
+        };
+
+        drop(reader);
+        Python::attach(|py| {
+            let observed = log.bind(py).extract::<Vec<String>>().unwrap();
+            assert_eq!(observed, vec!["inner", "shelter"]);
         });
     }
 }

--- a/python/sedonadb/tests/io/test_pyogrio.py
+++ b/python/sedonadb/tests/io/test_pyogrio.py
@@ -473,72 +473,6 @@ class _NativePullBoundaryReader:
         return self._reader.__arrow_c_stream__(requested_schema)
 
 
-class _NativeLifecycleBoundary:
-    def __init__(self, short_source, long_source):
-        self.short_source = short_source
-        self.long_source = long_source
-        self._open_read_barrier = threading.Barrier(2, timeout=10)
-        self._close_read_started = threading.Event()
-        self._lock = threading.Lock()
-        self._read_calls = {}
-        self._intervals = {"open": {}, "read": {}, "close": {}}
-
-    def open_reader(self, source, callback):
-        if source == self.long_source:
-            self._open_read_barrier.wait()
-        return self._record_call("open", source, callback)
-
-    def close_reader(self, source, callback):
-        if source == self.short_source and not self._close_read_started.wait(10):
-            raise TimeoutError("long reader did not start its close-overlap pull")
-        return self._record_call("close", source, callback)
-
-    def read_next_batch(self, source, reader):
-        with self._lock:
-            call_index = self._read_calls.get(source, 0)
-            self._read_calls[source] = call_index + 1
-
-        if source == self.short_source and call_index == 0:
-            self._open_read_barrier.wait()
-        elif source == self.long_source and call_index == 1:
-            # Let this real native pull start before the short reader closes.
-            self._close_read_started.set()
-
-        return self._record_call("read", source, reader.read_next_batch)
-
-    def _record_call(self, kind, source, callback):
-        started = time.perf_counter_ns()
-        result = callback()
-        finished = time.perf_counter_ns()
-        with self._lock:
-            self._intervals[kind].setdefault(source, []).append((started, finished))
-        return result
-
-    def overlaps(self, first_kind, first_source, second_kind, second_source):
-        with self._lock:
-            first = list(self._intervals[first_kind].get(first_source, ()))
-            second = list(self._intervals[second_kind].get(second_source, ()))
-
-        return sum(
-            max(first_start, second_start) < min(first_end, second_end)
-            for first_start, first_end in first
-            for second_start, second_end in second
-        )
-
-
-class _NativeLifecycleCloseContext:
-    def __init__(self, inner, boundary, source):
-        self._inner = inner
-        self._boundary = boundary
-        self._source = source
-
-    def __exit__(self, exc_type, exc_value, traceback_object):
-        return self._boundary.close_reader(
-            self._source,
-            lambda: self._inner.__exit__(exc_type, exc_value, traceback_object),
-        )
-
-
 def _run_independent_pyogrio_scans(result_sender, paths, expected_values):
     boundary = _NativePullBoundary()
     original_open_reader = PyogrioFormatSpec.open_reader
@@ -623,68 +557,6 @@ def _run_paused_pyogrio_readers(result_sender, paths, expected_values):
     except BaseException:
         result_sender.send({"ok": False, "error": traceback.format_exc()})
     finally:
-        result_sender.close()
-
-
-def _run_pyogrio_lifecycle_overlap(result_sender, paths, expected_values, short_side):
-    short_source = Path(paths[short_side]).name
-    long_source = Path(paths[1 - short_side]).name
-    boundary = _NativeLifecycleBoundary(short_source, long_source)
-    original_open_reader = PyogrioFormatSpec.open_reader
-    executor = None
-    futures = []
-
-    def open_reader(format_spec, args):
-        source = Path(args.src.to_url()).name
-        if args.file_schema is None:
-            return original_open_reader(format_spec, args)
-
-        inner = boundary.open_reader(
-            source, lambda: original_open_reader(format_spec, args)
-        )
-        if source == short_source:
-            inner._inner = _NativeLifecycleCloseContext(inner._inner, boundary, source)
-        return _NativePullBoundaryReader(inner, boundary, source)
-
-    try:
-        PyogrioFormatSpec.open_reader = open_reader
-        connections = [sedonadb.connect(), sedonadb.connect()]
-        for connection in connections:
-            connection.sql("SET datafusion.execution.batch_size TO 512").execute()
-
-        def scan(connection, path):
-            return connection.read_pyogrio(path).to_arrow_table()
-
-        executor = ThreadPoolExecutor(max_workers=2)
-        futures = [
-            executor.submit(scan, connections[index], paths[index])
-            for index in range(2)
-        ]
-        tables = [future.result() for future in futures]
-        row_counts = []
-        for index, table in enumerate(tables):
-            values = table.column("idx").to_pylist()
-            assert sorted(values) == expected_values[index]
-            row_counts.append(len(values))
-
-        result_sender.send(
-            {
-                "ok": True,
-                "open_read_overlaps": boundary.overlaps(
-                    "open", long_source, "read", short_source
-                ),
-                "close_read_overlaps": boundary.overlaps(
-                    "close", short_source, "read", long_source
-                ),
-                "row_counts": row_counts,
-            }
-        )
-    except BaseException:
-        result_sender.send({"ok": False, "error": traceback.format_exc()})
-    finally:
-        PyogrioFormatSpec.open_reader = original_open_reader
-        if executor is not None:
-            executor.shutdown(wait=all(future.done() for future in futures))
         result_sender.close()
 
 
@@ -793,29 +665,6 @@ def test_independent_reader_progress_while_first_reader_is_paused(extension):
 
     assert result["ok"], result["error"]
     assert result["first_batch_rows"] < len(expected_values[0])
-    assert result["row_counts"] == [len(values) for values in expected_values]
-
-
-@pytest.mark.parametrize("short_side", [0, 1])
-def test_independent_fgb_reader_lifecycle_overlaps_native_reads(short_side):
-    pytest.importorskip("pyogrio")
-    expected_values = (list(range(1024)), list(range(10000, 18192)))
-    if short_side == 1:
-        expected_values = (expected_values[1], expected_values[0])
-
-    with tempfile.TemporaryDirectory() as td:
-        paths = _write_pyogrio_pair(td, "fgb", expected_values)
-        result = _run_child_process(
-            _run_pyogrio_lifecycle_overlap,
-            paths,
-            expected_values,
-            short_side,
-            timeout=20,
-        )
-
-    assert result["ok"], result["error"]
-    assert result["open_read_overlaps"] >= 1
-    assert result["close_read_overlaps"] >= 1
     assert result["row_counts"] == [len(values) for values in expected_values]
 
 

--- a/python/sedonadb/tests/io/test_pyogrio.py
+++ b/python/sedonadb/tests/io/test_pyogrio.py
@@ -16,8 +16,11 @@
 # under the License.
 
 import io
+import multiprocessing
 import tempfile
 import threading
+import time
+import traceback
 import warnings
 import zipfile
 from concurrent.futures import ThreadPoolExecutor
@@ -399,21 +402,142 @@ def test_pyogrio_format_register():
         geopandas.testing.assert_geodataframe_equal(df.to_pandas(), gdf)
 
 
+class _ArrowStreamBoundary:
+    def __init__(self):
+        self._barrier = threading.Barrier(2, timeout=10)
+        self._lock = threading.Lock()
+        self.reached = 0
+        self.sources = []
+
+    def wait(self, source):
+        with self._lock:
+            self.reached += 1
+            self.sources.append(source)
+        self._barrier.wait()
+
+
+class _ArrowStreamBoundaryReader:
+    def __init__(self, inner, boundary, source):
+        self._inner = inner
+        self._boundary = boundary
+        self._source = source
+
+    def __arrow_c_stream__(self, requested_schema=None):
+        # The real open_reader() has already entered pyogrio/GDAL and created
+        # its shelter. Hold both real shelters live before importing either
+        # Arrow C stream, outside the shelter's open/close lock.
+        self._boundary.wait(self._source)
+        if requested_schema is None:
+            return self._inner.__arrow_c_stream__()
+        return self._inner.__arrow_c_stream__(requested_schema)
+
+
+def _run_independent_pyogrio_scans(result_sender, paths, expected_values):
+    boundary = _ArrowStreamBoundary()
+    original_open_reader = PyogrioFormatSpec.open_reader
+    executor = None
+    futures = []
+
+    def open_reader(format_spec, args):
+        return _ArrowStreamBoundaryReader(
+            original_open_reader(format_spec, args), boundary, args.src.to_url()
+        )
+
+    try:
+        PyogrioFormatSpec.open_reader = open_reader
+        connections = [sedonadb.connect(), sedonadb.connect()]
+
+        def scan(connection, path):
+            return connection.read_pyogrio(path).to_arrow_table()
+
+        executor = ThreadPoolExecutor(max_workers=2)
+        futures = [
+            executor.submit(scan, connection, path)
+            for connection, path in zip(connections, paths, strict=True)
+        ]
+        tables = [future.result() for future in futures]
+
+        for table, values in zip(tables, expected_values, strict=True):
+            assert table.num_rows == len(values)
+            assert sorted(table.column("idx").to_pylist()) == values
+        assert boundary.reached >= 2
+        assert {Path(source).name for source in boundary.sources} == {
+            Path(path).name for path in paths
+        }
+        result_sender.send(
+            {
+                "ok": True,
+                "reader_boundary_reached": boundary.reached,
+                "reader_boundary_sources": boundary.sources,
+            }
+        )
+    except BaseException:
+        result_sender.send(
+            {
+                "ok": False,
+                "error": traceback.format_exc(),
+                "reader_boundary_reached": boundary.reached,
+            }
+        )
+    finally:
+        PyogrioFormatSpec.open_reader = original_open_reader
+        if executor is not None:
+            executor.shutdown(wait=all(future.done() for future in futures))
+        result_sender.close()
+
+
+def _block_child_process(result_sender):
+    threading.Event().wait()
+
+
+def _terminate_child(process):
+    process.terminate()
+    process.join(5)
+    if process.is_alive():
+        process.kill()
+        process.join(5)
+
+
+def _run_child_process(target, *args, timeout):
+    context = multiprocessing.get_context("spawn")
+    result_receiver, result_sender = context.Pipe(duplex=False)
+    process = context.Process(target=target, args=(result_sender, *args))
+    process.start()
+    result_sender.close()
+    try:
+        process.join(timeout)
+        if process.is_alive():
+            _terminate_child(process)
+            raise TimeoutError(f"child process exceeded {timeout} seconds")
+
+        child_result = result_receiver.recv() if result_receiver.poll() else None
+        if process.exitcode != 0:
+            raise AssertionError(
+                f"child process exited with {process.exitcode}: {child_result}"
+            )
+        if child_result is None:
+            raise AssertionError("child process exited without reporting a result")
+        return child_result
+    finally:
+        if process.is_alive():
+            _terminate_child(process)
+        result_receiver.close()
+
+
+def test_independent_scans_child_timeout_is_bounded():
+    started = time.monotonic()
+    with pytest.raises(TimeoutError, match="exceeded 0.2 seconds"):
+        _run_child_process(_block_child_process, timeout=0.2)
+    assert time.monotonic() - started < 5
+
+
 def test_independent_scans_from_threads():
     pytest.importorskip("pyogrio")
-
-    # Use independent contexts to characterize whether pyogrio/GDAL scans can
-    # safely overlap outside the per-scan reader serialization in this PR.
-    left = sedonadb.connect()
-    right = sedonadb.connect()
-    datasets = (
-        (left, "left.fgb", [10, 11, 12]),
-        (right, "right.fgb", [20, 21, 22, 23]),
-    )
+    expected_values = ([10, 11, 12], [20, 21, 22, 23])
 
     with tempfile.TemporaryDirectory() as td:
         paths = []
-        for _, filename, values in datasets:
+        for filename, values in zip(("left.fgb", "right.fgb"), expected_values):
             path = Path(td) / filename
             geopandas.GeoDataFrame(
                 {"idx": values},
@@ -421,27 +545,18 @@ def test_independent_scans_from_threads():
                     values, values, crs="EPSG:4326"
                 ),
             ).to_file(path)
-            paths.append(path)
+            paths.append(str(path))
 
-        barrier = threading.Barrier(2)
+        result = _run_child_process(
+            _run_independent_pyogrio_scans, paths, expected_values, timeout=30
+        )
 
-        def scan(connection, path):
-            barrier.wait()
-            return connection.read_pyogrio(path).to_arrow_table()
-
-        executor = ThreadPoolExecutor(max_workers=2)
-        futures = [
-            executor.submit(scan, connection, path)
-            for (connection, _, _), path in zip(datasets, paths, strict=True)
-        ]
-        try:
-            tables = [future.result(timeout=30) for future in futures]
-        finally:
-            executor.shutdown(wait=all(future.done() for future in futures))
-
-    for table, (_, _, expected_values) in zip(tables, datasets, strict=True):
-        assert table.num_rows == len(expected_values)
-        assert sorted(table.column("idx").to_pylist()) == expected_values
+    assert result["ok"], result["error"]
+    assert result["reader_boundary_reached"] >= 2
+    assert {Path(source).name for source in result["reader_boundary_sources"]} == {
+        "left.fgb",
+        "right.fgb",
+    }
 
 
 # The geometry-column name is GDAL's OGR reader's, not ours: fgb/geojson/shp

--- a/python/sedonadb/tests/io/test_pyogrio.py
+++ b/python/sedonadb/tests/io/test_pyogrio.py
@@ -589,11 +589,11 @@ def _run_child_process(target, *args, timeout):
             raise TimeoutError(f"child process exceeded {timeout} seconds")
 
         child_result = None
-        if result_receiver.poll():
-            try:
+        try:
+            if result_receiver.poll():
                 child_result = result_receiver.recv()
-            except EOFError:
-                pass
+        except (BrokenPipeError, EOFError):
+            pass
         if process.exitcode != 0:
             raise AssertionError(
                 f"child process exited with {process.exitcode}: {child_result}"

--- a/python/sedonadb/tests/io/test_pyogrio.py
+++ b/python/sedonadb/tests/io/test_pyogrio.py
@@ -17,8 +17,10 @@
 
 import io
 import tempfile
+import threading
 import warnings
 import zipfile
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import geoarrow.pyarrow as ga
@@ -395,6 +397,51 @@ def test_pyogrio_format_register():
         # Should be able to SELECT * from 'file' after registering the format
         df = sd.sql(f"SELECT * FROM '{temp_fgb_path}' ORDER BY idx")
         geopandas.testing.assert_geodataframe_equal(df.to_pandas(), gdf)
+
+
+def test_independent_scans_from_threads():
+    pytest.importorskip("pyogrio")
+
+    # Use independent contexts to characterize whether pyogrio/GDAL scans can
+    # safely overlap outside the per-scan reader serialization in this PR.
+    left = sedonadb.connect()
+    right = sedonadb.connect()
+    datasets = (
+        (left, "left.fgb", [10, 11, 12]),
+        (right, "right.fgb", [20, 21, 22, 23]),
+    )
+
+    with tempfile.TemporaryDirectory() as td:
+        paths = []
+        for _, filename, values in datasets:
+            path = Path(td) / filename
+            geopandas.GeoDataFrame(
+                {"idx": values},
+                geometry=geopandas.GeoSeries.from_xy(
+                    values, values, crs="EPSG:4326"
+                ),
+            ).to_file(path)
+            paths.append(path)
+
+        barrier = threading.Barrier(2)
+
+        def scan(connection, path):
+            barrier.wait()
+            return connection.read_pyogrio(path).to_arrow_table()
+
+        executor = ThreadPoolExecutor(max_workers=2)
+        futures = [
+            executor.submit(scan, connection, path)
+            for (connection, _, _), path in zip(datasets, paths, strict=True)
+        ]
+        try:
+            tables = [future.result(timeout=30) for future in futures]
+        finally:
+            executor.shutdown(wait=all(future.done() for future in futures))
+
+    for table, (_, _, expected_values) in zip(tables, datasets, strict=True):
+        assert table.num_rows == len(expected_values)
+        assert sorted(table.column("idx").to_pylist()) == expected_values
 
 
 # The geometry-column name is GDAL's OGR reader's, not ours: fgb/geojson/shp

--- a/python/sedonadb/tests/io/test_pyogrio.py
+++ b/python/sedonadb/tests/io/test_pyogrio.py
@@ -402,51 +402,97 @@ def test_pyogrio_format_register():
         geopandas.testing.assert_geodataframe_equal(df.to_pandas(), gdf)
 
 
-class _ArrowStreamBoundary:
+class _NativePullBoundary:
     def __init__(self):
         self._barrier = threading.Barrier(2, timeout=10)
         self._lock = threading.Lock()
-        self.reached = 0
-        self.sources = []
+        self.pull_intervals = {}
 
-    def wait(self, source):
-        with self._lock:
-            self.reached += 1
-            self.sources.append(source)
+    def read_next_batch(self, source, reader):
+        # Rendezvous immediately before each real pyogrio Arrow batch pull.
+        # The interval covers the native read_next_batch() call itself, so an
+        # overlap is evidence that two independent GDAL readers were active at
+        # the same time rather than merely that their Python shelters coexisted.
         self._barrier.wait()
+        started = time.perf_counter_ns()
+        batch = reader.read_next_batch()
+        finished = time.perf_counter_ns()
+
+        with self._lock:
+            self.pull_intervals.setdefault(source, []).append((started, finished))
+        return batch
+
+    def batch_pulls(self):
+        with self._lock:
+            return {
+                source: len(intervals)
+                for source, intervals in self.pull_intervals.items()
+            }
+
+    def native_read_overlaps(self):
+        with self._lock:
+            sources = list(self.pull_intervals)
+            if len(sources) != 2:
+                return 0
+            left_intervals = self.pull_intervals[sources[0]]
+            right_intervals = self.pull_intervals[sources[1]]
+
+        return sum(
+            max(left_start, right_start) < min(left_end, right_end)
+            for left_start, left_end in left_intervals
+            for right_start, right_end in right_intervals
+        )
 
 
-class _ArrowStreamBoundaryReader:
+class _NativePullBoundaryReader:
     def __init__(self, inner, boundary, source):
-        self._inner = inner
-        self._boundary = boundary
-        self._source = source
+        native_reader = pa.RecordBatchReader.from_stream(inner)
+        self._reader = pa.RecordBatchReader.from_batches(
+            native_reader.schema,
+            self._read_batches(boundary, source, native_reader, inner),
+        )
+
+    @staticmethod
+    def _read_batches(boundary, source, reader, shelter):
+        try:
+            while True:
+                try:
+                    yield boundary.read_next_batch(source, reader)
+                except StopIteration:
+                    return
+        finally:
+            # Keep the original pyogrio shelter strongly referenced until its
+            # imported native Arrow stream is closed. This preserves the same
+            # stream-before-context cleanup order as the production bridge.
+            try:
+                reader.close()
+            finally:
+                del shelter
 
     def __arrow_c_stream__(self, requested_schema=None):
-        # The real open_reader() has already entered pyogrio/GDAL and created
-        # its shelter. Hold both real shelters live before importing either
-        # Arrow C stream, outside the shelter's open/close lock.
-        self._boundary.wait(self._source)
-        if requested_schema is None:
-            return self._inner.__arrow_c_stream__()
-        return self._inner.__arrow_c_stream__(requested_schema)
+        return self._reader.__arrow_c_stream__(requested_schema)
 
 
 def _run_independent_pyogrio_scans(result_sender, paths, expected_values):
-    boundary = _ArrowStreamBoundary()
+    boundary = _NativePullBoundary()
     original_open_reader = PyogrioFormatSpec.open_reader
     executor = None
     futures = []
 
     def open_reader(format_spec, args):
-        return _ArrowStreamBoundaryReader(
-            original_open_reader(format_spec, args), boundary, args.src.to_url()
-        )
+        inner = original_open_reader(format_spec, args)
+        if args.file_schema is None:
+            # Schema inference does not pull batches. Leave its real shelter
+            # untouched and instrument only the execution reader.
+            return inner
+        return _NativePullBoundaryReader(inner, boundary, args.src.to_url())
 
     try:
         PyogrioFormatSpec.open_reader = open_reader
         connections = [sedonadb.connect(), sedonadb.connect()]
         assert len(connections) == len(paths) == len(expected_values) == 2
+        for connection in connections:
+            connection.sql("SET datafusion.execution.batch_size TO 64").execute()
 
         def scan(connection, path):
             return connection.read_pyogrio(path).to_arrow_table()
@@ -464,29 +510,53 @@ def _run_independent_pyogrio_scans(result_sender, paths, expected_values):
             values = expected_values[index]
             assert table.num_rows == len(values)
             assert sorted(table.column("idx").to_pylist()) == values
-        assert boundary.reached >= 2
-        assert {Path(source).name for source in boundary.sources} == {
-            Path(path).name for path in paths
-        }
         result_sender.send(
             {
                 "ok": True,
-                "reader_boundary_reached": boundary.reached,
-                "reader_boundary_sources": boundary.sources,
+                "native_batch_pulls": boundary.batch_pulls(),
+                "native_read_overlaps": boundary.native_read_overlaps(),
             }
         )
     except BaseException:
-        result_sender.send(
-            {
-                "ok": False,
-                "error": traceback.format_exc(),
-                "reader_boundary_reached": boundary.reached,
-            }
-        )
+        result_sender.send({"ok": False, "error": traceback.format_exc()})
     finally:
         PyogrioFormatSpec.open_reader = original_open_reader
         if executor is not None:
             executor.shutdown(wait=all(future.done() for future in futures))
+        result_sender.close()
+
+
+def _run_paused_pyogrio_readers(result_sender, paths, expected_values):
+    try:
+        connections = [sedonadb.connect(), sedonadb.connect()]
+        for connection in connections:
+            connection.sql("SET datafusion.execution.batch_size TO 64").execute()
+
+        first_reader = connections[0].read_pyogrio(paths[0]).to_arrow_reader()
+        first_batch = first_reader.read_next_batch()
+        assert 0 < first_batch.num_rows < len(expected_values[0])
+
+        # Keep first_reader and its scan-local lifecycle guard alive while an
+        # independent connection opens and drains another real GDAL reader.
+        second_reader = connections[1].read_pyogrio(paths[1]).to_arrow_reader()
+        second_table = second_reader.read_all()
+        first_remainder = first_reader.read_all()
+        first_values = first_batch.column("idx").to_pylist()
+        first_values.extend(first_remainder.column("idx").to_pylist())
+        second_values = second_table.column("idx").to_pylist()
+        assert sorted(first_values) == expected_values[0]
+        assert sorted(second_values) == expected_values[1]
+
+        result_sender.send(
+            {
+                "ok": True,
+                "first_batch_rows": first_batch.num_rows,
+                "row_counts": [len(first_values), len(second_values)],
+            }
+        )
+    except BaseException:
+        result_sender.send({"ok": False, "error": traceback.format_exc()})
+    finally:
         result_sender.close()
 
 
@@ -537,6 +607,19 @@ def _run_child_process(target, *args, timeout):
         result_receiver.close()
 
 
+def _write_pyogrio_pair(directory, extension, expected_values):
+    paths = []
+    for index, side in enumerate(("left", "right")):
+        values = expected_values[index]
+        path = Path(directory) / f"{side}.{extension}"
+        geopandas.GeoDataFrame(
+            {"idx": values},
+            geometry=geopandas.GeoSeries.from_xy(values, values, crs="EPSG:4326"),
+        ).to_file(path)
+        paths.append(str(path))
+    return paths
+
+
 def test_independent_scans_child_timeout_is_bounded():
     started = time.monotonic()
     with pytest.raises(TimeoutError, match="exceeded 0.2 seconds"):
@@ -549,36 +632,40 @@ def test_child_process_nonzero_exit_is_reported():
         _run_child_process(_exit_child_process, timeout=5)
 
 
-def test_independent_scans_from_threads():
+@pytest.mark.parametrize("extension", ["fgb", "gpkg"])
+def test_independent_scans_from_threads(extension):
     pytest.importorskip("pyogrio")
-    expected_values = ([10, 11, 12], [20, 21, 22, 23])
-    filenames = ("left.fgb", "right.fgb")
-    assert len(filenames) == len(expected_values) == 2
+    expected_values = (list(range(2048)), list(range(10000, 12048)))
 
     with tempfile.TemporaryDirectory() as td:
-        paths = []
-        for index in range(2):
-            filename = filenames[index]
-            values = expected_values[index]
-            path = Path(td) / filename
-            geopandas.GeoDataFrame(
-                {"idx": values},
-                geometry=geopandas.GeoSeries.from_xy(values, values, crs="EPSG:4326"),
-            ).to_file(path)
-            paths.append(str(path))
-        assert len(paths) == 2
-
+        paths = _write_pyogrio_pair(td, extension, expected_values)
         result = _run_child_process(
             _run_independent_pyogrio_scans, paths, expected_values, timeout=30
         )
 
     assert result["ok"], result["error"]
-    assert result["reader_boundary_reached"] >= 2
-    assert len(result["reader_boundary_sources"]) >= 2
-    assert {Path(source).name for source in result["reader_boundary_sources"]} == {
-        "left.fgb",
-        "right.fgb",
+    assert {Path(source).name for source in result["native_batch_pulls"]} == {
+        f"left.{extension}",
+        f"right.{extension}",
     }
+    assert all(count > 1 for count in result["native_batch_pulls"].values())
+    assert result["native_read_overlaps"] >= 1
+
+
+@pytest.mark.parametrize("extension", ["fgb", "gpkg"])
+def test_independent_reader_progress_while_first_reader_is_paused(extension):
+    pytest.importorskip("pyogrio")
+    expected_values = (list(range(2048)), list(range(10000, 12048)))
+
+    with tempfile.TemporaryDirectory() as td:
+        paths = _write_pyogrio_pair(td, extension, expected_values)
+        result = _run_child_process(
+            _run_paused_pyogrio_readers, paths, expected_values, timeout=15
+        )
+
+    assert result["ok"], result["error"]
+    assert result["first_batch_rows"] < len(expected_values[0])
+    assert result["row_counts"] == [len(values) for values in expected_values]
 
 
 # The geometry-column name is GDAL's OGR reader's, not ours: fgb/geojson/shp

--- a/python/sedonadb/tests/io/test_pyogrio.py
+++ b/python/sedonadb/tests/io/test_pyogrio.py
@@ -406,42 +406,22 @@ class _NativePullBoundary:
     def __init__(self):
         self._barrier = threading.Barrier(2, timeout=10)
         self._lock = threading.Lock()
-        self.pull_intervals = {}
+        self._batch_pulls = {}
 
     def read_next_batch(self, source, reader):
         # Rendezvous immediately before each real pyogrio Arrow batch pull.
-        # The interval covers the native read_next_batch() call itself, so an
-        # overlap is evidence that two independent GDAL readers were active at
-        # the same time rather than merely that their Python shelters coexisted.
+        # This keeps both independent reader lifetimes active and repeatedly
+        # schedules their native work from the same execution boundary.
         self._barrier.wait()
-        started = time.perf_counter_ns()
         batch = reader.read_next_batch()
-        finished = time.perf_counter_ns()
 
         with self._lock:
-            self.pull_intervals.setdefault(source, []).append((started, finished))
+            self._batch_pulls[source] = self._batch_pulls.get(source, 0) + 1
         return batch
 
     def batch_pulls(self):
         with self._lock:
-            return {
-                source: len(intervals)
-                for source, intervals in self.pull_intervals.items()
-            }
-
-    def native_read_overlaps(self):
-        with self._lock:
-            sources = list(self.pull_intervals)
-            if len(sources) != 2:
-                return 0
-            left_intervals = self.pull_intervals[sources[0]]
-            right_intervals = self.pull_intervals[sources[1]]
-
-        return sum(
-            max(left_start, right_start) < min(left_end, right_end)
-            for left_start, left_end in left_intervals
-            for right_start, right_end in right_intervals
-        )
+            return dict(self._batch_pulls)
 
 
 class _NativePullBoundaryReader:
@@ -514,7 +494,6 @@ def _run_independent_pyogrio_scans(result_sender, paths, expected_values):
             {
                 "ok": True,
                 "native_batch_pulls": boundary.batch_pulls(),
-                "native_read_overlaps": boundary.native_read_overlaps(),
             }
         )
     except BaseException:
@@ -649,7 +628,6 @@ def test_independent_scans_from_threads(extension):
         f"right.{extension}",
     }
     assert all(count > 1 for count in result["native_batch_pulls"].values())
-    assert result["native_read_overlaps"] >= 1
 
 
 @pytest.mark.parametrize("extension", ["fgb", "gpkg"])

--- a/python/sedonadb/tests/io/test_pyogrio.py
+++ b/python/sedonadb/tests/io/test_pyogrio.py
@@ -563,9 +563,7 @@ def test_independent_scans_from_threads():
             path = Path(td) / filename
             geopandas.GeoDataFrame(
                 {"idx": values},
-                geometry=geopandas.GeoSeries.from_xy(
-                    values, values, crs="EPSG:4326"
-                ),
+                geometry=geopandas.GeoSeries.from_xy(values, values, crs="EPSG:4326"),
             ).to_file(path)
             paths.append(str(path))
         assert len(paths) == 2

--- a/python/sedonadb/tests/io/test_pyogrio.py
+++ b/python/sedonadb/tests/io/test_pyogrio.py
@@ -446,18 +446,22 @@ def _run_independent_pyogrio_scans(result_sender, paths, expected_values):
     try:
         PyogrioFormatSpec.open_reader = open_reader
         connections = [sedonadb.connect(), sedonadb.connect()]
+        assert len(connections) == len(paths) == len(expected_values) == 2
 
         def scan(connection, path):
             return connection.read_pyogrio(path).to_arrow_table()
 
         executor = ThreadPoolExecutor(max_workers=2)
         futures = [
-            executor.submit(scan, connection, path)
-            for connection, path in zip(connections, paths, strict=True)
+            executor.submit(scan, connections[index], paths[index])
+            for index in range(2)
         ]
         tables = [future.result() for future in futures]
+        assert len(futures) == len(tables) == 2
 
-        for table, values in zip(tables, expected_values, strict=True):
+        for index in range(2):
+            table = tables[index]
+            values = expected_values[index]
             assert table.num_rows == len(values)
             assert sorted(table.column("idx").to_pylist()) == values
         assert boundary.reached >= 2
@@ -490,6 +494,10 @@ def _block_child_process(result_sender):
     threading.Event().wait()
 
 
+def _exit_child_process(result_sender):
+    raise SystemExit(17)
+
+
 def _terminate_child(process):
     process.terminate()
     process.join(5)
@@ -510,7 +518,12 @@ def _run_child_process(target, *args, timeout):
             _terminate_child(process)
             raise TimeoutError(f"child process exceeded {timeout} seconds")
 
-        child_result = result_receiver.recv() if result_receiver.poll() else None
+        child_result = None
+        if result_receiver.poll():
+            try:
+                child_result = result_receiver.recv()
+            except EOFError:
+                pass
         if process.exitcode != 0:
             raise AssertionError(
                 f"child process exited with {process.exitcode}: {child_result}"
@@ -531,13 +544,22 @@ def test_independent_scans_child_timeout_is_bounded():
     assert time.monotonic() - started < 5
 
 
+def test_child_process_nonzero_exit_is_reported():
+    with pytest.raises(AssertionError, match="child process exited with 17: None"):
+        _run_child_process(_exit_child_process, timeout=5)
+
+
 def test_independent_scans_from_threads():
     pytest.importorskip("pyogrio")
     expected_values = ([10, 11, 12], [20, 21, 22, 23])
+    filenames = ("left.fgb", "right.fgb")
+    assert len(filenames) == len(expected_values) == 2
 
     with tempfile.TemporaryDirectory() as td:
         paths = []
-        for filename, values in zip(("left.fgb", "right.fgb"), expected_values):
+        for index in range(2):
+            filename = filenames[index]
+            values = expected_values[index]
             path = Path(td) / filename
             geopandas.GeoDataFrame(
                 {"idx": values},
@@ -546,6 +568,7 @@ def test_independent_scans_from_threads():
                 ),
             ).to_file(path)
             paths.append(str(path))
+        assert len(paths) == 2
 
         result = _run_child_process(
             _run_independent_pyogrio_scans, paths, expected_values, timeout=30
@@ -553,6 +576,7 @@ def test_independent_scans_from_threads():
 
     assert result["ok"], result["error"]
     assert result["reader_boundary_reached"] >= 2
+    assert len(result["reader_boundary_sources"]) >= 2
     assert {Path(source).name for source in result["reader_boundary_sources"]} == {
         "left.fgb",
         "right.fgb",

--- a/python/sedonadb/tests/io/test_pyogrio.py
+++ b/python/sedonadb/tests/io/test_pyogrio.py
@@ -473,6 +473,72 @@ class _NativePullBoundaryReader:
         return self._reader.__arrow_c_stream__(requested_schema)
 
 
+class _NativeLifecycleBoundary:
+    def __init__(self, short_source, long_source):
+        self.short_source = short_source
+        self.long_source = long_source
+        self._open_read_barrier = threading.Barrier(2, timeout=10)
+        self._close_read_started = threading.Event()
+        self._lock = threading.Lock()
+        self._read_calls = {}
+        self._intervals = {"open": {}, "read": {}, "close": {}}
+
+    def open_reader(self, source, callback):
+        if source == self.long_source:
+            self._open_read_barrier.wait()
+        return self._record_call("open", source, callback)
+
+    def close_reader(self, source, callback):
+        if source == self.short_source and not self._close_read_started.wait(10):
+            raise TimeoutError("long reader did not start its close-overlap pull")
+        return self._record_call("close", source, callback)
+
+    def read_next_batch(self, source, reader):
+        with self._lock:
+            call_index = self._read_calls.get(source, 0)
+            self._read_calls[source] = call_index + 1
+
+        if source == self.short_source and call_index == 0:
+            self._open_read_barrier.wait()
+        elif source == self.long_source and call_index == 1:
+            # Let this real native pull start before the short reader closes.
+            self._close_read_started.set()
+
+        return self._record_call("read", source, reader.read_next_batch)
+
+    def _record_call(self, kind, source, callback):
+        started = time.perf_counter_ns()
+        result = callback()
+        finished = time.perf_counter_ns()
+        with self._lock:
+            self._intervals[kind].setdefault(source, []).append((started, finished))
+        return result
+
+    def overlaps(self, first_kind, first_source, second_kind, second_source):
+        with self._lock:
+            first = list(self._intervals[first_kind].get(first_source, ()))
+            second = list(self._intervals[second_kind].get(second_source, ()))
+
+        return sum(
+            max(first_start, second_start) < min(first_end, second_end)
+            for first_start, first_end in first
+            for second_start, second_end in second
+        )
+
+
+class _NativeLifecycleCloseContext:
+    def __init__(self, inner, boundary, source):
+        self._inner = inner
+        self._boundary = boundary
+        self._source = source
+
+    def __exit__(self, exc_type, exc_value, traceback_object):
+        return self._boundary.close_reader(
+            self._source,
+            lambda: self._inner.__exit__(exc_type, exc_value, traceback_object),
+        )
+
+
 def _run_independent_pyogrio_scans(result_sender, paths, expected_values):
     boundary = _NativePullBoundary()
     original_open_reader = PyogrioFormatSpec.open_reader
@@ -557,6 +623,68 @@ def _run_paused_pyogrio_readers(result_sender, paths, expected_values):
     except BaseException:
         result_sender.send({"ok": False, "error": traceback.format_exc()})
     finally:
+        result_sender.close()
+
+
+def _run_pyogrio_lifecycle_overlap(result_sender, paths, expected_values, short_side):
+    short_source = Path(paths[short_side]).name
+    long_source = Path(paths[1 - short_side]).name
+    boundary = _NativeLifecycleBoundary(short_source, long_source)
+    original_open_reader = PyogrioFormatSpec.open_reader
+    executor = None
+    futures = []
+
+    def open_reader(format_spec, args):
+        source = Path(args.src.to_url()).name
+        if args.file_schema is None:
+            return original_open_reader(format_spec, args)
+
+        inner = boundary.open_reader(
+            source, lambda: original_open_reader(format_spec, args)
+        )
+        if source == short_source:
+            inner._inner = _NativeLifecycleCloseContext(inner._inner, boundary, source)
+        return _NativePullBoundaryReader(inner, boundary, source)
+
+    try:
+        PyogrioFormatSpec.open_reader = open_reader
+        connections = [sedonadb.connect(), sedonadb.connect()]
+        for connection in connections:
+            connection.sql("SET datafusion.execution.batch_size TO 512").execute()
+
+        def scan(connection, path):
+            return connection.read_pyogrio(path).to_arrow_table()
+
+        executor = ThreadPoolExecutor(max_workers=2)
+        futures = [
+            executor.submit(scan, connections[index], paths[index])
+            for index in range(2)
+        ]
+        tables = [future.result() for future in futures]
+        row_counts = []
+        for index, table in enumerate(tables):
+            values = table.column("idx").to_pylist()
+            assert sorted(values) == expected_values[index]
+            row_counts.append(len(values))
+
+        result_sender.send(
+            {
+                "ok": True,
+                "open_read_overlaps": boundary.overlaps(
+                    "open", long_source, "read", short_source
+                ),
+                "close_read_overlaps": boundary.overlaps(
+                    "close", short_source, "read", long_source
+                ),
+                "row_counts": row_counts,
+            }
+        )
+    except BaseException:
+        result_sender.send({"ok": False, "error": traceback.format_exc()})
+    finally:
+        PyogrioFormatSpec.open_reader = original_open_reader
+        if executor is not None:
+            executor.shutdown(wait=all(future.done() for future in futures))
         result_sender.close()
 
 
@@ -665,6 +793,29 @@ def test_independent_reader_progress_while_first_reader_is_paused(extension):
 
     assert result["ok"], result["error"]
     assert result["first_batch_rows"] < len(expected_values[0])
+    assert result["row_counts"] == [len(values) for values in expected_values]
+
+
+@pytest.mark.parametrize("short_side", [0, 1])
+def test_independent_fgb_reader_lifecycle_overlaps_native_reads(short_side):
+    pytest.importorskip("pyogrio")
+    expected_values = (list(range(1024)), list(range(10000, 18192)))
+    if short_side == 1:
+        expected_values = (expected_values[1], expected_values[0])
+
+    with tempfile.TemporaryDirectory() as td:
+        paths = _write_pyogrio_pair(td, "fgb", expected_values)
+        result = _run_child_process(
+            _run_pyogrio_lifecycle_overlap,
+            paths,
+            expected_values,
+            short_side,
+            timeout=20,
+        )
+
+    assert result["ok"], result["error"]
+    assert result["open_read_overlaps"] >= 1
+    assert result["close_read_overlaps"] >= 1
     assert result["row_counts"] == [len(values) for values in expected_values]
 
 

--- a/python/sedonadb/tests/test_read.py
+++ b/python/sedonadb/tests/test_read.py
@@ -15,12 +15,86 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from pathlib import Path
+import threading
+
 import geopandas
 import geopandas.testing
+import pyarrow as pa
 import pytest
 
 import sedonadb
 from sedonadb.datasource import ExternalFormatSpec
+
+
+class ReaderLifecycleState:
+    def __init__(self):
+        self.lock = threading.Lock()
+        self._condition = threading.Condition(self.lock)
+        self.active = 0
+        self.max_active = 0
+        self.opened = 0
+        self.closed = 0
+
+    def enter(self):
+        with self._condition:
+            self.active += 1
+            self.opened += 1
+            self.max_active = max(self.max_active, self.active)
+            self._condition.notify_all()
+
+    def wait_for_peer(self):
+        with self._condition:
+            if self.active == 1:
+                self._condition.wait_for(lambda: self.active > 1, timeout=0.25)
+
+    def exit(self):
+        with self._condition:
+            self.active -= 1
+            self.closed += 1
+            self._condition.notify_all()
+
+
+class TrackingArrowReader:
+    def __init__(self, state, src):
+        self._state = state
+        self._closed = False
+        self._state.enter()
+        self._state.wait_for_peer()
+        value = int(Path(src.to_url()).stem)
+        self._reader = pa.RecordBatchReader.from_batches(
+            pa.schema({"value": pa.int64()}),
+            [pa.record_batch({"value": [value]})],
+        )
+
+    def __del__(self):
+        if not self._closed:
+            self._closed = True
+            self._state.exit()
+
+    def __arrow_c_stream__(self, requested_schema=None):
+        if requested_schema is None:
+            return self._reader.__arrow_c_stream__()
+        return self._reader.__arrow_c_stream__(requested_schema)
+
+
+class TrackingFormatSpec(ExternalFormatSpec):
+    def __init__(self, state):
+        self._state = state
+
+    @property
+    def extension(self):
+        return "tracking"
+
+    @property
+    def supports_concurrent_file_reads(self):
+        return False
+
+    def infer_schema(self, src):
+        return pa.schema({"value": pa.int64()})
+
+    def open_reader(self, args):
+        return TrackingArrowReader(self._state, args.src)
 
 
 def test_read_guess_format(con):
@@ -101,3 +175,23 @@ def test_format_register():
 
     with pytest.raises(ValueError, match="test format spec!"):
         sd.read("test.foofy", options={"k": "v"})
+
+
+def test_external_format_serializes_reader_lifecycles(con, tmp_path):
+    paths = []
+    for value in range(16):
+        path = tmp_path / f"{value}.tracking"
+        path.write_text("tracking")
+        paths.append(path)
+
+    state = ReaderLifecycleState()
+    spec = TrackingFormatSpec(state)
+    con.sql("SET datafusion.execution.target_partitions TO 8").execute()
+
+    table = con.read(paths, format=spec).to_arrow_table()
+
+    assert table.num_rows == 16
+    assert sorted(table.column("value").to_pylist()) == list(range(16))
+    assert state.max_active == 1
+    assert state.active == 0
+    assert state.opened == state.closed

--- a/python/sedonadb/tests/test_read.py
+++ b/python/sedonadb/tests/test_read.py
@@ -45,7 +45,7 @@ class ReaderLifecycleState:
 
     def wait_for_peer(self):
         with self._condition:
-            if self.active == 1:
+            if self.opened == 1 and self.active == 1:
                 self._condition.wait_for(lambda: self.active > 1, timeout=0.25)
 
     def exit(self):
@@ -177,7 +177,7 @@ def test_format_register():
         sd.read("test.foofy", options={"k": "v"})
 
 
-def test_external_format_serializes_reader_lifecycles(con, tmp_path):
+def test_external_format_serializes_reader_lifecycles(tmp_path):
     paths = []
     for value in range(16):
         path = tmp_path / f"{value}.tracking"
@@ -186,6 +186,7 @@ def test_external_format_serializes_reader_lifecycles(con, tmp_path):
 
     state = ReaderLifecycleState()
     spec = TrackingFormatSpec(state)
+    con = sedonadb.connect()
     con.sql("SET datafusion.execution.target_partitions TO 8").execute()
 
     table = con.read(paths, format=spec).to_arrow_table()

--- a/rust/sedona-datasource/src/format.rs
+++ b/rust/sedona-datasource/src/format.rs
@@ -17,7 +17,8 @@
 
 use std::{any::Any, collections::HashMap, fmt::Debug, sync::Arc};
 
-use arrow_schema::{Schema, SchemaRef};
+use arrow_array::{RecordBatch, RecordBatchReader};
+use arrow_schema::{ArrowError, Schema, SchemaRef};
 use async_trait::async_trait;
 use datafusion::{
     config::ConfigOptions,
@@ -42,7 +43,10 @@ use datafusion_physical_plan::{
     metrics::ExecutionPlanMetricsSet,
     ExecutionPlan,
 };
-use futures::{StreamExt, TryStreamExt};
+use futures::{
+    lock::{Mutex, OwnedMutexGuard},
+    StreamExt, TryStreamExt,
+};
 use object_store::{ObjectMeta, ObjectStore};
 
 use crate::spec::{ExternalFormatSpec, Object, OpenReaderArgs, SupportsRepartition};
@@ -141,6 +145,12 @@ impl FileFormat for ExternalFileFormat {
             return plan_err!("Can't infer schema for zero objects. Does the input path exist?");
         }
 
+        let schema_concurrency = if self.spec.supports_concurrent_file_reads() {
+            state.config_options().execution.meta_fetch_concurrency
+        } else {
+            1
+        };
+
         let mut schemas: Vec<_> = futures::stream::iter(objects)
             .map(|object| async move {
                 let schema = self
@@ -155,7 +165,7 @@ impl FileFormat for ExternalFileFormat {
                 Ok::<_, DataFusionError>((object.location.clone(), schema))
             })
             .boxed() // Workaround https://github.com/rust-lang/rust/issues/64552
-            .buffered(state.config_options().execution.meta_fetch_concurrency)
+            .buffered(schema_concurrency)
             .try_collect()
             .await?;
 
@@ -216,6 +226,10 @@ impl FileFormat for ExternalFileFormat {
 #[derive(Debug, Clone)]
 struct ExternalFileSource {
     spec: Arc<dyn ExternalFormatSpec>,
+    /// Shared by all openers cloned from this physical scan. Keeping the lock
+    /// here scopes serialization to one scan instead of coupling independent
+    /// user streams through a process-wide lock.
+    reader_lock: Option<Arc<Mutex<()>>>,
     table_schema: TableSchema,
     batch_size: Option<usize>,
     /// Split projection: file_indices for column pruning, ProjectionOpener for the rest
@@ -226,8 +240,15 @@ struct ExternalFileSource {
 
 impl ExternalFileSource {
     pub fn new(spec: Arc<dyn ExternalFormatSpec>, table_schema: TableSchema) -> Self {
+        let reader_lock = if spec.supports_concurrent_file_reads() {
+            None
+        } else {
+            Some(Arc::new(Mutex::new(())))
+        };
+
         Self {
             spec,
+            reader_lock,
             table_schema,
             batch_size: None,
             split_projection: None,
@@ -265,6 +286,7 @@ impl FileSource for ExternalFileSource {
 
         let inner_opener: Arc<dyn FileOpener> = Arc::new(ExternalFileOpener {
             spec: self.spec.clone(),
+            reader_lock: self.reader_lock.clone(),
             args,
         });
 
@@ -380,6 +402,7 @@ impl FileSource for ExternalFileSource {
 #[derive(Debug, Clone)]
 struct ExternalFileOpener {
     spec: Arc<dyn ExternalFormatSpec>,
+    reader_lock: Option<Arc<Mutex<()>>>,
     args: OpenReaderArgs,
 }
 
@@ -389,11 +412,57 @@ impl FileOpener for ExternalFileOpener {
         Ok(Box::pin(async move {
             self_clone.args.src.meta.replace(file.object_meta);
             self_clone.args.src.range = file.range;
-            let reader = self_clone.spec.open_reader(&self_clone.args).await?;
+
+            let reader_guard = if let Some(reader_lock) = &self_clone.reader_lock {
+                Some(reader_lock.clone().lock_owned().await)
+            } else {
+                None
+            };
+
+            let inner = self_clone.spec.open_reader(&self_clone.args).await?;
+            let reader: Box<dyn RecordBatchReader + Send> = if let Some(reader_guard) = reader_guard
+            {
+                let schema = inner.schema();
+                Box::new(SerializedFileReader {
+                    inner: Some(inner),
+                    schema,
+                    reader_guard: Some(reader_guard),
+                })
+            } else {
+                inner
+            };
             let stream =
                 futures::stream::iter(reader.into_iter().map(|batch| batch.map_err(Into::into)));
             Ok(stream.boxed())
         }))
+    }
+}
+
+/// Keeps a scan-local exclusivity guard until its inner reader is exhausted or
+/// dropped. The inner reader is declared first so early cancellation drops and
+/// closes it before releasing the guard to the next file.
+struct SerializedFileReader {
+    inner: Option<Box<dyn RecordBatchReader + Send>>,
+    schema: SchemaRef,
+    reader_guard: Option<OwnedMutexGuard<()>>,
+}
+
+impl RecordBatchReader for SerializedFileReader {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+
+impl Iterator for SerializedFileReader {
+    type Item = Result<RecordBatch, ArrowError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let item = self.inner.as_mut().and_then(|inner| inner.next());
+        if item.is_none() {
+            self.inner = None;
+            self.reader_guard = None;
+        }
+        item
     }
 }
 
@@ -407,12 +476,15 @@ mod test {
     use datafusion::{
         assert_batches_eq,
         datasource::listing::ListingTableUrl,
-        prelude::{col, SessionContext},
+        prelude::{col, SessionConfig, SessionContext},
     };
     use datafusion_common::plan_err;
     use std::{
         io::{Read, Write},
         path::PathBuf,
+        sync::atomic::{AtomicUsize, Ordering},
+        thread,
+        time::Duration,
     };
     use tempfile::TempDir;
     use url::Url;
@@ -533,6 +605,124 @@ mod test {
 
             Ok(Box::new(RecordBatchIterator::new([Ok(batch)], schema)))
         }
+    }
+
+    #[derive(Debug, Clone, Default)]
+    struct SerialSpec {
+        active_readers: Arc<AtomicUsize>,
+        max_active_readers: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ExternalFormatSpec for SerialSpec {
+        fn extension(&self) -> &str {
+            "serialspec"
+        }
+
+        fn supports_concurrent_file_reads(&self) -> bool {
+            false
+        }
+
+        fn with_options(
+            &self,
+            _options: &HashMap<String, String>,
+        ) -> Result<Arc<dyn ExternalFormatSpec>> {
+            Ok(Arc::new(self.clone()))
+        }
+
+        async fn infer_schema(&self, location: &Object) -> Result<Schema> {
+            check_object_is_readable_file(location);
+            Ok(Schema::new(vec![Field::new(
+                "value",
+                DataType::Int32,
+                false,
+            )]))
+        }
+
+        async fn open_reader(
+            &self,
+            args: &OpenReaderArgs,
+        ) -> Result<Box<dyn RecordBatchReader + Send>> {
+            check_object_is_readable_file(&args.src);
+            let schema = Arc::new(self.infer_schema(&args.src).await?);
+            let batch =
+                RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![1]))])?;
+
+            let active = self.active_readers.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max_active_readers.fetch_max(active, Ordering::SeqCst);
+
+            Ok(Box::new(TrackedReader {
+                batch: Some(batch),
+                schema,
+                active_readers: self.active_readers.clone(),
+            }))
+        }
+    }
+
+    struct TrackedReader {
+        batch: Option<RecordBatch>,
+        schema: SchemaRef,
+        active_readers: Arc<AtomicUsize>,
+    }
+
+    impl RecordBatchReader for TrackedReader {
+        fn schema(&self) -> SchemaRef {
+            self.schema.clone()
+        }
+    }
+
+    impl Iterator for TrackedReader {
+        type Item = Result<RecordBatch, ArrowError>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.batch.is_some() {
+                // Give other file partitions enough time to attempt their
+                // opens while this reader remains active.
+                thread::sleep(Duration::from_millis(10));
+            }
+            self.batch.take().map(Ok)
+        }
+    }
+
+    impl Drop for TrackedReader {
+        fn drop(&mut self) {
+            self.active_readers.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn serializes_file_reader_lifecycles_within_one_scan() {
+        let spec = Arc::new(SerialSpec::default());
+        let ctx = SessionContext::new_with_config(SessionConfig::new().with_target_partitions(8));
+        let temp_dir = TempDir::new().unwrap();
+        let files = (0..16)
+            .map(|i| {
+                let path = temp_dir.path().join(format!("item{i}.serialspec"));
+                std::fs::File::create(&path)
+                    .unwrap()
+                    .write_all(b"not empty")
+                    .unwrap();
+                path
+            })
+            .collect::<Vec<_>>();
+
+        let provider = external_table(
+            spec.clone(),
+            &ctx,
+            files
+                .iter()
+                .map(|f| ListingTableUrl::parse(f.to_string_lossy()).unwrap())
+                .collect(),
+            true,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let batches = ctx.read_table(provider).unwrap().collect().await.unwrap();
+        assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 16);
+        assert_eq!(spec.max_active_readers.load(Ordering::SeqCst), 1);
+        assert_eq!(spec.active_readers.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]

--- a/rust/sedona-datasource/src/spec.rs
+++ b/rust/sedona-datasource/src/spec.rs
@@ -88,6 +88,16 @@ pub trait ExternalFormatSpec: Debug + Send + Sync {
         false
     }
 
+    /// Whether readers for different files in the same physical scan may be
+    /// opened and consumed concurrently.
+    ///
+    /// Return `false` for native libraries that require one file reader to be
+    /// fully consumed and closed before the scan opens the next. This limit is
+    /// scoped to a single physical scan; independent scans remain independent.
+    fn supports_concurrent_file_reads(&self) -> bool {
+        true
+    }
+
     /// Fill in default options from [TableOptions]
     ///
     /// The TableOptions are a DataFusion concept that provide a means by which


### PR DESCRIPTION
## What

- add an `ExternalFormatSpec` capability for formats that cannot safely consume multiple file readers concurrently
- disable concurrent file reads for pyogrio and serialize schema inference and the complete reader lifecycle within each physical scan
- drop the Arrow FFI stream before closing its owning Python context and releasing the scan permit
- add regression tests for scan-local serialization and deterministic Python-context cleanup

## Why

#1051 serialized pyogrio context entry and exit, but active Arrow streams could still overlap. Subsequent wheel runs continued to abort during multi-file and partitioned pyogrio reads, as tracked in #1072.

An unchanged CPython 3.12 comparison repeatedly ran the two affected tests in fresh processes and reproduced SIGABRT at iteration 72 during `test_read_ogr_partitioned`: [run 32625781579](https://github.com/jiayuasu/sedona-db/actions/runs/32625781579/job/97160805281).

This change keeps one scan-local permit from reader creation through consumption and native cleanup. Pyogrio multi-file scans therefore trade file-level parallelism for stability. Other external formats retain concurrent reads by default, and independent physical scans do not share a process-wide lock.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p sedona-datasource -p sedonadb --lib` (9 + 11 tests passed)
- `cargo clippy -p sedona-datasource -p sedonadb --lib --no-deps -- -D warnings`
- local pyogrio and external-read modules (22 tests passed)
- pinned CPython 3.12 stress run:
  - full pyogrio module: 18/18 passed
  - 500 same-process repetitions and 500 fresh-process repetitions
  - 2,002 executions of the two affected tests with no abort, hang, timeout, or test failure
  - [run 32628586406](https://github.com/jiayuasu/sedona-db/actions/runs/32628586406)
- all five core wheel platforms passed on the combined verification branch: [run 32627022432](https://github.com/jiayuasu/sedona-db/actions/runs/32627022432)

Closes #1072.

Follow-up to #924 and #1051. Replacing the Python reader with the native GDAL reader remains tracked in #1092.
