### PR TITLE
fix(rust/sedona-raster): carry band names through copy_raster_from

### DIFF
--- a/rust/sedona-raster-functions/src/rs_set_georeference.rs
+++ b/rust/sedona-raster-functions/src/rs_set_georeference.rs
@@ -32,8 +32,9 @@
 //! skewed rasters and round-trips with the getter.
 //!
 //! The raster is rebuilt with [`RasterBuilder::copy_raster_from`] overriding the
-//! transform; each band's pixel buffers are shared zero-copy, and the CRS is
-//! carried over unchanged.
+//! transform; each band's pixel buffers are shared zero-copy, and the CRS plus
+//! every inherited band field — name, nodata, OutDb pointers — are carried over
+//! unchanged.
 
 use std::sync::Arc;
 

--- a/rust/sedona-raster-functions/src/rs_set_georeference.rs
+++ b/rust/sedona-raster-functions/src/rs_set_georeference.rs
@@ -206,11 +206,12 @@ mod tests {
     use sedona_testing::raster_spec::{assert_rasters_equal, raster_array, RasterSpec};
     use sedona_testing::testers::ScalarUdfTester;
 
-    /// A 2x2 raster with a CRS — so the comparisons confirm the CRS (and pixels)
-    /// survive the transform swap.
+    /// A 2x2 raster with a CRS and a named band — so the comparisons confirm
+    /// the CRS, the band name, and the pixels all survive the transform swap.
     fn base() -> RasterSpec {
         RasterSpec::d2(2, 2)
             .band_values(&[1u8, 2, 3, 4])
+            .name("temperature")
             .crs(Some("OGC:CRS84"))
     }
 
@@ -260,6 +261,29 @@ mod tests {
             .invoke_array_scalar_scalar(Arc::new(base().build()), "2 0 0 -3 101 198.5", "ESRI")
             .unwrap();
         let expected = base().transform([100.0, 2.0, 0.0, 200.0, 0.0, -3.0]);
+        assert_rasters_equal(&result, &[Some(expected)]);
+    }
+
+    #[test]
+    fn preserves_per_band_names_across_multiple_bands() {
+        // Band names live on the raster (`RasterRef::band_name(i)`), not on
+        // `BandRef`, so the rebuild has to carry each one across by index.
+        // Two differently-named bands pin the indexing, not just the presence
+        // of a name.
+        let multi = || {
+            RasterSpec::d2(2, 2)
+                .band_values(&[1u8, 2, 3, 4])
+                .name("temperature")
+                .band_values(&[5u8, 6, 7, 8])
+                .name("precipitation")
+                .crs(Some("OGC:CRS84"))
+        };
+
+        let result = tester_2arg()
+            .invoke_array_scalar(Arc::new(multi().build()), "2 0 0 -3 100 200")
+            .unwrap();
+
+        let expected = multi().transform([100.0, 2.0, 0.0, 200.0, 0.0, -3.0]);
         assert_rasters_equal(&result, &[Some(expected)]);
     }
 

--- a/rust/sedona-raster/src/array.rs
+++ b/rust/sedona-raster/src/array.rs
@@ -42,6 +42,7 @@ struct BandRefImpl<'a> {
     dim_names_values: &'a StringArray,
     source_shape_list: &'a ListArray,
     source_shape_values: &'a Int64Array,
+    band_name_array: &'a StringArray,
     nodata_array: &'a BinaryArray,
     outdb_uri_array: &'a StringArray,
     outdb_format_array: &'a StringViewArray,
@@ -93,6 +94,14 @@ impl<'a> BandRef for BandRefImpl<'a> {
 
     fn data_type(&self) -> BandDataType {
         self.data_type
+    }
+
+    fn name(&self) -> Option<&str> {
+        if self.band_name_array.is_null(self.band_row) {
+            None
+        } else {
+            Some(self.band_name_array.value(self.band_row))
+        }
     }
 
     fn nodata(&self) -> Option<&[u8]> {
@@ -520,6 +529,7 @@ impl<'a> RasterRef for RasterRefImpl<'a> {
             dim_names_values: self.band_dim_names_values,
             source_shape_list: self.band_source_shape_list,
             source_shape_values: self.band_source_shape_values,
+            band_name_array: self.band_name_array,
             nodata_array: self.band_nodata_array,
             outdb_uri_array: self.band_outdb_uri_array,
             outdb_format_array: self.band_outdb_format_array,
@@ -822,6 +832,39 @@ mod tests {
     use sedona_schema::raster::{band_indices, raster_indices, BandDataType, RasterSchema};
     use sedona_testing::rasters::generate_test_rasters;
     use std::sync::Arc;
+
+    #[test]
+    fn band_ref_exposes_its_name() {
+        // `name()` is the band-level accessor that lets `copy_into` inherit the
+        // name; assert it directly (and agrees with the raster-level fast path)
+        // rather than only through a derive.
+        let transform = [0.0, 1.0, 0.0, 0.0, 0.0, -1.0];
+        let mut b = RasterBuilder::new(1);
+        b.start_raster_nd(&transform, &["x"], &[2], None).unwrap();
+        b.start_band(StartBandArgs {
+            name: Some("temperature"),
+            ..StartBandArgs::new(&["x"], &[2], BandDataType::UInt8)
+        })
+        .unwrap();
+        b.band_data_writer().append_value([1u8, 2]);
+        b.finish_band().unwrap();
+        // A second, deliberately unnamed band: `None` must survive too.
+        b.start_band(StartBandArgs::new(&["x"], &[2], BandDataType::UInt8))
+            .unwrap();
+        b.band_data_writer().append_value([3u8, 4]);
+        b.finish_band().unwrap();
+        b.finish_raster().unwrap();
+
+        let arr = b.finish().unwrap();
+        let rasters = RasterStructArray::try_new(&arr).unwrap();
+        let raster = rasters.get(0).unwrap();
+
+        assert_eq!(raster.band(0).unwrap().name(), Some("temperature"));
+        assert_eq!(raster.band(1).unwrap().name(), None);
+        // Band-level accessor and raster-level fast path must not disagree.
+        assert_eq!(raster.band(0).unwrap().name(), raster.band_name(0));
+        assert_eq!(raster.band(1).unwrap().name(), raster.band_name(1));
+    }
 
     #[test]
     fn copy_into_shares_buffer_zero_copy_and_overrides() {

--- a/rust/sedona-raster/src/builder.rs
+++ b/rust/sedona-raster/src/builder.rs
@@ -287,17 +287,9 @@ impl RasterBuilder {
     ) -> Result<(), ArrowError> {
         self.start_raster_from(source, overrides)?;
         for band_idx in 0..source.num_bands() {
-            // The band name lives on the *raster* (`RasterRef::band_name`), not
-            // on `BandRef`, so `copy_into` has nothing to inherit it from and
-            // must be handed it explicitly — otherwise every copied band comes
-            // out unnamed.
-            source.band(band_idx)?.copy_into(
-                self,
-                BandOverrides {
-                    name: source.band_name(band_idx),
-                    ..BandOverrides::default()
-                },
-            )?;
+            source
+                .band(band_idx)?
+                .copy_into(self, BandOverrides::default())?;
             self.finish_band()?;
         }
         self.finish_raster()

--- a/rust/sedona-raster/src/builder.rs
+++ b/rust/sedona-raster/src/builder.rs
@@ -287,9 +287,17 @@ impl RasterBuilder {
     ) -> Result<(), ArrowError> {
         self.start_raster_from(source, overrides)?;
         for band_idx in 0..source.num_bands() {
-            source
-                .band(band_idx)?
-                .copy_into(self, BandOverrides::default())?;
+            // The band name lives on the *raster* (`RasterRef::band_name`), not
+            // on `BandRef`, so `copy_into` has nothing to inherit it from and
+            // must be handed it explicitly — otherwise every copied band comes
+            // out unnamed.
+            source.band(band_idx)?.copy_into(
+                self,
+                BandOverrides {
+                    name: source.band_name(band_idx),
+                    ..BandOverrides::default()
+                },
+            )?;
             self.finish_band()?;
         }
         self.finish_raster()
@@ -883,6 +891,7 @@ mod tests {
         // Source: a CRS, a nodata sentinel, and pixel values to preserve.
         let source = RasterSpec::d2(2, 1)
             .band_values(&[1u8, 2])
+            .name("temperature")
             .nodata(9u8)
             .crs(Some("OGC:CRS84"))
             .build();
@@ -899,9 +908,11 @@ mod tests {
             .unwrap();
         let out: ArrayRef = Arc::new(builder.finish().unwrap());
 
-        // Only the transform changed; CRS, nodata, and pixels carried over.
+        // Only the transform changed; CRS, nodata, band name, and pixels
+        // carried over.
         let expected = RasterSpec::d2(2, 1)
             .band_values(&[1u8, 2])
+            .name("temperature")
             .nodata(9u8)
             .crs(Some("OGC:CRS84"))
             .transform([100.0, 2.0, 0.0, 200.0, 0.0, -3.0]);

--- a/rust/sedona-raster/src/traits.rs
+++ b/rust/sedona-raster/src/traits.rs
@@ -280,8 +280,8 @@ pub trait RasterRef {
 }
 
 /// Field overrides for [`BandRef::copy_into`]. Each field defaults to `None`,
-/// meaning "inherit from the source band". `name` has no source on a `BandRef`
-/// (band names live at the raster level), so it defaults to unnamed.
+/// meaning "inherit from the source band" — `name` included, sourced from
+/// [`BandRef::name`].
 #[derive(Default)]
 pub struct BandOverrides<'a> {
     /// Override the band name; `None` inherits the source's.

--- a/rust/sedona-raster/src/traits.rs
+++ b/rust/sedona-raster/src/traits.rs
@@ -284,7 +284,7 @@ pub trait RasterRef {
 /// (band names live at the raster level), so it defaults to unnamed.
 #[derive(Default)]
 pub struct BandOverrides<'a> {
-    /// Name for the derived band (the source has none to inherit).
+    /// Override the band name; `None` inherits the source's.
     pub name: Option<&'a str>,
     /// Override the dimension names; `None` inherits the source's.
     pub dim_names: Option<&'a [&'a str]>,
@@ -375,6 +375,15 @@ pub trait BandRef {
 
     /// Data type for all elements in this band
     fn data_type(&self) -> BandDataType;
+
+    /// Band name (e.g. a Zarr variable name). None for unnamed bands.
+    ///
+    /// The band-level counterpart to [`RasterRef::band_name`], which indexes
+    /// the same value from the raster. Required rather than defaulted: a
+    /// backend that silently returned `None` here would drop names on every
+    /// derived band, which is precisely the failure this accessor exists to
+    /// prevent.
+    fn name(&self) -> Option<&str>;
 
     /// Nodata value as raw bytes (None if not set)
     fn nodata(&self) -> Option<&[u8]>;
@@ -490,7 +499,7 @@ pub trait BandRef {
             None => source_view,
         };
         builder.start_band(StartBandArgs {
-            name: overrides.name,
+            name: overrides.name.or_else(|| self.name()),
             view: Some(effective_view.as_slice()),
             nodata: overrides.nodata.or_else(|| self.nodata()),
             outdb_uri: overrides.outdb_uri.or_else(|| self.outdb_uri()),
@@ -853,6 +862,9 @@ mod tests {
         }
         fn data_type(&self) -> BandDataType {
             BandDataType::UInt8
+        }
+        fn name(&self) -> Option<&str> {
+            None
         }
         fn nodata(&self) -> Option<&[u8]> {
             None

--- a/rust/sedona-testing/src/rasters.rs
+++ b/rust/sedona-testing/src/rasters.rs
@@ -441,6 +441,11 @@ pub fn assert_raster_equal(raster1: &impl RasterRef, raster2: &impl RasterRef) {
         let band2 = raster2.band(band_index).unwrap();
 
         assert_eq!(
+            raster1.band_name(band_index),
+            raster2.band_name(band_index),
+            "Band names do not match"
+        );
+        assert_eq!(
             band1.dim_names(),
             band2.dim_names(),
             "Band dim names do not match"


### PR DESCRIPTION
## Problem

`RS_SetGeoReference(raster, georef)` returns a raster whose band names are all NULL. User-visible for named bands — e.g. Zarr variable names like `temperature`.

Confirmed on `main` (8e0a26328):

```
SOURCE band_name = Some("temperature")
COPIED band_name = None
```

## Root cause

Band name lives on `RasterRef::band_name(index)`. **`BandRef` had no name accessor**, so `copy_into` could not inherit the name the way it inherits `nodata` / `outdb_uri` / `outdb_format` — every caller had to remember to thread the name through by index. `copy_raster_from` didn't, and `RS_SetGeoReference` is its only production caller.

## Two commits

**1. `fix:` carry band names through `copy_raster_from`** — pass `source.band_name(band_idx)` explicitly. Minimal, backportable.

**2. `refactor:` add `BandRef::name()` so `copy_into` inherits it** — removes the cause rather than patching the one call site. `copy_into` falls back to `self.name()`, which lets `copy_raster_from` go back to a plain `BandOverrides::default()`.

`name()` is required rather than defaulted: a backend silently returning `None` would drop names on every derived band, which is exactly the failure it exists to prevent. Only two implementors exist — the Arrow-backed `BandRefImpl` and a test stub.

## Why nothing caught it

Two gaps, both closed here:

1. `copy_raster_from_overrides_transform_and_preserves_bands` used an **unnamed** band — despite the name, it asserted nothing about band names.
2. **`assert_raster_arrays_equal` never compared band names at all.** It checks dim names, shape, dtype, nodata, pixels — but not the band name. That blind spot hid this suite-wide.

Added the missing assertion to the shared comparator. It passes across `sedona-raster`, `sedona-raster-functions`, and `sedona-raster-zarr` with no other fallout, which confirms this was the only band-name drop in the tree.

Then gave the affected fixtures real names. `preserves_per_band_names_across_multiple_bands` uses two differently-named bands so the per-index mapping is pinned, not just the presence of a name, and `band_ref_exposes_its_name` covers the new accessor directly (including that an unnamed band still reads back as `None`, and that it agrees with the raster-level fast path).

## Verification

Reverting *either* the explicit pass (commit 1) or the `or_else(|| self.name())` inheritance (commit 2) fails the same 8 tests with `Band names do not match` — 7 `RS_SetGeoReference` tests plus the `copy_raster_from` builder test.

```
sedona-raster            178 passed; 0 failed
sedona-raster-functions  255 passed; 0 failed
sedona-raster-zarr        66 passed; 0 failed
```

## Interaction with #1158

#1158 converts `BandOverrides` to a trinary `Override<T>`, and for `name` it currently collapses:

```rust
// A `BandRef` has no source name to inherit, so `Keep` and `Clear`
// both leave the derived band unnamed.
Override::Keep | Override::Clear => None,
```

`name` is the only field whose trinary degenerates, purely because of the missing accessor. Once this lands that can become `Keep => self.name(), Clear => None`, making `name` uniform with every other overridable field. Small follow-up on that branch; no conflict with this one.