### PR TITLE
refactor(rust/sedona-raster-functions): adopt start_raster_from / copy_into in the structural raster functions

### DIFF
--- a/rust/sedona-raster-functions/src/rs_dim_band.rs
+++ b/rust/sedona-raster-functions/src/rs_dim_band.rs
@@ -22,10 +22,9 @@ use datafusion_common::cast::as_string_view_array;
 use datafusion_common::error::Result;
 use datafusion_common::{arrow_datafusion_err, exec_err};
 use datafusion_expr::{ColumnarValue, Volatility};
-use sedona_common::sedona_internal_datafusion_err;
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
-use sedona_raster::builder::{RasterBuilder, StartBandArgs};
-use sedona_raster::traits::RasterRef;
+use sedona_raster::builder::{RasterBuilder, RasterOverrides, StartBandArgs};
+use sedona_raster::traits::{BandOverrides, RasterRef};
 use sedona_schema::datatypes::SedonaType;
 use sedona_schema::matchers::ArgMatcher;
 
@@ -90,16 +89,7 @@ impl SedonaScalarKernel for RsDimToBand {
 
                     require_any_band_has_dim(raster, name, "RS_DimToBand")?;
 
-                    let t: [f64; 6] = raster.transform().try_into().map_err(|_| {
-                        sedona_internal_datafusion_err!("raster transform is not 6 elements")
-                    })?;
-                    let spatial_dims = raster.spatial_dims();
-                    new_builder.start_raster_nd(
-                        &t,
-                        &spatial_dims,
-                        raster.spatial_shape(),
-                        raster.crs(),
-                    )?;
+                    new_builder.start_raster_from(raster, RasterOverrides::default())?;
 
                     for band_idx in 0..raster.num_bands() {
                         let band = raster
@@ -110,16 +100,7 @@ impl SedonaScalarKernel for RsDimToBand {
                         match maybe_dim_idx {
                             None => {
                                 // Band doesn't have this dimension -- pass through
-                                let dim_names = band.dim_names();
-                                let band_name = raster.band_name(band_idx);
-                                new_builder.start_band(StartBandArgs {
-                                    name: band_name,
-                                    nodata: band.nodata(),
-                                    ..StartBandArgs::new(&dim_names, band.shape(), band.data_type())
-                                })?;
-                                let ndb = band.nd_buffer()?;
-                                let data = ndb.as_contiguous()?;
-                                new_builder.band_data_writer().append_value(data);
+                                band.copy_into(&mut new_builder, BandOverrides::default())?;
                                 new_builder.finish_band()?;
                             }
                             Some(dim_idx) => {
@@ -292,16 +273,7 @@ impl SedonaScalarKernel for RsBandToDim {
 
                     let nodata = ref_nodata.as_deref();
 
-                    let t: [f64; 6] = raster.transform().try_into().map_err(|_| {
-                        sedona_internal_datafusion_err!("raster transform is not 6 elements")
-                    })?;
-                    let spatial_dims = raster.spatial_dims();
-                    new_builder.start_raster_nd(
-                        &t,
-                        &spatial_dims,
-                        raster.spatial_shape(),
-                        raster.crs(),
-                    )?;
+                    new_builder.start_raster_from(raster, RasterOverrides::default())?;
                     new_builder.start_band(StartBandArgs {
                         nodata,
                         ..StartBandArgs::new(&new_dim_names, &new_shape, ref_data_type)
@@ -379,6 +351,43 @@ mod tests {
         assert_eq!(raster.band_name(0), Some("temp_time_0"));
         assert_eq!(raster.band_name(1), Some("temp_time_1"));
         assert_eq!(raster.band_name(2), Some("temp_time_2"));
+    }
+
+    #[test]
+    fn dimtoband_passes_through_bands_without_dim_preserving_names() {
+        // Heterogeneous raster: the band carrying `time` expands into one band
+        // per index, while the band without it is passed through untouched.
+        // The pass-through derives the output band via `BandRef::copy_into`,
+        // which inherits the name — assert it survives, since a dropped name is
+        // silent otherwise.
+        let udf: ScalarUDF = rs_dimtoband_udf().into();
+        let tester = ScalarUdfTester::new(udf, vec![RASTER, SedonaType::Arrow(DataType::Utf8)]);
+
+        let rasters = RasterSpec::nd(&["time", "y", "x"], &[2, 2, 2])
+            .crs(None)
+            .band_nd(&["y", "x"], &[2, 2], BandDataType::UInt8)
+            .name("elevation")
+            .band(BandDataType::UInt8)
+            .name("temperature")
+            .build();
+
+        let result = tester
+            .invoke_array_scalar(Arc::new(rasters), "time")
+            .unwrap();
+
+        let result_struct = result.as_any().downcast_ref::<StructArray>().unwrap();
+        let raster_array = RasterStructArray::try_new(result_struct).unwrap();
+        let raster = raster_array.get(0).unwrap();
+
+        // Pass-through band keeps its own name; the expanded band contributes
+        // one suffixed band per `time` index.
+        assert_eq!(raster.num_bands(), 3);
+        assert_eq!(raster.band_name(0), Some("elevation"));
+        assert_eq!(raster.band_name(1), Some("temperature_time_0"));
+        assert_eq!(raster.band_name(2), Some("temperature_time_1"));
+        // The pass-through band is emitted unchanged, not expanded.
+        assert_eq!(raster.band(0).unwrap().dim_names(), vec!["y", "x"]);
+        assert_eq!(raster.band(0).unwrap().shape(), &[2, 2]);
     }
 
     #[test]

--- a/rust/sedona-raster-functions/src/rs_ensure_loaded.rs
+++ b/rust/sedona-raster-functions/src/rs_ensure_loaded.rs
@@ -40,7 +40,7 @@ use datafusion_expr::{
 };
 use sedona_common::{sedona_internal_datafusion_err, sedona_internal_err};
 use sedona_raster::array::RasterStructArray;
-use sedona_raster::builder::{RasterBuilder, StartBandArgs};
+use sedona_raster::builder::{RasterBuilder, RasterOverrides, StartBandArgs};
 use sedona_raster::raster_loader::{
     AsyncRasterLoader, RasterLoadRequest, RasterLoaderConfig, RasterLoaderRegistry,
 };
@@ -294,27 +294,11 @@ where
             )
         })?;
 
-        // Owned per-row metadata so the borrows don't span the per-band
-        // `await` points further down.
-        let transform: [f64; 6] = raster.transform().try_into().map_err(|_| {
-            sedona_internal_datafusion_err!(
-                "RS_EnsureLoaded: raster row {raster_idx} transform is not 6 elements"
-            )
-        })?;
-        let spatial_dims_owned: Vec<String> = raster
-            .spatial_dims()
-            .iter()
-            .map(|s| s.to_string())
-            .collect();
-        let spatial_dims: Vec<&str> = spatial_dims_owned.iter().map(String::as_str).collect();
-        let spatial_shape: Vec<i64> = raster.spatial_shape().to_vec();
-        let crs: Option<String> = raster.crs().map(|s| s.to_string());
-
         builder
-            .start_raster_nd(&transform, &spatial_dims, &spatial_shape, crs.as_deref())
+            .start_raster_from(&raster, RasterOverrides::default())
             .map_err(|e| {
                 sedona_internal_datafusion_err!(
-                    "RS_EnsureLoaded: start_raster_nd failed at row {raster_idx}: {e}"
+                    "RS_EnsureLoaded: start_raster_from failed at row {raster_idx}: {e}"
                 )
             })?;
 

--- a/rust/sedona-raster-functions/src/rs_slice.rs
+++ b/rust/sedona-raster-functions/src/rs_slice.rs
@@ -22,10 +22,9 @@ use datafusion_common::cast::{as_int64_array, as_string_array};
 use datafusion_common::error::Result;
 use datafusion_common::{arrow_datafusion_err, exec_err};
 use datafusion_expr::{ColumnarValue, Volatility};
-use sedona_common::sedona_internal_datafusion_err;
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
-use sedona_raster::builder::{RasterBuilder, StartBandArgs};
-use sedona_raster::traits::{BandRef, RasterRef};
+use sedona_raster::builder::{RasterBuilder, RasterOverrides, StartBandArgs};
+use sedona_raster::traits::{BandOverrides, BandRef, RasterRef};
 use sedona_schema::datatypes::SedonaType;
 use sedona_schema::matchers::ArgMatcher;
 
@@ -98,11 +97,7 @@ impl SedonaScalarKernel for RsSlice {
                     }
                     validate_not_spatial(raster, name, "RS_Slice")?;
 
-                    let t: [f64; 6] = raster.transform().try_into().map_err(|_| {
-                        sedona_internal_datafusion_err!("raster transform is not 6 elements")
-                    })?;
-                    let spatial_dims = raster.spatial_dims();
-                    new_builder.start_raster_nd(&t, &spatial_dims, raster.spatial_shape(), raster.crs())?;
+                    new_builder.start_raster_from(raster, RasterOverrides::default())?;
 
                     require_any_band_has_dim(raster, name, "RS_Slice")?;
 
@@ -116,16 +111,7 @@ impl SedonaScalarKernel for RsSlice {
                         // RS_DimToBand, and matches xarray's `isel` — variables
                         // without the indexed dim are left alone.
                         let Some(dim_idx) = band.dim_index(name) else {
-                            let dim_names = band.dim_names();
-                            let band_name = raster.band_name(band_idx);
-                            new_builder.start_band(StartBandArgs {
-                                name: band_name,
-                                nodata: band.nodata(),
-                                ..StartBandArgs::new(&dim_names, band.shape(), band.data_type())
-                            })?;
-                            let ndb = band.nd_buffer()?;
-                            let data = ndb.as_contiguous()?;
-                            new_builder.band_data_writer().append_value(data);
+                            band.copy_into(&mut new_builder, BandOverrides::default())?;
                             new_builder.finish_band()?;
                             continue;
                         };
@@ -259,11 +245,7 @@ impl SedonaScalarKernel for RsSliceRange {
                         );
                     }
 
-                    let t: [f64; 6] = raster.transform().try_into().map_err(|_| {
-                        sedona_internal_datafusion_err!("raster transform is not 6 elements")
-                    })?;
-                    let spatial_dims = raster.spatial_dims();
-                    new_builder.start_raster_nd(&t, &spatial_dims, raster.spatial_shape(), raster.crs())?;
+                    new_builder.start_raster_from(raster, RasterOverrides::default())?;
 
                     require_any_band_has_dim(raster, name, "RS_SliceRange")?;
 
@@ -276,16 +258,7 @@ impl SedonaScalarKernel for RsSliceRange {
                         // dimension are emitted unchanged. Same convention as
                         // RS_Slice and RS_DimToBand.
                         let Some(dim_idx) = band.dim_index(name) else {
-                            let dim_names = band.dim_names();
-                            let band_name = raster.band_name(band_idx);
-                            new_builder.start_band(StartBandArgs {
-                                name: band_name,
-                                nodata: band.nodata(),
-                                ..StartBandArgs::new(&dim_names, band.shape(), band.data_type())
-                            })?;
-                            let ndb = band.nd_buffer()?;
-                            let data = ndb.as_contiguous()?;
-                            new_builder.band_data_writer().append_value(data);
+                            band.copy_into(&mut new_builder, BandOverrides::default())?;
                             new_builder.finish_band()?;
                             continue;
                         };
@@ -424,7 +397,9 @@ mod tests {
         RasterSpec::nd(&["time", "y", "x"], &[3, 2, 3])
             .crs(None)
             .band_nd(&["y", "x"], &[2, 3], BandDataType::UInt8)
+            .name("elevation")
             .band(BandDataType::UInt8)
+            .name("temperature")
             .build()
     }
 
@@ -453,7 +428,9 @@ mod tests {
         let expected = RasterSpec::nd(&["time", "y", "x"], &[3, 2, 3])
             .crs(None)
             .band_values_nd(&["y", "x"], &[2, 3], &(0u8..6).collect::<Vec<u8>>())
-            .band_values_nd(&["y", "x"], &[2, 3], &(6u8..12).collect::<Vec<u8>>());
+            .name("elevation")
+            .band_values_nd(&["y", "x"], &[2, 3], &(6u8..12).collect::<Vec<u8>>())
+            .name("temperature");
         assert_rasters_equal(&result, &[Some(expected)]);
     }
 
@@ -485,11 +462,13 @@ mod tests {
         let expected = RasterSpec::nd(&["time", "y", "x"], &[3, 2, 3])
             .crs(None)
             .band_values_nd(&["y", "x"], &[2, 3], &(0u8..6).collect::<Vec<u8>>())
+            .name("elevation")
             .band_values_nd(
                 &["time", "y", "x"],
                 &[2, 2, 3],
                 &(6u8..18).collect::<Vec<u8>>(),
-            );
+            )
+            .name("temperature");
         assert_rasters_equal(&result, &[Some(expected)]);
     }
 


### PR DESCRIPTION
Closes DB-410.

## Header rebuild → `start_raster_from`

Five call sites each hand-rolled the same thing:

```rust
let t: [f64; 6] = raster.transform().try_into().map_err(|_| { ... })?;
let spatial_dims = raster.spatial_dims();
new_builder.start_raster_nd(&t, &spatial_dims, raster.spatial_shape(), raster.crs())?;
```

`RasterBuilder::start_raster_from` already does exactly this, so all five now call it: `RS_Slice`, `RS_SliceRange`, `RS_DimToBand`, `RS_BandToDim`, `RS_EnsureLoaded`.

In `RS_EnsureLoaded` this also retires a block of owned-metadata locals (`transform` / `spatial_dims_owned` / `spatial_shape` / `crs`) that existed only to keep borrows from spanning the per-band `await` points. The header is built synchronously before the band loop, so none of them are needed — verified nothing downstream reads them.

## Pass-through bands → `copy_into`

The pass-through paths in `RS_Slice`, `RS_SliceRange` and `RS_DimToBand` — bands that don't carry the named dimension and are emitted unchanged — did:

```rust
start_band(StartBandArgs { name, nodata, ..StartBandArgs::new(&dim_names, band.shape(), band.data_type()) })?;
let data = band.nd_buffer()?.as_contiguous()?;
band_data_writer().append_value(data);
```

That materialises a fresh identity band and re-copies the bytes. `copy_into` shares the source buffer zero-copy and carries `view()` forward instead of dropping it.

Two gates, both now open:
- **View persistence** — non-identity views weren't representable, so a view-preserving pass-through had nothing to land on. #1113 merged 2026-08-12.
- **Band-name inheritance** — `BandRef` had no name accessor, so `copy_into` couldn't inherit it. #1192 added `BandRef::name()` and has now merged, so these sites need only `BandOverrides::default()` rather than threading the name through by index.

## Test gap this exposed

The pass-through name preservation was **not covered anywhere**:

- `RS_Slice` / `RS_SliceRange` had mixed-dim pass-through tests, but with **unnamed** bands — so a dropped name was invisible.
- `RS_DimToBand` had **no pass-through test at all**; that branch was uncovered.

Named the existing `build_mixed_dim_raster` fixture and its expectations, and added `dimtoband_passes_through_bands_without_dim_preserving_names`, which also asserts the pass-through band stays 2-D rather than being expanded.

Reverting #1192's `or_else(|| self.name())` inheritance fails all three.

## Deliberately out of scope

`RS_EnsureLoaded`'s **band loop** is untouched. It's async with owned-data scoping around the `await`s, its InDb pass-through is already zero-copy via `append_band_data_from`, and it carries an explicit internal-error guard for non-identity views. Converting it is a restructure that also has to keep the OutDb loader path emitting identity bands — worth its own change, not a rider on a DRY pass. The ticket only calls for "revisit," so it stays a follow-up.

## Verification

```
sedona-raster            178 passed; 0 failed
sedona-raster-functions  256 passed; 0 failed
sedona-raster-zarr        66 passed; 0 failed
```

fmt and clippy clean.