### PR TITLE
feat(python/sedonadb-geopandas): add column assignment

### DIFF
--- a/python/sedonadb-geopandas/README.md
+++ b/python/sedonadb-geopandas/README.md
@@ -47,8 +47,11 @@ deliberately *not* identical to GeoPandas:
 - **No row index / alignment**: there is no pandas `Index`; joins and filters
   are positional/relational, not index-aligned.
 - **Immutable under the hood**: "in-place" style operations return a new frame.
-  Assigning a column with `gdf["x"] = ...` rebinds the frame, so a `Series` read
-  before the assignment is stale and cannot be combined with later reads.
+  A `Series` read from a frame stays usable across assignments that only *add*
+  columns (so `g = gdf.geometry` can supply `g.area`, `g.length`, ... in turn),
+  but replacing a column or filtering rebinds the frame, and a `Series` read
+  before that is stale and raises rather than silently resolving to different
+  values.
 - **Columns cannot be mixed across frames**: without row alignment, combining
   columns from two different frames raises rather than guessing. Join first.
 - **Plotting and arbitrary `apply`**: use the `to_geopandas()` escape hatch and
@@ -58,9 +61,6 @@ deliberately *not* identical to GeoPandas:
   against the destination and silently write the wrong values. Assign a `Series`
   read from the same frame, or a scalar (a geometry included). For anything the
   wrapper does not cover, drop to the SedonaDB `DataFrame` API directly.
-  NumPy and pandas temporal scalars (`datetime64`, `timedelta64`, `Timestamp`,
-  `Timedelta`, `NaT`) are temporarily rejected: representing them faithfully
-  needs dedicated unit and timezone handling, which arrives in a follow-up.
 
 See the SedonaDB "Migrating from GeoPandas" guide for the relational model that
 underlies each method.

--- a/python/sedonadb-geopandas/README.md
+++ b/python/sedonadb-geopandas/README.md
@@ -58,6 +58,9 @@ deliberately *not* identical to GeoPandas:
   against the destination and silently write the wrong values. Assign a `Series`
   read from the same frame, or a scalar (a geometry included). For anything the
   wrapper does not cover, drop to the SedonaDB `DataFrame` API directly.
+  NumPy and pandas temporal scalars (`datetime64`, `timedelta64`, `Timestamp`,
+  `Timedelta`, `NaT`) are temporarily rejected: representing them faithfully
+  needs dedicated unit and timezone handling, which arrives in a follow-up.
 
 See the SedonaDB "Migrating from GeoPandas" guide for the relational model that
 underlies each method.

--- a/python/sedonadb-geopandas/README.md
+++ b/python/sedonadb-geopandas/README.md
@@ -31,7 +31,8 @@ import sedonadb_geopandas as sgpd
 
 gdf = sgpd.from_geopandas(geopandas.read_file("cities.geojson"))
 big = gdf[gdf["pop"] > 1_000_000]          # boolean-mask filter
-buffered = gdf.geometry.buffer(0.5)        # element-wise .geo operation
+gdf["surveyed"] = True                     # broadcast a scalar column
+gdf["centers"] = gdf.geometry.centroid     # assign a computed column
 web = gdf.to_crs("EPSG:3857")              # reproject (CRS tracked through)
 result = web.to_geopandas()                # back to a real GeoDataFrame
 ```
@@ -46,8 +47,17 @@ deliberately *not* identical to GeoPandas:
 - **No row index / alignment**: there is no pandas `Index`; joins and filters
   are positional/relational, not index-aligned.
 - **Immutable under the hood**: "in-place" style operations return a new frame.
+  Assigning a column with `gdf["x"] = ...` rebinds the frame, so a `Series` read
+  before the assignment is stale and cannot be combined with later reads.
+- **Columns cannot be mixed across frames**: without row alignment, combining
+  columns from two different frames raises rather than guessing. Join first.
 - **Plotting and arbitrary `apply`**: use the `to_geopandas()` escape hatch and
   operate on the materialized result.
+- **Assignment takes a column or a scalar, not a bare expression**: a SedonaDB
+  expression records no origin, so one built from another frame would resolve
+  against the destination and silently write the wrong values. Assign a `Series`
+  read from the same frame, or a scalar (a geometry included). For anything the
+  wrapper does not cover, drop to the SedonaDB `DataFrame` API directly.
 
 See the SedonaDB "Migrating from GeoPandas" guide for the relational model that
 underlies each method.

--- a/python/sedonadb-geopandas/pyproject.toml
+++ b/python/sedonadb-geopandas/pyproject.toml
@@ -26,12 +26,12 @@ readme = "README.md"
 requires-python = ">=3.9"
 dynamic = ["version"]
 dependencies = [
-    # The `.geo` accessor and `DataFrame.unnest` this package builds on landed in
-    # 0.4.0. Keep this floor at a *released* version rather than raising it to
-    # the current development version: nightlies are versioned `X.Y.ZaN`, which
-    # PEP 440 orders *below* `X.Y.Z`, so a floor equal to the version being
-    # developed would reject the matching nightly wheels.
-    "sedonadb>=0.4.0",
+    # `DataFrame.mutate`, which `to_crs()` and column assignment are built on,
+    # first shipped in the released 0.4.1 (it is absent from 0.4.0). Nightlies
+    # version as `0.5.0aN`, which PEP 440 orders above `0.4.1`, so they satisfy
+    # this floor naturally. The APIs this wrapper needs from sedonadb-expr (the
+    # generated .geo accessor methods it calls) are all available in 0.4.0.
+    "sedonadb>=0.4.1",
     "sedonadb-expr>=0.4.0",
     "pyarrow",
 ]

--- a/python/sedonadb-geopandas/pyproject.toml
+++ b/python/sedonadb-geopandas/pyproject.toml
@@ -34,6 +34,10 @@ dependencies = [
     "sedonadb>=0.4.1",
     "sedonadb-expr>=0.4.0",
     "pyarrow",
+    # Geometry scalars (assignment, comparison operands) are Shapely objects;
+    # Shapely 2 dropped the sequence protocol on multipart geometries, which
+    # is what lets a geometry be told apart from an array-like generically.
+    "shapely>=2",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
@@ -347,7 +347,18 @@ class GeoDataFrame:
             )
             scalar_crs = getattr(raw.type, "crs", None)
             if str(raw.type.extension_name) == "geoarrow.wkb":
-                expr = ctx.lit(pa.array([raw.as_py()], type=raw.type))
+                arr_type = raw.type
+                if pa.types.is_large_binary(arr_type.storage_type):
+                    # SedonaDB's WKB importer requires Binary storage; the
+                    # type is rebuilt on Binary with the same CRS and edge
+                    # metadata rather than passed through and rejected.
+                    import geoarrow.pyarrow as ga
+
+                    rebuilt = ga.wkb().with_edge_type(arr_type.edge_type)
+                    if arr_type.crs is not None:
+                        rebuilt = rebuilt.with_crs(arr_type.crs)
+                    arr_type = rebuilt
+                expr = ctx.lit(pa.array([raw.as_py()], type=arr_type))
             elif missing:
                 # Non-WKB storage cannot become a literal; a null of it is
                 # rebuilt from its own metadata. Kind and CRS survive; the

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
@@ -16,7 +16,7 @@
 # under the License.
 """GeoPandas-style GeoDataFrame backed by a lazy SedonaDB frame."""
 
-from sedonadb_geopandas._series import GeoSeries, Series
+from sedonadb_geopandas._series import GeoSeries, Series, is_scalar
 
 # Rows to collect for the Jupyter rich-text (`_repr_html_`) preview.
 _REPR_HTML_ROWS = 10
@@ -29,6 +29,31 @@ _DERIVE = object()
 def _geometry_column_names(df):
     names = df.schema.names
     return {names[i] for i in df.schema.geometry_column_indices}
+
+
+def _expr_crs(df, expr):
+    """The CRS carried by `expr`, read from a projected schema (a plan build)."""
+    field = df.select(expr.alias("x")).schema.field("x")
+    return getattr(field.type, "crs", None)
+
+
+def _is_missing(value):
+    """Whether `value` is one of the missing-value sentinels.
+
+    `None`, NaN, and `pandas.NA` all mean "no value" to GeoPandas, and a geometry
+    column assigned any of them keeps its type and CRS rather than becoming an
+    ordinary column of nulls.
+    """
+    if value is None:
+        return True
+    try:
+        import pandas as pd
+
+        # Safe for scalars; geometries and numbers simply return False.
+        return bool(pd.isna(value))
+    except Exception:
+        # Without pandas, catch NaN via its self-inequality.
+        return isinstance(value, float) and value != value
 
 
 class GeoDataFrame:
@@ -77,6 +102,18 @@ class GeoDataFrame:
     def __getitem__(self, key):
         # Boolean mask -> row filter (gdf[gdf["pop"] > 1000]).
         if isinstance(key, Series):
+            if key._df is not self._df:
+                # Same check assignment makes. Without it a mask captured before an
+                # assignment is silently reused against the rebound frame: it
+                # happens to resolve while the referenced column still exists, and
+                # fails obscurely at collection when it does not.
+                raise ValueError(
+                    "Cannot filter with a mask built from a different DataFrame: "
+                    "there is no row alignment, so the result would be silently "
+                    "wrong. Note that assigning a column rebinds this frame, so a "
+                    "mask taken beforehand is stale; re-read it as gdf[...] > ... "
+                    "and try again."
+                )
             return GeoDataFrame(self._df.filter(key._expr), self._geometry_name)
 
         # Column subset -> GeoDataFrame. Matching GeoPandas, the active geometry
@@ -114,6 +151,132 @@ class GeoDataFrame:
             f"GeoDataFrame indices must be a column name, list of names, or "
             f"boolean mask, not {type(key).__name__}"
         )
+
+    def __setitem__(self, key, value):
+        """Add or replace a column, as in `gdf["buffered"] = gdf.geometry.buffer(1)`.
+
+        The underlying frame is immutable, so this rebinds this object to a new
+        frame rather than mutating data in place. A consequence worth knowing:
+        `Series` objects taken from this frame *before* the assignment still
+        refer to the previous frame, so combining one with a column read
+        afterwards raises rather than silently mixing two frames.
+
+        Args:
+            key: Column name to add or replace.
+            value: A `Series`/`GeoSeries` from this same frame, or a scalar (which
+                may be a geometry) to broadcast to every row.
+
+        A bare SedonaDB expression is deliberately not accepted. An expression
+        carries no record of the frame it was built from, so a column reference
+        taken from another frame would resolve against this one and silently
+        produce this frame's values instead of the intended ones.
+        """
+        if not isinstance(key, str):
+            raise TypeError(f"Column name must be a string, not {type(key).__name__}")
+
+        from sedonadb.expr import Expr, Literal
+
+        if isinstance(value, Series):
+            if value._df is not self._df:
+                raise ValueError(
+                    "Cannot assign a Series that comes from a different "
+                    "DataFrame: there is no row alignment, so the result would "
+                    "be silently wrong. Note that assigning to this frame "
+                    "rebinds it, so a Series read before an earlier assignment "
+                    "is already stale; re-read it as gdf[...] and try again."
+                )
+            expr = value._expr
+        elif isinstance(value, Literal):
+            # A literal holds a value rather than a column reference, so there is
+            # no frame for it to be misattributed to. It still goes through the
+            # scalar path so that a literal geometry gets the same CRS treatment as
+            # a plain one.
+            expr = self._scalar_expr(key, value)
+        elif isinstance(value, Expr):
+            raise TypeError(
+                "Assigning a bare expression isn't supported: an expression does "
+                "not record which frame its columns came from, so one built "
+                "against another frame would silently resolve against this one. "
+                "Assign a Series read from this frame, or a literal."
+            )
+        elif not is_scalar(value):
+            raise TypeError(
+                f"Assigning a {type(value).__name__} isn't supported (there is no "
+                f"row alignment, so the values could not be matched to rows). "
+                f"Build the column from this frame's own columns, or load the "
+                f"data as a frame and join it."
+            )
+        else:
+            expr = self._scalar_expr(key, value)
+
+        geometry_before = _geometry_column_names(self._df)
+        self._df = self._df.mutate(**{key: expr})
+
+        # Assignment can change whether the active geometry column is still a
+        # geometry: replacing it with a number leaves nothing to be active, and
+        # *creating* a geometry column on a frame without one activates it. The
+        # created-not-preexisting distinction matters: a frame whose geometry was
+        # explicitly deactivated (geometry=None) must not be reactivated by a
+        # no-op reassignment of a column that was already geometry.
+        geometry_after = _geometry_column_names(self._df)
+        if key == self._geometry_name and key not in geometry_after:
+            self._geometry_name = None
+        elif (
+            self._geometry_name is None
+            and key in geometry_after
+            and key not in geometry_before
+        ):
+            self._geometry_name = key
+
+    def _scalar_expr(self, key, value):
+        """Build the expression for broadcasting `value` into column `key`.
+
+        Replacing an existing geometry column keeps that column's type and CRS, as
+        GeoPandas does. A bare Shapely geometry carries no CRS of its own, and any
+        missing-value sentinel (`None`, NaN, `pandas.NA`) means "no geometry" rather
+        than "no longer a geometry column", so neither should silently reset what
+        the frame already knew.
+
+        A `Literal` is unwrapped and rebuilt on this frame's context: a literal
+        constructed by the bare `lit()` has no context, so functions cannot be
+        applied to it, and passing it straight through would skip the CRS handling.
+        """
+        from sedonadb.expr import Literal, lit
+
+        from sedonadb_geopandas._series import normalize_scalar
+
+        raw = value._value if isinstance(value, Literal) else value
+        raw = normalize_scalar(raw)
+
+        # Only geometry values inherit the column's type and CRS. Assigning a number
+        # over a geometry column is a legitimate way to turn it into an ordinary
+        # column, and must not be dressed up as geometry. Geometry-ness is decided
+        # from the resolved literal's schema rather than by duck-typing the Python
+        # value: a GeoArrow scalar carries no __geo_interface__ yet is geometry.
+        missing = _is_missing(raw)
+        replacing_geometry = key in _geometry_column_names(self._df)
+        if not replacing_geometry:
+            return lit(raw)
+        if not missing:
+            candidate = lit(raw)
+            projected = self._df.select(candidate.alias("x")).schema
+            if not projected.geometry_column_indices:
+                return candidate
+
+        crs = self._df.schema.field(key).type.crs
+        # A context-bound literal is needed to call functions on it.
+        ctx = self._df._ctx
+        if missing:
+            expr = ctx.lit(None).funcs.st_geomfromwkt()
+        else:
+            expr = ctx.lit(raw)
+        # The destination CRS is inherited only by genuinely CRS-less geometry.
+        # A value that carries its own CRS (a GeoSeries literal, say) keeps it:
+        # stamping the destination CRS over it would relabel the coordinates
+        # without transforming them, which is silently wrong data.
+        if crs is not None and _expr_crs(self._df, expr) is None:
+            expr = expr.funcs.st_setcrs(ctx.lit(crs.to_json()))
+        return expr
 
     def head(self, n=5):
         """Return a `GeoDataFrame` of at most `n` rows.

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
@@ -302,14 +302,12 @@ class GeoDataFrame:
         # value: a GeoArrow scalar carries no __geo_interface__ yet is geometry.
         missing = _is_missing(raw)
         replacing_geometry = key in _geometry_column_names(self._df)
-        if not replacing_geometry:
-            return lit(raw)
 
         # A GeoArrow-typed scalar — valid or null — is recognized from its
         # extension name, not by resolving it: the scalar resolver drops the
         # planar/spherical edge type and rejects non-WKB storage outright.
-        # Its one-element-array spelling resolves with the complete extension
-        # metadata, so that is the form it takes.
+        # It needs the handling below even for a brand-new or non-geometry
+        # column, so this must come before that early return.
         geoarrow_typed = False
         try:
             import pyarrow as pa
@@ -320,15 +318,24 @@ class GeoDataFrame:
         except ImportError:
             pass
 
+        if not replacing_geometry and not geoarrow_typed:
+            return lit(raw)
+
         if not missing and not geoarrow_typed:
             candidate = lit(raw)
             projected = self._df.select(candidate.alias("x")).schema
             if not projected.geometry_column_indices:
                 return candidate
 
-        dtype = self._df.schema.field(key).type
-        crs = dtype.crs
-        spherical = "SPHERICAL" in str(getattr(dtype, "edge_type", "")).upper()
+        if replacing_geometry:
+            dtype = self._df.schema.field(key).type
+            crs = dtype.crs
+            spherical = "SPHERICAL" in str(getattr(dtype, "edge_type", "")).upper()
+        else:
+            # A new or non-geometry destination has no type or CRS to
+            # inherit; the value's own metadata is all there is.
+            crs = None
+            spherical = False
         # A context-bound literal is needed to call functions on it.
         ctx = self._df._ctx
         inherits_crs = False
@@ -350,7 +357,15 @@ class GeoDataFrame:
                 else:
                     expr = ctx.lit(None).funcs.st_geomfromwkt()
                 if scalar_crs:
-                    expr = expr.funcs.st_setcrs(ctx.lit(str(scalar_crs)))
+                    # GeoArrow CRS wrappers stringify as StringCrs(...);
+                    # to_json() is the canonical PROJJSON form ST_SetCRS
+                    # accepts.
+                    crs_text = (
+                        scalar_crs.to_json()
+                        if hasattr(scalar_crs, "to_json")
+                        else str(scalar_crs)
+                    )
+                    expr = expr.funcs.st_setcrs(ctx.lit(crs_text))
                 else:
                     # A CRS-less carrier inherits the destination CRS like
                     # any other, shedding any constructor-synthesized one.

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
@@ -47,6 +47,22 @@ def _is_missing(value):
     if value is None:
         return True
     try:
+        import pyarrow as pa
+
+        # An Arrow-wrapped value means whatever its payload means: a typed
+        # null is missing like bare None, and a wrapped NaN is missing like
+        # bare NaN. The original scalar is kept by the caller for
+        # type-preserving literal construction; this only classifies.
+        if isinstance(value, pa.Scalar):
+            if not value.is_valid:
+                return True
+            if pa.types.is_floating(value.type):
+                payload = value.as_py()
+                return payload != payload
+            return False
+    except ImportError:
+        pass
+    try:
         import pandas as pd
 
         # Safe for scalars; geometries and numbers simply return False.
@@ -129,7 +145,10 @@ class GeoDataFrame:
         # Single column -> (Geo)Series.
         if isinstance(key, str):
             expr = self._df[key]
-            if key == self._geometry_name:
+            # Any geometry-typed column reads back as a GeoSeries — not just
+            # the active one — so a freshly assigned geometry column supports
+            # .area and .buffer() immediately, as it does in GeoPandas.
+            if key == self._geometry_name or key in _geometry_column_names(self._df):
                 return GeoSeries(self._df, expr, key)
             return Series(self._df, expr, key)
 
@@ -185,7 +204,7 @@ class GeoDataFrame:
                     "rebinds it, so a Series read before an earlier assignment "
                     "is already stale; re-read it as gdf[...] and try again."
                 )
-            expr = value._expr
+            expr = self._series_expr(key, value)
         elif isinstance(value, Literal):
             # A literal holds a value rather than a column reference, so there is
             # no frame for it to be misattributed to. It still goes through the
@@ -228,6 +247,28 @@ class GeoDataFrame:
         ):
             self._geometry_name = key
 
+    def _series_expr(self, key, value):
+        """Adjust a same-frame `Series` expression for assignment to `key`.
+
+        Mirrors the scalar path's CRS rule: a geometry column that carries no
+        CRS of its own inherits the destination column's CRS when it replaces
+        one that has it — GeoPandas keeps the frame CRS in this situation —
+        while a column that carries its own CRS keeps it, since restamping
+        would relabel coordinates without transforming them.
+        """
+        expr = value._expr
+        if key not in _geometry_column_names(self._df):
+            return expr
+        crs = self._df.schema.field(key).type.crs
+        if crs is None or _expr_crs(self._df, expr) is not None:
+            return expr
+        projected = self._df.select(expr.alias("x")).schema
+        if not projected.geometry_column_indices:
+            # A non-geometry value legitimately converts the column.
+            return expr
+        ctx = self._df._ctx
+        return expr.funcs.st_setcrs(ctx.lit(crs.to_json()))
+
     def _scalar_expr(self, key, value):
         """Build the expression for broadcasting `value` into column `key`.
 
@@ -263,11 +304,33 @@ class GeoDataFrame:
             if not projected.geometry_column_indices:
                 return candidate
 
-        crs = self._df.schema.field(key).type.crs
+        dtype = self._df.schema.field(key).type
+        crs = dtype.crs
+        spherical = "SPHERICAL" in str(getattr(dtype, "edge_type", "")).upper()
         # A context-bound literal is needed to call functions on it.
         ctx = self._df._ctx
         if missing:
-            expr = ctx.lit(None).funcs.st_geomfromwkt()
+            # The typed null is built with the destination's own spatial kind:
+            # a geography column stays geography rather than degrading to
+            # planar geometry.
+            if spherical:
+                expr = ctx.lit(None).funcs.st_geogfromwkt()
+            else:
+                expr = ctx.lit(None).funcs.st_geomfromwkt()
+        elif spherical:
+            try:
+                from shapely.geometry.base import BaseGeometry
+            except ImportError:
+                BaseGeometry = ()
+            if isinstance(raw, BaseGeometry):
+                # A bare Shapely value re-enters through WKB as geography.
+                # (A value that already carries a spatial type — a GeoArrow
+                # scalar, say — keeps it; converting between planar and
+                # spherical semantics is not something an assignment should
+                # do silently.)
+                expr = ctx.lit(raw.wkb).funcs.st_geogfromwkb()
+            else:
+                expr = ctx.lit(raw)
         else:
             expr = ctx.lit(raw)
         # The destination CRS is inherited only by genuinely CRS-less geometry.
@@ -305,13 +368,26 @@ class GeoDataFrame:
         the expected column active.
         """
         result = self._df.to_pandas()
-        if self._geometry_name is not None and hasattr(result, "set_geometry"):
-            try:
-                active = result.geometry.name
-            except Exception:
-                active = None
-            if active != self._geometry_name:
-                result = result.set_geometry(self._geometry_name)
+        if not hasattr(result, "set_geometry"):
+            return result
+        if self._geometry_name is None:
+            # The frame has no active geometry (possibly explicitly cleared),
+            # but the materializer heuristically activates one whenever a
+            # geometry column exists — and a later to_crs() on the result
+            # would silently target a column this frame never had active.
+            # Rebuilding through the GeoDataFrame constructor applies
+            # GeoPandas' own rule instead: only a geometry column literally
+            # named "geometry" comes back active.
+            import geopandas as gpd
+            import pandas as pd
+
+            return gpd.GeoDataFrame(pd.DataFrame(result))
+        try:
+            active = result.geometry.name
+        except Exception:
+            active = None
+        if active != self._geometry_name:
+            result = result.set_geometry(self._geometry_name)
         return result
 
     # Alias: results carry geometry, so this returns a GeoDataFrame too.

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
@@ -60,6 +60,12 @@ def _is_missing(value):
                 payload = value.as_py()
                 return payload != payload
             return False
+        if isinstance(value, pa.Array):
+            # A typed-null nested scalar is normalized into its one-element
+            # array spelling before missingness is judged; one null element
+            # is still one missing value. Classified here explicitly so the
+            # answer does not depend on optional pandas being installed.
+            return len(value) == 1 and value.null_count == 1
     except ImportError:
         pass
     try:
@@ -309,10 +315,13 @@ class GeoDataFrame:
         spherical = "SPHERICAL" in str(getattr(dtype, "edge_type", "")).upper()
         # A context-bound literal is needed to call functions on it.
         ctx = self._df._ctx
+        inherits_crs = False
         if missing:
             # The typed null is built with the destination's own spatial kind:
             # a geography column stays geography rather than degrading to
-            # planar geometry.
+            # planar geometry. A missing value has no CRS of its own, whatever
+            # CRS the constructor synthesizes.
+            inherits_crs = True
             if spherical:
                 expr = ctx.lit(None).funcs.st_geogfromwkt()
             else:
@@ -324,20 +333,24 @@ class GeoDataFrame:
                 BaseGeometry = ()
             if isinstance(raw, BaseGeometry):
                 # A bare Shapely value re-enters through WKB as geography.
-                # (A value that already carries a spatial type — a GeoArrow
-                # scalar, say — keeps it; converting between planar and
-                # spherical semantics is not something an assignment should
-                # do silently.)
+                # It carries no CRS of its own — the constructor synthesizes
+                # CRS84 — so the destination CRS applies. (A value that
+                # already carries a spatial type — a GeoArrow scalar, say —
+                # keeps it; converting between planar and spherical semantics
+                # is not something an assignment should do silently.)
+                inherits_crs = True
                 expr = ctx.lit(raw.wkb).funcs.st_geogfromwkb()
             else:
                 expr = ctx.lit(raw)
         else:
             expr = ctx.lit(raw)
-        # The destination CRS is inherited only by genuinely CRS-less geometry.
-        # A value that carries its own CRS (a GeoSeries literal, say) keeps it:
-        # stamping the destination CRS over it would relabel the coordinates
-        # without transforming them, which is silently wrong data.
-        if crs is not None and _expr_crs(self._df, expr) is None:
+        # The destination CRS is inherited by values that have none of their
+        # own: missing values, bare Shapely geometry, and anything whose
+        # projection shows no CRS. A value that carries its own CRS (a
+        # GeoSeries literal, say) keeps it: stamping the destination CRS over
+        # it would relabel the coordinates without transforming them, which
+        # is silently wrong data.
+        if crs is not None and (inherits_crs or _expr_crs(self._df, expr) is None):
             expr = expr.funcs.st_setcrs(ctx.lit(crs.to_json()))
         return expr
 
@@ -375,13 +388,16 @@ class GeoDataFrame:
             # but the materializer heuristically activates one whenever a
             # geometry column exists — and a later to_crs() on the result
             # would silently target a column this frame never had active.
-            # Rebuilding through the GeoDataFrame constructor applies
-            # GeoPandas' own rule instead: only a geometry column literally
-            # named "geometry" comes back active.
+            # There is no public constructor spelling for "GeoDataFrame
+            # with geometry columns but no active one" — the constructor
+            # auto-activates a geometry column literally named "geometry" —
+            # so the marker is cleared directly after rebuilding.
             import geopandas as gpd
             import pandas as pd
 
-            return gpd.GeoDataFrame(pd.DataFrame(result))
+            result = gpd.GeoDataFrame(pd.DataFrame(result))
+            result._geometry_column_name = None
+            return result
         try:
             active = result.geometry.name
         except Exception:

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
@@ -16,7 +16,11 @@
 # under the License.
 """GeoPandas-style GeoDataFrame backed by a lazy SedonaDB frame."""
 
-from sedonadb_geopandas._series import GeoSeries, Series, is_scalar
+import pyarrow as pa
+from sedonadb.expr import Expr, Literal, lit
+from shapely.geometry.base import BaseGeometry
+
+from sedonadb_geopandas._series import GeoSeries, Series, is_scalar, normalize_scalar
 
 # Rows to collect for the Jupyter rich-text (`_repr_html_`) preview.
 _REPR_HTML_ROWS = 10
@@ -46,28 +50,23 @@ def _is_missing(value):
     """
     if value is None:
         return True
-    try:
-        import pyarrow as pa
-
-        # An Arrow-wrapped value means whatever its payload means: a typed
-        # null is missing like bare None, and a wrapped NaN is missing like
-        # bare NaN. The original scalar is kept by the caller for
-        # type-preserving literal construction; this only classifies.
-        if isinstance(value, pa.Scalar):
-            if not value.is_valid:
-                return True
-            if pa.types.is_floating(value.type):
-                payload = value.as_py()
-                return payload != payload
-            return False
-        if isinstance(value, pa.Array):
-            # A typed-null nested scalar is normalized into its one-element
-            # array spelling before missingness is judged; one null element
-            # is still one missing value. Classified here explicitly so the
-            # answer does not depend on optional pandas being installed.
-            return len(value) == 1 and value.null_count == 1
-    except ImportError:
-        pass
+    # An Arrow-wrapped value means whatever its payload means: a typed null
+    # is missing like bare None, and a wrapped NaN is missing like bare NaN.
+    # The original scalar is kept by the caller for type-preserving literal
+    # construction; this only classifies.
+    if isinstance(value, pa.Scalar):
+        if not value.is_valid:
+            return True
+        if pa.types.is_floating(value.type):
+            payload = value.as_py()
+            return payload != payload
+        return False
+    if isinstance(value, pa.Array):
+        # A typed-null nested scalar is normalized into its one-element array
+        # spelling before missingness is judged; one null element is still
+        # one missing value. Classified here explicitly so the answer does
+        # not depend on optional pandas being installed.
+        return len(value) == 1 and value.null_count == 1
     try:
         import pandas as pd
 
@@ -89,6 +88,12 @@ class GeoDataFrame:
 
     def __init__(self, df, geometry=_DERIVE):
         self._df = df
+        # Earlier frames whose columns this one still contains unchanged, in
+        # the same rows: a Series read from any of them resolves correctly
+        # against this frame. Column-adding assignment extends the list;
+        # replacing a column resets it, and every other operation starts a
+        # new frame with an empty one.
+        self._ancestors = []
         if geometry is _DERIVE:
             # Fall back to SedonaDB's primary-geometry heuristic (same one
             # `to_geopandas` uses); `None` when the frame has no geometry.
@@ -101,6 +106,21 @@ class GeoDataFrame:
                 )
             raise ValueError(f"Column {geometry!r} is not a geometry column")
         self._geometry_name = geometry
+
+    def _accepts(self, series):
+        """Whether `series` can be resolved against this frame.
+
+        A Series records the frame it was read from. It stays valid across
+        assignments that only *add* columns — the rows and every column it
+        could reference are unchanged, so its expression resolves by name
+        to the same values — which is what lets a captured `g = gdf.geometry`
+        supply several derived columns in a row. Replacing a column, or any
+        row-changing operation (filter, reprojection, ...), invalidates
+        earlier reads, since the same expression would then resolve to
+        different values than the Series showed.
+        """
+        df = series._df
+        return df is self._df or any(df is ancestor for ancestor in self._ancestors)
 
     @property
     def geometry(self):
@@ -124,17 +144,18 @@ class GeoDataFrame:
     def __getitem__(self, key):
         # Boolean mask -> row filter (gdf[gdf["pop"] > 1000]).
         if isinstance(key, Series):
-            if key._df is not self._df:
-                # Same check assignment makes. Without it a mask captured before an
-                # assignment is silently reused against the rebound frame: it
-                # happens to resolve while the referenced column still exists, and
-                # fails obscurely at collection when it does not.
+            if not self._accepts(key):
+                # Same check assignment makes. Without it a mask captured
+                # before a column replacement or a filter is silently reused
+                # against the rebound frame: it happens to resolve while the
+                # referenced column still exists, and fails obscurely at
+                # collection when it does not.
                 raise ValueError(
                     "Cannot filter with a mask built from a different DataFrame: "
                     "there is no row alignment, so the result would be silently "
-                    "wrong. Note that assigning a column rebinds this frame, so a "
-                    "mask taken beforehand is stale; re-read it as gdf[...] > ... "
-                    "and try again."
+                    "wrong. Note that replacing a column or filtering rebinds "
+                    "this frame, so a mask taken beforehand is stale; re-read it "
+                    "as gdf[...] > ... and try again."
                 )
             return GeoDataFrame(self._df.filter(key._expr), self._geometry_name)
 
@@ -154,7 +175,7 @@ class GeoDataFrame:
             # Any geometry-typed column reads back as a GeoSeries — not just
             # the active one — so a freshly assigned geometry column supports
             # .area and .buffer() immediately, as it does in GeoPandas.
-            if key == self._geometry_name or key in _geometry_column_names(self._df):
+            if key in _geometry_column_names(self._df):
                 return GeoSeries(self._df, expr, key)
             return Series(self._df, expr, key)
 
@@ -181,10 +202,11 @@ class GeoDataFrame:
         """Add or replace a column, as in `gdf["buffered"] = gdf.geometry.buffer(1)`.
 
         The underlying frame is immutable, so this rebinds this object to a new
-        frame rather than mutating data in place. A consequence worth knowing:
-        `Series` objects taken from this frame *before* the assignment still
-        refer to the previous frame, so combining one with a column read
-        afterwards raises rather than silently mixing two frames.
+        frame rather than mutating data in place. A `Series` read from this
+        frame stays usable across assignments that only add columns, so one
+        captured geometry can supply several derived columns; replacing a
+        column (or filtering) invalidates earlier reads, which then raise
+        rather than silently resolving to different values.
 
         Args:
             key: Column name to add or replace.
@@ -199,16 +221,14 @@ class GeoDataFrame:
         if not isinstance(key, str):
             raise TypeError(f"Column name must be a string, not {type(key).__name__}")
 
-        from sedonadb.expr import Expr, Literal
-
         if isinstance(value, Series):
-            if value._df is not self._df:
+            if not self._accepts(value):
                 raise ValueError(
                     "Cannot assign a Series that comes from a different "
                     "DataFrame: there is no row alignment, so the result would "
-                    "be silently wrong. Note that assigning to this frame "
-                    "rebinds it, so a Series read before an earlier assignment "
-                    "is already stale; re-read it as gdf[...] and try again."
+                    "be silently wrong. Note that replacing a column or "
+                    "filtering rebinds this frame, so a Series read before "
+                    "that is stale; re-read it as gdf[...] and try again."
                 )
             expr = self._series_expr(key, value)
         elif isinstance(value, Literal):
@@ -235,6 +255,13 @@ class GeoDataFrame:
             expr = self._scalar_expr(key, value)
 
         geometry_before = _geometry_column_names(self._df)
+        if key in self._df.schema.names:
+            # Replacing a column: an earlier Series may reference it and
+            # would now resolve to the new values, so earlier reads are no
+            # longer valid.
+            self._ancestors = []
+        else:
+            self._ancestors.append(self._df)
         self._df = self._df.mutate(**{key: expr})
 
         # Assignment can change whether the active geometry column is still a
@@ -288,10 +315,6 @@ class GeoDataFrame:
         constructed by the bare `lit()` has no context, so functions cannot be
         applied to it, and passing it straight through would skip the CRS handling.
         """
-        from sedonadb.expr import Literal, lit
-
-        from sedonadb_geopandas._series import normalize_scalar
-
         raw = value._value if isinstance(value, Literal) else value
         raw = normalize_scalar(raw)
 
@@ -308,15 +331,9 @@ class GeoDataFrame:
         # planar/spherical edge type and rejects non-WKB storage outright.
         # It needs the handling below even for a brand-new or non-geometry
         # column, so this must come before that early return.
-        geoarrow_typed = False
-        try:
-            import pyarrow as pa
-
-            geoarrow_typed = isinstance(raw, pa.Scalar) and str(
-                getattr(raw.type, "extension_name", "")
-            ).startswith("geoarrow.")
-        except ImportError:
-            pass
+        geoarrow_typed = isinstance(raw, pa.Scalar) and str(
+            getattr(raw.type, "extension_name", "")
+        ).startswith("geoarrow.")
 
         if not replacing_geometry and not geoarrow_typed:
             return lit(raw)
@@ -401,10 +418,6 @@ class GeoDataFrame:
             else:
                 expr = ctx.lit(None).funcs.st_geomfromwkt()
         elif spherical:
-            try:
-                from shapely.geometry.base import BaseGeometry
-            except ImportError:
-                BaseGeometry = ()
             if isinstance(raw, BaseGeometry):
                 # A bare Shapely value re-enters through WKB as geography.
                 # It carries no CRS of its own — the constructor synthesizes
@@ -445,8 +458,6 @@ class GeoDataFrame:
         """Reproject the geometry column to `crs` (`ST_Transform`)."""
         if self._geometry_name is None:
             raise ValueError("to_crs() requires an active geometry column")
-        from sedonadb.expr import lit
-
         transformed = self._df[self._geometry_name].geo.transform(lit(crs))
         new_df = self._df.mutate(**{self._geometry_name: transformed})
         return GeoDataFrame(new_df, self._geometry_name)

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
@@ -304,27 +304,27 @@ class GeoDataFrame:
         replacing_geometry = key in _geometry_column_names(self._df)
         if not replacing_geometry:
             return lit(raw)
-        if not missing:
+
+        # A GeoArrow-typed scalar — valid or null — is recognized from its
+        # extension name, not by resolving it: the scalar resolver drops the
+        # planar/spherical edge type and rejects non-WKB storage outright.
+        # Its one-element-array spelling resolves with the complete extension
+        # metadata, so that is the form it takes.
+        geoarrow_typed = False
+        try:
+            import pyarrow as pa
+
+            geoarrow_typed = isinstance(raw, pa.Scalar) and str(
+                getattr(raw.type, "extension_name", "")
+            ).startswith("geoarrow.")
+        except ImportError:
+            pass
+
+        if not missing and not geoarrow_typed:
             candidate = lit(raw)
             projected = self._df.select(candidate.alias("x")).schema
             if not projected.geometry_column_indices:
                 return candidate
-
-        # A typed spatial null (an invalid GeoArrow scalar, say) is a geometry
-        # value that happens to be null: it carries its own kind and CRS
-        # metadata, which synthesizing a destination-kind null would discard.
-        # It takes the value path below. Typed *non-spatial* nulls stay on the
-        # missing path, like the bare sentinels.
-        spatial_typed_null = False
-        if missing:
-            try:
-                import pyarrow as pa
-
-                if isinstance(raw, pa.Scalar):
-                    projected = self._df.select(lit(raw).alias("x")).schema
-                    spatial_typed_null = bool(projected.geometry_column_indices)
-            except ImportError:
-                pass
 
         dtype = self._df.schema.field(key).type
         crs = dtype.crs
@@ -333,7 +333,36 @@ class GeoDataFrame:
         ctx = self._df._ctx
         inherits_crs = False
         strips_crs = False
-        if missing and not spatial_typed_null:
+        expr = None
+        if geoarrow_typed:
+            scalar_spherical = (
+                "SPHERICAL" in str(getattr(raw.type, "edge_type", "")).upper()
+            )
+            scalar_crs = getattr(raw.type, "crs", None)
+            if str(raw.type.extension_name) == "geoarrow.wkb":
+                expr = ctx.lit(pa.array([raw.as_py()], type=raw.type))
+            elif missing:
+                # Non-WKB storage cannot become a literal; a null of it is
+                # rebuilt from its own metadata. Kind and CRS survive; the
+                # storage kind, which holds nothing for a null, does not.
+                if scalar_spherical:
+                    expr = ctx.lit(None).funcs.st_geogfromwkt()
+                else:
+                    expr = ctx.lit(None).funcs.st_geomfromwkt()
+                if scalar_crs:
+                    expr = expr.funcs.st_setcrs(ctx.lit(str(scalar_crs)))
+                else:
+                    # A CRS-less carrier inherits the destination CRS like
+                    # any other, shedding any constructor-synthesized one.
+                    inherits_crs = True
+                    strips_crs = crs is None
+            else:
+                # A valid non-WKB GeoArrow scalar keeps the literal
+                # resolver's own error, which names the unsupported storage.
+                expr = ctx.lit(raw)
+        if expr is not None:
+            pass
+        elif missing:
             # The typed null is built with the destination's own spatial kind:
             # a geography column stays geography rather than degrading to
             # planar geometry. A missing value has no CRS of its own, whatever
@@ -345,8 +374,6 @@ class GeoDataFrame:
                 strips_crs = crs is None
             else:
                 expr = ctx.lit(None).funcs.st_geomfromwkt()
-        elif missing:
-            expr = ctx.lit(raw)
         elif spherical:
             try:
                 from shapely.geometry.base import BaseGeometry
@@ -375,7 +402,9 @@ class GeoDataFrame:
         if crs is not None and (inherits_crs or _expr_crs(self._df, expr) is None):
             expr = expr.funcs.st_setcrs(ctx.lit(crs.to_json()))
         elif strips_crs and _expr_crs(self._df, expr) is not None:
-            expr = expr.funcs.st_setcrs(ctx.lit(None))
+            # SRID 0 means "no CRS" and keeps the value; st_setcrs(NULL)
+            # would null-propagate and erase every row.
+            expr = expr.funcs.st_setsrid(ctx.lit(0))
         return expr
 
     def head(self, n=5):

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
@@ -310,22 +310,43 @@ class GeoDataFrame:
             if not projected.geometry_column_indices:
                 return candidate
 
+        # A typed spatial null (an invalid GeoArrow scalar, say) is a geometry
+        # value that happens to be null: it carries its own kind and CRS
+        # metadata, which synthesizing a destination-kind null would discard.
+        # It takes the value path below. Typed *non-spatial* nulls stay on the
+        # missing path, like the bare sentinels.
+        spatial_typed_null = False
+        if missing:
+            try:
+                import pyarrow as pa
+
+                if isinstance(raw, pa.Scalar):
+                    projected = self._df.select(lit(raw).alias("x")).schema
+                    spatial_typed_null = bool(projected.geometry_column_indices)
+            except ImportError:
+                pass
+
         dtype = self._df.schema.field(key).type
         crs = dtype.crs
         spherical = "SPHERICAL" in str(getattr(dtype, "edge_type", "")).upper()
         # A context-bound literal is needed to call functions on it.
         ctx = self._df._ctx
         inherits_crs = False
-        if missing:
+        strips_crs = False
+        if missing and not spatial_typed_null:
             # The typed null is built with the destination's own spatial kind:
             # a geography column stays geography rather than degrading to
             # planar geometry. A missing value has no CRS of its own, whatever
-            # CRS the constructor synthesizes.
+            # CRS the constructor synthesizes — so a CRS-less destination
+            # strips the synthesized one back off.
             inherits_crs = True
             if spherical:
                 expr = ctx.lit(None).funcs.st_geogfromwkt()
+                strips_crs = crs is None
             else:
                 expr = ctx.lit(None).funcs.st_geomfromwkt()
+        elif missing:
+            expr = ctx.lit(raw)
         elif spherical:
             try:
                 from shapely.geometry.base import BaseGeometry
@@ -339,6 +360,7 @@ class GeoDataFrame:
                 # keeps it; converting between planar and spherical semantics
                 # is not something an assignment should do silently.)
                 inherits_crs = True
+                strips_crs = crs is None
                 expr = ctx.lit(raw.wkb).funcs.st_geogfromwkb()
             else:
                 expr = ctx.lit(raw)
@@ -352,6 +374,8 @@ class GeoDataFrame:
         # is silently wrong data.
         if crs is not None and (inherits_crs or _expr_crs(self._df, expr) is None):
             expr = expr.funcs.st_setcrs(ctx.lit(crs.to_json()))
+        elif strips_crs and _expr_crs(self._df, expr) is not None:
+            expr = expr.funcs.st_setcrs(ctx.lit(None))
         return expr
 
     def head(self, n=5):
@@ -388,14 +412,11 @@ class GeoDataFrame:
             # but the materializer heuristically activates one whenever a
             # geometry column exists — and a later to_crs() on the result
             # would silently target a column this frame never had active.
-            # There is no public constructor spelling for "GeoDataFrame
-            # with geometry columns but no active one" — the constructor
-            # auto-activates a geometry column literally named "geometry" —
-            # so the marker is cleared directly after rebuilding.
-            import geopandas as gpd
-            import pandas as pd
-
-            result = gpd.GeoDataFrame(pd.DataFrame(result))
+            # There is no public spelling for "GeoDataFrame with geometry
+            # columns but no active one", so the marker is cleared in place.
+            # (Reconstructing the frame instead would let the constructor
+            # coerce an unrelated all-null column named "geometry" to
+            # geometry dtype.)
             result._geometry_column_name = None
             return result
         try:

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
@@ -106,6 +106,29 @@ def normalize_scalar(value):
                 "NumPy temporal scalars are not supported yet; faithful unit "
                 "handling arrives in a follow-up change"
             )
+        if isinstance(value, np.void):
+            import pyarrow as pa
+
+            if value.dtype.fields is None:
+                # A plain void's payload is its bytes.
+                return value.item()
+            # A structured scalar flattened to a tuple loses its field names
+            # and dtypes (int16 became float64 inside a list column); a typed
+            # Arrow struct keeps both. Exotic field dtypes with no Arrow
+            # mapping are rejected rather than stored lossily.
+            try:
+                fields = [
+                    (name, pa.from_numpy_dtype(value.dtype[name]))
+                    for name in value.dtype.names
+                ]
+            except (pa.ArrowNotImplementedError, ValueError) as err:
+                raise TypeError(
+                    f"Cannot represent a structured NumPy scalar of dtype "
+                    f"{value.dtype} faithfully; use a typed Arrow struct "
+                    f"scalar instead"
+                ) from err
+            payload = {name: value[name].item() for name in value.dtype.names}
+            return pa.scalar(payload, type=pa.struct(fields))
         if isinstance(value, np.generic) and not isinstance(
             value, (str, bytes, np.void)
         ):

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
@@ -17,6 +17,91 @@
 """pandas/GeoPandas-style Series backed by a SedonaDB expression."""
 
 
+def is_scalar(value):
+    """Whether `value` is a single value that can be broadcast to every row.
+
+    Checking for `__array__` alone is not enough in either direction: a list or
+    tuple has no `__array__` yet is a sequence, while a NumPy scalar has one and
+    *is* a single value. So sequences are rejected explicitly, and anything
+    array-like is judged by its dimensionality — 0-d is a scalar, anything else
+    holds multiple values and has no defined row alignment here.
+
+    Shared by operators and assignment so the two cannot disagree about what
+    counts as a scalar.
+    """
+    if isinstance(value, (str, bytes, bytearray)):
+        return True
+    try:
+        import pyarrow as pa
+
+        # An Arrow scalar is one value even when it implements __len__ (a
+        # ListScalar's length is its element count, not a row count).
+        if isinstance(value, pa.Scalar):
+            return True
+    except ImportError:
+        pass
+    if isinstance(value, (list, tuple, set, frozenset, dict, range)):
+        return False
+    if hasattr(value, "__array__"):
+        return getattr(value, "ndim", None) == 0
+    # Non-sequence objects (numbers, shapely geometries, None, ...) broadcast.
+    return not hasattr(value, "__len__")
+
+
+def normalize_scalar(value):
+    """Normalize an accepted scalar into something a literal can hold.
+
+    Passing the classifier is not the same as being constructible: a 0-d NumPy
+    array is a scalar but `lit()` cannot take it, and `pandas.NA` is a missing
+    sentinel `lit()` does not recognize. Unwrap the former to its Python value
+    and convert missing sentinels to `None` (SQL null). Callers apply this only
+    after `is_scalar` has accepted the value.
+
+    NumPy and pandas temporal scalars are rejected for now: representing them
+    faithfully needs dedicated unit and timezone handling (`lit()` would
+    silently truncate nanoseconds or reject most NumPy units), which arrives
+    as its own change.
+    """
+    try:
+        import numpy as np
+
+        # A masked value's .item() would expose the hidden data, silently turning
+        # a missing value into a real number; masked means missing.
+        if value is np.ma.masked or np.ma.is_masked(value):
+            return None
+        # A 0-D array is unwrapped first and the result re-normalized: the
+        # wrapped value may itself need handling below (an object-dtype 0-d
+        # array can hold a NumPy temporal). Temporal dtypes unwrap via [()]
+        # because .item() would flatten them to integer ticks.
+        if isinstance(value, np.ndarray) and value.ndim == 0:
+            unwrapped = value[()] if value.dtype.kind in "mM" else value.item()
+            return normalize_scalar(unwrapped)
+        if isinstance(value, (np.datetime64, np.timedelta64)):
+            raise TypeError(
+                "NumPy temporal scalars are not supported yet; faithful unit "
+                "handling arrives in a follow-up change"
+            )
+    except ImportError:
+        pass
+    if hasattr(value, "__array__") and getattr(value, "ndim", None) == 0:
+        value = value.item()
+    try:
+        import pandas as pd
+
+        if isinstance(value, (pd.Timestamp, pd.Timedelta)):
+            raise TypeError(
+                "pandas temporal scalars are not supported yet; faithful unit "
+                "handling arrives in a follow-up change"
+            )
+        # NaN is deliberately left as-is — pandas keeps NaN a float value; only
+        # the NA sentinel becomes SQL null.
+        if value is pd.NA:
+            return None
+    except ImportError:
+        pass
+    return value
+
+
 def _operand(df, other):
     """Coerce the right-hand side of an operator into something usable.
 

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
@@ -16,6 +16,10 @@
 # under the License.
 """pandas/GeoPandas-style Series backed by a SedonaDB expression."""
 
+import pyarrow as pa
+
+from sedonadb_geopandas._temporal import normalize_temporal_scalar
+
 
 def is_scalar(value):
     """Whether `value` is a single value that can be broadcast to every row.
@@ -31,25 +35,10 @@ def is_scalar(value):
     """
     if isinstance(value, (str, bytes, bytearray)):
         return True
-    try:
-        import pyarrow as pa
-
-        # An Arrow scalar is one value even when it implements __len__ (a
-        # ListScalar's length is its element count, not a row count).
-        if isinstance(value, pa.Scalar):
-            return True
-    except ImportError:
-        pass
-    try:
-        from shapely.geometry.base import BaseGeometry
-
-        # Shapely 1.x multipart geometries implement __len__ and __iter__;
-        # they are still single values. (Shapely 2 removed the sequence
-        # protocol, but the package floor does not require Shapely 2.)
-        if isinstance(value, BaseGeometry):
-            return True
-    except ImportError:
-        pass
+    # An Arrow scalar is one value even when it implements __len__ (a
+    # ListScalar's length is its element count, not a row count).
+    if isinstance(value, pa.Scalar):
+        return True
     if isinstance(value, (list, tuple, set, frozenset, dict, range)):
         return False
     if hasattr(value, "__array__"):
@@ -67,25 +56,18 @@ def normalize_scalar(value):
     and convert missing sentinels to `None` (SQL null). Callers apply this only
     after `is_scalar` has accepted the value.
 
-    NumPy and pandas temporal scalars are rejected for now: representing them
-    faithfully needs dedicated unit and timezone handling (`lit()` would
-    silently truncate nanoseconds or reject most NumPy units), which arrives
-    as its own change.
+    Temporal scalars are handed to `_temporal.normalize_temporal_scalar`,
+    which chooses units losslessly and keeps timezones.
     """
-    try:
-        import pyarrow as pa
-
-        # lit() rejects a typed-null *nested* scalar (list, map, struct); a
-        # one-element typed Arrow array is the resolver's supported spelling
-        # of the same broadcast value.
-        if (
-            isinstance(value, pa.Scalar)
-            and not value.is_valid
-            and pa.types.is_nested(value.type)
-        ):
-            return pa.array([None], type=value.type)
-    except ImportError:
-        pass
+    # lit() rejects a typed-null *nested* scalar (list, map, struct); a
+    # one-element typed Arrow array is the resolver's supported spelling of
+    # the same broadcast value.
+    if (
+        isinstance(value, pa.Scalar)
+        and not value.is_valid
+        and pa.types.is_nested(value.type)
+    ):
+        return pa.array([None], type=value.type)
     try:
         import numpy as np
 
@@ -94,8 +76,6 @@ def normalize_scalar(value):
         # record is missing; otherwise it broadcasts as a typed struct with
         # each masked field as null.
         if isinstance(value, np.ma.mvoid):
-            import pyarrow as pa
-
             names = value.dtype.names or ()
             fields_vals = {name: value[name] for name in names}
             if names and all(v is np.ma.masked for v in fields_vals.values()):
@@ -139,14 +119,11 @@ def normalize_scalar(value):
             # [()] keeps the typed NumPy scalar; .item() would promote it to a
             # Python int/float (and flatten temporals to integer ticks).
             return normalize_scalar(value[()])
+        # NumPy temporal scalars need unit-faithful handling: lit() rejects
+        # most NumPy units directly, and .item() would flatten them to ticks.
         if isinstance(value, (np.datetime64, np.timedelta64)):
-            raise TypeError(
-                "NumPy temporal scalars are not supported yet; faithful unit "
-                "handling arrives in a follow-up change"
-            )
+            return normalize_temporal_scalar(value)
         if isinstance(value, np.void):
-            import pyarrow as pa
-
             if value.dtype.fields is None:
                 # A plain void's payload is its bytes.
                 return value.item()
@@ -175,24 +152,25 @@ def normalize_scalar(value):
             # uint64 values past int64, which the engine supports natively.
             # (np.void has no Arrow scalar form; it falls through to .item(),
             # which yields its bytes.)
-            import pyarrow as pa
-
             return pa.scalar(value)
     except ImportError:
         pass
     if hasattr(value, "__array__") and getattr(value, "ndim", None) == 0:
         value = value.item()
+    # Temporal Arrow scalars need sentinel-aware handling.
+    if isinstance(value, pa.Scalar) and (
+        pa.types.is_duration(value.type) or pa.types.is_timestamp(value.type)
+    ):
+        return normalize_temporal_scalar(value)
     try:
         import pandas as pd
 
+        # pandas temporal scalars need unit- and zone-faithful handling. NaT
+        # is an instance of neither Timestamp nor Timedelta but is just as
+        # temporal, and assigns as a datetime missing value the way pandas
+        # assigns it.
         if value is pd.NaT or isinstance(value, (pd.Timestamp, pd.Timedelta)):
-            # NaT is an instance of neither Timestamp nor Timedelta, but it is
-            # just as temporal: without this it fails ordinary assignment with
-            # a backend error while geometry assignment absorbs it as missing.
-            raise TypeError(
-                "pandas temporal scalars are not supported yet; faithful unit "
-                "handling arrives in a follow-up change"
-            )
+            return normalize_temporal_scalar(value)
         # NaN is deliberately left as-is — pandas keeps NaN a float value; only
         # the NA sentinel becomes SQL null.
         if value is pd.NA:

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
@@ -123,7 +123,10 @@ def normalize_scalar(value):
             and value.ndim == 0
             and value.dtype.names
         ):
-            return normalize_scalar(value[()])
+            # Unwrap through the base MaskedArray view: MaskedRecords' own
+            # [()] returns another 0-d MaskedRecords, recursing forever,
+            # while the base view yields the record form.
+            return normalize_scalar(value.view(np.ma.MaskedArray)[()])
         # A masked value's .item() would expose the hidden data, silently turning
         # a missing value into a real number; masked means missing.
         if value is np.ma.masked or np.ma.is_masked(value):

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
@@ -106,10 +106,14 @@ def normalize_scalar(value):
                 "NumPy temporal scalars are not supported yet; faithful unit "
                 "handling arrives in a follow-up change"
             )
-        if isinstance(value, np.generic) and not isinstance(value, (str, bytes)):
+        if isinstance(value, np.generic) and not isinstance(
+            value, (str, bytes, np.void)
+        ):
             # A typed Arrow scalar keeps the NumPy dtype: .item() would
             # promote int8/float32 to int64/float64 columns and overflow
             # uint64 values past int64, which the engine supports natively.
+            # (np.void has no Arrow scalar form; it falls through to .item(),
+            # which yields its bytes.)
             import pyarrow as pa
 
             return pa.scalar(value)

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
@@ -115,6 +115,15 @@ def normalize_scalar(value):
                 for name, v in fields_vals.items()
             }
             return pa.scalar(payload, type=pa.struct(fields))
+        # A 0-d structured masked container unwraps to its record form first:
+        # the generic mask check below itself raises on structured dtypes.
+        # (np.ma.masked has no field names, so it never matches here.)
+        if (
+            isinstance(value, np.ma.MaskedArray)
+            and value.ndim == 0
+            and value.dtype.names
+        ):
+            return normalize_scalar(value[()])
         # A masked value's .item() would expose the hidden data, silently turning
         # a missing value into a real number; masked means missing.
         if value is np.ma.masked or np.ma.is_masked(value):

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
@@ -89,6 +89,32 @@ def normalize_scalar(value):
     try:
         import numpy as np
 
+        # A structured masked record must come before the generic mask check:
+        # np.ma.is_masked itself raises on the mask dtype. A fully masked
+        # record is missing; otherwise it broadcasts as a typed struct with
+        # each masked field as null.
+        if isinstance(value, np.ma.mvoid):
+            import pyarrow as pa
+
+            names = value.dtype.names or ()
+            fields_vals = {name: value[name] for name in names}
+            if names and all(v is np.ma.masked for v in fields_vals.values()):
+                return None
+            try:
+                fields = [
+                    (name, pa.from_numpy_dtype(value.dtype[name])) for name in names
+                ]
+            except (pa.ArrowNotImplementedError, ValueError) as err:
+                raise TypeError(
+                    f"Cannot represent a structured NumPy scalar of dtype "
+                    f"{value.dtype} faithfully; use a typed Arrow struct "
+                    f"scalar instead"
+                ) from err
+            payload = {
+                name: None if v is np.ma.masked else v.item()
+                for name, v in fields_vals.items()
+            }
+            return pa.scalar(payload, type=pa.struct(fields))
         # A masked value's .item() would expose the hidden data, silently turning
         # a missing value into a real number; masked means missing.
         if value is np.ma.masked or np.ma.is_masked(value):

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_series.py
@@ -40,6 +40,16 @@ def is_scalar(value):
             return True
     except ImportError:
         pass
+    try:
+        from shapely.geometry.base import BaseGeometry
+
+        # Shapely 1.x multipart geometries implement __len__ and __iter__;
+        # they are still single values. (Shapely 2 removed the sequence
+        # protocol, but the package floor does not require Shapely 2.)
+        if isinstance(value, BaseGeometry):
+            return True
+    except ImportError:
+        pass
     if isinstance(value, (list, tuple, set, frozenset, dict, range)):
         return False
     if hasattr(value, "__array__"):
@@ -63,6 +73,20 @@ def normalize_scalar(value):
     as its own change.
     """
     try:
+        import pyarrow as pa
+
+        # lit() rejects a typed-null *nested* scalar (list, map, struct); a
+        # one-element typed Arrow array is the resolver's supported spelling
+        # of the same broadcast value.
+        if (
+            isinstance(value, pa.Scalar)
+            and not value.is_valid
+            and pa.types.is_nested(value.type)
+        ):
+            return pa.array([None], type=value.type)
+    except ImportError:
+        pass
+    try:
         import numpy as np
 
         # A masked value's .item() would expose the hidden data, silently turning
@@ -74,13 +98,21 @@ def normalize_scalar(value):
         # array can hold a NumPy temporal). Temporal dtypes unwrap via [()]
         # because .item() would flatten them to integer ticks.
         if isinstance(value, np.ndarray) and value.ndim == 0:
-            unwrapped = value[()] if value.dtype.kind in "mM" else value.item()
-            return normalize_scalar(unwrapped)
+            # [()] keeps the typed NumPy scalar; .item() would promote it to a
+            # Python int/float (and flatten temporals to integer ticks).
+            return normalize_scalar(value[()])
         if isinstance(value, (np.datetime64, np.timedelta64)):
             raise TypeError(
                 "NumPy temporal scalars are not supported yet; faithful unit "
                 "handling arrives in a follow-up change"
             )
+        if isinstance(value, np.generic) and not isinstance(value, (str, bytes)):
+            # A typed Arrow scalar keeps the NumPy dtype: .item() would
+            # promote int8/float32 to int64/float64 columns and overflow
+            # uint64 values past int64, which the engine supports natively.
+            import pyarrow as pa
+
+            return pa.scalar(value)
     except ImportError:
         pass
     if hasattr(value, "__array__") and getattr(value, "ndim", None) == 0:
@@ -88,7 +120,10 @@ def normalize_scalar(value):
     try:
         import pandas as pd
 
-        if isinstance(value, (pd.Timestamp, pd.Timedelta)):
+        if value is pd.NaT or isinstance(value, (pd.Timestamp, pd.Timedelta)):
+            # NaT is an instance of neither Timestamp nor Timedelta, but it is
+            # just as temporal: without this it fails ordinary assignment with
+            # a backend error while geometry assignment absorbs it as missing.
             raise TypeError(
                 "pandas temporal scalars are not supported yet; faithful unit "
                 "handling arrives in a follow-up change"

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_temporal.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_temporal.py
@@ -1,0 +1,133 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Temporal (duration and timestamp) compatibility with numpy-backed pandas.
+
+Everything temporal lives here rather than in the general scalar and frame
+helpers, because temporal values need handling nothing else does:
+
+- numpy-backed pandas stores NaT as INT64_MIN ticks — a representable Arrow
+  value — so data arriving through Arrow can carry the missing-value sentinel
+  as real data, and it must become SQL null before any operator sees it.
+- NumPy temporal units span attoseconds to years while Arrow holds s/ms/us/ns;
+  conversions pick a lossless unit and reject or overflow-check the rest, and
+  pandas scalars resolve to microsecond literals that silently truncate
+  nanoseconds unless routed through their numpy form.
+"""
+
+import pyarrow as pa
+
+TICK_SENTINEL = -(2**63)
+"""INT64_MIN: a representable Arrow temporal tick, but pandas' NaT."""
+
+
+def nat_scalar(dtype):
+    """The explicit missing value (NaT) for an Arrow temporal type.
+
+    Relationally NaT is SQL null; this constructor keeps it *typed* null, so
+    an expression built from it casts and coerces as the temporal type rather
+    than as untyped NULL.
+    """
+    return pa.scalar(None, dtype)
+
+
+def normalize_temporal_scalar(value):
+    """Normalize a temporal scalar into a form a literal can hold faithfully.
+
+    NumPy temporals are rebuilt as typed Arrow scalars: `.item()` would
+    flatten them to integer ticks and `lit()` rejects most NumPy units
+    directly. The Arrow unit is chosen losslessly rather than forcing
+    nanoseconds: the ns range covers only 1677-2262, so an unchecked astype
+    silently wraps coarse-unit values centuries away. pandas scalars route
+    through their numpy form (their own literal resolution is microseconds,
+    silently truncating nanoseconds); a timezone-aware Timestamp is rebuilt
+    at nanosecond ticks with its zone preserved. An Arrow temporal scalar
+    holding the tick sentinel is missing, not data.
+    """
+    import numpy as np
+
+    if isinstance(value, (np.datetime64, np.timedelta64)):
+        is_datetime = isinstance(value, np.datetime64)
+        kind = "datetime64" if is_datetime else "timedelta64"
+        is_datetime = isinstance(value, np.datetime64)
+        kind = "datetime64" if is_datetime else "timedelta64"
+        if np.isnat(value):
+            null_type = pa.timestamp("ns") if is_datetime else pa.duration("ns")
+            return nat_scalar(null_type)
+
+        unit = np.datetime_data(value.dtype)[0]
+        if unit in ("s", "ms", "us", "ns"):
+            # Arrow-native resolution: keep it exactly.
+            target = unit
+        elif unit in ("W", "D", "h", "m") or (is_datetime and unit in ("Y", "M")):
+            # Whole multiples of seconds — and for datetimes, calendar
+            # year/month positions — convert exactly to seconds.
+            target = "s"
+        elif is_datetime:
+            # Sub-nanosecond datetimes narrow to nanoseconds; the
+            # round-trip check below rejects only the values that
+            # actually lose precision (GeoPandas silently truncates
+            # these instead, which this layer deliberately does not do).
+            target = "ns"
+        else:
+            # timedelta64 in months/years is ambiguous, and pandas
+            # rejects sub-nanosecond timedeltas outright, exactly
+            # representable or not.
+            raise ValueError(
+                f"Cannot represent a {kind}[{unit}] value exactly; use an "
+                f"unambiguous unit no finer than nanoseconds"
+            )
+        converted = value.astype(f"{kind}[{target}]")
+        if converted.astype(value.dtype) != value:
+            # A same-unit conversion is the identity, so a mismatch means
+            # either a sub-nanosecond value that has no exact ns form or
+            # a coarse value whose seconds form overflows int64.
+            if unit not in ("s", "ms", "us", "ns", "W", "D", "h", "m", "Y", "M"):
+                raise ValueError(
+                    f"{value!r} loses precision at the Arrow 'ns' resolution"
+                )
+            raise OverflowError(
+                f"{value!r} does not fit the Arrow {target!r} resolution"
+            )
+        return pa.scalar(converted)
+
+    try:
+        import pandas as pd
+
+        if value is pd.NaT:
+            # NaT is an instance of neither Timestamp nor Timedelta. pandas
+            # assigns it as a datetime missing value, so it becomes a typed
+            # timestamp null rather than untyped NULL.
+            return nat_scalar(pa.timestamp("ns"))
+        if isinstance(value, pd.Timestamp) and value.tz is not None:
+            # pyarrow resolves the zone but at microsecond resolution;
+            # rebuild the same zone at nanosecond ticks (.value is the
+            # UTC-epoch nanosecond count).
+            resolved = pa.scalar(value)
+            return pa.scalar(value.value, pa.timestamp("ns", resolved.type.tz))
+        if isinstance(value, (pd.Timestamp, pd.Timedelta)):
+            return normalize_temporal_scalar(value.asm8)
+    except ImportError:
+        pass
+
+    if (
+        isinstance(value, pa.Scalar)
+        and (pa.types.is_duration(value.type) or pa.types.is_timestamp(value.type))
+        and value.is_valid
+        and value.value == TICK_SENTINEL
+    ):
+        return nat_scalar(value.type)
+    return value

--- a/python/sedonadb-geopandas/tests/test_geopandas_compat.py
+++ b/python/sedonadb-geopandas/tests/test_geopandas_compat.py
@@ -970,3 +970,59 @@ def test_zero_dim_structured_masked_containers(points):
     assert out["b"].tolist() == [{"count": None, "ratio": 1.5}] * len(points)
     assert out["c"].isna().all()
     assert out["d"].tolist() == [{"count": None, "ratio": 1.5}] * len(points)
+
+
+def test_large_wkb_scalars_normalize_to_binary_storage(points):
+    # ga.large_wkb() scalars carry LargeBinary storage, which SedonaDB's WKB
+    # importer rejects; they are rebuilt on Binary storage with the same CRS
+    # and edge metadata. Valid and null, direct and Literal, fresh and
+    # geometry destinations.
+    import geoarrow.pyarrow as ga
+    import geopandas as gpd
+    import pyarrow as pa
+    from shapely.geometry import Point
+
+    from sedonadb.expr import lit
+
+    crs4267 = gpd.GeoSeries.from_wkt(["POINT (0 0)"], crs="EPSG:4267").crs
+    lws = (
+        ga.large_wkb().with_edge_type(ga.EdgeType.SPHERICAL).with_crs(crs4267.to_json())
+    )
+    for payload in (Point(1, 1).wkb, None):
+        gdf = sgpd.from_geopandas(points)
+        gdf["fresh"] = pa.scalar(payload, lws)
+        dtype = str(gdf._df.schema.field("fresh").type)
+        assert "geography" in dtype and "4267" in dtype
+    gdf = sgpd.from_geopandas(points)
+    gdf["geometry"] = lit(pa.scalar(Point(1, 1).wkb, ga.large_wkb()))
+    assert "3857" in str(gdf._df.schema.field("geometry").type)
+    assert gdf.to_geopandas()["geometry"].tolist() == [Point(1, 1)] * len(points)
+
+
+def test_masked_records_do_not_recurse(points):
+    # 0-d MaskedRecords' own [()] returns another 0-d MaskedRecords, so the
+    # structured-masked unwrap recursed until RecursionError; the base
+    # MaskedArray view yields the record form. All three mask states, direct
+    # and through Literal.
+    import numpy as np
+    import numpy.ma.mrecords as mrecords
+
+    from sedonadb.expr import lit
+
+    dtype = [("count", "int16"), ("ratio", "float32")]
+
+    def record(mask):
+        return np.ma.MaskedArray((3, 1.5), mask=mask, dtype=dtype).view(
+            mrecords.MaskedRecords
+        )
+
+    gdf = sgpd.from_geopandas(points)
+    gdf["a"] = record((False, False))
+    gdf["b"] = record((True, False))
+    gdf["c"] = record((True, True))
+    gdf["d"] = lit(record((True, False)))
+    out = gdf.to_geopandas()
+    assert out["a"].tolist() == [{"count": 3, "ratio": 1.5}] * len(points)
+    assert out["b"].tolist() == [{"count": None, "ratio": 1.5}] * len(points)
+    assert out["c"].isna().all()
+    assert out["d"].tolist() == [{"count": None, "ratio": 1.5}] * len(points)

--- a/python/sedonadb-geopandas/tests/test_geopandas_compat.py
+++ b/python/sedonadb-geopandas/tests/test_geopandas_compat.py
@@ -44,16 +44,6 @@ def cities():
 
 
 @pytest.fixture
-def points():
-    """A small frame in a projected CRS, shared across the tests."""
-    return gpd.GeoDataFrame(
-        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
-        geometry=gpd.GeoSeries.from_wkt(["POINT (0 0)", "POINT (5 5)", "POINT (9 9)"]),
-        crs="EPSG:3857",
-    )
-
-
-@pytest.fixture
 def con_free_geom_frame():
     """A frame whose active geometry column is *not* the heuristic's pick.
 
@@ -264,30 +254,47 @@ def test_head(cities):
     assert isinstance(gdf.head(2).geometry, GeoSeries)
 
 
-# -- column assignment -------------------------------------------------------
-
-
-def test_setitem_from_series(points):
+def test_setitem_from_series():
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = sgpd.from_geopandas(points)
     gdf["v2"] = gdf["v"]
     got = gdf.to_geopandas().sort_values("name")
     assert got["v2"].tolist() == points["v"].tolist()
 
 
-def test_setitem_replaces_existing_column(points):
+def test_setitem_replaces_existing_column():
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = sgpd.from_geopandas(points)
     gdf["v"] = gdf["name"]
     assert sorted(gdf.to_geopandas()["v"]) == ["A", "B", "C"]
     assert gdf.columns.count("v") == 1
 
 
-def test_setitem_scalar_broadcasts(points):
+def test_setitem_scalar_broadcasts():
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = sgpd.from_geopandas(points)
     gdf["k"] = 7
     assert gdf.to_geopandas()["k"].tolist() == [7, 7, 7]
 
 
-def test_setitem_geometry_column(points):
+def test_setitem_geometry_column():
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = sgpd.from_geopandas(points)
     gdf["buffered"] = gdf.geometry.buffer(0.5)
     assert "buffered" in gdf.columns
@@ -313,7 +320,12 @@ def test_setitem_non_geometry_leaves_frame_without_geometry():
     assert plain._geometry_name is None
 
 
-def test_setitem_rejects_bad_inputs(points):
+def test_setitem_rejects_bad_inputs():
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = sgpd.from_geopandas(points)
     with pytest.raises(TypeError, match="must be a string"):
         gdf[0] = 1
@@ -325,10 +337,15 @@ def test_setitem_rejects_bad_inputs(points):
         gdf["y"] = other["v"]
 
 
-def test_setitem_stale_series_raises(points):
+def test_setitem_stale_series_raises():
     # Replacing a column rebinds the frame in a way earlier reads cannot
     # follow: a Series read beforehand would resolve to the new values, so it
     # is stale and raises.
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = sgpd.from_geopandas(points)
     before = gdf["v"]
     gdf["v"] = gdf["name"]
@@ -336,10 +353,15 @@ def test_setitem_stale_series_raises(points):
         gdf["z"] = before
 
 
-def test_series_survives_column_adding_assignments(points):
+def test_series_survives_column_adding_assignments():
     # One captured geometry can supply several derived columns in turn: an
     # assignment that only adds a column leaves rows and existing columns
     # untouched, so an earlier Series still resolves to the values it showed.
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = sgpd.from_geopandas(points)
     g = gdf.geometry
     v = gdf["v"]
@@ -355,16 +377,26 @@ def test_series_survives_column_adding_assignments(points):
     assert len(gdf[mask]) == 2
 
 
-def test_setitem_rejects_bare_expression(points):
+def test_setitem_rejects_bare_expression():
     # A bare expression carries no origin, so one built from another frame would
     # resolve against this frame and silently write this frame's values.
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     left = sgpd.from_geopandas(points)
     right = sgpd.from_geopandas(points)
     with pytest.raises(TypeError, match="bare expression"):
         left["copied"] = right["v"]._expr
 
 
-def test_series_has_no_unguarded_expr_escape_hatch(points):
+def test_series_has_no_unguarded_expr_escape_hatch():
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     assert not hasattr(sgpd.from_geopandas(points)["v"], "expr")
 
 
@@ -373,34 +405,53 @@ def test_series_has_no_unguarded_expr_escape_hatch(points):
     [[10, 20, 30], (10, 20, 30), {10, 20}],
     ids=["list", "tuple", "set"],
 )
-def test_setitem_rejects_sequences(points, value):
+def test_setitem_rejects_sequences(value):
     # Sequences have no __array__, so they used to be broadcast whole into every
     # row rather than rejected.
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = sgpd.from_geopandas(points)
     with pytest.raises(TypeError, match="isn't supported"):
         gdf["x"] = value
 
 
-def test_setitem_accepts_numpy_scalar(points):
+def test_setitem_accepts_numpy_scalar():
     # NumPy scalars do have __array__ but are single values, so they used to be
     # rejected as array-likes.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = sgpd.from_geopandas(points)
     gdf["x"] = np.int64(5)
     assert gdf.to_geopandas()["x"].tolist() == [5, 5, 5]
 
 
-def test_setitem_rejects_numpy_array(points):
+def test_setitem_rejects_numpy_array():
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = sgpd.from_geopandas(points)
     with pytest.raises(TypeError, match="isn't supported"):
         gdf["x"] = np.array([1, 2, 3])
 
 
-def test_getitem_rejects_stale_mask(points):
+def test_getitem_rejects_stale_mask():
     # Replacing a column (or filtering) rebinds the frame, so a mask captured
     # beforehand belongs to the previous one. It used to be accepted and
     # quietly resolve against the new frame while the referenced column
     # happened to still exist.
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = sgpd.from_geopandas(points)
     mask = gdf["v"] > 1
     gdf["v"] = gdf["name"]
@@ -413,9 +464,14 @@ def test_getitem_rejects_stale_mask(points):
         filtered[mask]
 
 
-def test_setitem_none_keeps_geometry_column(points):
+def test_setitem_none_keeps_geometry_column():
     # Assigning None used to turn the column untyped and clear the active geometry;
     # GeoPandas keeps a geometry column with its CRS.
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = sgpd.from_geopandas(points)
     gdf["geometry"] = None
     assert gdf._geometry_name == "geometry"
@@ -423,8 +479,13 @@ def test_setitem_none_keeps_geometry_column(points):
     assert gdf.to_geopandas().geometry.isna().all()
 
 
-def test_setitem_non_geometry_over_geometry_still_clears(points):
+def test_setitem_non_geometry_over_geometry_still_clears():
     # The CRS-preserving path must not dress a number up as geometry.
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = sgpd.from_geopandas(points)
     gdf["geometry"] = 7
     assert gdf._geometry_name is None
@@ -435,11 +496,15 @@ def test_setitem_non_geometry_over_geometry_still_clears(points):
     "value_name",
     ["none", "nan", "pandas_na", "geometry", "literal_geometry", "literal_none"],
 )
-def test_setitem_geometry_scalars_keep_type_and_crs(points, value_name):
+def test_setitem_geometry_scalars_keep_type_and_crs(value_name):
     # Every supported scalar path has to go through the CRS-preserving branch:
     # GeoPandas treats None, NaN and pd.NA as missing geometry and keeps the typed
     # column and its CRS.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     values = {
         "none": None,
         "nan": np.nan,
@@ -454,38 +519,61 @@ def test_setitem_geometry_scalars_keep_type_and_crs(points, value_name):
     assert "3857" in str(gdf.crs)
 
 
-def test_setitem_crs_carrying_literal_keeps_its_crs(points):
+def test_setitem_crs_carrying_literal_keeps_its_crs():
     # A literal that carries its own CRS must not be relabeled with the
     # destination column's CRS — that changes what the coordinates mean without
     # transforming them.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     src = gpd.GeoSeries.from_wkt(["POINT (10 10)"], crs="EPSG:4326")
     gdf = sgpd.from_geopandas(points)  # column is EPSG:3857
     gdf["geometry"] = lit(src)
     assert "4326" in str(gdf.crs)
 
 
-def test_pandas_na_assigns_as_null_to_ordinary_column(points):
+def test_pandas_na_assigns_as_null_to_ordinary_column():
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = sgpd.from_geopandas(points)
     gdf["z"] = pd.NA
     assert gdf.to_geopandas()["z"].isna().all()
 
 
-def test_zero_dimensional_array_normalizes(points):
+def test_zero_dimensional_array_normalizes():
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = sgpd.from_geopandas(points)
     gdf["z"] = np.array(5)  # 0-d: scalar by classification, unwrapped on use
     assert gdf.to_geopandas()["z"].tolist() == [5, 5, 5]
 
 
-def test_masked_scalar_assigns_as_missing(points):
+def test_masked_scalar_assigns_as_missing():
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = sgpd.from_geopandas(points)
     gdf["m"] = np.ma.masked
     assert gdf.to_geopandas()["m"].isna().all()
 
 
-def test_pyarrow_scalars_broadcast(points):
+def test_pyarrow_scalars_broadcast():
     # Arrow scalars implement __len__ but are single values.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     assert is_scalar(pa.scalar([1, 2]))
     assert is_scalar(pa.scalar({"a": 1}))
     gdf = sgpd.from_geopandas(points)
@@ -493,10 +581,14 @@ def test_pyarrow_scalars_broadcast(points):
     assert len(gdf.to_geopandas()["tags"]) == 3
 
 
-def test_geoarrow_scalar_inherits_crs(points):
+def test_geoarrow_scalar_inherits_crs():
     # A GeoArrow WKB scalar has no __geo_interface__, so geometry-ness must come
     # from the resolved schema; it is CRS-less and inherits the column's CRS.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     w = ga.as_wkb(ga.array(["POINT (5 5)"]))[0]
     gdf = sgpd.from_geopandas(points)
     gdf["geometry"] = w
@@ -504,22 +596,29 @@ def test_geoarrow_scalar_inherits_crs(points):
     assert "3857" in str(gdf.crs)
 
 
-def test_explicitly_inactive_geometry_stays_inactive(points):
+def test_explicitly_inactive_geometry_stays_inactive():
     # geometry=None is a choice; a no-op reassignment of an existing geometry
     # column must not silently reactivate it.
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     df = sgpd.default_context().create_data_frame(points)
     gdf = GeoDataFrame(df, geometry=None)
     gdf["geometry"] = gdf["geometry"]
     assert gdf._geometry_name is None
 
 
-# -- regressions from review ------------------------------------------------
-
-
-def test_assigned_geometry_column_reads_back_as_geoseries(points):
+def test_assigned_geometry_column_reads_back_as_geoseries():
     # Only the active geometry name produced a GeoSeries, so the advertised
     # gdf["buffered"] = gdf.geometry.buffer(...) gave back a plain Series
     # with no .area or .buffer(). Geometry-ness comes from the schema.
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = sgpd.from_geopandas(points)
     gdf["buffered"] = gdf.geometry.buffer(0.5)
     col = gdf["buffered"]
@@ -527,11 +626,16 @@ def test_assigned_geometry_column_reads_back_as_geoseries(points):
     assert (col.area.to_pandas() > 0).all()
 
 
-def test_cleared_geometry_is_not_resurrected_by_materialization(points):
+def test_cleared_geometry_is_not_resurrected_by_materialization():
     # With the active geometry replaced by a number, the wrapper records no
     # active geometry — but the materializer heuristically activated any
     # remaining geometry column, so a later to_crs() on the result silently
     # targeted a column this frame never had active.
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = sgpd.from_geopandas(points)
     gdf["copy"] = gdf.geometry
     gdf["geometry"] = 7
@@ -602,10 +706,14 @@ def test_geography_column_replacement_preserves_geography():
         assert "4267" in dtype
 
 
-def test_numpy_scalar_dtypes_are_preserved(points):
+def test_numpy_scalar_dtypes_are_preserved():
     # .item() promoted np.int8/np.float32 to int64/float64 columns and
     # overflowed np.uint64 past int64, which the engine supports natively.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = sgpd.from_geopandas(points)
     gdf["i8"] = np.int8(5)
     gdf["f4"] = np.float32(1.5)
@@ -618,11 +726,15 @@ def test_numpy_scalar_dtypes_are_preserved(points):
     assert str(out["z"].dtype) == "int32"
 
 
-def test_arrow_wrapped_missing_values_keep_geometry(points):
+def test_arrow_wrapped_missing_values_keep_geometry():
     # pa.scalar(None), typed Arrow nulls, and Arrow-wrapped NaN cleared the
     # active geometry and CRS, unlike the equivalent bare None/NaN; a wrapped
     # value means whatever its payload means.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     for value in (
         pa.scalar(None),
         pa.scalar(None, pa.float64()),
@@ -635,10 +747,14 @@ def test_arrow_wrapped_missing_values_keep_geometry(points):
         assert gdf.to_geopandas()["geometry"].isna().all()
 
 
-def test_typed_null_nested_scalars_broadcast(points):
+def test_typed_null_nested_scalars_broadcast():
     # Valid nested Arrow scalars broadcast, but their typed-null forms failed
     # literal construction; they re-enter as one-element typed arrays.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     for value in (
         pa.scalar(None, pa.list_(pa.int64())),
         pa.scalar(None, pa.map_(pa.string(), pa.int64())),
@@ -648,9 +764,14 @@ def test_typed_null_nested_scalars_broadcast(points):
         assert gdf.to_geopandas()["x"].isna().all()
 
 
-def test_multipart_geometries_classify_as_scalars(points):
+def test_multipart_geometries_classify_as_scalars():
     # A multipart geometry is a single value (Shapely 2 no longer gives it a
     # sequence protocol, and the package requires Shapely 2).
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     value = MultiPoint([(0, 0), (1, 1)])
     assert is_scalar(value)
     gdf = sgpd.from_geopandas(points)
@@ -658,12 +779,17 @@ def test_multipart_geometries_classify_as_scalars(points):
     assert gdf.to_geopandas()["mp"].tolist() == [value] * len(points)
 
 
-def test_no_active_geometry_survives_any_column_name(points):
+def test_no_active_geometry_survives_any_column_name():
     # The materializer rebuild went through the GeoDataFrame constructor,
     # which auto-activates a geometry column literally named "geometry" — so
     # clearing the active `geom` resurrected the secondary column and a later
     # to_crs() would transform it. The no-active marker is preserved
     # explicitly, whatever the remaining columns are called.
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = GeoDataFrame(
         sgpd.default_context().sql(
             "SELECT ST_SetSRID(ST_Point(0.0, 0.0), 3857) AS geom, "
@@ -685,10 +811,14 @@ def test_no_active_geometry_survives_any_column_name(points):
         out.geometry
 
 
-def test_numpy_void_scalars_broadcast_as_binary(points):
+def test_numpy_void_scalars_broadcast_as_binary():
     # np.void has no Arrow scalar form, so the typed-scalar conversion broke
     # what previously worked: void values broadcast through .item() as bytes.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = sgpd.from_geopandas(points)
     gdf["x"] = np.void(b"abcd")
     assert gdf.to_geopandas()["x"].tolist() == [b"abcd"] * len(points)
@@ -696,13 +826,17 @@ def test_numpy_void_scalars_broadcast_as_binary(points):
     assert gdf.to_geopandas()["y"].tolist() == [b"ab"] * len(points)
 
 
-def test_typed_null_nested_scalar_keeps_geometry(points):
+def test_typed_null_nested_scalar_keeps_geometry():
     # Normalization rewrites a typed-null nested scalar into its one-element
     # array spelling before missingness is judged; recognizing that spelling
     # only worked through pandas coincidence, and without pandas the null
     # converted the geometry column to a list column. Classification is
     # explicit now: one null element is one missing value.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = sgpd.from_geopandas(points)
     gdf["geometry"] = pa.scalar(None, pa.list_(pa.int64()))
     assert gdf._geometry_name == "geometry"
@@ -740,13 +874,17 @@ def test_crs_less_geography_replacement_stays_crs_less():
             assert got.tolist() == [value]
 
 
-def test_typed_spatial_null_keeps_its_own_crs(points):
+def test_typed_spatial_null_keeps_its_own_crs():
     # An invalid GeoArrow scalar typed EPSG:4267 was routed through the
     # missing path, which synthesized a destination-kind null stamped with
     # the destination CRS — while the equivalent valid scalar kept 4267. A
     # typed spatial null is a geometry value that happens to be null: it
     # keeps its own kind and CRS metadata.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     crs4267 = gpd.GeoSeries.from_wkt(["POINT (0 0)"], crs="EPSG:4267").crs
     null_scalar = pa.scalar(None, ga.wkb().with_crs(crs4267.to_json()))
     gdf = sgpd.from_geopandas(points)
@@ -760,12 +898,16 @@ def test_typed_spatial_null_keeps_its_own_crs(points):
     assert "3857" in str(gdf._df.schema.field("geometry").type)
 
 
-def test_spherical_geoarrow_scalars_keep_geography(points):
+def test_spherical_geoarrow_scalars_keep_geography():
     # The scalar literal resolver drops the edge type, so both a null and a
     # valid spherical WKB scalar silently became planar geometry; the
     # one-element-array spelling resolves with the complete extension
     # metadata.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     crs4267 = gpd.GeoSeries.from_wkt(["POINT (0 0)"], crs="EPSG:4267").crs
     sph = ga.wkb().with_edge_type(ga.EdgeType.SPHERICAL).with_crs(crs4267.to_json())
     for payload in (None, Point(1, 1).wkb):
@@ -776,12 +918,16 @@ def test_spherical_geoarrow_scalars_keep_geography(points):
         assert "4267" in dtype
 
 
-def test_non_wkb_geoarrow_nulls_do_not_crash(points):
+def test_non_wkb_geoarrow_nulls_do_not_crash():
     # Null WKT/point GeoArrow scalars raised ValueError from the literal
     # resolver inside the spatial-null detector. They now either resolve
     # through the array spelling or degrade to the destination-kind null —
     # never an error, and always still geometry.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     for typ in (ga.wkt(), ga.point()):
         gdf = sgpd.from_geopandas(points)
         gdf["geometry"] = pa.scalar(None, typ)
@@ -806,11 +952,15 @@ def test_clearing_active_geometry_does_not_retype_columns():
         out.geometry
 
 
-def test_structured_numpy_scalars_keep_fields_and_dtypes(points):
+def test_structured_numpy_scalars_keep_fields_and_dtypes():
     # A structured np.void flattened to a tuple, silently storing
     # [("count", int16), ("ratio", float32)] as list<float64>; it broadcasts
     # as a typed Arrow struct with field names and dtypes intact.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     rec = np.array([(3, 1.5)], dtype=[("count", "int16"), ("ratio", "float32")])[0]
     gdf = sgpd.from_geopandas(points)
     gdf["x"] = rec
@@ -832,12 +982,16 @@ def test_is_missing_handles_null_array_without_pandas(monkeypatch):
     assert not _is_missing(value_array)
 
 
-def test_masked_structured_records(points):
+def test_masked_structured_records():
     # A structured scalar drawn from a MaskedArray failed inside
     # np.ma.is_masked before any conversion ran — even fully unmasked.
     # Unmasked and partially masked records broadcast as typed structs with
     # masked fields null; a fully masked record is missing.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     dtype = [("count", "int16"), ("ratio", "float32")]
 
     def record(mask):
@@ -853,12 +1007,16 @@ def test_masked_structured_records(points):
     assert out["c"].isna().all()
 
 
-def test_geoarrow_scalars_to_new_columns(points):
+def test_geoarrow_scalars_to_new_columns():
     # The new-column fast path returned lit(raw) before GeoArrow handling
     # began: null WKT/point scalars raised ValueError, and a spherical WKB
     # scalar silently became planar — and could even become the active
     # geometry of a geometry-less frame with the wrong semantics.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     crs4267 = gpd.GeoSeries.from_wkt(["POINT (0 0)"], crs="EPSG:4267").crs
     sph = ga.wkb().with_edge_type(ga.EdgeType.SPHERICAL).with_crs(crs4267.to_json())
 
@@ -877,11 +1035,15 @@ def test_geoarrow_scalars_to_new_columns(points):
     assert plain._geometry_name == "g"
 
 
-def test_non_wkb_geoarrow_null_keeps_its_own_crs(points):
+def test_non_wkb_geoarrow_null_keeps_its_own_crs():
     # The metadata-rebuilt null stamped str(StringCrs(...)) into ST_SetCRS,
     # which is not PROJJSON and failed deserialization; the canonical
     # to_json() form is used instead.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     crs4267 = gpd.GeoSeries.from_wkt(["POINT (0 0)"], crs="EPSG:4267").crs
     gdf = sgpd.from_geopandas(points)
     gdf["geometry"] = pa.scalar(None, ga.wkt().with_crs(crs4267.to_json()))
@@ -890,11 +1052,15 @@ def test_non_wkb_geoarrow_null_keeps_its_own_crs(points):
     assert gdf.to_geopandas()["geometry"].isna().all()
 
 
-def test_zero_dim_structured_masked_containers(points):
+def test_zero_dim_structured_masked_containers():
     # A 0-d structured MaskedArray raised an opaque structured-dtype-to-bool
     # TypeError inside the generic mask check, directly and inside a Literal;
     # it unwraps to its record form first.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     dtype = [("count", "int16"), ("ratio", "float32")]
 
     def container(mask):
@@ -912,12 +1078,16 @@ def test_zero_dim_structured_masked_containers(points):
     assert out["d"].tolist() == [{"count": None, "ratio": 1.5}] * len(points)
 
 
-def test_large_wkb_scalars_normalize_to_binary_storage(points):
+def test_large_wkb_scalars_normalize_to_binary_storage():
     # ga.large_wkb() scalars carry LargeBinary storage, which SedonaDB's WKB
     # importer rejects; they are rebuilt on Binary storage with the same CRS
     # and edge metadata. Valid and null, direct and Literal, fresh and
     # geometry destinations.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     crs4267 = gpd.GeoSeries.from_wkt(["POINT (0 0)"], crs="EPSG:4267").crs
     lws = (
         ga.large_wkb().with_edge_type(ga.EdgeType.SPHERICAL).with_crs(crs4267.to_json())
@@ -933,12 +1103,16 @@ def test_large_wkb_scalars_normalize_to_binary_storage(points):
     assert gdf.to_geopandas()["geometry"].tolist() == [Point(1, 1)] * len(points)
 
 
-def test_masked_records_do_not_recurse(points):
+def test_masked_records_do_not_recurse():
     # 0-d MaskedRecords' own [()] returns another 0-d MaskedRecords, so the
     # structured-masked unwrap recursed until RecursionError; the base
     # MaskedArray view yields the record form. All three mask states, direct
     # and through Literal.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     dtype = [("count", "int16"), ("ratio", "float32")]
 
     def record(mask):
@@ -958,9 +1132,6 @@ def test_masked_records_do_not_recurse(points):
     assert out["d"].tolist() == [{"count": None, "ratio": 1.5}] * len(points)
 
 
-# -- temporal scalars --------------------------------------------------------
-
-
 @pytest.mark.parametrize(
     "value_name,expected_kind",
     [
@@ -972,11 +1143,15 @@ def test_masked_records_do_not_recurse(points):
         ("timedelta_nat", "timedelta_nat"),
     ],
 )
-def test_numpy_temporals_materialize_correctly(points, value_name, expected_kind):
+def test_numpy_temporals_materialize_correctly(value_name, expected_kind):
     # Asserted end to end (assignment then collection), not on the normalization
     # helper: .item() flattening, unit rejection, and zeroed durations were all
     # invisible to helper-level equality checks.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     values = {
         "ns_datetime": np.datetime64("2026-01-01", "ns"),
         "zero_d_ns_datetime": np.array(np.datetime64("2026-01-01", "ns")),
@@ -999,14 +1174,18 @@ def test_numpy_temporals_materialize_correctly(points, value_name, expected_kind
         assert expected_dtype in str(out.dtype)
 
 
-def test_coarse_unit_temporals_are_exact(points):
+def test_coarse_unit_temporals_are_exact():
     # Forcing every temporal through nanoseconds silently wrapped values
     # outside the ns range (1677-2262): 2500-01-01 materialized as 1915-06-14.
     # Coarse units convert exactly to seconds instead. Expectations are
     # independent second-resolution constants — deriving them from the
     # materialized dtype would repeat the conversion under test and wrap
     # identically against a broken implementation.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     cases = [
         (np.datetime64("2500-01-01", "D"), np.datetime64("2500-01-01T00:00:00", "s")),
         (np.timedelta64(200000, "D"), np.timedelta64(200000 * 86400, "s")),
@@ -1020,11 +1199,15 @@ def test_coarse_unit_temporals_are_exact(points):
         assert got == expected
 
 
-def test_ambiguous_and_subnano_temporal_units_are_rejected(points):
+def test_ambiguous_and_subnano_temporal_units_are_rejected():
     # Matches pandas, exception type included: timedelta months/years have no
     # fixed length, and pandas raises ValueError for sub-nanosecond timedeltas
     # even when the value is exactly representable.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = sgpd.from_geopandas(points)
     for unit in ("M", "Y", "ps"):
         with pytest.raises(ValueError, match="exactly"):
@@ -1035,12 +1218,16 @@ def test_ambiguous_and_subnano_temporal_units_are_rejected(points):
         gdf["t"] = np.timedelta64(1000, "ps")
 
 
-def test_exact_subnanosecond_datetimes_are_accepted(points):
+def test_exact_subnanosecond_datetimes_are_accepted():
     # 10**6 fs and 10**9 as are exactly one nanosecond and GeoPandas accepts
     # them, so rejecting every sub-ns datetime unit up front was too broad.
     # Lossy values are still rejected — GeoPandas silently truncates those to
     # nanoseconds instead, which this layer deliberately does not do.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     for value in (np.datetime64(10**6, "fs"), np.datetime64(10**9, "as")):
         gdf = sgpd.from_geopandas(points)
         gdf["t"] = value
@@ -1051,24 +1238,32 @@ def test_exact_subnanosecond_datetimes_are_accepted(points):
         gdf["t"] = np.datetime64(1, "fs")
 
 
-def test_zero_dim_object_array_holding_temporal(points):
+def test_zero_dim_object_array_holding_temporal():
     # A 0-d object array classifies as a broadcastable scalar, but its .item()
     # returns the wrapped numpy temporal, which bypassed temporal
     # normalization and failed assignment for non-Arrow-native units.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = sgpd.from_geopandas(points)
     gdf["t"] = np.array(np.datetime64("2500-01-01", "D"), dtype=object)
     got = gdf.to_geopandas()["t"].values[0]
     assert got == np.datetime64("2500-01-01T00:00:00", "s")
 
 
-def test_pandas_temporal_scalars_keep_nanoseconds(points):
+def test_pandas_temporal_scalars_keep_nanoseconds():
     # pandas Timestamp/Timedelta scalars resolved to microsecond literals:
     # assignment silently zeroed nanoseconds, and duration arithmetic lost
     # them behind an interval coercion (`t + pd.Timedelta(1)` came back as
     # DateOffset objects with the tick dropped). They route through their
     # numpy form and its lossless unit handling instead.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = sgpd.from_geopandas(points)
     gdf["t"] = pd.Timedelta(1)
     got = gdf.to_geopandas()["t"]
@@ -1078,11 +1273,15 @@ def test_pandas_temporal_scalars_keep_nanoseconds(points):
     assert got.tolist() == [pd.Timestamp("2026-01-01 00:00:00.000000001")] * len(got)
 
 
-def test_tz_aware_timestamp_scalars_keep_nanoseconds_and_zone(points):
+def test_tz_aware_timestamp_scalars_keep_nanoseconds_and_zone():
     # pyarrow resolves a zone-aware Timestamp at microseconds, silently
     # truncating nanoseconds; the scalar is rebuilt at nanosecond ticks with
     # its zone preserved.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = sgpd.from_geopandas(points)
     stamp = pd.Timestamp("2026-01-01 00:00:00.000000001", tz="US/Pacific")
     gdf["ts"] = stamp
@@ -1091,13 +1290,17 @@ def test_tz_aware_timestamp_scalars_keep_nanoseconds_and_zone(points):
     assert got.tolist() == [stamp] * len(got)
 
 
-def test_nat_assigns_as_datetime_missing(points):
+def test_nat_assigns_as_datetime_missing():
     # pd.NaT is an instance of neither Timestamp nor Timedelta, so it slipped
     # past temporal normalization entirely: ordinary assignment failed with a
     # backend error while geometry assignment absorbed it as missing. It now
     # assigns the way pandas assigns it — a datetime column of missing values —
     # while geometry columns keep treating it as a missing geometry.
-
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
     gdf = sgpd.from_geopandas(points)
     gdf["x"] = pd.NaT
     got = gdf.to_geopandas()["x"]

--- a/python/sedonadb-geopandas/tests/test_geopandas_compat.py
+++ b/python/sedonadb-geopandas/tests/test_geopandas_compat.py
@@ -513,3 +513,160 @@ def test_temporal_scalars_are_deferred(points):
     ):
         with pytest.raises(TypeError, match="not supported yet"):
             gdf["t"] = value
+
+
+# -- regressions from review ------------------------------------------------
+
+
+def test_assigned_geometry_column_reads_back_as_geoseries(points):
+    # Only the active geometry name produced a GeoSeries, so the advertised
+    # gdf["buffered"] = gdf.geometry.buffer(...) gave back a plain Series
+    # with no .area or .buffer(). Geometry-ness comes from the schema.
+    gdf = sgpd.from_geopandas(points)
+    gdf["buffered"] = gdf.geometry.buffer(0.5)
+    col = gdf["buffered"]
+    assert isinstance(col, type(gdf.geometry))
+    assert (col.area.to_pandas() > 0).all()
+
+
+def test_cleared_geometry_is_not_resurrected_by_materialization(points):
+    # With the active geometry replaced by a number, the wrapper records no
+    # active geometry — but the materializer heuristically activated any
+    # remaining geometry column, so a later to_crs() on the result silently
+    # targeted a column this frame never had active.
+    gdf = sgpd.from_geopandas(points)
+    gdf["copy"] = gdf.geometry
+    gdf["geometry"] = 7
+    assert gdf._geometry_name is None
+    out = gdf.to_geopandas()
+    with pytest.raises(AttributeError):
+        out.geometry
+
+
+def test_series_assignment_inherits_destination_crs():
+    # Assigning a CRS-less same-frame geometry column over a column that has
+    # a CRS dropped it; GeoPandas keeps the frame CRS. A column carrying its
+    # own CRS keeps it instead.
+    gdf = GeoDataFrame(
+        sgpd.default_context().sql(
+            "SELECT ST_SetSRID(ST_Point(0.0, 0.0), 3857) AS geometry, "
+            "ST_Point(5.0, 5.0) AS bare, "
+            "ST_SetSRID(ST_Point(7.0, 7.0), 4326) AS own, 1 AS v"
+        )
+    )
+    gdf["geometry"] = gdf["bare"]
+    assert "3857" in str(gdf.crs)
+    gdf["geometry"] = gdf["own"]
+    # The engine reports SRID 4326 as OGC:CRS84; the point is that the
+    # source's own CRS survives instead of being restamped with 3857.
+    assert gdf.crs is not None
+    assert "3857" not in str(gdf.crs)
+
+
+def test_geography_column_replacement_preserves_geography():
+    # Replacing a geography column with None or a Shapely scalar rebuilt it
+    # as planar geometry; replacements are constructed with the destination's
+    # own spatial kind.
+    from shapely.geometry import Point
+
+    def geog_frame():
+        return GeoDataFrame(
+            sgpd.default_context().sql(
+                "SELECT ST_GeogFromWKT('POINT (0 0)') AS g, 1 AS v"
+            ),
+            geometry="g",
+        )
+
+    gdf = geog_frame()
+    gdf["g"] = None
+    assert "geography" in str(gdf._df.schema.field("g").type)
+    assert gdf._geometry_name == "g"
+    gdf = geog_frame()
+    gdf["g"] = Point(1, 1)
+    assert "geography" in str(gdf._df.schema.field("g").type)
+    got = gdf.to_geopandas()["g"]
+    assert got.tolist()[0] == Point(1, 1)
+
+
+def test_numpy_scalar_dtypes_are_preserved(points):
+    # .item() promoted np.int8/np.float32 to int64/float64 columns and
+    # overflowed np.uint64 past int64, which the engine supports natively.
+    import numpy as np
+
+    gdf = sgpd.from_geopandas(points)
+    gdf["i8"] = np.int8(5)
+    gdf["f4"] = np.float32(1.5)
+    gdf["u64"] = np.uint64(2**63 + 1)
+    gdf["z"] = np.array(np.int32(9))  # 0-d arrays unwrap to the typed scalar
+    out = gdf.to_geopandas()
+    assert str(out["i8"].dtype) == "int8"
+    assert str(out["f4"].dtype) == "float32"
+    assert out["u64"].tolist() == [2**63 + 1] * len(out)
+    assert str(out["z"].dtype) == "int32"
+
+
+def test_arrow_wrapped_missing_values_keep_geometry(points):
+    # pa.scalar(None), typed Arrow nulls, and Arrow-wrapped NaN cleared the
+    # active geometry and CRS, unlike the equivalent bare None/NaN; a wrapped
+    # value means whatever its payload means.
+    import pyarrow as pa
+
+    for value in (
+        pa.scalar(None),
+        pa.scalar(None, pa.float64()),
+        pa.scalar(float("nan")),
+    ):
+        gdf = sgpd.from_geopandas(points)
+        gdf["geometry"] = value
+        assert gdf._geometry_name == "geometry"
+        assert "3857" in str(gdf.crs)
+        assert gdf.to_geopandas()["geometry"].isna().all()
+
+
+def test_typed_null_nested_scalars_broadcast(points):
+    # Valid nested Arrow scalars broadcast, but their typed-null forms failed
+    # literal construction; they re-enter as one-element typed arrays.
+    import pyarrow as pa
+
+    for value in (
+        pa.scalar(None, pa.list_(pa.int64())),
+        pa.scalar(None, pa.map_(pa.string(), pa.int64())),
+    ):
+        gdf = sgpd.from_geopandas(points)
+        gdf["x"] = value
+        assert gdf.to_geopandas()["x"].isna().all()
+
+
+def test_nat_is_rejected_like_other_temporals(points):
+    # pd.NaT is an instance of neither Timestamp nor Timedelta, so it slipped
+    # past the temporal deferral: ordinary assignment failed with a backend
+    # error while geometry assignment absorbed it as missing.
+    import pandas as pd
+
+    gdf = sgpd.from_geopandas(points)
+    with pytest.raises(TypeError, match="not supported yet"):
+        gdf["x"] = pd.NaT
+    with pytest.raises(TypeError, match="not supported yet"):
+        gdf["geometry"] = pd.NaT
+
+
+def test_multipart_geometries_classify_as_scalars(points):
+    # Shapely 1.x multipart geometries implement __len__, so the generic
+    # sequence check rejected them; any BaseGeometry is a single value.
+    from shapely.geometry import MultiPoint
+    from shapely.geometry.base import BaseGeometry
+
+    from sedonadb_geopandas._series import is_scalar
+
+    value = MultiPoint([(0, 0), (1, 1)])
+    assert is_scalar(value)
+    import warnings
+
+    legacy = type("LegacyMultipart", (BaseGeometry,), {"__len__": lambda self: 2})
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")  # instantiating BaseGeometry warns
+        instance = legacy.__new__(legacy)
+    assert is_scalar(instance)
+    gdf = sgpd.from_geopandas(points)
+    gdf["mp"] = value
+    assert gdf.to_geopandas()["mp"].tolist() == [value] * len(points)

--- a/python/sedonadb-geopandas/tests/test_geopandas_compat.py
+++ b/python/sedonadb-geopandas/tests/test_geopandas_compat.py
@@ -764,6 +764,14 @@ def test_crs_less_geography_replacement_stays_crs_less():
         dtype = gdf._df.schema.field("g").type
         assert "geography" in str(dtype)
         assert dtype.crs is None
+        # The schema alone is not enough: stripping the CRS with a
+        # null-propagating expression kept the type right while erasing
+        # every value.
+        got = gdf.to_geopandas()["g"]
+        if value is None:
+            assert got.isna().all()
+        else:
+            assert got.tolist() == [value]
 
 
 def test_typed_spatial_null_keeps_its_own_crs(points):
@@ -787,6 +795,41 @@ def test_typed_spatial_null_keeps_its_own_crs(points):
     gdf = sgpd.from_geopandas(points)
     gdf["geometry"] = pa.scalar(None, pa.float64())
     assert "3857" in str(gdf._df.schema.field("geometry").type)
+
+
+def test_spherical_geoarrow_scalars_keep_geography(points):
+    # The scalar literal resolver drops the edge type, so both a null and a
+    # valid spherical WKB scalar silently became planar geometry; the
+    # one-element-array spelling resolves with the complete extension
+    # metadata.
+    import geoarrow.pyarrow as ga
+    import geopandas as gpd
+    import pyarrow as pa
+    from shapely.geometry import Point
+
+    crs4267 = gpd.GeoSeries.from_wkt(["POINT (0 0)"], crs="EPSG:4267").crs
+    sph = ga.wkb().with_edge_type(ga.EdgeType.SPHERICAL).with_crs(crs4267.to_json())
+    for payload in (None, Point(1, 1).wkb):
+        gdf = sgpd.from_geopandas(points)
+        gdf["geometry"] = pa.scalar(payload, sph)
+        dtype = str(gdf._df.schema.field("geometry").type)
+        assert "geography" in dtype
+        assert "4267" in dtype
+
+
+def test_non_wkb_geoarrow_nulls_do_not_crash(points):
+    # Null WKT/point GeoArrow scalars raised ValueError from the literal
+    # resolver inside the spatial-null detector. They now either resolve
+    # through the array spelling or degrade to the destination-kind null —
+    # never an error, and always still geometry.
+    import geoarrow.pyarrow as ga
+    import pyarrow as pa
+
+    for typ in (ga.wkt(), ga.point()):
+        gdf = sgpd.from_geopandas(points)
+        gdf["geometry"] = pa.scalar(None, typ)
+        assert "geometry" in str(gdf._df.schema.field("geometry").type)
+        assert gdf.to_geopandas()["geometry"].isna().all()
 
 
 def test_clearing_active_geometry_does_not_retype_columns():
@@ -831,6 +874,30 @@ def test_is_missing_handles_null_array_without_pandas(monkeypatch):
 
     from sedonadb_geopandas._frame import _is_missing
 
+    null_array = pa.array([None], type=pa.list_(pa.int64()))
+    value_array = pa.array([1], type=pa.int64())
     monkeypatch.setitem(sys.modules, "pandas", None)
-    assert _is_missing(pa.array([None], type=pa.list_(pa.int64())))
-    assert not _is_missing(pa.array([1], type=pa.int64()))
+    assert _is_missing(null_array)
+    assert not _is_missing(value_array)
+
+
+def test_masked_structured_records(points):
+    # A structured scalar drawn from a MaskedArray failed inside
+    # np.ma.is_masked before any conversion ran — even fully unmasked.
+    # Unmasked and partially masked records broadcast as typed structs with
+    # masked fields null; a fully masked record is missing.
+    import numpy as np
+
+    dtype = [("count", "int16"), ("ratio", "float32")]
+
+    def record(mask):
+        return np.ma.MaskedArray([(3, 1.5)], mask=[mask], dtype=dtype)[0]
+
+    gdf = sgpd.from_geopandas(points)
+    gdf["a"] = record((False, False))
+    gdf["b"] = record((True, False))
+    gdf["c"] = record((True, True))
+    out = gdf.to_geopandas()
+    assert out["a"].tolist() == [{"count": 3, "ratio": 1.5}] * len(points)
+    assert out["b"].tolist() == [{"count": None, "ratio": 1.5}] * len(points)
+    assert out["c"].isna().all()

--- a/python/sedonadb-geopandas/tests/test_geopandas_compat.py
+++ b/python/sedonadb-geopandas/tests/test_geopandas_compat.py
@@ -741,3 +741,96 @@ def test_typed_null_nested_scalar_keeps_geometry(points):
     assert gdf._geometry_name == "geometry"
     assert "3857" in str(gdf.crs)
     assert gdf.to_geopandas()["geometry"].isna().all()
+
+
+def test_crs_less_geography_replacement_stays_crs_less():
+    # A geography constructor synthesizes CRS84, so replacing a CRS-less
+    # geography with None or a Shapely value silently gained a CRS; the
+    # synthesized one is stripped back off when the destination has none.
+    from shapely.geometry import Point
+
+    def crs_less():
+        df = sgpd.default_context().sql(
+            "SELECT ST_GeogFromWKT('POINT (0 0)') AS g, 1 AS v"
+        )
+        df = df.mutate(g=df["g"].funcs.st_setcrs(df._ctx.lit(None)))
+        return GeoDataFrame(df, geometry="g")
+
+    base = crs_less()
+    assert base._df.schema.field("g").type.crs is None
+    for value in (None, Point(1, 1)):
+        gdf = crs_less()
+        gdf["g"] = value
+        dtype = gdf._df.schema.field("g").type
+        assert "geography" in str(dtype)
+        assert dtype.crs is None
+
+
+def test_typed_spatial_null_keeps_its_own_crs(points):
+    # An invalid GeoArrow scalar typed EPSG:4267 was routed through the
+    # missing path, which synthesized a destination-kind null stamped with
+    # the destination CRS — while the equivalent valid scalar kept 4267. A
+    # typed spatial null is a geometry value that happens to be null: it
+    # keeps its own kind and CRS metadata.
+    import geopandas as gpd
+    import geoarrow.pyarrow as ga
+    import pyarrow as pa
+
+    crs4267 = gpd.GeoSeries.from_wkt(["POINT (0 0)"], crs="EPSG:4267").crs
+    null_scalar = pa.scalar(None, ga.wkb().with_crs(crs4267.to_json()))
+    gdf = sgpd.from_geopandas(points)
+    gdf["geometry"] = null_scalar
+    dtype = gdf._df.schema.field("geometry").type
+    assert "4267" in str(dtype)
+    assert gdf.to_geopandas()["geometry"].isna().all()
+    # A typed *non-spatial* null still means "missing geometry".
+    gdf = sgpd.from_geopandas(points)
+    gdf["geometry"] = pa.scalar(None, pa.float64())
+    assert "3857" in str(gdf._df.schema.field("geometry").type)
+
+
+def test_clearing_active_geometry_does_not_retype_columns():
+    # Clearing the marker by reconstructing the frame let the GeoDataFrame
+    # constructor coerce an unrelated all-null column named "geometry" to
+    # geometry dtype; the marker is cleared in place instead.
+    gdf = GeoDataFrame(
+        sgpd.default_context().sql(
+            "SELECT CAST(NULL AS VARCHAR) AS geometry, "
+            "ST_SetSRID(ST_Point(0.0, 0.0), 3857) AS copy"
+        ),
+        geometry=None,
+    )
+    out = gdf.to_geopandas()
+    assert str(out["geometry"].dtype) != "geometry"
+    with pytest.raises(AttributeError):
+        out.geometry
+
+
+def test_structured_numpy_scalars_keep_fields_and_dtypes(points):
+    # A structured np.void flattened to a tuple, silently storing
+    # [("count", int16), ("ratio", float32)] as list<float64>; it broadcasts
+    # as a typed Arrow struct with field names and dtypes intact.
+    import numpy as np
+
+    rec = np.array([(3, 1.5)], dtype=[("count", "int16"), ("ratio", "float32")])[0]
+    gdf = sgpd.from_geopandas(points)
+    gdf["x"] = rec
+    dtype = str(gdf._df.schema.field("x").type)
+    assert "Int16" in dtype and "Float32" in dtype
+    assert gdf.to_geopandas()["x"].tolist() == [{"count": 3, "ratio": 1.5}] * len(
+        points
+    )
+
+
+def test_is_missing_handles_null_array_without_pandas(monkeypatch):
+    # The one-element-null array classification must not depend on optional
+    # pandas; blocking the import proves the branch answers on its own.
+    import sys
+
+    import pyarrow as pa
+
+    from sedonadb_geopandas._frame import _is_missing
+
+    monkeypatch.setitem(sys.modules, "pandas", None)
+    assert _is_missing(pa.array([None], type=pa.list_(pa.int64())))
+    assert not _is_missing(pa.array([1], type=pa.int64()))

--- a/python/sedonadb-geopandas/tests/test_geopandas_compat.py
+++ b/python/sedonadb-geopandas/tests/test_geopandas_compat.py
@@ -587,6 +587,23 @@ def test_geography_column_replacement_preserves_geography():
     got = gdf.to_geopandas()["g"]
     assert got.tolist()[0] == Point(1, 1)
 
+    # A non-default CRS survives too: the geography constructors synthesize
+    # CRS84, which must not be mistaken for a CRS the value carried itself.
+    def geog_4267():
+        return GeoDataFrame(
+            sgpd.default_context().sql(
+                "SELECT ST_SetSRID(ST_GeogFromWKT('POINT (0 0)'), 4267) AS g, 1 AS v"
+            ),
+            geometry="g",
+        )
+
+    for value in (None, Point(1, 1)):
+        gdf = geog_4267()
+        gdf["g"] = value
+        dtype = str(gdf._df.schema.field("g").type)
+        assert "geography" in dtype
+        assert "4267" in dtype
+
 
 def test_numpy_scalar_dtypes_are_preserved(points):
     # .item() promoted np.int8/np.float32 to int64/float64 columns and
@@ -670,3 +687,57 @@ def test_multipart_geometries_classify_as_scalars(points):
     gdf = sgpd.from_geopandas(points)
     gdf["mp"] = value
     assert gdf.to_geopandas()["mp"].tolist() == [value] * len(points)
+
+
+def test_no_active_geometry_survives_any_column_name(points):
+    # The materializer rebuild went through the GeoDataFrame constructor,
+    # which auto-activates a geometry column literally named "geometry" — so
+    # clearing the active `geom` resurrected the secondary column and a later
+    # to_crs() would transform it. The no-active marker is preserved
+    # explicitly, whatever the remaining columns are called.
+    gdf = GeoDataFrame(
+        sgpd.default_context().sql(
+            "SELECT ST_SetSRID(ST_Point(0.0, 0.0), 3857) AS geom, "
+            "ST_SetSRID(ST_Point(9.0, 9.0), 4326) AS geometry, 1 AS a"
+        ),
+        geometry="geom",
+    )
+    gdf["geom"] = 7
+    assert gdf._geometry_name is None
+    out = gdf.to_geopandas()
+    with pytest.raises(AttributeError):
+        out.geometry
+
+    explicit = GeoDataFrame(
+        sgpd.default_context().create_data_frame(points), geometry=None
+    )
+    out = explicit.to_geopandas()
+    with pytest.raises(AttributeError):
+        out.geometry
+
+
+def test_numpy_void_scalars_broadcast_as_binary(points):
+    # np.void has no Arrow scalar form, so the typed-scalar conversion broke
+    # what previously worked: void values broadcast through .item() as bytes.
+    import numpy as np
+
+    gdf = sgpd.from_geopandas(points)
+    gdf["x"] = np.void(b"abcd")
+    assert gdf.to_geopandas()["x"].tolist() == [b"abcd"] * len(points)
+    gdf["y"] = np.array(np.void(b"ab"))
+    assert gdf.to_geopandas()["y"].tolist() == [b"ab"] * len(points)
+
+
+def test_typed_null_nested_scalar_keeps_geometry(points):
+    # Normalization rewrites a typed-null nested scalar into its one-element
+    # array spelling before missingness is judged; recognizing that spelling
+    # only worked through pandas coincidence, and without pandas the null
+    # converted the geometry column to a list column. Classification is
+    # explicit now: one null element is one missing value.
+    import pyarrow as pa
+
+    gdf = sgpd.from_geopandas(points)
+    gdf["geometry"] = pa.scalar(None, pa.list_(pa.int64()))
+    assert gdf._geometry_name == "geometry"
+    assert "3857" in str(gdf.crs)
+    assert gdf.to_geopandas()["geometry"].isna().all()

--- a/python/sedonadb-geopandas/tests/test_geopandas_compat.py
+++ b/python/sedonadb-geopandas/tests/test_geopandas_compat.py
@@ -901,3 +901,72 @@ def test_masked_structured_records(points):
     assert out["a"].tolist() == [{"count": 3, "ratio": 1.5}] * len(points)
     assert out["b"].tolist() == [{"count": None, "ratio": 1.5}] * len(points)
     assert out["c"].isna().all()
+
+
+def test_geoarrow_scalars_to_new_columns(points):
+    # The new-column fast path returned lit(raw) before GeoArrow handling
+    # began: null WKT/point scalars raised ValueError, and a spherical WKB
+    # scalar silently became planar — and could even become the active
+    # geometry of a geometry-less frame with the wrong semantics.
+    import geoarrow.pyarrow as ga
+    import geopandas as gpd
+    import pyarrow as pa
+    from shapely.geometry import Point
+
+    crs4267 = gpd.GeoSeries.from_wkt(["POINT (0 0)"], crs="EPSG:4267").crs
+    sph = ga.wkb().with_edge_type(ga.EdgeType.SPHERICAL).with_crs(crs4267.to_json())
+
+    gdf = sgpd.from_geopandas(points)
+    gdf["fresh"] = pa.scalar(Point(1, 1).wkb, sph)
+    dtype = str(gdf._df.schema.field("fresh").type)
+    assert "geography" in dtype and "4267" in dtype
+    for typ in (ga.wkt(), ga.point()):
+        gdf = sgpd.from_geopandas(points)
+        gdf["fresh"] = pa.scalar(None, typ)
+        assert "geometry" in str(gdf._df.schema.field("fresh").type)
+
+    plain = GeoDataFrame(sgpd.default_context().sql("SELECT 1 AS a"))
+    plain["g"] = pa.scalar(Point(1, 1).wkb, sph)
+    assert "geography" in str(plain._df.schema.field("g").type)
+    assert plain._geometry_name == "g"
+
+
+def test_non_wkb_geoarrow_null_keeps_its_own_crs(points):
+    # The metadata-rebuilt null stamped str(StringCrs(...)) into ST_SetCRS,
+    # which is not PROJJSON and failed deserialization; the canonical
+    # to_json() form is used instead.
+    import geoarrow.pyarrow as ga
+    import geopandas as gpd
+    import pyarrow as pa
+
+    crs4267 = gpd.GeoSeries.from_wkt(["POINT (0 0)"], crs="EPSG:4267").crs
+    gdf = sgpd.from_geopandas(points)
+    gdf["geometry"] = pa.scalar(None, ga.wkt().with_crs(crs4267.to_json()))
+    dtype = str(gdf._df.schema.field("geometry").type)
+    assert "4267" in dtype
+    assert gdf.to_geopandas()["geometry"].isna().all()
+
+
+def test_zero_dim_structured_masked_containers(points):
+    # A 0-d structured MaskedArray raised an opaque structured-dtype-to-bool
+    # TypeError inside the generic mask check, directly and inside a Literal;
+    # it unwraps to its record form first.
+    import numpy as np
+
+    from sedonadb.expr import lit
+
+    dtype = [("count", "int16"), ("ratio", "float32")]
+
+    def container(mask):
+        return np.ma.MaskedArray((3, 1.5), mask=mask, dtype=dtype)
+
+    gdf = sgpd.from_geopandas(points)
+    gdf["a"] = container((False, False))
+    gdf["b"] = container((True, False))
+    gdf["c"] = container((True, True))
+    gdf["d"] = lit(container((True, False)))
+    out = gdf.to_geopandas()
+    assert out["a"].tolist() == [{"count": 3, "ratio": 1.5}] * len(points)
+    assert out["b"].tolist() == [{"count": None, "ratio": 1.5}] * len(points)
+    assert out["c"].isna().all()
+    assert out["d"].tolist() == [{"count": None, "ratio": 1.5}] * len(points)

--- a/python/sedonadb-geopandas/tests/test_geopandas_compat.py
+++ b/python/sedonadb-geopandas/tests/test_geopandas_compat.py
@@ -32,6 +32,16 @@ def cities():
 
 
 @pytest.fixture
+def points():
+    """A small frame in a projected CRS, shared across the tests."""
+    return gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.GeoSeries.from_wkt(["POINT (0 0)", "POINT (5 5)", "POINT (9 9)"]),
+        crs="EPSG:3857",
+    )
+
+
+@pytest.fixture
 def con_free_geom_frame():
     """A frame whose active geometry column is *not* the heuristic's pick.
 
@@ -242,3 +252,264 @@ def test_head(cities):
     assert len(gdf.head(2)) == 2
     # head() keeps the active geometry column.
     assert isinstance(gdf.head(2).geometry, GeoSeries)
+
+
+# -- column assignment -------------------------------------------------------
+
+
+def test_setitem_from_series(points):
+    gdf = sgpd.from_geopandas(points)
+    gdf["v2"] = gdf["v"]
+    got = gdf.to_geopandas().sort_values("name")
+    assert got["v2"].tolist() == points["v"].tolist()
+
+
+def test_setitem_replaces_existing_column(points):
+    gdf = sgpd.from_geopandas(points)
+    gdf["v"] = gdf["name"]
+    assert sorted(gdf.to_geopandas()["v"]) == ["A", "B", "C"]
+    assert gdf.columns.count("v") == 1
+
+
+def test_setitem_scalar_broadcasts(points):
+    gdf = sgpd.from_geopandas(points)
+    gdf["k"] = 7
+    assert gdf.to_geopandas()["k"].tolist() == [7, 7, 7]
+
+
+def test_setitem_geometry_column(points):
+    gdf = sgpd.from_geopandas(points)
+    gdf["buffered"] = gdf.geometry.buffer(0.5)
+    assert "buffered" in gdf.columns
+    # The active geometry column is unchanged by adding another one.
+    assert gdf.geometry._name == "geometry"
+
+
+def test_setitem_makes_geometry_active_when_frame_had_none():
+    # A frame that starts without geometry gains an active geometry column when
+    # one is assigned.
+    from shapely.geometry import Point
+
+    plain = GeoDataFrame(sgpd.default_context().sql("SELECT 1 AS a"))
+    assert plain._geometry_name is None
+
+    plain["geometry"] = Point(1, 2)
+    assert plain._geometry_name == "geometry"
+    assert plain.to_geopandas().geometry.to_wkt().tolist() == ["POINT (1 2)"]
+
+
+def test_setitem_non_geometry_leaves_frame_without_geometry():
+    plain = GeoDataFrame(sgpd.default_context().sql("SELECT 1.0 AS x"))
+    plain["doubled"] = plain["x"]
+    assert plain._geometry_name is None
+
+
+def test_setitem_rejects_bad_inputs(points):
+    gdf = sgpd.from_geopandas(points)
+    with pytest.raises(TypeError, match="must be a string"):
+        gdf[0] = 1
+    with pytest.raises(TypeError, match="isn't supported"):
+        gdf["x"] = points["v"]
+    # A Series from a different frame has no row alignment.
+    other = sgpd.from_geopandas(points)
+    with pytest.raises(ValueError, match="different"):
+        gdf["y"] = other["v"]
+
+
+def test_setitem_stale_series_raises(points):
+    # Assignment rebinds the frame, so a Series read beforehand is stale.
+    gdf = sgpd.from_geopandas(points)
+    before = gdf["v"]
+    gdf["k"] = 1
+    with pytest.raises(ValueError, match="different"):
+        gdf["z"] = before
+
+
+def test_setitem_rejects_bare_expression(points):
+    # A bare expression carries no origin, so one built from another frame would
+    # resolve against this frame and silently write this frame's values.
+    left = sgpd.from_geopandas(points)
+    right = sgpd.from_geopandas(points)
+    with pytest.raises(TypeError, match="bare expression"):
+        left["copied"] = right["v"]._expr
+
+
+def test_series_has_no_unguarded_expr_escape_hatch(points):
+    assert not hasattr(sgpd.from_geopandas(points)["v"], "expr")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [[10, 20, 30], (10, 20, 30), {10, 20}],
+    ids=["list", "tuple", "set"],
+)
+def test_setitem_rejects_sequences(points, value):
+    # Sequences have no __array__, so they used to be broadcast whole into every
+    # row rather than rejected.
+    gdf = sgpd.from_geopandas(points)
+    with pytest.raises(TypeError, match="isn't supported"):
+        gdf["x"] = value
+
+
+def test_setitem_accepts_numpy_scalar(points):
+    # NumPy scalars do have __array__ but are single values, so they used to be
+    # rejected as array-likes.
+    import numpy as np
+
+    gdf = sgpd.from_geopandas(points)
+    gdf["x"] = np.int64(5)
+    assert gdf.to_geopandas()["x"].tolist() == [5, 5, 5]
+
+
+def test_setitem_rejects_numpy_array(points):
+    import numpy as np
+
+    gdf = sgpd.from_geopandas(points)
+    with pytest.raises(TypeError, match="isn't supported"):
+        gdf["x"] = np.array([1, 2, 3])
+
+
+def test_getitem_rejects_stale_mask(points):
+    # Assignment rebinds the frame, so a mask captured beforehand belongs to the
+    # previous one. It used to be accepted and quietly resolve against the new
+    # frame while the referenced column happened to still exist.
+    gdf = sgpd.from_geopandas(points)
+    mask = gdf["v"] > 1
+    gdf["k"] = 1
+    with pytest.raises(ValueError, match="different DataFrame"):
+        gdf[mask]
+
+
+def test_setitem_none_keeps_geometry_column(points):
+    # Assigning None used to turn the column untyped and clear the active geometry;
+    # GeoPandas keeps a geometry column with its CRS.
+    gdf = sgpd.from_geopandas(points)
+    gdf["geometry"] = None
+    assert gdf._geometry_name == "geometry"
+    assert "3857" in str(gdf.crs)
+    assert gdf.to_geopandas().geometry.isna().all()
+
+
+def test_setitem_non_geometry_over_geometry_still_clears(points):
+    # The CRS-preserving path must not dress a number up as geometry.
+    gdf = sgpd.from_geopandas(points)
+    gdf["geometry"] = 7
+    assert gdf._geometry_name is None
+    assert gdf.to_geopandas()["geometry"].tolist() == [7, 7, 7]
+
+
+@pytest.mark.parametrize(
+    "value_name",
+    ["none", "nan", "pandas_na", "geometry", "literal_geometry", "literal_none"],
+)
+def test_setitem_geometry_scalars_keep_type_and_crs(points, value_name):
+    # Every supported scalar path has to go through the CRS-preserving branch:
+    # GeoPandas treats None, NaN and pd.NA as missing geometry and keeps the typed
+    # column and its CRS.
+    import numpy as np
+    import pandas as pd
+    from shapely.geometry import Point
+
+    from sedonadb.expr import lit
+
+    values = {
+        "none": None,
+        "nan": np.nan,
+        "pandas_na": pd.NA,
+        "geometry": Point(5, 5),
+        "literal_geometry": lit(Point(5, 5)),
+        "literal_none": lit(None),
+    }
+    gdf = sgpd.from_geopandas(points)
+    gdf["geometry"] = values[value_name]
+    assert gdf._geometry_name == "geometry"
+    assert "3857" in str(gdf.crs)
+
+
+def test_setitem_crs_carrying_literal_keeps_its_crs(points):
+    # A literal that carries its own CRS must not be relabeled with the
+    # destination column's CRS — that changes what the coordinates mean without
+    # transforming them.
+    from sedonadb.expr import lit
+
+    src = gpd.GeoSeries.from_wkt(["POINT (10 10)"], crs="EPSG:4326")
+    gdf = sgpd.from_geopandas(points)  # column is EPSG:3857
+    gdf["geometry"] = lit(src)
+    assert "4326" in str(gdf.crs)
+
+
+def test_pandas_na_assigns_as_null_to_ordinary_column(points):
+    import pandas as pd
+
+    gdf = sgpd.from_geopandas(points)
+    gdf["z"] = pd.NA
+    assert gdf.to_geopandas()["z"].isna().all()
+
+
+def test_zero_dimensional_array_normalizes(points):
+    import numpy as np
+
+    gdf = sgpd.from_geopandas(points)
+    gdf["z"] = np.array(5)  # 0-d: scalar by classification, unwrapped on use
+    assert gdf.to_geopandas()["z"].tolist() == [5, 5, 5]
+
+
+def test_masked_scalar_assigns_as_missing(points):
+    import numpy as np
+
+    gdf = sgpd.from_geopandas(points)
+    gdf["m"] = np.ma.masked
+    assert gdf.to_geopandas()["m"].isna().all()
+
+
+def test_pyarrow_scalars_broadcast(points):
+    # Arrow scalars implement __len__ but are single values.
+    import pyarrow as pa
+
+    from sedonadb_geopandas._series import is_scalar
+
+    assert is_scalar(pa.scalar([1, 2]))
+    assert is_scalar(pa.scalar({"a": 1}))
+    gdf = sgpd.from_geopandas(points)
+    gdf["tags"] = pa.scalar([1, 2])
+    assert len(gdf.to_geopandas()["tags"]) == 3
+
+
+def test_geoarrow_scalar_inherits_crs(points):
+    # A GeoArrow WKB scalar has no __geo_interface__, so geometry-ness must come
+    # from the resolved schema; it is CRS-less and inherits the column's CRS.
+    import geoarrow.pyarrow as ga
+
+    w = ga.as_wkb(ga.array(["POINT (5 5)"]))[0]
+    gdf = sgpd.from_geopandas(points)
+    gdf["geometry"] = w
+    assert gdf._geometry_name == "geometry"
+    assert "3857" in str(gdf.crs)
+
+
+def test_explicitly_inactive_geometry_stays_inactive(points):
+    # geometry=None is a choice; a no-op reassignment of an existing geometry
+    # column must not silently reactivate it.
+    df = sgpd.default_context().create_data_frame(points)
+    gdf = GeoDataFrame(df, geometry=None)
+    gdf["geometry"] = gdf["geometry"]
+    assert gdf._geometry_name is None
+
+
+def test_temporal_scalars_are_deferred(points):
+    # Representing temporal scalars faithfully needs dedicated unit and
+    # timezone handling — a naive literal would silently truncate nanoseconds
+    # or reject most NumPy units — which arrives as its own change; until
+    # then they are rejected outright rather than stored subtly wrong.
+    import numpy as np
+    import pandas as pd
+
+    gdf = sgpd.from_geopandas(points)
+    for value in (
+        np.datetime64("2026-01-01", "ns"),
+        np.timedelta64(1, "ns"),
+        pd.Timestamp("2026-01-01"),
+        pd.Timedelta(1),
+    ):
+        with pytest.raises(TypeError, match="not supported yet"):
+            gdf["t"] = value

--- a/python/sedonadb-geopandas/tests/test_geopandas_compat.py
+++ b/python/sedonadb-geopandas/tests/test_geopandas_compat.py
@@ -15,11 +15,23 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import sys
+
+import geoarrow.pyarrow as ga
 import geopandas as gpd
+import numpy as np
+import numpy.ma.mrecords as mrecords
+import pandas as pd
+import pyarrow as pa
 import pytest
+from geopandas.testing import assert_geodataframe_equal
+from sedonadb.expr import lit
+from shapely.geometry import MultiPoint, Point
 
 import sedonadb_geopandas as sgpd
 from sedonadb_geopandas import GeoDataFrame, GeoSeries, Series
+from sedonadb_geopandas._frame import _is_missing
+from sedonadb_geopandas._series import is_scalar
 
 
 @pytest.fixture
@@ -65,7 +77,6 @@ def assert_geopandas_expr_equal(gdf, op, *, sort_by):
     row index. `check_crs` is left on, so CRS propagation is asserted too.
     Useful for throwing a corpus of GeoPandas ops at the wrapper.
     """
-    from geopandas.testing import assert_geodataframe_equal
 
     expected = op(gdf).sort_values(sort_by).reset_index(drop=True)
     got = (
@@ -169,7 +180,6 @@ def test_crs_propagates_from_projected_and_geographic(source_crs):
 
 def test_operand_accepts_literal(cities):
     # lit() is a supported escape hatch (and the way to carry a CRS).
-    from sedonadb.expr import lit
 
     gdf = sgpd.from_geopandas(cities)
     out = gdf[gdf["pop"] > lit(150)].to_geopandas().sort_values("name")
@@ -288,7 +298,6 @@ def test_setitem_geometry_column(points):
 def test_setitem_makes_geometry_active_when_frame_had_none():
     # A frame that starts without geometry gains an active geometry column when
     # one is assigned.
-    from shapely.geometry import Point
 
     plain = GeoDataFrame(sgpd.default_context().sql("SELECT 1 AS a"))
     assert plain._geometry_name is None
@@ -317,12 +326,33 @@ def test_setitem_rejects_bad_inputs(points):
 
 
 def test_setitem_stale_series_raises(points):
-    # Assignment rebinds the frame, so a Series read beforehand is stale.
+    # Replacing a column rebinds the frame in a way earlier reads cannot
+    # follow: a Series read beforehand would resolve to the new values, so it
+    # is stale and raises.
     gdf = sgpd.from_geopandas(points)
     before = gdf["v"]
-    gdf["k"] = 1
+    gdf["v"] = gdf["name"]
     with pytest.raises(ValueError, match="different"):
         gdf["z"] = before
+
+
+def test_series_survives_column_adding_assignments(points):
+    # One captured geometry can supply several derived columns in turn: an
+    # assignment that only adds a column leaves rows and existing columns
+    # untouched, so an earlier Series still resolves to the values it showed.
+    gdf = sgpd.from_geopandas(points)
+    g = gdf.geometry
+    v = gdf["v"]
+    gdf["buffered"] = g.buffer(1.0)
+    gdf["area"] = g.buffer(1.0).area
+    gdf["x_plus"] = v
+    out = gdf.to_geopandas().sort_values("name")
+    assert out["x_plus"].tolist() == points["v"].tolist()
+    assert (out["area"] > 3.0).all()
+    # ... and a filter by an earlier mask is equally valid.
+    mask = gdf["v"] > 1
+    gdf["k"] = 1
+    assert len(gdf[mask]) == 2
 
 
 def test_setitem_rejects_bare_expression(points):
@@ -354,7 +384,6 @@ def test_setitem_rejects_sequences(points, value):
 def test_setitem_accepts_numpy_scalar(points):
     # NumPy scalars do have __array__ but are single values, so they used to be
     # rejected as array-likes.
-    import numpy as np
 
     gdf = sgpd.from_geopandas(points)
     gdf["x"] = np.int64(5)
@@ -362,22 +391,26 @@ def test_setitem_accepts_numpy_scalar(points):
 
 
 def test_setitem_rejects_numpy_array(points):
-    import numpy as np
-
     gdf = sgpd.from_geopandas(points)
     with pytest.raises(TypeError, match="isn't supported"):
         gdf["x"] = np.array([1, 2, 3])
 
 
 def test_getitem_rejects_stale_mask(points):
-    # Assignment rebinds the frame, so a mask captured beforehand belongs to the
-    # previous one. It used to be accepted and quietly resolve against the new
-    # frame while the referenced column happened to still exist.
+    # Replacing a column (or filtering) rebinds the frame, so a mask captured
+    # beforehand belongs to the previous one. It used to be accepted and
+    # quietly resolve against the new frame while the referenced column
+    # happened to still exist.
     gdf = sgpd.from_geopandas(points)
     mask = gdf["v"] > 1
-    gdf["k"] = 1
+    gdf["v"] = gdf["name"]
     with pytest.raises(ValueError, match="different DataFrame"):
         gdf[mask]
+    gdf = sgpd.from_geopandas(points)
+    mask = gdf["v"] > 1
+    filtered = gdf[gdf["v"] > 0]
+    with pytest.raises(ValueError, match="different DataFrame"):
+        filtered[mask]
 
 
 def test_setitem_none_keeps_geometry_column(points):
@@ -406,11 +439,6 @@ def test_setitem_geometry_scalars_keep_type_and_crs(points, value_name):
     # Every supported scalar path has to go through the CRS-preserving branch:
     # GeoPandas treats None, NaN and pd.NA as missing geometry and keeps the typed
     # column and its CRS.
-    import numpy as np
-    import pandas as pd
-    from shapely.geometry import Point
-
-    from sedonadb.expr import lit
 
     values = {
         "none": None,
@@ -430,7 +458,6 @@ def test_setitem_crs_carrying_literal_keeps_its_crs(points):
     # A literal that carries its own CRS must not be relabeled with the
     # destination column's CRS — that changes what the coordinates mean without
     # transforming them.
-    from sedonadb.expr import lit
 
     src = gpd.GeoSeries.from_wkt(["POINT (10 10)"], crs="EPSG:4326")
     gdf = sgpd.from_geopandas(points)  # column is EPSG:3857
@@ -439,24 +466,18 @@ def test_setitem_crs_carrying_literal_keeps_its_crs(points):
 
 
 def test_pandas_na_assigns_as_null_to_ordinary_column(points):
-    import pandas as pd
-
     gdf = sgpd.from_geopandas(points)
     gdf["z"] = pd.NA
     assert gdf.to_geopandas()["z"].isna().all()
 
 
 def test_zero_dimensional_array_normalizes(points):
-    import numpy as np
-
     gdf = sgpd.from_geopandas(points)
     gdf["z"] = np.array(5)  # 0-d: scalar by classification, unwrapped on use
     assert gdf.to_geopandas()["z"].tolist() == [5, 5, 5]
 
 
 def test_masked_scalar_assigns_as_missing(points):
-    import numpy as np
-
     gdf = sgpd.from_geopandas(points)
     gdf["m"] = np.ma.masked
     assert gdf.to_geopandas()["m"].isna().all()
@@ -464,9 +485,6 @@ def test_masked_scalar_assigns_as_missing(points):
 
 def test_pyarrow_scalars_broadcast(points):
     # Arrow scalars implement __len__ but are single values.
-    import pyarrow as pa
-
-    from sedonadb_geopandas._series import is_scalar
 
     assert is_scalar(pa.scalar([1, 2]))
     assert is_scalar(pa.scalar({"a": 1}))
@@ -478,7 +496,6 @@ def test_pyarrow_scalars_broadcast(points):
 def test_geoarrow_scalar_inherits_crs(points):
     # A GeoArrow WKB scalar has no __geo_interface__, so geometry-ness must come
     # from the resolved schema; it is CRS-less and inherits the column's CRS.
-    import geoarrow.pyarrow as ga
 
     w = ga.as_wkb(ga.array(["POINT (5 5)"]))[0]
     gdf = sgpd.from_geopandas(points)
@@ -494,25 +511,6 @@ def test_explicitly_inactive_geometry_stays_inactive(points):
     gdf = GeoDataFrame(df, geometry=None)
     gdf["geometry"] = gdf["geometry"]
     assert gdf._geometry_name is None
-
-
-def test_temporal_scalars_are_deferred(points):
-    # Representing temporal scalars faithfully needs dedicated unit and
-    # timezone handling — a naive literal would silently truncate nanoseconds
-    # or reject most NumPy units — which arrives as its own change; until
-    # then they are rejected outright rather than stored subtly wrong.
-    import numpy as np
-    import pandas as pd
-
-    gdf = sgpd.from_geopandas(points)
-    for value in (
-        np.datetime64("2026-01-01", "ns"),
-        np.timedelta64(1, "ns"),
-        pd.Timestamp("2026-01-01"),
-        pd.Timedelta(1),
-    ):
-        with pytest.raises(TypeError, match="not supported yet"):
-            gdf["t"] = value
 
 
 # -- regressions from review ------------------------------------------------
@@ -567,7 +565,6 @@ def test_geography_column_replacement_preserves_geography():
     # Replacing a geography column with None or a Shapely scalar rebuilt it
     # as planar geometry; replacements are constructed with the destination's
     # own spatial kind.
-    from shapely.geometry import Point
 
     def geog_frame():
         return GeoDataFrame(
@@ -608,7 +605,6 @@ def test_geography_column_replacement_preserves_geography():
 def test_numpy_scalar_dtypes_are_preserved(points):
     # .item() promoted np.int8/np.float32 to int64/float64 columns and
     # overflowed np.uint64 past int64, which the engine supports natively.
-    import numpy as np
 
     gdf = sgpd.from_geopandas(points)
     gdf["i8"] = np.int8(5)
@@ -626,7 +622,6 @@ def test_arrow_wrapped_missing_values_keep_geometry(points):
     # pa.scalar(None), typed Arrow nulls, and Arrow-wrapped NaN cleared the
     # active geometry and CRS, unlike the equivalent bare None/NaN; a wrapped
     # value means whatever its payload means.
-    import pyarrow as pa
 
     for value in (
         pa.scalar(None),
@@ -643,7 +638,6 @@ def test_arrow_wrapped_missing_values_keep_geometry(points):
 def test_typed_null_nested_scalars_broadcast(points):
     # Valid nested Arrow scalars broadcast, but their typed-null forms failed
     # literal construction; they re-enter as one-element typed arrays.
-    import pyarrow as pa
 
     for value in (
         pa.scalar(None, pa.list_(pa.int64())),
@@ -654,36 +648,11 @@ def test_typed_null_nested_scalars_broadcast(points):
         assert gdf.to_geopandas()["x"].isna().all()
 
 
-def test_nat_is_rejected_like_other_temporals(points):
-    # pd.NaT is an instance of neither Timestamp nor Timedelta, so it slipped
-    # past the temporal deferral: ordinary assignment failed with a backend
-    # error while geometry assignment absorbed it as missing.
-    import pandas as pd
-
-    gdf = sgpd.from_geopandas(points)
-    with pytest.raises(TypeError, match="not supported yet"):
-        gdf["x"] = pd.NaT
-    with pytest.raises(TypeError, match="not supported yet"):
-        gdf["geometry"] = pd.NaT
-
-
 def test_multipart_geometries_classify_as_scalars(points):
-    # Shapely 1.x multipart geometries implement __len__, so the generic
-    # sequence check rejected them; any BaseGeometry is a single value.
-    from shapely.geometry import MultiPoint
-    from shapely.geometry.base import BaseGeometry
-
-    from sedonadb_geopandas._series import is_scalar
-
+    # A multipart geometry is a single value (Shapely 2 no longer gives it a
+    # sequence protocol, and the package requires Shapely 2).
     value = MultiPoint([(0, 0), (1, 1)])
     assert is_scalar(value)
-    import warnings
-
-    legacy = type("LegacyMultipart", (BaseGeometry,), {"__len__": lambda self: 2})
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")  # instantiating BaseGeometry warns
-        instance = legacy.__new__(legacy)
-    assert is_scalar(instance)
     gdf = sgpd.from_geopandas(points)
     gdf["mp"] = value
     assert gdf.to_geopandas()["mp"].tolist() == [value] * len(points)
@@ -719,7 +688,6 @@ def test_no_active_geometry_survives_any_column_name(points):
 def test_numpy_void_scalars_broadcast_as_binary(points):
     # np.void has no Arrow scalar form, so the typed-scalar conversion broke
     # what previously worked: void values broadcast through .item() as bytes.
-    import numpy as np
 
     gdf = sgpd.from_geopandas(points)
     gdf["x"] = np.void(b"abcd")
@@ -734,7 +702,6 @@ def test_typed_null_nested_scalar_keeps_geometry(points):
     # only worked through pandas coincidence, and without pandas the null
     # converted the geometry column to a list column. Classification is
     # explicit now: one null element is one missing value.
-    import pyarrow as pa
 
     gdf = sgpd.from_geopandas(points)
     gdf["geometry"] = pa.scalar(None, pa.list_(pa.int64()))
@@ -747,7 +714,6 @@ def test_crs_less_geography_replacement_stays_crs_less():
     # A geography constructor synthesizes CRS84, so replacing a CRS-less
     # geography with None or a Shapely value silently gained a CRS; the
     # synthesized one is stripped back off when the destination has none.
-    from shapely.geometry import Point
 
     def crs_less():
         df = sgpd.default_context().sql(
@@ -780,9 +746,6 @@ def test_typed_spatial_null_keeps_its_own_crs(points):
     # the destination CRS — while the equivalent valid scalar kept 4267. A
     # typed spatial null is a geometry value that happens to be null: it
     # keeps its own kind and CRS metadata.
-    import geopandas as gpd
-    import geoarrow.pyarrow as ga
-    import pyarrow as pa
 
     crs4267 = gpd.GeoSeries.from_wkt(["POINT (0 0)"], crs="EPSG:4267").crs
     null_scalar = pa.scalar(None, ga.wkb().with_crs(crs4267.to_json()))
@@ -802,10 +765,6 @@ def test_spherical_geoarrow_scalars_keep_geography(points):
     # valid spherical WKB scalar silently became planar geometry; the
     # one-element-array spelling resolves with the complete extension
     # metadata.
-    import geoarrow.pyarrow as ga
-    import geopandas as gpd
-    import pyarrow as pa
-    from shapely.geometry import Point
 
     crs4267 = gpd.GeoSeries.from_wkt(["POINT (0 0)"], crs="EPSG:4267").crs
     sph = ga.wkb().with_edge_type(ga.EdgeType.SPHERICAL).with_crs(crs4267.to_json())
@@ -822,8 +781,6 @@ def test_non_wkb_geoarrow_nulls_do_not_crash(points):
     # resolver inside the spatial-null detector. They now either resolve
     # through the array spelling or degrade to the destination-kind null —
     # never an error, and always still geometry.
-    import geoarrow.pyarrow as ga
-    import pyarrow as pa
 
     for typ in (ga.wkt(), ga.point()):
         gdf = sgpd.from_geopandas(points)
@@ -853,7 +810,6 @@ def test_structured_numpy_scalars_keep_fields_and_dtypes(points):
     # A structured np.void flattened to a tuple, silently storing
     # [("count", int16), ("ratio", float32)] as list<float64>; it broadcasts
     # as a typed Arrow struct with field names and dtypes intact.
-    import numpy as np
 
     rec = np.array([(3, 1.5)], dtype=[("count", "int16"), ("ratio", "float32")])[0]
     gdf = sgpd.from_geopandas(points)
@@ -868,11 +824,6 @@ def test_structured_numpy_scalars_keep_fields_and_dtypes(points):
 def test_is_missing_handles_null_array_without_pandas(monkeypatch):
     # The one-element-null array classification must not depend on optional
     # pandas; blocking the import proves the branch answers on its own.
-    import sys
-
-    import pyarrow as pa
-
-    from sedonadb_geopandas._frame import _is_missing
 
     null_array = pa.array([None], type=pa.list_(pa.int64()))
     value_array = pa.array([1], type=pa.int64())
@@ -886,7 +837,6 @@ def test_masked_structured_records(points):
     # np.ma.is_masked before any conversion ran — even fully unmasked.
     # Unmasked and partially masked records broadcast as typed structs with
     # masked fields null; a fully masked record is missing.
-    import numpy as np
 
     dtype = [("count", "int16"), ("ratio", "float32")]
 
@@ -908,10 +858,6 @@ def test_geoarrow_scalars_to_new_columns(points):
     # began: null WKT/point scalars raised ValueError, and a spherical WKB
     # scalar silently became planar — and could even become the active
     # geometry of a geometry-less frame with the wrong semantics.
-    import geoarrow.pyarrow as ga
-    import geopandas as gpd
-    import pyarrow as pa
-    from shapely.geometry import Point
 
     crs4267 = gpd.GeoSeries.from_wkt(["POINT (0 0)"], crs="EPSG:4267").crs
     sph = ga.wkb().with_edge_type(ga.EdgeType.SPHERICAL).with_crs(crs4267.to_json())
@@ -935,9 +881,6 @@ def test_non_wkb_geoarrow_null_keeps_its_own_crs(points):
     # The metadata-rebuilt null stamped str(StringCrs(...)) into ST_SetCRS,
     # which is not PROJJSON and failed deserialization; the canonical
     # to_json() form is used instead.
-    import geoarrow.pyarrow as ga
-    import geopandas as gpd
-    import pyarrow as pa
 
     crs4267 = gpd.GeoSeries.from_wkt(["POINT (0 0)"], crs="EPSG:4267").crs
     gdf = sgpd.from_geopandas(points)
@@ -951,9 +894,6 @@ def test_zero_dim_structured_masked_containers(points):
     # A 0-d structured MaskedArray raised an opaque structured-dtype-to-bool
     # TypeError inside the generic mask check, directly and inside a Literal;
     # it unwraps to its record form first.
-    import numpy as np
-
-    from sedonadb.expr import lit
 
     dtype = [("count", "int16"), ("ratio", "float32")]
 
@@ -977,12 +917,6 @@ def test_large_wkb_scalars_normalize_to_binary_storage(points):
     # importer rejects; they are rebuilt on Binary storage with the same CRS
     # and edge metadata. Valid and null, direct and Literal, fresh and
     # geometry destinations.
-    import geoarrow.pyarrow as ga
-    import geopandas as gpd
-    import pyarrow as pa
-    from shapely.geometry import Point
-
-    from sedonadb.expr import lit
 
     crs4267 = gpd.GeoSeries.from_wkt(["POINT (0 0)"], crs="EPSG:4267").crs
     lws = (
@@ -1004,10 +938,6 @@ def test_masked_records_do_not_recurse(points):
     # structured-masked unwrap recursed until RecursionError; the base
     # MaskedArray view yields the record form. All three mask states, direct
     # and through Literal.
-    import numpy as np
-    import numpy.ma.mrecords as mrecords
-
-    from sedonadb.expr import lit
 
     dtype = [("count", "int16"), ("ratio", "float32")]
 
@@ -1026,3 +956,154 @@ def test_masked_records_do_not_recurse(points):
     assert out["b"].tolist() == [{"count": None, "ratio": 1.5}] * len(points)
     assert out["c"].isna().all()
     assert out["d"].tolist() == [{"count": None, "ratio": 1.5}] * len(points)
+
+
+# -- temporal scalars --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value_name,expected_kind",
+    [
+        ("ns_datetime", "datetime"),
+        ("zero_d_ns_datetime", "datetime"),
+        ("day_unit_datetime", "datetime"),
+        ("day_unit_timedelta", "timedelta"),
+        ("datetime_nat", "datetime_nat"),
+        ("timedelta_nat", "timedelta_nat"),
+    ],
+)
+def test_numpy_temporals_materialize_correctly(points, value_name, expected_kind):
+    # Asserted end to end (assignment then collection), not on the normalization
+    # helper: .item() flattening, unit rejection, and zeroed durations were all
+    # invisible to helper-level equality checks.
+
+    values = {
+        "ns_datetime": np.datetime64("2026-01-01", "ns"),
+        "zero_d_ns_datetime": np.array(np.datetime64("2026-01-01", "ns")),
+        "day_unit_datetime": np.datetime64("2026-01-01"),
+        "day_unit_timedelta": np.timedelta64(2, "D"),
+        "datetime_nat": np.datetime64("NaT", "ns"),
+        "timedelta_nat": np.timedelta64("NaT", "ns"),
+    }
+    gdf = sgpd.from_geopandas(points)
+    gdf["t"] = values[value_name]
+    out = gdf.to_geopandas()["t"]
+    if expected_kind == "datetime":
+        assert out.tolist() == [pd.Timestamp("2026-01-01")] * 3
+    elif expected_kind == "timedelta":
+        assert out.tolist() == [pd.Timedelta(days=2)] * 3
+    else:
+        # NaT stays a typed null of the right family.
+        assert out.isna().all()
+        expected_dtype = "datetime64" if "datetime" in expected_kind else "timedelta64"
+        assert expected_dtype in str(out.dtype)
+
+
+def test_coarse_unit_temporals_are_exact(points):
+    # Forcing every temporal through nanoseconds silently wrapped values
+    # outside the ns range (1677-2262): 2500-01-01 materialized as 1915-06-14.
+    # Coarse units convert exactly to seconds instead. Expectations are
+    # independent second-resolution constants — deriving them from the
+    # materialized dtype would repeat the conversion under test and wrap
+    # identically against a broken implementation.
+
+    cases = [
+        (np.datetime64("2500-01-01", "D"), np.datetime64("2500-01-01T00:00:00", "s")),
+        (np.timedelta64(200000, "D"), np.timedelta64(200000 * 86400, "s")),
+        (np.datetime64("2500", "Y"), np.datetime64("2500-01-01T00:00:00", "s")),
+    ]
+    for value, expected in cases:
+        gdf = sgpd.from_geopandas(points)
+        gdf["t"] = value
+        got = gdf.to_geopandas()["t"].values[0]
+        assert got.dtype == expected.dtype
+        assert got == expected
+
+
+def test_ambiguous_and_subnano_temporal_units_are_rejected(points):
+    # Matches pandas, exception type included: timedelta months/years have no
+    # fixed length, and pandas raises ValueError for sub-nanosecond timedeltas
+    # even when the value is exactly representable.
+
+    gdf = sgpd.from_geopandas(points)
+    for unit in ("M", "Y", "ps"):
+        with pytest.raises(ValueError, match="exactly"):
+            gdf["t"] = np.timedelta64(1, unit)
+    # 1000 ps is exactly one nanosecond, and both pandas and GeoPandas still
+    # reject it — the rejection is per unit, not per value.
+    with pytest.raises(ValueError, match="exactly"):
+        gdf["t"] = np.timedelta64(1000, "ps")
+
+
+def test_exact_subnanosecond_datetimes_are_accepted(points):
+    # 10**6 fs and 10**9 as are exactly one nanosecond and GeoPandas accepts
+    # them, so rejecting every sub-ns datetime unit up front was too broad.
+    # Lossy values are still rejected — GeoPandas silently truncates those to
+    # nanoseconds instead, which this layer deliberately does not do.
+
+    for value in (np.datetime64(10**6, "fs"), np.datetime64(10**9, "as")):
+        gdf = sgpd.from_geopandas(points)
+        gdf["t"] = value
+        assert gdf.to_geopandas()["t"].values[0] == np.datetime64(1, "ns")
+
+    gdf = sgpd.from_geopandas(points)
+    with pytest.raises(ValueError, match="precision"):
+        gdf["t"] = np.datetime64(1, "fs")
+
+
+def test_zero_dim_object_array_holding_temporal(points):
+    # A 0-d object array classifies as a broadcastable scalar, but its .item()
+    # returns the wrapped numpy temporal, which bypassed temporal
+    # normalization and failed assignment for non-Arrow-native units.
+
+    gdf = sgpd.from_geopandas(points)
+    gdf["t"] = np.array(np.datetime64("2500-01-01", "D"), dtype=object)
+    got = gdf.to_geopandas()["t"].values[0]
+    assert got == np.datetime64("2500-01-01T00:00:00", "s")
+
+
+def test_pandas_temporal_scalars_keep_nanoseconds(points):
+    # pandas Timestamp/Timedelta scalars resolved to microsecond literals:
+    # assignment silently zeroed nanoseconds, and duration arithmetic lost
+    # them behind an interval coercion (`t + pd.Timedelta(1)` came back as
+    # DateOffset objects with the tick dropped). They route through their
+    # numpy form and its lossless unit handling instead.
+
+    gdf = sgpd.from_geopandas(points)
+    gdf["t"] = pd.Timedelta(1)
+    got = gdf.to_geopandas()["t"]
+    assert got.tolist() == [pd.Timedelta(1)] * len(got)
+    gdf["ts"] = pd.Timestamp("2026-01-01 00:00:00.000000001")
+    got = gdf.to_geopandas()["ts"]
+    assert got.tolist() == [pd.Timestamp("2026-01-01 00:00:00.000000001")] * len(got)
+
+
+def test_tz_aware_timestamp_scalars_keep_nanoseconds_and_zone(points):
+    # pyarrow resolves a zone-aware Timestamp at microseconds, silently
+    # truncating nanoseconds; the scalar is rebuilt at nanosecond ticks with
+    # its zone preserved.
+
+    gdf = sgpd.from_geopandas(points)
+    stamp = pd.Timestamp("2026-01-01 00:00:00.000000001", tz="US/Pacific")
+    gdf["ts"] = stamp
+    got = gdf.to_geopandas()["ts"]
+    assert got.dt.tz is not None
+    assert got.tolist() == [stamp] * len(got)
+
+
+def test_nat_assigns_as_datetime_missing(points):
+    # pd.NaT is an instance of neither Timestamp nor Timedelta, so it slipped
+    # past temporal normalization entirely: ordinary assignment failed with a
+    # backend error while geometry assignment absorbed it as missing. It now
+    # assigns the way pandas assigns it — a datetime column of missing values —
+    # while geometry columns keep treating it as a missing geometry.
+
+    gdf = sgpd.from_geopandas(points)
+    gdf["x"] = pd.NaT
+    got = gdf.to_geopandas()["x"]
+    assert got.isna().all()
+    assert str(got.dtype).startswith("datetime64")
+    gdf = sgpd.from_geopandas(points)
+    gdf["geometry"] = pd.NaT
+    assert gdf._geometry_name == "geometry"
+    assert gdf.to_geopandas()["geometry"].isna().all()

--- a/python/sedonadb-geopandas/tests/test_temporal.py
+++ b/python/sedonadb-geopandas/tests/test_temporal.py
@@ -1,0 +1,158 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Direct tests of the temporal scalar normalization.
+
+The compatibility tests exercise these through assignment and materialization;
+this file pins the unit table and error classes on the helper itself.
+"""
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pytest
+
+from sedonadb_geopandas._temporal import (
+    TICK_SENTINEL,
+    nat_scalar,
+    normalize_temporal_scalar,
+)
+
+
+def test_nat_scalar_is_typed_null():
+    scalar = nat_scalar(pa.duration("us"))
+    assert not scalar.is_valid
+    assert scalar.type == pa.duration("us")
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        # Arrow-native units keep their resolution.
+        (
+            np.datetime64("2026-01-01T00:00:00", "s"),
+            pa.scalar(np.datetime64("2026-01-01T00:00:00", "s")),
+        ),
+        (np.timedelta64(5, "ms"), pa.scalar(np.timedelta64(5, "ms"))),
+        (
+            np.datetime64("2026-01-01T00:00:00.000000001", "ns"),
+            pa.scalar(np.datetime64("2026-01-01T00:00:00.000000001", "ns")),
+        ),
+        # Whole multiples of seconds convert exactly to seconds — including
+        # values far outside the nanosecond range.
+        (
+            np.datetime64("2500-01-01", "D"),
+            pa.scalar(np.datetime64("2500-01-01T00:00:00", "s")),
+        ),
+        (np.timedelta64(3, "W"), pa.scalar(np.timedelta64(3 * 7 * 86400, "s"))),
+        (np.timedelta64(200000, "D"), pa.scalar(np.timedelta64(200000 * 86400, "s"))),
+        # Calendar positions are exact instants for a datetime.
+        (
+            np.datetime64("2500", "Y"),
+            pa.scalar(np.datetime64("2500-01-01T00:00:00", "s")),
+        ),
+        (
+            np.datetime64("2500-06", "M"),
+            pa.scalar(np.datetime64("2500-06-01T00:00:00", "s")),
+        ),
+        # Sub-nanosecond datetimes narrow to ns when exact.
+        (np.datetime64(10**6, "fs"), pa.scalar(np.datetime64(1, "ns"))),
+        # pandas scalars keep nanoseconds (their own literal path is µs).
+        (pd.Timedelta(1), pa.scalar(np.timedelta64(1, "ns"))),
+        (
+            pd.Timestamp("2026-01-01 00:00:00.000000001"),
+            pa.scalar(np.datetime64("2026-01-01T00:00:00.000000001", "ns")),
+        ),
+    ],
+    ids=[
+        "s",
+        "ms",
+        "ns",
+        "day",
+        "week",
+        "big_day",
+        "year",
+        "month",
+        "fs_exact",
+        "pd_timedelta",
+        "pd_timestamp",
+    ],
+)
+def test_normalize_temporal_scalar_units(value, expected):
+    got = normalize_temporal_scalar(value)
+    assert got.type == expected.type
+    assert got == expected
+
+
+def test_normalize_temporal_scalar_zone_aware():
+    stamp = pd.Timestamp("2026-01-01 00:00:00.000000001", tz="US/Pacific")
+    got = normalize_temporal_scalar(stamp)
+    assert got.type == pa.timestamp("ns", "US/Pacific")
+    assert got.as_py() == stamp
+
+
+@pytest.mark.parametrize(
+    "value,expected_type",
+    [
+        (np.datetime64("NaT", "ns"), pa.timestamp("ns")),
+        (np.datetime64("NaT", "D"), pa.timestamp("ns")),
+        (np.timedelta64("NaT", "ns"), pa.duration("ns")),
+        (pd.NaT, pa.timestamp("ns")),
+        (pa.scalar(TICK_SENTINEL, pa.duration("ns")), pa.duration("ns")),
+        (pa.scalar(TICK_SENTINEL, pa.timestamp("us")), pa.timestamp("us")),
+    ],
+    ids=[
+        "np_datetime_nat",
+        "np_datetime_nat_day",
+        "np_timedelta_nat",
+        "pd_nat",
+        "sentinel_duration",
+        "sentinel_timestamp",
+    ],
+)
+def test_normalize_temporal_scalar_missing(value, expected_type):
+    got = normalize_temporal_scalar(value)
+    assert not got.is_valid
+    assert got.type == expected_type
+
+
+def test_normalize_temporal_scalar_passes_valid_arrow_scalars_through():
+    scalar = pa.scalar(5, pa.duration("us"))
+    assert normalize_temporal_scalar(scalar) is scalar
+
+
+@pytest.mark.parametrize(
+    "value,error,match",
+    [
+        (np.timedelta64(1, "M"), ValueError, "exactly"),
+        (np.timedelta64(1, "Y"), ValueError, "exactly"),
+        (np.timedelta64(1, "ps"), ValueError, "exactly"),
+        (np.timedelta64(1000, "ps"), ValueError, "exactly"),
+        (np.datetime64(1, "fs"), ValueError, "precision"),
+    ],
+    ids=["td_month", "td_year", "td_ps", "td_ps_exact", "dt_fs_lossy"],
+)
+def test_normalize_temporal_scalar_errors(value, error, match):
+    with pytest.raises(error, match=match):
+        normalize_temporal_scalar(value)
+
+
+def test_normalize_temporal_scalar_overflow():
+    # A coarse value whose seconds form exceeds int64. Newer NumPy raises its
+    # own OverflowError inside the unit conversion; older NumPy wraps silently
+    # and the round-trip guard raises instead. Either way: OverflowError.
+    with pytest.raises(OverflowError):
+        normalize_temporal_scalar(np.timedelta64(2**62, "D"))


### PR DESCRIPTION
## What changes

This is the first slice of the column assignment / arithmetic / dissolve work drafted in #1184, which grew too large to review as one change. It is being split into four focused PRs — assignment, dissolve, arithmetic, temporal support — that build on each other, so each can be reviewed on its own terms.

This PR adds `gdf[key] = value` to the experimental `sedonadb-geopandas` package:

- **Same-frame `Series` assignment.** A `Series` read from the same frame can be assigned back (renamed or replacing a column). A `Series` from a different frame, a bare SedonaDB expression, and array-likes are rejected with actionable messages: none of them records a usable row provenance, and each previously failed obscurely or would silently write wrong values. Because assignment rebinds the frame, a `Series` read before an assignment is stale and is rejected the same way.
- **Scalar broadcasting.** Python scalars, NumPy scalars (including 0-d arrays), Arrow scalars, masked values, and `pandas.NA` broadcast to every row, via a shared scalar classifier/normalizer (`is_scalar` / `normalize_scalar`).
- **Geometry assignment with CRS bookkeeping.** Assigning a geometry value keeps its type and CRS; a destination CRS is stamped only onto CRS-less geometry. A newly assigned geometry column becomes the active geometry only when the frame had none, and replacing the active geometry column with a non-geometry value clears the active geometry, matching GeoPandas.
- **Temporal scalars.** NumPy `datetime64`/`timedelta64` values are converted at a lossless Arrow unit (ambiguous or sub-nanosecond units are rejected the way pandas rejects them, with an overflow check); pandas `Timestamp`/`Timedelta` keep their nanoseconds, zone-aware timestamps keep their zone, and `NaT` assigns as a datetime missing value.
- **Series stay usable across column-adding assignments.** A `Series` read from a frame remains valid while assignments only add columns, so one captured geometry can supply several derived columns; replacing a column or filtering invalidates earlier reads, which then raise instead of silently resolving to different values.
- Raises the `sedonadb` floor to 0.4.1, the first released version with `DataFrame.mutate`, which assignment is built on.
- Declares `shapely>=2` as a dependency (geometry scalars are Shapely objects; Shapely 2 dropped the sequence protocol on multipart geometries).

## Testing

118 tests (96 new, including direct tests of the temporal scalar normalization), run with warnings promoted to errors against both a source-built current main and the released sedonadb 0.4.1 in a clean environment (covering pandas 2.x and 3.x). Ruff lint/format clean.








