### PR TITLE
refactor(rust/sedona-raster): make ViewEntries the interface for passing views

### DIFF
--- a/python/sedonadb-zarr/src/lib.rs
+++ b/python/sedonadb-zarr/src/lib.rs
@@ -30,7 +30,7 @@ use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::ffi::Py_buffer;
 use pyo3::prelude::*;
 use pyo3::types::PyCapsule;
-use sedona_raster::view_entries::ViewEntry;
+use sedona_raster::view_entries::{ViewEntries, ViewEntry};
 use sedona_raster_zarr::{
     object_store_for_uri, open_storage_from_uri, ZarrChunkReader, ZarrLoader,
 };
@@ -341,7 +341,7 @@ impl PyZarrRasterLoader {
                 uri,
                 dim_names,
                 source_shape,
-                view,
+                view: ViewEntries::new(view),
                 data_type,
             });
         }
@@ -386,7 +386,7 @@ impl PyZarrRasterLoader {
                     source_shape: r.source_shape,
                     view: r
                         .view
-                        .into_iter()
+                        .iter()
                         .map(|v| ZarrViewEntry {
                             source_axis: v.source_axis,
                             start: v.start,
@@ -411,7 +411,7 @@ struct OwnedLoadRequest {
     uri: String,
     dim_names: Vec<String>,
     source_shape: Vec<i64>,
-    view: Vec<ViewEntry>,
+    view: ViewEntries,
     data_type: sedona_schema::raster::BandDataType,
 }
 

--- a/python/sedonadb/src/raster_loader.rs
+++ b/python/sedonadb/src/raster_loader.rs
@@ -29,7 +29,7 @@ use pyo3::{
 };
 use sedona_raster::{
     raster_loader::{AsyncRasterLoader, RasterLoadRequest, RasterLoadResult},
-    view_entries::ViewEntry,
+    view_entries::{ViewEntries, ViewEntry},
 };
 use sedona_schema::raster::BandDataType;
 
@@ -92,7 +92,7 @@ impl AsyncRasterLoader for PyRasterLoader {
                 uri: req.uri.to_string(),
                 dim_names: req.dim_names.iter().map(|s| s.to_string()).collect(),
                 source_shape: req.source_shape.to_vec(),
-                view: req.view.to_vec(),
+                view: req.view.as_slice().to_vec(),
                 data_type: req.data_type,
             })
             .collect();
@@ -204,7 +204,7 @@ impl AsyncRasterLoader for PyRasterLoader {
             .map(|r| RasterLoadResult {
                 bytes: Buffer::from(r.bytes),
                 source_shape: r.source_shape,
-                view: r.view,
+                view: ViewEntries::new(r.view),
             })
             .collect();
 

--- a/rust/sedona-raster-functions/src/rs_ensure_loaded.rs
+++ b/rust/sedona-raster-functions/src/rs_ensure_loaded.rs
@@ -45,7 +45,7 @@ use sedona_raster::raster_loader::{
     AsyncRasterLoader, RasterLoadRequest, RasterLoaderConfig, RasterLoaderRegistry,
 };
 use sedona_raster::traits::RasterRef;
-use sedona_raster::view_entries::ViewEntry;
+use sedona_raster::view_entries::ViewEntries;
 
 /// `SedonaScalarUDF` metadata key marking a UDF whose kernels read raster
 /// pixel bytes. A raster function sets it (value `"true"`) via
@@ -140,21 +140,6 @@ fn lookup_loader(
     })?;
     // The registry owns format resolution + the missing-loader diagnostic.
     guard.get_or_error(format)
-}
-
-/// True if `view` is the canonical identity over `source_shape` (each visible
-/// axis maps to the same source axis, full extent, unit step). An empty view
-/// is treated as identity. Used to detect whether a loader returned an
-/// already-resolved (identity) layout we can build directly.
-fn view_is_identity(view: &[ViewEntry], source_shape: &[i64]) -> bool {
-    view.is_empty()
-        || (view.len() == source_shape.len()
-            && view.iter().enumerate().all(|(i, v)| {
-                v.source_axis == i as i64
-                    && v.start == 0
-                    && v.step == 1
-                    && v.steps == source_shape[i]
-            }))
 }
 
 // One RsEnsureLoaded per session by construction — equality and hash
@@ -327,7 +312,7 @@ where
                 let source_shape: Vec<i64> = band.raw_source_shape().to_vec();
                 // Passed to the loader so it can (eventually) prune I/O; today
                 // every loader ignores it and returns the full source.
-                let view_owned: Vec<ViewEntry> = band.view().to_vec();
+                let view_owned: ViewEntries = band.view().clone();
                 let data_type = band.data_type();
                 let nodata: Option<Vec<u8>> = band.nodata().map(|b| b.to_vec());
                 let outdb_uri: Option<String> = band.outdb_uri().map(|s| s.to_string());
@@ -342,7 +327,7 @@ where
                 // internal gap it is. Fixed alongside the view-preserving
                 // passthrough
                 // https://github.com/apache/sedona-db/pull/897
-                if is_indb && !view_is_identity(&view_owned, &source_shape) {
+                if is_indb && !view_owned.is_identity(&source_shape) {
                     return sedona_internal_err!(
                         "RS_EnsureLoaded: InDb band ({raster_idx},{band_idx}) has a \
                          non-identity view; view-preserving passthrough is not \
@@ -438,7 +423,7 @@ where
                 // https://github.com/apache/sedona-db/issues/897.
                 let result = &result[0];
                 if result.source_shape != source_shape
-                    || !view_is_identity(&result.view, &result.source_shape)
+                    || !result.view.is_identity(&result.source_shape)
                 {
                     return sedona_internal_err!(
                         "RS_EnsureLoaded: band ({raster_idx},{band_idx}) loader returned a \
@@ -496,6 +481,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sedona_raster::view_entries::ViewEntry;
     use std::sync::Mutex;
 
     use arrow_array::Array;
@@ -886,7 +872,7 @@ mod tests {
                             bytes: Buffer::from_vec(vec![0u8; len]),
                             source_shape: req.source_shape.to_vec(),
                             // Non-identity: first axis sliced to a single step.
-                            view: vec![
+                            view: ViewEntries::new(vec![
                                 ViewEntry {
                                     source_axis: 0,
                                     start: 0,
@@ -899,7 +885,7 @@ mod tests {
                                     step: 1,
                                     steps: 3,
                                 },
-                            ],
+                            ]),
                         }
                     })
                     .collect())

--- a/rust/sedona-raster-gdal/src/raster_loader.rs
+++ b/rust/sedona-raster-gdal/src/raster_loader.rs
@@ -373,6 +373,7 @@ mod tests {
     use super::*;
     use crate::gdal_common::with_gdal;
     use sedona_gdal::raster::types::Buffer as GdalBuffer;
+    use sedona_raster::view_entries::ViewEntries;
     use sedona_schema::raster::BandDataType;
     use tempfile::TempDir;
 
@@ -433,7 +434,7 @@ mod tests {
             uri: &uri,
             dim_names: &["y", "x"],
             source_shape: &[2, 3],
-            view: &[],
+            view: &ViewEntries::identity_for_shape(&[2, 3]),
             data_type: BandDataType::UInt8,
         };
 
@@ -453,7 +454,7 @@ mod tests {
             uri: &uri,
             dim_names: &["y", "x"],
             source_shape: &[2, 3],
-            view: &[],
+            view: &ViewEntries::identity_for_shape(&[2, 3]),
             data_type: BandDataType::UInt8,
         };
         let result = loader.load(&[&req]).await.unwrap();
@@ -467,7 +468,7 @@ mod tests {
             uri: "ignored",
             dim_names: &["t", "y", "x"],
             source_shape: &[2, 3, 4],
-            view: &[],
+            view: &ViewEntries::identity_for_shape(&[2, 3, 4]),
             data_type: BandDataType::UInt8,
         };
         let err = loader.load(&[&req]).await.unwrap_err();
@@ -484,7 +485,7 @@ mod tests {
             uri: "ignored",
             dim_names: &["x", "y"], // transposed — not a recognized (y, x) pair
             source_shape: &[2, 3],
-            view: &[],
+            view: &ViewEntries::identity_for_shape(&[2, 3]),
             data_type: BandDataType::UInt8,
         };
         let err = loader.load(&[&req]).await.unwrap_err();
@@ -505,7 +506,7 @@ mod tests {
             uri: &uri,
             dim_names: &["lat", "lon"],
             source_shape: &[2, 3],
-            view: &[],
+            view: &ViewEntries::identity_for_shape(&[2, 3]),
             data_type: BandDataType::UInt8,
         };
         // lat/lon is a recognized spatial pair, so the request is accepted and
@@ -525,7 +526,7 @@ mod tests {
             uri: &uri,
             dim_names: &["y", "x"],
             source_shape: &[2, 3],
-            view: &[], // File is UInt8 but we claim Int16 — should fail with a
+            view: &ViewEntries::identity_for_shape(&[2, 3]), // File is UInt8 but we claim Int16 — should fail with a
             // clear dtype-mismatch message, not garbled bytes.
             data_type: BandDataType::Int16,
         };
@@ -544,7 +545,7 @@ mod tests {
             uri: "/nonexistent/path/to/file.tif#band=1",
             dim_names: &["y", "x"],
             source_shape: &[2, 3],
-            view: &[],
+            view: &ViewEntries::identity_for_shape(&[2, 3]),
             data_type: BandDataType::UInt8,
         };
         let err = loader.load(&[&req]).await.unwrap_err();
@@ -564,7 +565,7 @@ mod tests {
             uri: &uri,
             dim_names: &["y", "x"],
             source_shape: &[2, 3],
-            view: &[],
+            view: &ViewEntries::identity_for_shape(&[2, 3]),
             data_type: BandDataType::UInt8,
         };
         let err = loader.load(&[&req]).await.unwrap_err();
@@ -588,7 +589,7 @@ mod tests {
             uri: "ignored",
             dim_names: &["y", "x"],
             source_shape: &[1 << 16, 1 << 16],
-            view: &[],
+            view: &ViewEntries::identity_for_shape(&[1 << 16, 1 << 16]),
             data_type: BandDataType::Float32,
         };
         let err = loader.load(&[&req]).await.unwrap_err();
@@ -612,7 +613,7 @@ mod tests {
             uri: &uri,
             dim_names: &["y", "x"],
             source_shape: &[64, 16],
-            view: &[],
+            view: &ViewEntries::identity_for_shape(&[64, 16]),
             data_type: BandDataType::UInt8,
         };
         let result = loader.load(&[&req]).await.unwrap();

--- a/rust/sedona-raster-zarr/src/raster_loader.rs
+++ b/rust/sedona-raster-zarr/src/raster_loader.rs
@@ -153,6 +153,7 @@ impl ZarrLoader {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sedona_raster::view_entries::ViewEntries;
     use std::sync::Arc;
 
     use sedona_schema::raster::BandDataType;
@@ -207,7 +208,7 @@ mod tests {
             uri: &uri,
             dim_names: &["y", "x"],
             source_shape: &[2, 3],
-            view: &[],
+            view: &ViewEntries::identity_for_shape(&[2, 3]),
             data_type: BandDataType::UInt8,
         };
         let result = loader.load(&[&req]).await.unwrap();
@@ -225,7 +226,7 @@ mod tests {
             uri: &uri,
             dim_names: &["y", "x"],
             source_shape: &[2, 3],
-            view: &[], // Array is UInt8 but the band claims Int16.
+            view: &ViewEntries::identity_for_shape(&[2, 3]), // Array is UInt8 but the band claims Int16.
             data_type: BandDataType::Int16,
         };
         let err = loader.load(&[&req]).await.unwrap_err();
@@ -243,7 +244,7 @@ mod tests {
             uri: "file:///tmp/foo.zarr", // missing fragment
             dim_names: &["y", "x"],
             source_shape: &[2, 3],
-            view: &[],
+            view: &ViewEntries::identity_for_shape(&[2, 3]),
             data_type: BandDataType::UInt8,
         };
         let err = loader.load(&[&req]).await.unwrap_err();
@@ -265,7 +266,7 @@ mod tests {
             uri: &uri,
             dim_names: &["y", "x"],
             source_shape: &[2, 3],
-            view: &[],
+            view: &ViewEntries::identity_for_shape(&[2, 3]),
             data_type: BandDataType::UInt8,
         };
         let err = loader.load(&[&req]).await.unwrap_err();
@@ -286,7 +287,7 @@ mod tests {
             uri: &uri,
             dim_names: &["y", "x"],
             source_shape: &[2, 3],
-            view: &[],
+            view: &ViewEntries::identity_for_shape(&[2, 3]),
             data_type: BandDataType::UInt8,
         };
         let err = loader.load(&[&req]).await.unwrap_err();

--- a/rust/sedona-raster/src/array.rs
+++ b/rust/sedona-raster/src/array.rs
@@ -88,8 +88,8 @@ impl<'a> BandRef for BandRefImpl<'a> {
         &self.source_shape_values.values()[start..end]
     }
 
-    fn view(&self) -> &[ViewEntry] {
-        self.view_entries.as_slice()
+    fn view(&self) -> &ViewEntries {
+        &self.view_entries
     }
 
     fn data_type(&self) -> BandDataType {
@@ -937,12 +937,12 @@ mod tests {
         let in_raster = in_rasters.get(0).unwrap();
         let in_band = in_raster.band(0).unwrap();
 
-        let identity = [ViewEntry {
+        let identity = ViewEntries::new(vec![ViewEntry {
             source_axis: 0,
             start: 0,
             step: 1,
             steps: 4,
-        }];
+        }]);
         let mut ob = RasterBuilder::new(1);
         ob.start_raster_nd(&transform, &["x"], &[4], None).unwrap();
         in_band
@@ -1218,12 +1218,12 @@ mod tests {
             .unwrap();
         builder
             .start_band(StartBandArgs {
-                view: Some(&[ViewEntry {
+                view: Some(&ViewEntries::new(vec![ViewEntry {
                     source_axis: 0,
                     start: 1,
                     step: 2,
                     steps: 3,
-                }]),
+                }])),
                 ..StartBandArgs::new(&["x"], &[8], BandDataType::UInt8)
             })
             .unwrap();
@@ -1387,12 +1387,12 @@ mod tests {
         builder
             .start_band(StartBandArgs {
                 name: Some("a"),
-                view: Some(&[ViewEntry {
+                view: Some(&ViewEntries::new(vec![ViewEntry {
                     source_axis: 0,
                     start: 1,
                     step: 2,
                     steps: 3,
-                }]),
+                }])),
                 nodata: Some(&[0u8, 0, 0, 0]),
                 outdb_uri: Some("s3://bucket/a.tif"),
                 outdb_format: Some("GTiff"),
@@ -1711,7 +1711,7 @@ mod tests {
         builder
             .start_band(StartBandArgs {
                 name: Some("broadcast_time"),
-                view: Some(&[
+                view: Some(&ViewEntries::new(vec![
                     ViewEntry {
                         source_axis: 0,
                         start: 0,
@@ -1724,7 +1724,7 @@ mod tests {
                         step: 0,
                         steps: big,
                     },
-                ]),
+                ])),
                 ..StartBandArgs::new(&["y", "t"], &[4, 1], BandDataType::UInt8)
             })
             .unwrap();

--- a/rust/sedona-raster/src/band_builder.rs
+++ b/rust/sedona-raster/src/band_builder.rs
@@ -32,7 +32,6 @@ use sedona_schema::raster::RasterSchema;
 
 use crate::builder::StartBandArgs;
 use crate::error::RasterError;
-use crate::view_entries::ViewEntries;
 
 /// Maximum byte length of an inline `BinaryViewArray` view. Views this short
 /// store their bytes in the 16-byte view itself; longer views reference a data
@@ -191,10 +190,9 @@ impl BandArrayBuilder {
                     view.len()
                 )));
             }
-            let view_entries = ViewEntries::new(view.to_vec());
-            view_entries.validate(source_shape)?;
+            view.validate(source_shape)?;
 
-            if !view_entries.is_identity(source_shape) {
+            if !view.is_identity(source_shape) {
                 // -- Non-identity view: persist the explicit ViewEntry list. --
                 match name {
                     Some(n) => self.name.append_value(n),
@@ -251,7 +249,7 @@ impl BandArrayBuilder {
                 // the band's *visible* shape against its raster's spatial_shape.
                 return Ok((
                     dim_names.iter().map(|s| s.to_string()).collect(),
-                    view_entries.visible_shape(),
+                    view.visible_shape(),
                 ));
             }
         }

--- a/rust/sedona-raster/src/builder.rs
+++ b/rust/sedona-raster/src/builder.rs
@@ -28,7 +28,7 @@ use sedona_schema::raster::{BandDataType, RasterSchema};
 use crate::band_builder::{BandArrayBuilder, BandWriter};
 use crate::error::RasterError;
 use crate::traits::{BandOverrides, BandRef, RasterRef};
-use crate::view_entries::ViewEntry;
+use crate::view_entries::ViewEntries;
 
 /// Raster-level metadata overrides for [`RasterBuilder::start_raster_from`] and
 /// [`RasterBuilder::copy_raster_from`]. A `None` field inherits the source
@@ -117,7 +117,7 @@ pub struct StartBandArgs<'a> {
     pub source_shape: &'a [i64],
     /// Per-axis window of offsets/steps over `source_shape`. `None` is the
     /// canonical identity view (the whole source buffer in C order).
-    pub view: Option<&'a [ViewEntry]>,
+    pub view: Option<&'a ViewEntries>,
     pub data_type: BandDataType,
     pub nodata: Option<&'a [u8]>,
     pub outdb_uri: Option<&'a str>,
@@ -153,7 +153,7 @@ pub struct WithViewArgs<'a> {
     pub name: Option<&'a str>,
     pub dim_names: &'a [&'a str],
     pub input: &'a dyn BandRef,
-    pub view: &'a [ViewEntry],
+    pub view: &'a ViewEntries,
     pub nodata: Option<&'a [u8]>,
     pub outdb_uri: Option<&'a str>,
     pub outdb_format: Option<&'a str>,
@@ -664,6 +664,7 @@ mod tests {
     use super::*;
     use crate::array::RasterStructArray;
     use crate::traits::RasterRef;
+    use crate::view_entries::ViewEntry;
     use arrow_array::RecordBatch;
     use arrow_ipc::reader::StreamReader;
     use arrow_ipc::writer::StreamWriter;
@@ -1680,7 +1681,7 @@ mod tests {
     fn build_viewed_u8(
         source_shape: &[i64],
         dim_names: &[&str],
-        view: &[ViewEntry],
+        view: &ViewEntries,
         data: Vec<u8>,
     ) -> StructArray {
         let mut b = RasterBuilder::new(1);
@@ -1733,7 +1734,7 @@ mod tests {
         // is indistinguishable from the `None` path: null view row, same
         // visible shape/strides, zero-copy borrow.
         use arrow_array::Array;
-        let view = [ve(0, 0, 1, 2), ve(1, 0, 1, 3)];
+        let view = ViewEntries::new(vec![ve(0, 0, 1, 2), ve(1, 0, 1, 3)]);
         let pixels: Vec<u8> = (0..6).collect();
         let array = build_viewed_u8(&[2, 3], &["y", "x"], &view, pixels.clone());
 
@@ -1775,7 +1776,7 @@ mod tests {
         // offset 0, so the region is contiguous and borrows the source prefix
         // zero-copy.
         let data: Vec<u8> = (0..9).collect();
-        let view = [ve(0, 0, 1, 2), ve(1, 0, 1, 3)];
+        let view = ViewEntries::new(vec![ve(0, 0, 1, 2), ve(1, 0, 1, 3)]);
         let array = build_viewed_u8(&[3, 3], &["y", "x"], &view, data.clone());
         let rasters = RasterStructArray::try_new(&array).unwrap();
         let r = rasters.get(0).unwrap();
@@ -1796,7 +1797,7 @@ mod tests {
         // Every-other slice of an 8-element source: start=1, step=2, steps=3
         // addresses source indices 1, 3, 5.
         let data: Vec<u8> = (0..8).collect();
-        let array = build_viewed_u8(&[8], &["x"], &[ve(0, 1, 2, 3)], data);
+        let array = build_viewed_u8(&[8], &["x"], &ViewEntries::new(vec![ve(0, 1, 2, 3)]), data);
         let rasters = RasterStructArray::try_new(&array).unwrap();
         let r = rasters.get(0).unwrap();
         let band = r.band(0).unwrap();
@@ -1816,7 +1817,7 @@ mod tests {
     fn view_broadcast_zero_stride_repeats_source_row() {
         // 2D broadcast: source shape [1, 3], the view broadcasts axis 0 four
         // times (step 0) so every visible row equals the source's single row.
-        let view = [ve(0, 0, 0, 4), ve(1, 0, 1, 3)];
+        let view = ViewEntries::new(vec![ve(0, 0, 0, 4), ve(1, 0, 1, 3)]);
         let array = build_viewed_u8(&[1, 3], &["row", "col"], &view, vec![10u8, 20, 30]);
         let rasters = RasterStructArray::try_new(&array).unwrap();
         let r = rasters.get(0).unwrap();
@@ -1847,7 +1848,7 @@ mod tests {
         // Visible[i, j] (i over X 0..3, j over Y {1,3}) sits at source byte
         // 3 + i + 6j → C-order gather = [3, 9, 4, 10, 5, 11].
         let data: Vec<u8> = (0..12).collect();
-        let view = [ve(1, 0, 1, 3), ve(0, 1, 2, 2)];
+        let view = ViewEntries::new(vec![ve(1, 0, 1, 3), ve(0, 1, 2, 2)]);
         let array = build_viewed_u8(&[4, 3], &["x", "y"], &view, data);
         let rasters = RasterStructArray::try_new(&array).unwrap();
         let r = rasters.get(0).unwrap();
@@ -1868,7 +1869,7 @@ mod tests {
         // 1D source [0..8]; start=6, step=-2, steps=3 walks backwards picking
         // every other element: source indices 6, 4, 2.
         let data: Vec<u8> = (0..8).collect();
-        let array = build_viewed_u8(&[8], &["x"], &[ve(0, 6, -2, 3)], data);
+        let array = build_viewed_u8(&[8], &["x"], &ViewEntries::new(vec![ve(0, 6, -2, 3)]), data);
         let rasters = RasterStructArray::try_new(&array).unwrap();
         let r = rasters.get(0).unwrap();
         let band = r.band(0).unwrap();
@@ -1888,7 +1889,7 @@ mod tests {
     fn view_multidim_with_zero_axis_borrows_empty() {
         // A zero-extent middle axis addresses no bytes: the visible region is
         // empty, trivially contiguous, and as_contiguous borrows an empty slice.
-        let view = [ve(0, 0, 1, 3), ve(1, 0, 1, 0), ve(2, 0, 1, 5)];
+        let view = ViewEntries::new(vec![ve(0, 0, 1, 3), ve(1, 0, 1, 0), ve(2, 0, 1, 5)]);
         let array = build_viewed_u8(&[3, 4, 5], &["a", "b", "c"], &view, vec![0u8; 60]);
         let rasters = RasterStructArray::try_new(&array).unwrap();
         let r = rasters.get(0).unwrap();
@@ -1912,7 +1913,7 @@ mod tests {
             .unwrap();
         let err = builder
             .start_band(StartBandArgs {
-                view: Some(&[]),
+                view: Some(&ViewEntries::new(vec![])),
                 ..StartBandArgs::new(&[], &[], BandDataType::UInt8)
             })
             .unwrap_err();
@@ -1933,7 +1934,7 @@ mod tests {
             .unwrap();
         let err = builder
             .start_band(StartBandArgs {
-                view: Some(&[ve(0, 1, 2, 4)]),
+                view: Some(&ViewEntries::new(vec![ve(0, 1, 2, 4)])),
                 ..StartBandArgs::new(&["x"], &[7], BandDataType::UInt8)
             })
             .unwrap_err();
@@ -1976,7 +1977,7 @@ mod tests {
             name: None,
             dim_names: &["x"],
             input: input_band.as_ref(),
-            view: &[ve(0, 1, 2, 3)],
+            view: &ViewEntries::new(vec![ve(0, 1, 2, 3)]),
             nodata: None,
             outdb_uri: None,
             outdb_format: None,
@@ -2020,7 +2021,7 @@ mod tests {
             name: None,
             dim_names: &["x"],
             input: input_band.as_ref(),
-            view: &[ve(0, 1, 2, 4)],
+            view: &ViewEntries::new(vec![ve(0, 1, 2, 4)]),
             nodata: None,
             outdb_uri: None,
             outdb_format: None,
@@ -2044,7 +2045,7 @@ mod tests {
             name: None,
             dim_names: &["x"],
             input: mid_band.as_ref(),
-            view: &[ve(0, 1, 1, 2)],
+            view: &ViewEntries::new(vec![ve(0, 1, 1, 2)]),
             nodata: None,
             outdb_uri: None,
             outdb_format: None,
@@ -2098,7 +2099,7 @@ mod tests {
             name: None,
             dim_names: &["x"],
             input: input_band.as_ref(),
-            view: &[ve(0, 1, 2, 3)],
+            view: &ViewEntries::new(vec![ve(0, 1, 2, 3)]),
             nodata: None,
             outdb_uri: None,
             outdb_format: None,
@@ -2119,7 +2120,7 @@ mod tests {
         assert_eq!(out_band.outdb_uri(), Some("s3://bucket/file.tif#band=1"));
         assert_eq!(out_band.outdb_format(), Some("geotiff"));
         // Input had identity view, so composed == supplied view verbatim.
-        assert_eq!(out_band.view(), &[ve(0, 1, 2, 3)]);
+        assert_eq!(out_band.view().as_slice(), &[ve(0, 1, 2, 3)]);
         assert_eq!(out_band.raw_source_shape(), &[8]);
         assert_eq!(out_band.shape(), &[3]);
     }
@@ -2160,7 +2161,7 @@ mod tests {
             name: None,
             dim_names: &["x"],
             input: in_band.as_ref(),
-            view: &[ve(0, 0, 2, 2)],
+            view: &ViewEntries::new(vec![ve(0, 0, 2, 2)]),
             nodata: None,
             outdb_uri: None,
             outdb_format: None,
@@ -2287,7 +2288,7 @@ mod tests {
             .unwrap();
         builder
             .start_band(StartBandArgs {
-                view: Some(&[ve(0, 1, 2, 3)]),
+                view: Some(&ViewEntries::new(vec![ve(0, 1, 2, 3)])),
                 ..StartBandArgs::new(&["x"], &[8], BandDataType::UInt8)
             })
             .unwrap();

--- a/rust/sedona-raster/src/raster_loader.rs
+++ b/rust/sedona-raster/src/raster_loader.rs
@@ -37,7 +37,7 @@ use datafusion_common::config::{
 use datafusion_common::{config_err, Result as DFResult};
 use sedona_schema::raster::BandDataType;
 
-use crate::view_entries::ViewEntry;
+use crate::view_entries::ViewEntries;
 
 /// Everything a backend needs to materialise a single OutDb band's bytes.
 ///
@@ -70,7 +70,7 @@ pub struct RasterLoadRequest<'a> {
     /// may ignore it and return the full source (reporting the view
     /// unresolved), or honor it and return only the visible region; the
     /// returned [`RasterLoadResult`] says which.
-    pub view: &'a [ViewEntry],
+    pub view: &'a ViewEntries,
     /// Pixel type the band claims. The loader returns bytes encoding this
     /// type and errors if the source disagrees (e.g. file's dtype differs).
     pub data_type: BandDataType,
@@ -94,7 +94,7 @@ pub struct RasterLoadResult {
     pub source_shape: Vec<i64>,
     /// View to apply to `bytes` to obtain the visible region (identity when
     /// the loader already resolved the crop).
-    pub view: Vec<ViewEntry>,
+    pub view: ViewEntries,
 }
 
 impl RasterLoadResult {
@@ -104,7 +104,7 @@ impl RasterLoadResult {
         Self {
             bytes,
             source_shape: req.source_shape.to_vec(),
-            view: req.view.to_vec(),
+            view: req.view.clone(),
         }
     }
 }
@@ -388,6 +388,7 @@ impl ExtensionOptions for RasterLoaderConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::view_entries::ViewEntries;
     use std::sync::Mutex;
 
     /// Minimal in-test loader: records the request and returns a buffer
@@ -522,7 +523,7 @@ mod tests {
             uri: "file:///tmp/foo.tif",
             dim_names: &["y", "x"],
             source_shape: &[3, 4],
-            view: &[],
+            view: &ViewEntries::identity_for_shape(&[3, 4]),
             data_type: BandDataType::UInt8,
         };
         let result = loader.load(&[&req]).await.unwrap();
@@ -546,7 +547,7 @@ mod tests {
             uri: "s3://bucket/cube.zarr",
             dim_names: &["t", "y", "x"],
             source_shape: &[2, 3, 4],
-            view: &[],
+            view: &ViewEntries::identity_for_shape(&[2, 3, 4]),
             data_type: BandDataType::Float32,
         };
         let loader = r.get(Some("zarr")).unwrap();

--- a/rust/sedona-raster/src/traits.rs
+++ b/rust/sedona-raster/src/traits.rs
@@ -20,7 +20,7 @@ use sedona_schema::raster::BandDataType;
 use crate::band_builder::BandWriter;
 use crate::builder::StartBandArgs;
 use crate::error::RasterError;
-use crate::view_entries::{ViewEntries, ViewEntry};
+use crate::view_entries::ViewEntries;
 
 /// Recognized spatial dimension-name pairs, in band C-order: the slower-
 /// varying Y-like (row) axis first, the faster-varying X-like (column) axis
@@ -297,7 +297,7 @@ pub struct BandOverrides<'a> {
     /// view unchanged. A non-identity result is persisted on the derived band
     /// (as a slice, broadcast, permutation, or reverse) and decoded back by the
     /// reader; the underlying bytes are carried over unchanged.
-    pub view: Option<&'a [ViewEntry]>,
+    pub view: Option<&'a ViewEntries>,
 }
 
 /// Trait for accessing a single band/variable within an N-D raster.
@@ -339,7 +339,7 @@ pub trait BandRef {
     /// Per-visible-dimension view entries describing how the band's
     /// visible axes map onto its `source_shape`. `view().len() == ndim()`.
     /// See `ViewEntry` for per-entry semantics.
-    fn view(&self) -> &[ViewEntry];
+    fn view(&self) -> &ViewEntries;
 
     /// Size of a named dimension (None if doesn't exist)
     fn dim_size(&self, name: &str) -> Option<i64> {
@@ -489,14 +489,13 @@ pub trait BandRef {
         // Compose the caller's override (if any) onto the source's own view, so
         // the override is interpreted in the source's visible space and the
         // caller doesn't have to. `None` keeps the source view unchanged.
-        let source_view = ViewEntries::new(self.view().to_vec());
         let effective_view = match overrides.view {
-            Some(v) => source_view.compose(&ViewEntries::new(v.to_vec()))?,
-            None => source_view,
+            Some(v) => self.view().compose(v)?,
+            None => self.view().clone(),
         };
         builder.start_band(StartBandArgs {
             name: overrides.name.or_else(|| self.name()),
-            view: Some(effective_view.as_slice()),
+            view: Some(&effective_view),
             nodata: overrides.nodata.or_else(|| self.nodata()),
             outdb_uri: overrides.outdb_uri.or_else(|| self.outdb_uri()),
             outdb_format: overrides.outdb_format.or_else(|| self.outdb_format()),
@@ -683,6 +682,7 @@ pub fn nodata_f64_to_bytes(value: f64, dt: &BandDataType) -> Result<Vec<u8>, Ras
 mod tests {
     use super::*;
     use crate::builder::RasterBuilder;
+    use crate::view_entries::ViewEntry;
 
     #[test]
     fn test_nodata_bytes_to_f64_uint8() {
@@ -837,7 +837,7 @@ mod tests {
         dim_names: Vec<String>,
         source_shape: Vec<i64>,
         shape: Vec<i64>,
-        view: Vec<ViewEntry>,
+        view: ViewEntries,
     }
 
     impl BandRef for StubBand {
@@ -853,7 +853,7 @@ mod tests {
         fn raw_source_shape(&self) -> &[i64] {
             &self.source_shape
         }
-        fn view(&self) -> &[ViewEntry] {
+        fn view(&self) -> &ViewEntries {
             &self.view
         }
         fn data_type(&self) -> BandDataType {
@@ -879,7 +879,7 @@ mod tests {
             dim_names: dims.iter().map(|s| (*s).to_string()).collect(),
             source_shape: source_shape.to_vec(),
             shape,
-            view: view.to_vec(),
+            view: ViewEntries::new(view.to_vec()),
         }
     }
 
@@ -903,7 +903,7 @@ mod tests {
         let mut ib = RasterBuilder::new(1);
         ib.start_raster_nd(&transform, &["x"], &[3], None).unwrap();
         ib.start_band(StartBandArgs {
-            view: Some(&[ve(0, 1, 2, 3)]),
+            view: Some(&ViewEntries::new(vec![ve(0, 1, 2, 3)])),
             ..StartBandArgs::new(&["x"], &[8], BandDataType::UInt8)
         })
         .unwrap();
@@ -928,7 +928,7 @@ mod tests {
         let out_raster = out_rasters.get(0).unwrap();
         let out_band = out_raster.band(0).unwrap();
 
-        assert_eq!(out_band.view(), &[ve(0, 1, 2, 3)]);
+        assert_eq!(out_band.view().as_slice(), &[ve(0, 1, 2, 3)]);
         assert_eq!(out_band.shape(), &[3]);
         assert_eq!(out_band.raw_source_shape(), &[8]);
         let buf = out_band.nd_buffer().unwrap();
@@ -962,7 +962,7 @@ mod tests {
         let in_raster = in_rasters.get(0).unwrap();
         let in_band = in_raster.band(0).unwrap();
 
-        let override_view = [ve(0, 0, 2, 2)];
+        let override_view = ViewEntries::new(vec![ve(0, 0, 2, 2)]);
         let mut ob = RasterBuilder::new(1);
         ob.start_raster_nd(&transform, &["x"], &[2], None).unwrap();
         in_band
@@ -981,7 +981,7 @@ mod tests {
         let out_raster = out_rasters.get(0).unwrap();
         let out_band = out_raster.band(0).unwrap();
 
-        assert_eq!(out_band.view(), &[ve(0, 0, 2, 2)]);
+        assert_eq!(out_band.view().as_slice(), &[ve(0, 0, 2, 2)]);
         assert_eq!(out_band.shape(), &[2]);
         assert_eq!(out_band.raw_source_shape(), &[4]);
         let buf = out_band.nd_buffer().unwrap();

--- a/rust/sedona-raster/src/view_entries.rs
+++ b/rust/sedona-raster/src/view_entries.rs
@@ -239,9 +239,10 @@ impl ViewEntries {
     /// [`validate`] the result against the source shape before use.
     ///
     /// [`validate`]: Self::validate
-    pub fn compose(&self, next: &Self) -> Result<Self, RasterError> {
-        let mut out = Vec::with_capacity(next.0.len());
-        for (k, next_entry) in next.0.iter().enumerate() {
+    pub fn compose(&self, next: impl AsRef<[ViewEntry]>) -> Result<Self, RasterError> {
+        let next = next.as_ref();
+        let mut out = Vec::with_capacity(next.len());
+        for (k, next_entry) in next.iter().enumerate() {
             if next_entry.source_axis < 0 || (next_entry.source_axis as usize) >= self.0.len() {
                 return Err(RasterError::Invalid(format!(
                     "compose: next[{k}].source_axis ({}) is out of range \


### PR DESCRIPTION
## The smell

```rust
ViewEntries::new(input.view().to_vec()).compose(&ViewEntries::new(view.to_vec()))?
```

Two heap allocations to read two slices. It looks like a workaround because it is one.

## Why it was there

`ViewEntries` existed as the container type, but nothing actually passed it around. `BandRef::view()` returned `&[ViewEntry]`, and every struct field carrying a view held a bare slice:

| | before |
|---|---|
| `BandRef::view()` | `&[ViewEntry]` |
| `StartBandArgs::view` | `Option<&[ViewEntry]>` |
| `WithViewArgs::view` | `&[ViewEntry]` |
| `BandOverrides::view` | `Option<&[ViewEntry]>` |
| `RasterLoadRequest::view` | `&[ViewEntry]` |
| `RasterLoadResult::view` | `Vec<ViewEntry>` |

So slices were the real currency and `ViewEntries` was a method bag. `compose` was the only operation demanding the owned type on *both* sides — which is why every caller had to allocate its way in.

Two supporting details:

- `BandRefImpl` **already stored** a `ViewEntries` and called `.as_slice()` on the way out. Returning the container removes a conversion rather than adding one.
- Both doc comments describing this API were **uncompilable as written** — they said `source.view().compose(&next)?`, but `view()` returned a slice, which has no `compose`. They described the API this PR builds.

## Changes

- `BandRef::view() -> &ViewEntries`
- `compose`'s `next` takes `impl AsRef<[ViewEntry]>`, so a `ViewEntries` or a bare slice both work — existing `a.compose(&b)` call sites are untouched
- The six fields above all carry `ViewEntries`

The motivating site is now:

```rust
let effective_view = match overrides.view {
    Some(v) => self.view().compose(v)?,
    None => self.view().clone(),
};
```

## A duplicate identity check, silently diverged

Chasing the same thread turned up `rs_ensure_loaded::view_is_identity`, a private copy of `ViewEntries::is_identity` — which had **drifted from it**:

| | empty view, `source_shape = [2, 3]` |
|---|---|
| `view_is_identity` | `true` (short-circuits on `is_empty()`) |
| `ViewEntries::is_identity` | `false` (length mismatch) |

An empty view is identity only for a 0-dimensional raster, which is what the method already implements — the local copy was wrong.

It was unreachable in production: `RasterLoadResult::unresolved` clones the request's view, the request's view is the band's view, and `start_band` rejects 0-dimensional bands outright. The only things exercising the divergence were loader tests passing an empty view alongside a 2-D or 3-D `source_shape` — a state that cannot occur. Those fixtures now pass a real identity view over their source shape, and the helper is deleted in favour of the method.

## No behaviour change

Composition, validation, and persistence are untouched. The only semantic change is that the identity check now has one definition instead of two that disagreed.

```
sedona-raster            183 passed; 0 failed
sedona-raster-functions  256 passed; 0 failed
sedona-raster-zarr        66 passed; 0 failed
```

fmt clean, clippy clean (no unused imports), `sedona-raster-gdal` builds.

## Note

#1158 is stacked on this branch — it converts `BandOverrides` to a trinary `Override<T>`, which composes cleanly with the type change here.