### PR TITLE
feat(rust/sedona-expr): parse logical spatial filters

### DIFF
--- a/rust/sedona-expr/src/spatial_filter.rs
+++ b/rust/sedona-expr/src/spatial_filter.rs
@@ -21,7 +21,7 @@ use datafusion_common::config::ConfigOptions;
 use datafusion_common::{exec_datafusion_err, DataFusionError, Result, ScalarValue};
 use datafusion_expr::{Expr, Operator};
 use datafusion_physical_expr::{
-    expressions::{BinaryExpr, Column, Literal, NegativeExpr},
+    expressions::{BinaryExpr, Column, Literal},
     PhysicalExpr, ScalarFunctionExpr,
 };
 use geo_traits::Dimensions;
@@ -237,44 +237,8 @@ impl SpatialFilterFactory {
     /// Logical columns are resolved by name, so the index stored in the resulting
     /// [Column] is always zero.
     pub fn try_from_logical_expr(&self, expr: &Expr) -> Result<SpatialFilter> {
-        if let Some(spatial_filter) = self.try_from_logical_range_predicate(expr)? {
-            Ok(spatial_filter)
-        } else if let Some(spatial_filter) = self.try_from_logical_distance_predicate(expr)? {
-            Ok(spatial_filter)
-        } else if let Expr::BinaryExpr(binary_expr) = expr {
-            match binary_expr.op {
-                Operator::And => Ok(SpatialFilter::And(
-                    Box::new(self.try_from_logical_expr(&binary_expr.left)?),
-                    Box::new(self.try_from_logical_expr(&binary_expr.right)?),
-                )),
-                Operator::Or => Ok(SpatialFilter::Or(
-                    Box::new(self.try_from_logical_expr(&binary_expr.left)?),
-                    Box::new(self.try_from_logical_expr(&binary_expr.right)?),
-                )),
-                _ => Ok(SpatialFilter::Unknown),
-            }
-        } else if let Expr::Literal(ScalarValue::Boolean(Some(value)), _) = expr {
-            if *value {
-                Ok(SpatialFilter::Unknown)
-            } else {
-                Ok(SpatialFilter::LiteralFalse)
-            }
-        } else {
-            Ok(SpatialFilter::Unknown)
-        }
-    }
-
-    fn try_from_logical_range_predicate(&self, expr: &Expr) -> Result<Option<SpatialFilter>> {
-        let Expr::ScalarFunction(_) = expr else {
-            return Ok(None);
-        };
         let physical_expr = logical_to_physical_expr(expr)?;
-        self.try_from_range_predicate(&physical_expr)
-    }
-
-    fn try_from_logical_distance_predicate(&self, expr: &Expr) -> Result<Option<SpatialFilter>> {
-        let physical_expr = logical_to_physical_expr(expr)?;
-        self.try_from_distance_predicate(&physical_expr)
+        self.try_from_expr(&physical_expr)
     }
 
     fn try_from_range_predicate(
@@ -571,9 +535,44 @@ fn logical_to_physical_expr(expr: &Expr) -> Result<Arc<dyn PhysicalExpr>> {
         }
         // Preserve an unsupported node as a physical expression that the shared
         // argument parser will classify as `Other`.
-        _ => Ok(Arc::new(NegativeExpr::new(Arc::new(Literal::new(
-            ScalarValue::Int64(Some(0)),
-        ))))),
+        _ => Ok(Arc::new(UnknownSentinelExpr)),
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct UnknownSentinelExpr;
+
+impl std::fmt::Display for UnknownSentinelExpr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("UnknownSentinelExpr")
+    }
+}
+
+impl PhysicalExpr for UnknownSentinelExpr {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn evaluate(
+        &self,
+        _batch: &arrow_array::RecordBatch,
+    ) -> Result<datafusion_expr::ColumnarValue> {
+        sedona_internal_err!("Unexpected call to evaluate()")
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn PhysicalExpr>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> Result<Arc<dyn PhysicalExpr>> {
+        Ok(self)
+    }
+
+    fn fmt_sql(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("UnknownSentinelExpr")
     }
 }
 

--- a/rust/sedona-expr/src/spatial_filter.rs
+++ b/rust/sedona-expr/src/spatial_filter.rs
@@ -939,13 +939,30 @@ mod test {
             func: Arc::new(distance),
             args: vec![
                 datafusion_expr::col("geometry"),
-                literal,
+                literal.clone(),
                 Expr::Literal(ScalarValue::Float64(Some(10.0)), None),
             ],
         });
         assert!(matches!(
             factory.try_from_logical_expr(&distance_expr).unwrap(),
             SpatialFilter::Intersects(_, _)
+        ));
+
+        let st_distance = create_dummy_spatial_function("st_distance", 2);
+        let distance_comparison = Expr::ScalarFunction(ScalarFunction {
+            func: Arc::new(st_distance),
+            args: vec![datafusion_expr::col("geometry"), literal.clone()],
+        })
+        .lt_eq(Expr::Literal(ScalarValue::Float64(Some(10.0)), None));
+        assert!(matches!(
+            factory.try_from_logical_expr(&distance_comparison).unwrap(),
+            SpatialFilter::Intersects(_, _)
+        ));
+
+        let unsupported = datafusion_expr::col("geometry").alias("aliased_geometry");
+        assert!(matches!(
+            factory.try_from_logical_expr(&unsupported).unwrap(),
+            SpatialFilter::Unknown
         ));
     }
 

--- a/rust/sedona-expr/src/spatial_filter.rs
+++ b/rust/sedona-expr/src/spatial_filter.rs
@@ -16,11 +16,12 @@
 // under the License.
 use std::{collections::HashMap, fmt::Debug, sync::Arc};
 
-use arrow_schema::{DataType, Schema};
+use arrow_schema::{DataType, Field, Schema};
+use datafusion_common::config::ConfigOptions;
 use datafusion_common::{exec_datafusion_err, DataFusionError, Result, ScalarValue};
-use datafusion_expr::Operator;
+use datafusion_expr::{Expr, Operator};
 use datafusion_physical_expr::{
-    expressions::{BinaryExpr, Column, Literal},
+    expressions::{BinaryExpr, Column, Literal, NegativeExpr},
     PhysicalExpr, ScalarFunctionExpr,
 };
 use geo_traits::Dimensions;
@@ -228,6 +229,52 @@ impl SpatialFilterFactory {
             // Not an expression we know about
             Ok(SpatialFilter::Unknown)
         }
+    }
+
+    /// Construct a SpatialPredicate from a logical [Expr].
+    ///
+    /// Parses `expr` to extract known expressions we can evaluate against statistics.
+    /// Logical columns are resolved by name, so the index stored in the resulting
+    /// [Column] is always zero.
+    pub fn try_from_logical_expr(&self, expr: &Expr) -> Result<SpatialFilter> {
+        if let Some(spatial_filter) = self.try_from_logical_range_predicate(expr)? {
+            Ok(spatial_filter)
+        } else if let Some(spatial_filter) = self.try_from_logical_distance_predicate(expr)? {
+            Ok(spatial_filter)
+        } else if let Expr::BinaryExpr(binary_expr) = expr {
+            match binary_expr.op {
+                Operator::And => Ok(SpatialFilter::And(
+                    Box::new(self.try_from_logical_expr(&binary_expr.left)?),
+                    Box::new(self.try_from_logical_expr(&binary_expr.right)?),
+                )),
+                Operator::Or => Ok(SpatialFilter::Or(
+                    Box::new(self.try_from_logical_expr(&binary_expr.left)?),
+                    Box::new(self.try_from_logical_expr(&binary_expr.right)?),
+                )),
+                _ => Ok(SpatialFilter::Unknown),
+            }
+        } else if let Expr::Literal(ScalarValue::Boolean(Some(value)), _) = expr {
+            if *value {
+                Ok(SpatialFilter::Unknown)
+            } else {
+                Ok(SpatialFilter::LiteralFalse)
+            }
+        } else {
+            Ok(SpatialFilter::Unknown)
+        }
+    }
+
+    fn try_from_logical_range_predicate(&self, expr: &Expr) -> Result<Option<SpatialFilter>> {
+        let Expr::ScalarFunction(_) = expr else {
+            return Ok(None);
+        };
+        let physical_expr = logical_to_physical_expr(expr)?;
+        self.try_from_range_predicate(&physical_expr)
+    }
+
+    fn try_from_logical_distance_predicate(&self, expr: &Expr) -> Result<Option<SpatialFilter>> {
+        let physical_expr = logical_to_physical_expr(expr)?;
+        self.try_from_distance_predicate(&physical_expr)
     }
 
     fn try_from_range_predicate(
@@ -488,6 +535,48 @@ impl SpatialFilterFactory {
     }
 }
 
+/// Convert the small logical-expression subset understood by the spatial filter
+/// parser to its physical counterparts. This keeps logical and physical parsing
+/// on the same implementation path.
+fn logical_to_physical_expr(expr: &Expr) -> Result<Arc<dyn PhysicalExpr>> {
+    match expr {
+        Expr::Column(column) => Ok(Arc::new(Column::new(&column.name, 0))),
+        Expr::Literal(value, metadata) => Ok(Arc::new(Literal::new_with_metadata(
+            value.clone(),
+            metadata.clone(),
+        ))),
+        Expr::BinaryExpr(binary) => Ok(Arc::new(BinaryExpr::new(
+            logical_to_physical_expr(&binary.left)?,
+            binary.op,
+            logical_to_physical_expr(&binary.right)?,
+        ))),
+        Expr::ScalarFunction(function) => {
+            let args = function
+                .args
+                .iter()
+                .map(logical_to_physical_expr)
+                .collect::<Result<Vec<_>>>()?;
+            let return_type = if function.func.name() == "st_distance" {
+                DataType::Float64
+            } else {
+                DataType::Boolean
+            };
+            Ok(Arc::new(ScalarFunctionExpr::new(
+                function.func.name(),
+                Arc::clone(&function.func),
+                args,
+                Arc::new(Field::new("", return_type, true)),
+                Arc::new(ConfigOptions::default()),
+            )))
+        }
+        // Preserve an unsupported node as a physical expression that the shared
+        // argument parser will classify as `Other`.
+        _ => Ok(Arc::new(NegativeExpr::new(Arc::new(Literal::new(
+            ScalarValue::Int64(Some(0)),
+        ))))),
+    }
+}
+
 /// Table GeoStatistics
 ///
 /// Enables providing a collection of GeoStatistics to [SpatialFilter::evaluate]
@@ -598,7 +687,9 @@ fn parse_arg(arg: &Arc<dyn PhysicalExpr>) -> ArgRef<'_> {
 mod test {
     use arrow_schema::{DataType, Field};
     use datafusion_common::config::ConfigOptions;
-    use datafusion_expr::{ScalarUDF, Signature, SimpleScalarUDF, Volatility};
+    use datafusion_expr::{
+        expr::ScalarFunction, ScalarUDF, Signature, SimpleScalarUDF, Volatility,
+    };
     use rstest::rstest;
     use sedona_geometry::{bounding_box::BoundingBox, interval::Interval};
     use sedona_schema::datatypes::{WKB_GEOGRAPHY, WKB_GEOMETRY};
@@ -813,6 +904,49 @@ mod test {
         assert!(matches!(
             factory.try_from_expr(&expr_no_args).unwrap(),
             SpatialFilter::Unknown
+        ));
+    }
+
+    #[test]
+    fn predicate_from_logical_expr() {
+        let factory = SpatialFilterFactory::default();
+        let storage_field = WKB_GEOMETRY.to_storage_field("", true).unwrap();
+        let literal = Expr::Literal(
+            create_scalar(Some("POINT (1 2)"), &WKB_GEOMETRY),
+            Some(storage_field.metadata().clone().into()),
+        );
+        let intersects = create_dummy_spatial_function("st_intersects", 2);
+        let spatial_expr = Expr::ScalarFunction(ScalarFunction {
+            func: Arc::new(intersects),
+            args: vec![datafusion_expr::col("geometry"), literal.clone()],
+        });
+
+        let predicate = factory.try_from_logical_expr(&spatial_expr).unwrap();
+        let SpatialFilter::Intersects(column, bounds) = predicate else {
+            panic!("expected an intersects filter");
+        };
+        assert_eq!(column.name(), "geometry");
+        assert_eq!(column.index(), 0);
+        assert!(bounds.contains(&BoundingBox::xy((1.0, 1.0), (2.0, 2.0))));
+
+        let combined = spatial_expr.and(Expr::Literal(ScalarValue::Boolean(Some(false)), None));
+        let predicate = factory.try_from_logical_expr(&combined).unwrap();
+        assert!(
+            matches!(predicate, SpatialFilter::And(_, rhs) if matches!(*rhs, SpatialFilter::LiteralFalse))
+        );
+
+        let distance = create_dummy_spatial_function("st_dwithin", 3);
+        let distance_expr = Expr::ScalarFunction(ScalarFunction {
+            func: Arc::new(distance),
+            args: vec![
+                datafusion_expr::col("geometry"),
+                literal,
+                Expr::Literal(ScalarValue::Float64(Some(10.0)), None),
+            ],
+        });
+        assert!(matches!(
+            factory.try_from_logical_expr(&distance_expr).unwrap(),
+            SpatialFilter::Intersects(_, _)
         ));
     }
 


### PR DESCRIPTION
Adds logical Expr parsing to SpatialFilterFactory while sharing the existing physical predicate parser. Supports spatial range and distance predicates, boolean AND/OR, boolean literals, literal metadata, and name-based logical columns.

This is done by converting to a physical expression and reusing that parsing. I think this is a good thing because the logic is complicated for the specific functions and the chance of an error in the dummy conversion is smaller than a chance of an error in the parsing / bounding logic.

Closes #1152