### PR TITLE
fix(rust/sedona-raster-gdal): make sedona-proj dev-only

### DIFF
--- a/rust/sedona-raster-gdal/Cargo.toml
+++ b/rust/sedona-raster-gdal/Cargo.toml
@@ -42,7 +42,6 @@ sedona-common = { workspace = true }
 sedona-expr = { workspace = true }
 sedona-functions = { workspace = true }
 sedona-gdal = { workspace = true }
-sedona-proj = { workspace = true }
 sedona-raster = { workspace = true }
 sedona-raster-functions = { workspace = true }
 sedona-schema = { workspace = true }


### PR DESCRIPTION
Remove sedona-proj from regular dependencies because all uses are test-only. The existing dev-dependency retains proj-sys for tests.

closes #1036