### PR TITLE
feat(python/sedonadb): construct DataFrame from DataFrame

### DIFF
--- a/python/sedonadb/python/sedonadb/dataframe.py
+++ b/python/sedonadb/python/sedonadb/dataframe.py
@@ -142,9 +142,21 @@ class DataFrame:
         └────────────┘
     """
 
-    def __init__(self, ctx, impl):
-        self._ctx = ctx
-        self._impl = impl
+    def __init__(self, ctx, impl=None):
+        if isinstance(ctx, DataFrame):
+            if impl is not None:
+                raise TypeError(
+                    "impl must not be provided when constructing from a DataFrame"
+                )
+
+            self._ctx = ctx._ctx
+            self._impl = ctx._impl
+        else:
+            if impl is None:
+                raise TypeError("impl is required when ctx is not a DataFrame")
+
+            self._ctx = ctx
+            self._impl = impl
 
     @property
     def schema(self):

--- a/python/sedonadb/tests/test_dataframe.py
+++ b/python/sedonadb/tests/test_dataframe.py
@@ -25,7 +25,24 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 import sedonadb
+from sedonadb.dataframe import DataFrame
 from sedonadb.testing import skip_if_not_exists
+
+
+def test_dataframe_constructor_from_dataframe(con):
+    class DataFrameSubclass(DataFrame):
+        def __init__(self, df):
+            super().__init__(df)
+
+    df = con.sql("SELECT 1 AS value")
+    copied = DataFrame(df)
+    subclassed = DataFrameSubclass(df)
+
+    assert copied._ctx is df._ctx
+    assert copied._impl is df._impl
+    assert subclassed._ctx is df._ctx
+    assert subclassed._impl is df._impl
+    pd.testing.assert_frame_equal(subclassed.to_pandas(), df.to_pandas())
 
 
 def test_dataframe_from_dataframe(con):


### PR DESCRIPTION
Allow `DataFrame(existing_df)` to reuse the existing context and implementation, enabling subclasses to initialize with `super().__init__(df)`. Preserve the existing internal `(context, implementation)` constructor path and add regression coverage for direct and subclass construction.

The general idea here is to allow "tables" from a catalog to also be DataFrames, so that when we implement our catalog abstraction ( https://github.com/apache/sedona-db/issues/1150 ), one can `.filter()` tables directly without us having to duplicate a bunch of code.

closes #1157