### PR TITLE
chore(rust): update to DataFusion 55

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,61 +3,13 @@
 version = 4
 
 [[package]]
-name = "abi_stable"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d6512d3eb05ffe5004c59c206de7f99c34951504056ce23fc953842f12c445"
-dependencies = [
- "abi_stable_derive",
- "abi_stable_shared",
- "const_panic",
- "core_extensions",
- "crossbeam-channel",
- "generational-arena",
- "libloading 0.7.4",
- "lock_api",
- "parking_lot",
- "paste",
- "repr_offset",
- "rustc_version",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "abi_stable_derive"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7178468b407a4ee10e881bc7a328a65e739f0863615cca4429d43916b05e898"
-dependencies = [
- "abi_stable_shared",
- "as_derive_utils",
- "core_extensions",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 1.0.109",
- "typed-arena",
-]
-
-[[package]]
-name = "abi_stable_shared"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b5df7688c123e63f4d4d649cba63f2967ba7f7861b1664fca3f77d3dad2b63"
-dependencies = [
- "core_extensions",
-]
-
-[[package]]
 name = "adbc_core"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46b169525a7c41670fe95874103c7c6ce713ac699123f81a200bc31f9ad3b02e"
 dependencies = [
- "arrow-array",
- "arrow-schema",
+ "arrow-array 57.3.0",
+ "arrow-schema 57.3.0",
 ]
 
 [[package]]
@@ -67,8 +19,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6851c2ab953511cf7a244aadcbc0586442fd3c67dfe371457369048880dd513"
 dependencies = [
  "adbc_core",
- "arrow-array",
- "arrow-schema",
+ "arrow-array 57.3.0",
+ "arrow-schema 57.3.0",
 ]
 
 [[package]]
@@ -226,35 +178,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
-name = "apache-avro"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36fa98bc79671c7981272d91a8753a928ff6a1cd8e4f20a44c45bd5d313840bf"
-dependencies = [
- "bigdecimal",
- "bon",
- "bzip2",
- "crc32fast",
- "digest 0.10.7",
- "liblzma",
- "log",
- "miniz_oxide",
- "num-bigint",
- "quad-rand",
- "rand 0.9.2",
- "regex-lite",
- "serde",
- "serde_bytes",
- "serde_json",
- "snap",
- "strum",
- "strum_macros",
- "thiserror 2.0.17",
- "uuid",
- "zstd",
-]
-
-[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,35 +218,35 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "57.1.0"
+version = "59.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb372a7cbcac02a35d3fb7b3fc1f969ec078e871f9bb899bf00a2e1809bec8a3"
+checksum = "7c14b3d39f306bc28fd639d59f06e17a0f377d0021e1b7e9054e4d6fedc98774"
 dependencies = [
  "arrow-arith",
- "arrow-array",
- "arrow-buffer",
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
  "arrow-cast",
  "arrow-csv",
- "arrow-data",
+ "arrow-data 59.3.0",
  "arrow-ipc",
  "arrow-json",
  "arrow-ord",
  "arrow-row",
- "arrow-schema",
+ "arrow-schema 59.3.0",
  "arrow-select",
  "arrow-string",
 ]
 
 [[package]]
 name = "arrow-arith"
-version = "57.1.0"
+version = "59.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f377dcd19e440174596d83deb49cd724886d91060c07fec4f67014ef9d54049"
+checksum = "ce2961626677665b2195eb59242af4c7befe7b8737ca2050295389362380104e"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-data 59.3.0",
+ "arrow-schema 59.3.0",
  "chrono",
  "num-traits",
 ]
@@ -335,16 +258,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8955af33b25f3b175ee10af580577280b4bd01f7e823d94c7cdef7cf8c9aef"
 dependencies = [
  "ahash",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
  "chrono",
- "chrono-tz",
  "half",
  "hashbrown 0.16.1",
  "num-complex",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "59.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e5f6adeffdf587d7a31db5d2266189624b526730cd3627f9ff9fedae97ad584"
+dependencies = [
+ "ahash",
+ "arrow-buffer 59.3.0",
+ "arrow-data 59.3.0",
+ "arrow-schema 59.3.0",
+ "chrono",
+ "chrono-tz",
+ "half",
+ "hashbrown 0.17.1",
+ "libc",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-avro"
+version = "59.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9145b685d586482102e4fe3d40349fe00086c0b219d51cae9daaead4698849ea"
+dependencies = [
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-schema 59.3.0",
+ "bytes",
+ "bzip2",
+ "crc",
+ "flate2",
+ "indexmap 2.14.1",
+ "liblzma",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "snap",
+ "strum_macros",
+ "uuid",
+ "zstd",
 ]
 
 [[package]]
@@ -355,24 +321,36 @@ checksum = "c697ddca96183182f35b3a18e50b9110b11e916d7b7799cbfd4d34662f2c56c2"
 dependencies = [
  "bytes",
  "half",
- "num-bigint",
+ "num-bigint 0.4.6",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "59.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "097d193003ce7995d5d087089069ec2a6e0187faf5a6f8c9f38af2645d987182"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint 0.5.1",
  "num-traits",
 ]
 
 [[package]]
 name = "arrow-cast"
-version = "57.3.0"
+version = "59.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "646bbb821e86fd57189c10b4fcdaa941deaf4181924917b0daa92735baa6ada5"
+checksum = "635c9c635668ad26adf76cce8fb276c4be7cf06e63bd516de7da514f9680ee53"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-data 59.3.0",
  "arrow-ord",
- "arrow-schema",
+ "arrow-schema 59.3.0",
  "arrow-select",
  "atoi",
- "base64",
+ "base64 0.23.1",
  "chrono",
  "comfy-table 7.2.2",
  "half",
@@ -383,13 +361,13 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "57.1.0"
+version = "59.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2275877a0e5e7e7c76954669366c2aa1a829e340ab1f612e647507860906fb6b"
+checksum = "4c2ebf8d631e79b02c16cf5ae860561272c26024ec88fce389a56aaddd558e86"
 dependencies = [
- "arrow-array",
+ "arrow-array 59.3.0",
  "arrow-cast",
- "arrow-schema",
+ "arrow-schema 59.3.0",
  "chrono",
  "csv",
  "csv-core",
@@ -402,8 +380,21 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fdd994a9d28e6365aa78e15da3f3950c0fdcea6b963a12fa1c391afb637b304"
 dependencies = [
- "arrow-buffer",
- "arrow-schema",
+ "arrow-buffer 57.3.0",
+ "arrow-schema 57.3.0",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-data"
+version = "59.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba2f832eaeca24b8f26143dba750e42ee4ab51cf7d65e701ca9607cfda9f358"
+dependencies = [
+ "arrow-buffer 59.3.0",
+ "arrow-schema 59.3.0",
  "half",
  "num-integer",
  "num-traits",
@@ -411,34 +402,35 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "57.3.0"
+version = "59.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf7df950701ab528bf7c0cf7eeadc0445d03ef5d6ffc151eaae6b38a58feff1"
+checksum = "dcc41681ea80f521df14c36725b74d4c60702c47f0793af2be469c04527e2599"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-data 59.3.0",
+ "arrow-schema 59.3.0",
  "arrow-select",
  "flatbuffers",
- "lz4_flex",
+ "lz4_flex 0.14.0",
  "zstd",
 ]
 
 [[package]]
 name = "arrow-json"
-version = "57.3.0"
+version = "59.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ff8357658bedc49792b13e2e862b80df908171275f8e6e075c460da5ee4bf86"
+checksum = "a2f57d7a81969f24ccf80809587b76c09897e6f829d2d65a5976bfb3218851f1"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
  "arrow-cast",
- "arrow-data",
- "arrow-schema",
+ "arrow-ord",
+ "arrow-schema 59.3.0",
+ "arrow-select",
  "chrono",
  "half",
- "indexmap 2.13.0",
+ "indexmap 2.14.1",
  "itoa",
  "lexical-core",
  "memchr",
@@ -451,27 +443,27 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "57.3.0"
+version = "59.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d8f1870e03d4cbed632959498bcc84083b5a24bded52905ae1695bd29da45b"
+checksum = "2c900759f3bd8354fd4196bc4403eee846894dc2adf66b4225472006a0bf18c5"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-data 59.3.0",
+ "arrow-schema 59.3.0",
  "arrow-select",
 ]
 
 [[package]]
 name = "arrow-row"
-version = "57.1.0"
+version = "59.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169676f317157dc079cc5def6354d16db63d8861d61046d2f3883268ced6f99f"
+checksum = "f4c6425032e28266e3fc4ff680805e57e670d6ea92473043f3e65b7ed6ac79f2"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-data 59.3.0",
+ "arrow-schema 59.3.0",
  "half",
 ]
 
@@ -482,34 +474,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c872d36b7bf2a6a6a2b40de9156265f0242910791db366a2c17476ba8330d68"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "59.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10fab8d4563491417ba801fab29d205104d20d4bdf37bda6cd1cf425cff598cd"
+dependencies = [
+ "bitflags",
  "serde_core",
  "serde_json",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "57.3.0"
+version = "59.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68bf3e3efbd1278f770d67e5dc410257300b161b93baedb3aae836144edcaf4b"
+checksum = "fc58569193c2525915f3cc6310edba3792f1200f65d6e9ed330aa33e691493b8"
 dependencies = [
  "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-data 59.3.0",
+ "arrow-schema 59.3.0",
  "num-traits",
 ]
 
 [[package]]
 name = "arrow-string"
-version = "57.1.0"
+version = "59.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf35e8ef49dcf0c5f6d175edee6b8af7b45611805333129c541a8b89a0fc0534"
+checksum = "2e0813f3c35c1cfea65e14c20a953440f7783c088b7ad2d0db162ccdeefcec14"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-data 59.3.0",
+ "arrow-schema 59.3.0",
  "arrow-select",
  "memchr",
  "num-traits",
@@ -530,18 +531,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "as_derive_utils"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff3c96645900a44cf11941c111bd08a6573b0e2f9f69bc9264b179d8fae753c4"
-dependencies = [
- "core_extensions",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,9 +547,6 @@ name = "async-ffi"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4de21c0feef7e5a556e51af767c953f0501f7f300ba785cc99c47bdc8081a50"
-dependencies = [
- "abi_stable",
-]
 
 [[package]]
 name = "async-generic"
@@ -845,7 +831,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.0",
  "percent-encoding",
- "sha2 0.11.0",
+ "sha2",
  "time",
  "tracing",
 ]
@@ -1062,6 +1048,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,10 +1071,9 @@ checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
 dependencies = [
  "autocfg",
  "libm",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -1172,35 +1163,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4e0c17eaa785d2673fe58c22fc817946c2330ed47f3d9f79835d65950d32a45"
 dependencies = [
  "flate2",
- "lz4_flex",
+ "lz4_flex 0.12.1",
  "pkg-config",
  "snap",
  "zstd",
-]
-
-[[package]]
-name = "bon"
-version = "3.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234655ec178edd82b891e262ea7cf71f6584bcd09eff94db786be23f1821825c"
-dependencies = [
- "bon-macros",
- "rustversion",
-]
-
-[[package]]
-name = "bon-macros"
-version = "3.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ec27229c38ed0eb3c0feee3d2c1d6a4379ae44f418a29a658890e062d8f365"
-dependencies = [
- "darling",
- "ident_case",
- "prettyplease",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -1342,9 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1550,15 +1516,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_panic"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
-dependencies = [
- "typewit",
-]
-
-[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1590,21 +1547,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core_extensions"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42bb5e5d0269fd4f739ea6cedaf29c16d81c27a7ce7582008e90eb50dcd57003"
-dependencies = [
- "core_extensions_proc_macros",
-]
-
-[[package]]
-name = "core_extensions_proc_macros"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533d38ecd2709b7608fb8e18e4504deb99e9a72879e6aa66373a76d8dc4259ea"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,6 +1563,21 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32c"
@@ -1829,9 +1786,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1843,14 +1800,13 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7541353e77dc7262b71ca27be07d8393661737e3a73b5d1b1c6f7d814c64fa2a"
+checksum = "96f76f0167ed0842b29a3d1e41be3c034c0a46409a3a703cc4cc84ee8c24abf4"
 dependencies = [
  "arrow",
- "arrow-schema",
+ "arrow-schema 59.3.0",
  "async-trait",
- "bytes",
  "bzip2",
  "chrono",
  "datafusion-catalog",
@@ -1881,14 +1837,13 @@ dependencies = [
  "datafusion-sql",
  "flate2",
  "futures",
- "itertools 0.14.0",
+ "indexmap 2.14.1",
+ "itertools 0.15.0",
  "liblzma",
  "log",
  "object_store",
  "parking_lot",
  "parquet",
- "rand 0.9.2",
- "regex",
  "sqlparser",
  "tempfile",
  "tokio",
@@ -1899,9 +1854,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9997731f90fa5398ef831ad0e69600f92c861b79c0d38bd1a29b6f0e3a0ce4c8"
+checksum = "d79ec3460f6ed5c58f9b3f2d873fbc77748b82653bff1b4cdaf06de33bb4e05f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1915,7 +1870,7 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "object_store",
  "parking_lot",
@@ -1924,9 +1879,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b30a3dd50dec860c9559275c8d97d9de602e611237a6ecfbda0b3b63b872352"
+checksum = "b48cef241e2efcfd496fe05ae4d0d5de20793451862faefe406c397a467e12d4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1940,41 +1895,44 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "futures",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "object_store",
+ "percent-encoding",
 ]
 
 [[package]]
 name = "datafusion-common"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d551054acec0398ca604512310b77ce05c46f66e54b54d48200a686e385cca4e"
+checksum = "3f72810485975c258f1b4d00baab31728470676c60c5546f366ebd0d99f05ab6"
 dependencies = [
- "ahash",
- "apache-avro",
  "arrow",
  "arrow-ipc",
+ "arrow-schema 59.3.0",
  "chrono",
+ "foldhash 0.2.0",
  "half",
- "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.1",
+ "itertools 0.15.0",
  "libc",
  "log",
+ "num-traits",
  "object_store",
  "parquet",
- "paste",
  "recursive",
  "sqlparser",
  "tokio",
+ "uuid",
  "web-time",
 ]
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567d40e285f5b79f8737b576605721cd6c1133b5d2b00bdbd5d9838d90d0812f"
+checksum = "533c28e75dba52f41bde187d23a1cb24ab91c7c097966824fa471e67b60320ea"
 dependencies = [
  "futures",
  "log",
@@ -1983,9 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27d2668f51b3b30befae2207472569e37807fdedd1d14da58acc6f8ca6257eae"
+checksum = "5b00a1fa0da26f6087136a82fea7f13c76a672cbab452d4086952a7cf770a19b"
 dependencies = [
  "arrow",
  "async-compression",
@@ -2001,14 +1959,16 @@ dependencies = [
  "datafusion-physical-expr-adapter",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
+ "datafusion-proto-models",
  "datafusion-session",
  "flate2",
  "futures",
  "glob",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "liblzma",
  "log",
  "object_store",
+ "parking_lot",
  "rand 0.9.2",
  "tokio",
  "tokio-util",
@@ -2018,9 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-arrow"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02e1b3e3a8ec55f1f62de4252b0407c8567363d056078769a197e24fc834a0f"
+checksum = "5ad17ec881bff2ed7768b4bfe971d3efbf3473f2fd1f9d365447bccbdf908678"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -2033,38 +1993,38 @@ dependencies = [
  "datafusion-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
+ "datafusion-proto-models",
  "datafusion-session",
  "futures",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "object_store",
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-datasource-avro"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541d447bb3c9ae30b38607f6fba43947fc768041968cbd9f04ed4b22c0dd1ce5"
+checksum = "c1c9587cff8163f9bfcb186e8664ba85cb327031b8ff14330307f961ea2fc196"
 dependencies = [
- "apache-avro",
  "arrow",
+ "arrow-avro",
  "async-trait",
  "bytes",
  "datafusion-common",
  "datafusion-datasource",
- "datafusion-physical-expr-common",
+ "datafusion-physical-expr-adapter",
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "num-traits",
  "object_store",
 ]
 
 [[package]]
 name = "datafusion-datasource-csv"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b559d7bf87d4f900f847baba8509634f838d9718695389e903604cdcccdb01f3"
+checksum = "b5345285b0c3eaab412e7539b706973c083bd7e5bce575de5e0a3da488d08d1d"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2076,6 +2036,7 @@ dependencies = [
  "datafusion-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
+ "datafusion-proto-models",
  "datafusion-session",
  "futures",
  "object_store",
@@ -2085,9 +2046,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-json"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "250e2d7591ba8b638f063854650faa40bca4e8bd4059b2ece8836f6388d02db4"
+checksum = "da02fb9324f56bd8c53f1ee2e949547425cb66f76adc6832b10d44f80a1221d2"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2099,19 +2060,22 @@ dependencies = [
  "datafusion-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
+ "datafusion-proto-models",
  "datafusion-session",
  "futures",
  "object_store",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
 name = "datafusion-datasource-parquet"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b043149f2c3557ca94abc58de40f68a8d412ff53365c06126ed234f8596399d"
+checksum = "3c0b0dc1453952952fd5c69ad1c7f6042176e69ed233011d47e07cf74ed0949e"
 dependencies = [
  "arrow",
+ "arrow-schema 59.3.0",
  "async-trait",
  "bytes",
  "datafusion-common",
@@ -2119,15 +2083,17 @@ dependencies = [
  "datafusion-datasource",
  "datafusion-execution",
  "datafusion-expr",
+ "datafusion-functions",
  "datafusion-functions-aggregate-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-adapter",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
+ "datafusion-proto-models",
  "datafusion-pruning",
  "datafusion-session",
  "futures",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "object_store",
  "parking_lot",
@@ -2137,38 +2103,44 @@ dependencies = [
 
 [[package]]
 name = "datafusion-doc"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9496cb0db222dbb9a3735760ceca7fc56f35e1d5502c38d0caa77a81e9c1f6a"
+checksum = "a88fd985bc0550c36f557db69543cc9d6393b1509783520b30e902f23c555da6"
 
 [[package]]
 name = "datafusion-execution"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc45d23c516ed8d3637751e44e09e21b45b3f58b473c802dddd1f1ad4fe435ff"
+checksum = "a98f1052f91b4991f0bf2ce1e4e36dfbdcda454a956b8c8d562c7c845e8fce1d"
 dependencies = [
  "arrow",
+ "arrow-buffer 59.3.0",
  "async-trait",
- "chrono",
+ "bytes",
  "dashmap",
  "datafusion-common",
  "datafusion-expr",
+ "datafusion-physical-expr-common",
  "futures",
  "log",
  "object_store",
  "parking_lot",
+ "pin-project-lite",
  "rand 0.9.2",
  "tempfile",
+ "tokio",
+ "tokio-util",
  "url",
 ]
 
 [[package]]
 name = "datafusion-expr"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63dd30526d2db4fda6440806a41e4676334a94bc0596cc9cc2a0efed20ef2c44"
+checksum = "464625a1f0e4b9df552d894fafcc8aac953ebbc8b0fa0acdaf20975fd615040e"
 dependencies = [
  "arrow",
+ "arrow-schema 59.3.0",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -2177,9 +2149,10 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
- "indexmap 2.13.0",
- "itertools 0.14.0",
- "paste",
+ "datafusion-proto-common",
+ "datafusion-proto-models",
+ "indexmap 2.14.1",
+ "itertools 0.15.0",
  "recursive",
  "serde_json",
  "sqlparser",
@@ -2187,28 +2160,27 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b486b5f6255d40976b88bb83813b0d035a8333e0ec39864824e78068cf42fa6"
+checksum = "2604994999d5aeca1d1df645ffc98bc787447aaff05dde27aad0342b48fc1fe0"
 dependencies = [
  "arrow",
  "datafusion-common",
- "indexmap 2.13.0",
- "itertools 0.14.0",
- "paste",
+ "indexmap 2.14.1",
+ "itertools 0.15.0",
 ]
 
 [[package]]
 name = "datafusion-ffi"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b04181cffefd632e57acfc233ed239626863682dd8bb30ab366293f441bba8"
+checksum = "ada11061028faad12bf1a45f2d5fa6624b7fcf65274fbf10a71ffe46c77cd10b"
 dependencies = [
- "abi_stable",
  "arrow",
- "arrow-schema",
+ "arrow-schema 59.3.0",
  "async-ffi",
  "async-trait",
+ "chrono",
  "datafusion-catalog",
  "datafusion-common",
  "datafusion-datasource",
@@ -2217,26 +2189,29 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
+ "datafusion-physical-optimizer",
  "datafusion-physical-plan",
  "datafusion-proto",
  "datafusion-proto-common",
  "datafusion-session",
  "futures",
+ "libloading 0.9.0",
  "log",
  "prost",
  "semver",
+ "stabby",
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-functions"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07356c94118d881130dd0ffbff127540407d969c8978736e324edcd6c41cd48f"
+checksum = "051e97533e6af53e4aa0a0667cadc886abcaf36c4a5925019c55c0aa4c218fde"
 dependencies = [
  "arrow",
- "arrow-buffer",
- "base64",
+ "arrow-buffer 59.3.0",
+ "base64 0.23.1",
  "blake2",
  "blake3",
  "chrono",
@@ -2247,25 +2222,25 @@ dependencies = [
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-macros",
+ "datafusion-physical-expr-common",
  "hex",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
- "md-5",
+ "md-5 0.11.0",
+ "memchr",
  "num-traits",
  "rand 0.9.2",
  "regex",
- "sha2 0.10.9",
- "unicode-segmentation",
+ "sha2",
  "uuid",
 ]
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b644f9cf696df9233ce6958b9807666d78563b56f923267474dd6c07795f1f8f"
+checksum = "2d0f1bb166d3572b6ed40e1afb2faaacade962abc08c2fcf04babee74681c56b"
 dependencies = [
- "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-doc",
@@ -2276,17 +2251,17 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "half",
+ "hashbrown 0.17.1",
  "log",
- "paste",
+ "num-traits",
 ]
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1de2deaaabe8923ce9ea9f29c47bbb4ee14f67ea2fe1ab5398d9bbebcf86e56"
+checksum = "7ed756770f5f98369e181d692fd5ee6b1127ffd7322caba92f3730f9f5c92333"
 dependencies = [
- "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr-common",
@@ -2295,9 +2270,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552f8d92e4331ee91d23c02d12bb6acf32cbfd5215117e01c0fb63cd4b15af1a"
+checksum = "91173fdb5c0ff2a41169a8ffa1b385b8844f18728747bb0a37e35ad7d5772a4f"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -2311,32 +2286,34 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-macros",
  "datafusion-physical-expr-common",
- "itertools 0.14.0",
+ "hashbrown 0.17.1",
+ "itertools 0.15.0",
+ "itoa",
  "log",
- "paste",
+ "memchr",
 ]
 
 [[package]]
 name = "datafusion-functions-table"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "970fd0cdd3df8802b9a9975ff600998289ba9d46682a4f7285cba4820c9ada78"
+checksum = "b1bcdfb286a745461b126719c32700777e83df4f17cc44db5d71ebce5731e840"
 dependencies = [
  "arrow",
  "async-trait",
  "datafusion-catalog",
  "datafusion-common",
  "datafusion-expr",
+ "datafusion-physical-expr",
  "datafusion-physical-plan",
  "parking_lot",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-window"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b4c21a7c8a986a1866c0a87ab756d0bbf7b5f41f306009fa2d9af79c52ed31"
+checksum = "9ec4b508f1f93f00038ba3e737e894ec6c775528b4369413386655ae6125f0fc"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2347,14 +2324,13 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "log",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1210ad73b8b3211aeaf4a42bef9bd7a2b7fce3ec119a478831f18c6ff7f7b93"
+checksum = "0b352020834140073fbf5b46ee0ceb926e5074a9d0bcae1dbd91d0586d999cde"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -2362,20 +2338,20 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaa566a963013a38681ad82a727a654bc7feb19632426aea8c3412d415d200c5"
+checksum = "15192effab05d38cce10e92a6fb48c967b5f166b27b7195a165a72b232569c58"
 dependencies = [
  "datafusion-doc",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "datafusion-optimizer"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff9aa82b240252a88dee118372f9b9757c545ab9e53c0736bebab2e7da0ef1f2"
+checksum = "854445d9f7847e1e46089cf61b8d341a64382f14484e912c83a0f23b31216896"
 dependencies = [
  "arrow",
  "chrono",
@@ -2383,8 +2359,8 @@ dependencies = [
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-physical-expr",
- "indexmap 2.13.0",
- "itertools 0.14.0",
+ "indexmap 2.14.1",
+ "itertools 0.15.0",
  "log",
  "recursive",
  "regex",
@@ -2393,23 +2369,22 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d48022b8af9988c1d852644f9e8b5584c490659769a550c5e8d39457a1da0a5"
+checksum = "671558dad1d2aa253c39c0a4c52515958b99eb91abf649f4b88d5e69cc55282f"
 dependencies = [
- "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-functions-aggregate-common",
  "datafusion-physical-expr-common",
+ "datafusion-proto-models",
  "half",
- "hashbrown 0.16.1",
- "indexmap 2.13.0",
- "itertools 0.14.0",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.1",
+ "itertools 0.15.0",
  "parking_lot",
- "paste",
  "petgraph",
  "recursive",
  "tokio",
@@ -2417,9 +2392,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-adapter"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae7a8abc0b4fe624000972a9b145b30b7f1b680bffaa950ea53f78d9b21c27c3"
+checksum = "ffae3d78c2da80ecc829cb58536cc5aca2e99cf1365eda694fc75bfe288861e0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2427,31 +2402,32 @@ dependencies = [
  "datafusion-functions",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
- "itertools 0.14.0",
+ "itertools 0.15.0",
 ]
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147253ca3e6b9d59c162de64c02800973018660e13340dd1886dd038d17ac429"
+checksum = "3d9092ed15e7203fbd0903215172f7c9d18f10d94cba35137f3b3836f7c46f16"
 dependencies = [
- "ahash",
  "arrow",
  "chrono",
  "datafusion-common",
  "datafusion-expr-common",
- "hashbrown 0.16.1",
- "indexmap 2.13.0",
- "itertools 0.14.0",
+ "datafusion-proto-models",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.1",
+ "itertools 0.15.0",
  "parking_lot",
+ "pin-project",
 ]
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "689156bb2282107b6239db8d7ef44b4dab10a9b33d3491a0c74acac5e4fedd72"
+checksum = "9005b6cf50b57b72d476c6ed4662b04be7ca6be5320ba9127c6d0b7e4218095b"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2462,21 +2438,24 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-pruning",
- "itertools 0.14.0",
+ "datafusion-session",
+ "itertools 0.15.0",
  "recursive",
 ]
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68253dc0ee5330aa558b2549c9b0da5af9fc17d753ae73022939014ad616fc28"
+checksum = "5787e4fcff4adc4fce8948441103a99705018b49c8dff0720b650bd7a15da112"
 dependencies = [
- "ahash",
  "arrow",
+ "arrow-data 59.3.0",
+ "arrow-ipc",
  "arrow-ord",
- "arrow-schema",
+ "arrow-schema 59.3.0",
  "async-trait",
+ "bytes",
  "datafusion-common",
  "datafusion-common-runtime",
  "datafusion-execution",
@@ -2486,25 +2465,28 @@ dependencies = [
  "datafusion-functions-window-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
+ "datafusion-proto-common",
+ "datafusion-proto-models",
  "futures",
  "half",
- "hashbrown 0.16.1",
- "indexmap 2.13.0",
- "itertools 0.14.0",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.1",
+ "itertools 0.15.0",
  "log",
+ "num-traits",
  "parking_lot",
  "pin-project-lite",
+ "serde_json",
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-proto"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f5ab57d0b5a368258fff1d828f1619a10541fa5c4ec4930a383deb3a23204c8"
+checksum = "0df0504eb9028d5e01f481af3519cde3f97ab650fd50ce7b787e94b69a7a193c"
 dependencies = [
  "arrow",
- "chrono",
  "datafusion-catalog",
  "datafusion-catalog-listing",
  "datafusion-common",
@@ -2520,15 +2502,16 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-proto-common",
+ "datafusion-proto-models",
  "object_store",
  "prost",
 ]
 
 [[package]]
 name = "datafusion-proto-common"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd21d2c804802ca4b1719191dfe8e3d0860686649de6375ddc9237f85beb82b3"
+checksum = "6b92415a2442964f180d39cdcd8ff1edd99f9260c1499ba80a396499c2154d11"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2536,10 +2519,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "datafusion-pruning"
-version = "52.5.0"
+name = "datafusion-proto-models"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcad240a54d0b1d3e8f668398900260a53122d522b2102ab57218590decacd6"
+checksum = "62e4c0bd6af4fcabdbe201ee86fbeef2ac423a44e1d8fda56d994c9e2d1d3ad2"
+dependencies = [
+ "datafusion-common",
+ "datafusion-proto-common",
+ "prost",
+]
+
+[[package]]
+name = "datafusion-pruning"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e651c8df0b90daed6a7be5921ec0ee379e6909705f063eeff70fd4e35010e4c"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2548,16 +2542,16 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
- "itertools 0.14.0",
  "log",
 ]
 
 [[package]]
 name = "datafusion-session"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58e83a68bb67007a8fcbf005c44cefe441270c7ee7f6dee10c0e0109b556f6d"
+checksum = "fb56667ee38217efab19b895d9a936052cfb47ed438a19663351bdc42a6214a1"
 dependencies = [
+ "arrow-schema 59.3.0",
  "async-trait",
  "datafusion-common",
  "datafusion-execution",
@@ -2568,20 +2562,22 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "52.5.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be53e9eb55db0fbb8980bb6d87f2435b0524acf4c718ed54a57cabbb299b2ab3"
+checksum = "9c29067cb9d32f8e603c45e15d61ea18f1069f96ceafeceb4e18466b8e5b31d9"
 dependencies = [
  "arrow",
  "bigdecimal",
  "chrono",
  "datafusion-common",
  "datafusion-expr",
- "indexmap 2.13.0",
+ "datafusion-functions-nested",
+ "indexmap 2.14.1",
  "log",
  "recursive",
  "regex",
  "sqlparser",
+ "stacker",
 ]
 
 [[package]]
@@ -2842,13 +2838,13 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
- "libz-rs-sys",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -3003,15 +2999,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generational-arena"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877e94aff08e743b651baaea359664321055749b398adff8740a7399af7796e7"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3104,9 +3091,9 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1cc4106ac0a0a512c398961ce95d8150475c84a84e17c4511c3643fa120a17"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-schema 57.3.0",
  "geo-traits",
  "geoarrow-schema",
  "num-traits",
@@ -3120,7 +3107,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e97be4e9f523f92bd6a0e0458323f4b783d073d011664decd8dbf05651704f34"
 dependencies = [
- "arrow-schema",
+ "arrow-schema 57.3.0",
  "geo-traits",
  "serde",
  "serde_json",
@@ -3240,7 +3227,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -3323,9 +3310,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -3524,7 +3511,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -3778,21 +3765,15 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
-
-[[package]]
-name = "integer-encoding"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "inventory"
@@ -3859,6 +3840,15 @@ name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -4057,16 +4047,6 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
-dependencies = [
- "cfg-if",
- "winapi",
-]
-
-[[package]]
-name = "libloading"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
@@ -4143,15 +4123,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-rs-sys"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c10501e7805cee23da17c7790e59df2870c0d4043ec6d03f67d31e2b53e77415"
-dependencies = [
- "zlib-rs",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4220,7 +4191,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -4249,6 +4220,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4266,6 +4246,16 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4291,9 +4281,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -4404,7 +4394,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -4420,7 +4410,16 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "serde",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -4465,7 +4464,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
 ]
@@ -4513,30 +4512,32 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.12.4"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1be0c6c22ec0817cdc77d3842f721a17fd30ab6965001415b5402a74e6b740"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "form_urlencoded",
- "futures",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
  "http 1.4.0",
  "http-body-util",
  "httparse",
  "humantime",
  "hyper",
  "itertools 0.14.0",
- "md-5",
+ "md-5 0.10.6",
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand 0.9.2",
+ "rand 0.10.1",
  "reqwest",
  "ring",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -4551,9 +4552,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -4578,15 +4579,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "outref"
@@ -4635,37 +4627,34 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "57.3.0"
+version = "59.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee96b29972a257b855ff2341b37e61af5f12d6af1158b6dcdb5b31ea07bb3cb"
+checksum = "ff322f54b1a0f9288e614ed1f2d329b380af5476420db19f46ffb865e1163d73"
 dependencies = [
  "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-data 59.3.0",
  "arrow-ipc",
- "arrow-schema",
+ "arrow-schema 59.3.0",
  "arrow-select",
- "base64",
+ "base64 0.23.1",
  "brotli",
  "bytes",
  "chrono",
  "flate2",
  "futures",
  "half",
- "hashbrown 0.16.1",
- "lz4_flex",
- "num-bigint",
+ "hashbrown 0.17.1",
+ "lz4_flex 0.14.0",
+ "num-bigint 0.5.1",
  "num-integer",
  "num-traits",
  "object_store",
  "parquet-geospatial",
- "paste",
  "seq-macro",
  "simdutf8",
  "snap",
- "thrift",
  "tokio",
  "twox-hash",
  "zstd",
@@ -4673,11 +4662,11 @@ dependencies = [
 
 [[package]]
 name = "parquet-geospatial"
-version = "57.3.0"
+version = "59.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8572f8a5633f7dbdd274f3b66009ffb703df367a66a1cf9d2e6fae7837dc117"
+checksum = "634827365851180ca26bf54c76e970dc1c14c075684c0580ee97d8d0c953faf1"
 dependencies = [
- "arrow-schema",
+ "arrow-schema 59.3.0",
  "geo-traits",
  "serde",
  "serde_json",
@@ -4716,7 +4705,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.1",
  "serde",
 ]
 
@@ -4736,6 +4725,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4977,16 +4986,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "quad-rand"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a651516ddc9168ebd67b24afd085a718be02f8858fe406591b013d101ce2f40"
-
-[[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
  "serde",
@@ -5296,21 +5299,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
-name = "repr_offset"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb1070755bd29dffc19d0971cab794e607839ba2ef4b69a9e6fbc8733c1b72ea"
-dependencies = [
- "tstr",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5523,15 +5517,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5704,9 +5689,9 @@ dependencies = [
 name = "sedona"
 version = "0.5.0"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-schema 59.3.0",
  "async-trait",
  "aws-config",
  "aws-credential-types",
@@ -5762,8 +5747,8 @@ version = "0.5.0"
 dependencies = [
  "adbc_core",
  "adbc_ffi",
- "arrow-array",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-schema 59.3.0",
  "datafusion",
  "futures",
  "sedona",
@@ -5809,8 +5794,8 @@ dependencies = [
 name = "sedona-datasource"
 version = "0.5.0"
 dependencies = [
- "arrow-array",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-schema 59.3.0",
  "async-trait",
  "datafusion",
  "datafusion-catalog",
@@ -5834,9 +5819,9 @@ dependencies = [
 name = "sedona-expr"
 version = "0.5.0"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-schema 59.3.0",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
@@ -5855,8 +5840,8 @@ dependencies = [
 name = "sedona-extension"
 version = "0.5.0"
 dependencies = [
- "arrow-array",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-schema 59.3.0",
  "async-trait",
  "datafusion",
  "datafusion-catalog",
@@ -5882,10 +5867,10 @@ dependencies = [
 name = "sedona-functions"
 version = "0.5.0"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
  "arrow-json",
- "arrow-schema",
+ "arrow-schema 59.3.0",
  "criterion",
  "datafusion",
  "datafusion-common",
@@ -5921,9 +5906,9 @@ dependencies = [
 name = "sedona-geo"
 version = "0.5.0"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-schema 59.3.0",
  "criterion",
  "datafusion-common",
  "datafusion-expr",
@@ -5985,8 +5970,8 @@ dependencies = [
 name = "sedona-geoarrow-c"
 version = "0.5.0"
 dependencies = [
- "arrow-array",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-schema 59.3.0",
  "cc",
  "criterion",
  "datafusion-common",
@@ -6022,8 +6007,8 @@ dependencies = [
 name = "sedona-geoparquet"
 version = "0.5.0"
 dependencies = [
- "arrow-array",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-schema 59.3.0",
  "async-trait",
  "bytes",
  "chrono",
@@ -6062,8 +6047,8 @@ dependencies = [
 name = "sedona-geos"
 version = "0.5.0"
 dependencies = [
- "arrow-array",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-schema 59.3.0",
  "bytemuck",
  "byteorder",
  "criterion",
@@ -6087,8 +6072,8 @@ dependencies = [
 name = "sedona-libgpuspatial"
 version = "0.5.0"
 dependencies = [
- "arrow-array",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-schema 59.3.0",
  "bindgen",
  "cmake",
  "geo",
@@ -6106,10 +6091,10 @@ dependencies = [
 name = "sedona-pointcloud"
 version = "0.5.0"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
  "arrow-ipc",
- "arrow-schema",
+ "arrow-schema 59.3.0",
  "async-stream",
  "async-trait",
  "byteorder",
@@ -6157,7 +6142,7 @@ name = "sedona-query-planner"
 version = "0.5.0"
 dependencies = [
  "arrow",
- "arrow-schema",
+ "arrow-schema 59.3.0",
  "async-trait",
  "datafusion",
  "datafusion-common",
@@ -6176,11 +6161,11 @@ name = "sedona-raster"
 version = "0.5.0"
 dependencies = [
  "approx",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-data 59.3.0",
  "arrow-ipc",
- "arrow-schema",
+ "arrow-schema 59.3.0",
  "async-trait",
  "datafusion-common",
  "sedona-common",
@@ -6194,9 +6179,9 @@ dependencies = [
 name = "sedona-raster-functions"
 version = "0.5.0"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-schema 59.3.0",
  "async-trait",
  "criterion",
  "datafusion-common",
@@ -6220,9 +6205,9 @@ dependencies = [
 name = "sedona-raster-gdal"
 version = "0.5.0"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-schema 59.3.0",
  "async-trait",
  "criterion",
  "datafusion-common",
@@ -6245,9 +6230,9 @@ dependencies = [
 name = "sedona-raster-zarr"
 version = "0.5.0"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-schema 59.3.0",
  "async-trait",
  "datafusion-common",
  "futures",
@@ -6270,8 +6255,8 @@ dependencies = [
 name = "sedona-s2geography"
 version = "0.5.0"
 dependencies = [
- "arrow-array",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-schema 59.3.0",
  "cmake",
  "criterion",
  "datafusion-common",
@@ -6296,8 +6281,8 @@ dependencies = [
 name = "sedona-schema"
 version = "0.5.0"
 dependencies = [
- "arrow-array",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-schema 59.3.0",
  "criterion",
  "datafusion-common",
  "lru 0.18.0",
@@ -6311,8 +6296,8 @@ name = "sedona-spatial-join"
 version = "0.5.0"
 dependencies = [
  "arrow",
- "arrow-array",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-schema 59.3.0",
  "async-trait",
  "criterion",
  "datafusion",
@@ -6359,8 +6344,8 @@ name = "sedona-spatial-join-geography"
 version = "0.5.0"
 dependencies = [
  "arrow",
- "arrow-array",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-schema 59.3.0",
  "async-trait",
  "datafusion",
  "datafusion-common",
@@ -6390,8 +6375,8 @@ name = "sedona-spatial-join-gpu"
 version = "0.5.0"
 dependencies = [
  "arrow",
- "arrow-array",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-schema 59.3.0",
  "async-trait",
  "criterion",
  "datafusion",
@@ -6421,8 +6406,8 @@ dependencies = [
 name = "sedona-spatial-join-raster"
 version = "0.5.0"
 dependencies = [
- "arrow-array",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-schema 59.3.0",
  "datafusion",
  "datafusion-common",
  "datafusion-expr",
@@ -6446,9 +6431,9 @@ dependencies = [
 name = "sedona-testing"
 version = "0.5.0"
 dependencies = [
- "arrow-array",
+ "arrow-array 59.3.0",
  "arrow-cast",
- "arrow-schema",
+ "arrow-schema 59.3.0",
  "criterion",
  "datafusion-common",
  "datafusion-expr",
@@ -6473,8 +6458,8 @@ dependencies = [
 name = "sedona-tg"
 version = "0.5.0"
 dependencies = [
- "arrow-array",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-schema 59.3.0",
  "cc",
  "criterion",
  "datafusion-common",
@@ -6495,9 +6480,9 @@ name = "sedonadb"
 version = "0.5.0"
 dependencies = [
  "adbc_core",
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-schema 59.3.0",
  "async-trait",
  "bytes",
  "datafusion",
@@ -6530,8 +6515,8 @@ dependencies = [
 name = "sedonadb-zarr"
 version = "0.5.0"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
  "object_store",
  "pyo3",
  "sedona-raster",
@@ -6545,8 +6530,8 @@ dependencies = [
 name = "sedonadbr"
 version = "0.5.0"
 dependencies = [
- "arrow-array",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-schema 59.3.0",
  "datafusion",
  "datafusion-common",
  "datafusion-execution",
@@ -6568,9 +6553,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "seq-macro"
@@ -6586,16 +6571,6 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -6624,7 +6599,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.1",
  "itoa",
  "memchr",
  "serde",
@@ -6661,12 +6636,12 @@ version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.1",
  "jiff",
  "schemars 0.9.0",
  "schemars 1.2.1",
@@ -6701,17 +6676,6 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
@@ -6720,6 +6684,12 @@ dependencies = [
  "cpufeatures 0.3.0",
  "digest 0.11.3",
 ]
+
+[[package]]
+name = "sha2-const-stable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f179d4e11094a893b82fff208f74d448a7512f99f5a0acbd5c679b705f83ed9"
 
 [[package]]
 name = "shlex"
@@ -6822,9 +6792,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.59.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4591acadbcf52f0af60eafbb2c003232b2b4cd8de5f0e9437cb8b1b59046cc0f"
+checksum = "13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec"
 dependencies = [
  "log",
  "recursive",
@@ -6833,10 +6803,44 @@ dependencies = [
 
 [[package]]
 name = "sqlparser_derive"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
+checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "stabby"
+version = "72.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d53d2428934c46277fafd2d41e39357595aa1e47954c75db2b14ed90632f3cc"
+dependencies = [
+ "rustversion",
+ "stabby-abi",
+]
+
+[[package]]
+name = "stabby-abi"
+version = "72.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f375eae680bb54203ee5e47d4cd2ae7b79c0a79ed90919279f38f500ad53f190"
+dependencies = [
+ "rustc_version",
+ "rustversion",
+ "sha2-const-stable",
+ "stabby-macros",
+]
+
+[[package]]
+name = "stabby-macros"
+version = "72.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea664671a576c5f7e32fee291ac123d82af5e92b0689beb3555347c00c76eef1"
+dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6850,15 +6854,15 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stacker"
-version = "0.1.22"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1f8b29fb42aafcea4edeeb6b2f2d7ecd0d969c48b4cf0d2e64aafc471dd6e59"
+checksum = "707f49d46706bacf8a2b00d51dace3f9de527c13eec3778f570c411f89e69967"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6868,16 +6872,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-
-[[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -6893,9 +6891,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6904,9 +6902,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7025,17 +7023,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "thrift"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
-dependencies = [
- "byteorder",
- "integer-encoding",
- "ordered-float",
 ]
 
 [[package]]
@@ -7161,6 +7148,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -7191,7 +7179,7 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.1",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -7289,43 +7277,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "tstr"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8e0294f14baae476d0dd0a2d780b2e24d66e349a9de876f5126777a37bdba7"
-dependencies = [
- "tstr_proc_macros",
-]
-
-[[package]]
-name = "tstr_proc_macros"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78122066b0cb818b8afd08f7ed22f7fdbc3e90815035726f0840d0d26c0747a"
-
-[[package]]
 name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
-name = "typed-arena"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
-
-[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
-name = "typewit"
-version = "1.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c1ae7cc0fdb8b842d65d127cb981574b0d2b249b74d1c7a2986863dc134f71"
 
 [[package]]
 name = "unicode-ident"
@@ -7395,13 +7356,12 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "js-sys",
- "serde_core",
  "wasm-bindgen",
 ]
 
@@ -7541,7 +7501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.1",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -7567,7 +7527,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.1",
  "semver",
 ]
 
@@ -7697,15 +7657,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -7906,7 +7857,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.1",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -7937,7 +7888,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.13.0",
+ "indexmap 2.14.1",
  "log",
  "serde",
  "serde_derive",
@@ -7956,7 +7907,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.1",
  "log",
  "semver",
  "serde",
@@ -8057,7 +8008,7 @@ dependencies = [
  "async-generic",
  "async-lock",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "blosc-src",
  "blusc",
  "bytemuck",
@@ -8218,9 +8169,9 @@ dependencies = [
 
 [[package]]
 name = "zarrs_object_store"
-version = "0.5.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d9d0d3db426dd50dfb0b5d7cc1660bda368caeb5cd8645c60c46bc4f261a19"
+checksum = "ba1662bcdc585be1923a8b98ee5d6314d19af8c5775d6516a69ca33fd88b46af"
 dependencies = [
  "async-trait",
  "futures",
@@ -8338,9 +8289,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,14 +71,14 @@ categories = ["science::geo", "database"]
 adbc_core = ">=0.23.0"
 adbc_ffi = ">=0.23.0"
 approx = "0.5"
-arrow = { version = "57.1.0", features = ["prettyprint", "ffi", "chrono-tz"] }
-arrow-array = { version = "57.1.0" }
-arrow-buffer = { version = "57.1.0" }
-arrow-cast = { version = "57.1.0" }
-arrow-data = { version = "57.1.0" }
-arrow-ipc = { version = "57.1.0" }
-arrow-json = { version = "57.1.0" }
-arrow-schema = { version = "57.1.0" }
+arrow = { version = "59.3.0", features = ["prettyprint", "ffi", "chrono-tz"] }
+arrow-array = { version = "59.3.0" }
+arrow-buffer = { version = "59.3.0" }
+arrow-cast = { version = "59.3.0" }
+arrow-data = { version = "59.3.0" }
+arrow-ipc = { version = "59.3.0" }
+arrow-json = { version = "59.3.0" }
+arrow-schema = { version = "59.3.0" }
 async-trait = { version = "0.1.87" }
 bytemuck = "1.25"
 byteorder = "1"
@@ -86,21 +86,21 @@ bytes = "1.11"
 chrono = { version = "0.4.41", default-features = false }
 comfy-table = { version = "8.0" }
 criterion = { version = "0.8", features = ["html_reports"] }
-datafusion = { version = "52.5.0", default-features = false }
-datafusion-catalog = { version = "52.5.0" }
-datafusion-common = { version = "52.5.0", default-features = false }
-datafusion-common-runtime = { version = "52.5.0", default-features = false }
-datafusion-proto = { version = "52.5.0", default-features = false }
-datafusion-datasource = { version = "52.5.0", default-features = false }
-datafusion-datasource-parquet = { version = "52.5.0" }
-datafusion-execution = { version = "52.5.0", default-features = false }
-datafusion-expr = { version = "52.5.0" }
-datafusion-ffi = {  version = "52.5.0" }
-datafusion-optimizer = { version = "52.5.0" }
-datafusion-physical-expr = { version = "52.5.0" }
-datafusion-physical-plan = { version = "52.5.0" }
-datafusion-pruning = { version = "52.5.0" }
-datafusion-session = { version = "52.5.0" }
+datafusion = { version = "55.0.0", default-features = false }
+datafusion-catalog = { version = "55.0.0" }
+datafusion-common = { version = "55.0.0", default-features = false }
+datafusion-common-runtime = { version = "55.0.0", default-features = false }
+datafusion-proto = { version = "55.0.0", default-features = false }
+datafusion-datasource = { version = "55.0.0", default-features = false }
+datafusion-datasource-parquet = { version = "55.0.0" }
+datafusion-execution = { version = "55.0.0", default-features = false }
+datafusion-expr = { version = "55.0.0" }
+datafusion-ffi = {  version = "55.0.0" }
+datafusion-optimizer = { version = "55.0.0" }
+datafusion-physical-expr = { version = "55.0.0" }
+datafusion-physical-plan = { version = "55.0.0" }
+datafusion-pruning = { version = "55.0.0" }
+datafusion-session = { version = "55.0.0" }
 dirs = "6.0.0"
 env_logger = "0.11"
 fastrand = "2.4"
@@ -119,11 +119,11 @@ libloading = "0.9"
 lru = "0.18"
 mimalloc = { version = "0.1", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
-object_store = { version = "0.12.4", default-features = false }
+object_store = { version = "0.13.2", default-features = false }
 once_cell = "1.20"
 parking_lot = "0.12"
-parquet = { version = "57.1.0", default-features = false, features = ["arrow", "async", "geospatial", "object_store"] }
-parquet-geospatial = { version = "57.1.0" }
+parquet = { version = "59.3.0", default-features = false, features = ["arrow", "async", "geospatial", "object_store"] }
+parquet-geospatial = { version = "59.3.0" }
 pin-project-lite = "0.2"
 pyo3 = { version = "0.29.0" }
 rand = "0.10"
@@ -141,7 +141,7 @@ wkb = "0.9.2"
 wkt = "0.14.0"
 zarrs = { version = "0.23", default-features = false }
 zarrs_filesystem = "0.3"
-zarrs_object_store = "0.5"
+zarrs_object_store = "0.6"
 
 # Workspace path dependencies for internal crates
 sedona = { version = "0.5.0", path = "rust/sedona" }

--- a/rust/sedona-expr/src/aggregate_udf.rs
+++ b/rust/sedona-expr/src/aggregate_udf.rs
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-use std::{any::Any, fmt::Debug, sync::Arc};
+use std::{fmt::Debug, sync::Arc};
 
 use arrow_schema::{DataType, FieldRef};
 use datafusion_common::{not_impl_err, Result};
@@ -153,10 +153,6 @@ impl SedonaAggregateUDF {
 }
 
 impl AggregateUDFImpl for SedonaAggregateUDF {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn name(&self) -> &str {
         &self.name
     }

--- a/rust/sedona-expr/src/metadata_preserving_column.rs
+++ b/rust/sedona-expr/src/metadata_preserving_column.rs
@@ -26,7 +26,6 @@
 //! from `return_field()` regardless of the input schema, allowing projection
 //! pushdown to work correctly while preserving GeoArrow extension metadata.
 
-use std::any::Any;
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::Hash;
 use std::sync::Arc;
@@ -60,7 +59,7 @@ impl Hash for MetadataPreservingColumn {
 
 impl PartialEq for MetadataPreservingColumn {
     fn eq(&self, other: &Self) -> bool {
-        self.inner.as_ref().dyn_eq(other.inner.as_any()) && self.field == other.field
+        self.inner.as_ref().dyn_eq(other.inner.as_ref()) && self.field == other.field
     }
 }
 
@@ -89,10 +88,6 @@ impl Display for MetadataPreservingColumn {
 }
 
 impl PhysicalExpr for MetadataPreservingColumn {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn data_type(&self, _input_schema: &Schema) -> Result<DataType> {
         // Return data type from our stored field instead of looking up from input schema
         // This avoids index mismatch issues when the schema differs from the original

--- a/rust/sedona-expr/src/placeholder_udf.rs
+++ b/rust/sedona-expr/src/placeholder_udf.rs
@@ -37,8 +37,9 @@ use datafusion_execution::FunctionRegistry;
 use datafusion_expr::{
     expr::ScalarFunction,
     function::{AccumulatorArgs, PartitionEvaluatorArgs, WindowUDFFieldArgs},
-    Accumulator, AggregateUDF, AggregateUDFImpl, Expr, PartitionEvaluator, ScalarUDF,
-    ScalarUDFImpl, Signature, Volatility, WindowFunctionDefinition, WindowUDF, WindowUDFImpl,
+    Accumulator, AggregateUDF, AggregateUDFImpl, Expr, HigherOrderUDF, PartitionEvaluator,
+    ScalarUDF, ScalarUDFImpl, Signature, Volatility, WindowFunctionDefinition, WindowUDF,
+    WindowUDFImpl,
 };
 use sedona_common::sedona_internal_err;
 
@@ -55,13 +56,7 @@ impl PlaceholderRegistry {
         let mut found = false;
         expr.apply(|e| {
             if let Expr::ScalarFunction(func) = e {
-                if func
-                    .func
-                    .inner()
-                    .as_any()
-                    .downcast_ref::<PlaceholderUDF>()
-                    .is_some()
-                {
+                if func.func.inner().downcast_ref::<PlaceholderUDF>().is_some() {
                     found = true;
                     return Ok(TreeNodeRecursion::Stop);
                 }
@@ -78,13 +73,7 @@ impl PlaceholderRegistry {
         expr.apply(|e| {
             match e {
                 Expr::ScalarFunction(func) => {
-                    if func
-                        .func
-                        .inner()
-                        .as_any()
-                        .downcast_ref::<PlaceholderUDF>()
-                        .is_some()
-                    {
+                    if func.func.inner().downcast_ref::<PlaceholderUDF>().is_some() {
                         found = true;
                         return Ok(TreeNodeRecursion::Stop);
                     }
@@ -93,7 +82,6 @@ impl PlaceholderRegistry {
                     if func
                         .func
                         .inner()
-                        .as_any()
                         .downcast_ref::<PlaceholderUDAF>()
                         .is_some()
                     {
@@ -103,12 +91,7 @@ impl PlaceholderRegistry {
                 }
                 Expr::WindowFunction(func) => {
                     if let WindowFunctionDefinition::WindowUDF(ref udf) = func.fun {
-                        if udf
-                            .inner()
-                            .as_any()
-                            .downcast_ref::<PlaceholderUDWF>()
-                            .is_some()
-                        {
+                        if udf.inner().downcast_ref::<PlaceholderUDWF>().is_some() {
                             found = true;
                             return Ok(TreeNodeRecursion::Stop);
                         }
@@ -129,13 +112,7 @@ impl PlaceholderRegistry {
         expr.transform_up(|e| {
             match &e {
                 Expr::ScalarFunction(func) => {
-                    if func
-                        .func
-                        .inner()
-                        .as_any()
-                        .downcast_ref::<PlaceholderUDF>()
-                        .is_some()
-                    {
+                    if func.func.inner().downcast_ref::<PlaceholderUDF>().is_some() {
                         let real_udf = registry.udf(func.name())?;
                         let replaced = Expr::ScalarFunction(ScalarFunction {
                             func: real_udf,
@@ -148,7 +125,6 @@ impl PlaceholderRegistry {
                     if func
                         .func
                         .inner()
-                        .as_any()
                         .downcast_ref::<PlaceholderUDAF>()
                         .is_some()
                     {
@@ -168,12 +144,7 @@ impl PlaceholderRegistry {
                 }
                 Expr::WindowFunction(func) => {
                     if let WindowFunctionDefinition::WindowUDF(ref udf) = func.fun {
-                        if udf
-                            .inner()
-                            .as_any()
-                            .downcast_ref::<PlaceholderUDWF>()
-                            .is_some()
-                        {
+                        if udf.inner().downcast_ref::<PlaceholderUDWF>().is_some() {
                             let real_udwf = registry.udwf(udf.name())?;
                             let replaced = Expr::WindowFunction(Box::new(
                                 datafusion_expr::expr::WindowFunction {
@@ -198,6 +169,10 @@ impl FunctionRegistry for PlaceholderRegistry {
         HashSet::new()
     }
 
+    fn higher_order_function_names(&self) -> HashSet<String> {
+        HashSet::new()
+    }
+
     fn udafs(&self) -> HashSet<String> {
         HashSet::new()
     }
@@ -210,6 +185,10 @@ impl FunctionRegistry for PlaceholderRegistry {
         Ok(Arc::new(ScalarUDF::new_from_impl(PlaceholderUDF::new(
             name,
         ))))
+    }
+
+    fn higher_order_function(&self, name: &str) -> Result<Arc<HigherOrderUDF>> {
+        sedona_internal_err!("Higher-order placeholder function '{name}' is not supported")
     }
 
     fn udaf(&self, name: &str) -> Result<Arc<AggregateUDF>> {
@@ -248,10 +227,6 @@ impl PlaceholderUDF {
 }
 
 impl ScalarUDFImpl for PlaceholderUDF {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn name(&self) -> &str {
         &self.name
     }
@@ -301,10 +276,6 @@ impl PlaceholderUDAF {
 }
 
 impl AggregateUDFImpl for PlaceholderUDAF {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn name(&self) -> &str {
         &self.name
     }
@@ -348,10 +319,6 @@ impl PlaceholderUDWF {
 }
 
 impl WindowUDFImpl for PlaceholderUDWF {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn name(&self) -> &str {
         &self.name
     }
@@ -401,7 +368,7 @@ mod tests {
 
         // Verify it's a PlaceholderUDF
         let inner = udf.inner();
-        assert!(inner.as_any().downcast_ref::<PlaceholderUDF>().is_some());
+        assert!(inner.downcast_ref::<PlaceholderUDF>().is_some());
     }
 
     #[test]
@@ -412,7 +379,7 @@ mod tests {
 
         // Verify it's a PlaceholderUDAF
         let inner = udaf.inner();
-        assert!(inner.as_any().downcast_ref::<PlaceholderUDAF>().is_some());
+        assert!(inner.downcast_ref::<PlaceholderUDAF>().is_some());
     }
 
     #[test]
@@ -423,7 +390,7 @@ mod tests {
 
         // Verify it's a PlaceholderUDWF
         let inner = udwf.inner();
-        assert!(inner.as_any().downcast_ref::<PlaceholderUDWF>().is_some());
+        assert!(inner.downcast_ref::<PlaceholderUDWF>().is_some());
     }
 
     #[test]
@@ -620,6 +587,10 @@ mod tests {
                 HashSet::new()
             }
 
+            fn higher_order_function_names(&self) -> HashSet<String> {
+                HashSet::new()
+            }
+
             fn udafs(&self) -> HashSet<String> {
                 HashSet::new()
             }
@@ -638,6 +609,10 @@ mod tests {
                 )
                 .into();
                 Ok(Arc::new(udf))
+            }
+
+            fn higher_order_function(&self, name: &str) -> Result<Arc<HigherOrderUDF>> {
+                sedona_internal_err!("attempt to replace higher-order function '{name}'")
             }
 
             fn udaf(&self, name: &str) -> Result<Arc<AggregateUDF>> {
@@ -668,11 +643,7 @@ mod tests {
             Expr::ScalarFunction(ScalarFunction { func, .. }) => {
                 assert_eq!(func.name(), "original");
                 // Verify it's NOT a PlaceholderUDF anymore
-                assert!(func
-                    .inner()
-                    .as_any()
-                    .downcast_ref::<PlaceholderUDF>()
-                    .is_none());
+                assert!(func.inner().downcast_ref::<PlaceholderUDF>().is_none());
             }
             other => panic!("Expected ScalarFunction, got {:?}", other),
         }

--- a/rust/sedona-expr/src/scalar_udf.rs
+++ b/rust/sedona-expr/src/scalar_udf.rs
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-use std::{any::Any, collections::HashMap, fmt::Debug, sync::Arc};
+use std::{collections::HashMap, fmt::Debug, sync::Arc};
 
 use arrow_schema::{DataType, FieldRef};
 use datafusion_common::config::ConfigOptions;
@@ -284,10 +284,6 @@ impl SedonaScalarUDF {
 }
 
 impl ScalarUDFImpl for SedonaScalarUDF {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn name(&self) -> &str {
         &self.name
     }

--- a/rust/sedona-expr/src/spatial_filter.rs
+++ b/rust/sedona-expr/src/spatial_filter.rs
@@ -201,7 +201,7 @@ impl SpatialFilterFactory {
             Ok(spatial_filter)
         } else if let Some(spatial_filter) = self.try_from_distance_predicate(expr)? {
             Ok(spatial_filter)
-        } else if let Some(binary_expr) = expr.as_any().downcast_ref::<BinaryExpr>() {
+        } else if let Some(binary_expr) = expr.downcast_ref::<BinaryExpr>() {
             match binary_expr.op() {
                 Operator::And => Ok(SpatialFilter::And(
                     Box::new(self.try_from_expr(binary_expr.left())?),
@@ -214,7 +214,7 @@ impl SpatialFilterFactory {
                 // Not a binary expression we know about
                 _ => Ok(SpatialFilter::Unknown),
             }
-        } else if let Some(literal) = expr.as_any().downcast_ref::<Literal>() {
+        } else if let Some(literal) = expr.downcast_ref::<Literal>() {
             if let ScalarValue::Boolean(Some(value)) = literal.value() {
                 match value {
                     true => Ok(SpatialFilter::Unknown),
@@ -234,7 +234,7 @@ impl SpatialFilterFactory {
         &self,
         expr: &Arc<dyn PhysicalExpr>,
     ) -> Result<Option<SpatialFilter>> {
-        let Some(scalar_fun) = expr.as_any().downcast_ref::<ScalarFunctionExpr>() else {
+        let Some(scalar_fun) = expr.downcast_ref::<ScalarFunctionExpr>() else {
             return Ok(None);
         };
 
@@ -575,19 +575,19 @@ fn parse_args(args: &[Arc<dyn PhysicalExpr>]) -> Vec<ArgRef<'_>> {
 }
 
 fn parse_arg(arg: &Arc<dyn PhysicalExpr>) -> ArgRef<'_> {
-    if let Some(column_wrapper) = arg.as_any().downcast_ref::<MetadataPreservingColumn>() {
+    if let Some(column_wrapper) = arg.downcast_ref::<MetadataPreservingColumn>() {
         return parse_arg(column_wrapper.inner());
     }
 
-    if let Some(column) = arg.as_any().downcast_ref::<Column>() {
+    if let Some(column) = arg.downcast_ref::<Column>() {
         ArgRef::Col(column.clone())
-    } else if let Some(column_wrapper) = arg.as_any().downcast_ref::<MetadataPreservingColumn>() {
-        if let Some(column) = column_wrapper.inner().as_any().downcast_ref::<Column>() {
+    } else if let Some(column_wrapper) = arg.downcast_ref::<MetadataPreservingColumn>() {
+        if let Some(column) = column_wrapper.inner().downcast_ref::<Column>() {
             ArgRef::Col(column.clone())
         } else {
             ArgRef::Other
         }
-    } else if let Some(literal) = arg.as_any().downcast_ref::<Literal>() {
+    } else if let Some(literal) = arg.downcast_ref::<Literal>() {
         ArgRef::Lit(literal)
     } else {
         ArgRef::Other

--- a/rust/sedona-expr/src/utils.rs
+++ b/rust/sedona-expr/src/utils.rs
@@ -75,7 +75,7 @@ pub struct ParsedDistancePredicate {
 /// - `st_distance(geom_a, geom_b) <= 50.0`
 /// - `25.0 >= st_distance(geom_x, geom_y)`
 pub fn parse_distance_predicate(expr: &Arc<dyn PhysicalExpr>) -> Option<ParsedDistancePredicate> {
-    if let Some(binary_expr) = expr.as_any().downcast_ref::<BinaryExpr>() {
+    if let Some(binary_expr) = expr.downcast_ref::<BinaryExpr>() {
         let left = binary_expr.left();
         let right = binary_expr.right();
         let (st_distance_expr, distance_bound_expr) = match *binary_expr.op() {
@@ -84,10 +84,7 @@ pub fn parse_distance_predicate(expr: &Arc<dyn PhysicalExpr>) -> Option<ParsedDi
             _ => return None,
         };
 
-        if let Some(st_distance_expr) = st_distance_expr
-            .as_any()
-            .downcast_ref::<ScalarFunctionExpr>()
-        {
+        if let Some(st_distance_expr) = st_distance_expr.downcast_ref::<ScalarFunctionExpr>() {
             if st_distance_expr.fun().name() != "st_distance" {
                 return None;
             }
@@ -102,7 +99,7 @@ pub fn parse_distance_predicate(expr: &Arc<dyn PhysicalExpr>) -> Option<ParsedDi
         } else {
             None
         }
-    } else if let Some(st_dwithin_expr) = expr.as_any().downcast_ref::<ScalarFunctionExpr>() {
+    } else if let Some(st_dwithin_expr) = expr.downcast_ref::<ScalarFunctionExpr>() {
         if st_dwithin_expr.fun().name() != "st_dwithin" {
             return None;
         }

--- a/rust/sedona-functions/src/st_analyze_agg.rs
+++ b/rust/sedona-functions/src/st_analyze_agg.rs
@@ -415,7 +415,7 @@ impl<T: WkbBounder2D + Default + std::fmt::Debug> AnalyzeAccumulator<T> {
     }
 }
 
-impl<T: WkbBounder2D + Default + std::fmt::Debug> Accumulator for AnalyzeAccumulator<T> {
+impl<T: WkbBounder2D + Default + std::fmt::Debug + 'static> Accumulator for AnalyzeAccumulator<T> {
     fn update_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
         if values.is_empty() {
             return sedona_internal_err!("No input arrays provided to accumulator");

--- a/rust/sedona-functions/src/st_envelope_agg.rs
+++ b/rust/sedona-functions/src/st_envelope_agg.rs
@@ -173,7 +173,7 @@ impl<T: std::fmt::Debug + WkbBounder2D + Default> BoundsAccumulator2D<T> {
     }
 }
 
-impl<T: std::fmt::Debug + WkbBounder2D + Default> Accumulator for BoundsAccumulator2D<T> {
+impl<T: std::fmt::Debug + WkbBounder2D + Default + 'static> Accumulator for BoundsAccumulator2D<T> {
     fn update_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
         Self::check_update_input_len(values, 1, "update_batch")?;
         let arg_types = [self.input_type.clone()];
@@ -417,7 +417,7 @@ impl<T: WkbBounder2D + Default> BoundsGroupsAccumulator2D<T> {
     }
 }
 
-impl<T: WkbBounder2D + Default> GroupsAccumulator for BoundsGroupsAccumulator2D<T> {
+impl<T: WkbBounder2D + Default + 'static> GroupsAccumulator for BoundsGroupsAccumulator2D<T> {
     fn update_batch(
         &mut self,
         values: &[ArrayRef],
@@ -442,10 +442,21 @@ impl<T: WkbBounder2D + Default> GroupsAccumulator for BoundsGroupsAccumulator2D<
         &mut self,
         values: &[ArrayRef],
         group_indices: &[usize],
-        opt_filter: Option<&arrow_array::BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
-        self.merge_state(values, group_indices, opt_filter, total_num_groups)
+        self.merge_state(values, group_indices, None, total_num_groups)
+    }
+
+    fn convert_to_state(
+        &self,
+        values: &[ArrayRef],
+        opt_filter: Option<&BooleanArray>,
+    ) -> Result<Vec<ArrayRef>> {
+        let num_rows = values.first().map_or(0, |array| array.len());
+        let group_indices = (0..num_rows).collect::<Vec<_>>();
+        let mut accumulator = Self::new(self.input_type.clone());
+        accumulator.update_batch(values, &group_indices, opt_filter, num_rows)?;
+        accumulator.state(EmitTo::All)
     }
 
     fn evaluate(&mut self, emit_to: EmitTo) -> Result<ArrayRef> {

--- a/rust/sedona-geo/src/st_convexhull_agg.rs
+++ b/rust/sedona-geo/src/st_convexhull_agg.rs
@@ -377,10 +377,21 @@ impl GroupsAccumulator for ConvexHullGroupsAccumulator {
         &mut self,
         values: &[ArrayRef],
         group_indices: &[usize],
-        opt_filter: Option<&BooleanArray>,
         total_num_groups: usize,
     ) -> Result<()> {
-        self.merge_state(values, group_indices, opt_filter, total_num_groups)
+        self.merge_state(values, group_indices, None, total_num_groups)
+    }
+
+    fn convert_to_state(
+        &self,
+        values: &[ArrayRef],
+        opt_filter: Option<&BooleanArray>,
+    ) -> Result<Vec<ArrayRef>> {
+        let num_rows = values.first().map_or(0, |array| array.len());
+        let group_indices = (0..num_rows).collect::<Vec<_>>();
+        let mut accumulator = Self::new(self.input_type.clone());
+        accumulator.update_batch(values, &group_indices, opt_filter, num_rows)?;
+        accumulator.state(EmitTo::All)
     }
 
     fn evaluate(&mut self, emit_to: EmitTo) -> Result<ArrayRef> {

--- a/rust/sedona-geoparquet/src/file_opener.rs
+++ b/rust/sedona-geoparquet/src/file_opener.rs
@@ -78,7 +78,7 @@ impl GeoParquetFileOpenerMetrics {
     pub fn new(execution_plan_global_metrics: &ExecutionPlanMetricsSet) -> Self {
         let files_ranges_spatial_pruned = PruningMetrics::new();
         MetricBuilder::new(execution_plan_global_metrics)
-            .with_type(MetricType::SUMMARY)
+            .with_type(MetricType::Summary)
             .build(MetricValue::PruningMetrics {
                 name: "files_ranges_spatial_pruned".into(),
                 pruning_metrics: files_ranges_spatial_pruned.clone(),
@@ -86,7 +86,7 @@ impl GeoParquetFileOpenerMetrics {
 
         let row_groups_spatial_pruned = PruningMetrics::new();
         MetricBuilder::new(execution_plan_global_metrics)
-            .with_type(MetricType::SUMMARY)
+            .with_type(MetricType::Summary)
             .build(MetricValue::PruningMetrics {
                 name: "row_groups_spatial_pruned".into(),
                 pruning_metrics: row_groups_spatial_pruned.clone(),
@@ -113,7 +113,7 @@ pub(crate) struct GeoParquetFileOpener {
     pub enable_pruning: bool,
     pub metrics: GeoParquetFileOpenerMetrics,
     pub options: TableGeoParquetOptions,
-    pub metadata_cache: Option<Arc<dyn FileMetadataCache>>,
+    pub metadata_cache: Option<Arc<FileMetadataCache>>,
     /// Factory for creating bounders used for spatial pruning
     ///
     /// Enables spatial pruning for both GEOMETRY and GEOGRAPHY columns.
@@ -181,7 +181,7 @@ impl FileOpener for GeoParquetFileOpener {
 
             // We could also consider filtering using null_count here in the future (i.e.,
             // skip row groups that are all null)
-            let file = file.with_extensions(Arc::new(access_plan));
+            let file = file.with_extension(access_plan);
             let stream = self_clone.inner.open(file)?.await?;
 
             // Validate geometry columns when enabled from read option.

--- a/rust/sedona-geoparquet/src/format.rs
+++ b/rust/sedona-geoparquet/src/format.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::{
-    any::Any,
     collections::{HashMap, HashSet},
     sync::Arc,
 };
@@ -119,7 +118,7 @@ impl FileFormatFactory for GeoParquetFormatFactory {
         }
 
         let inner_format = self.inner.create(state, &format_options_mut)?;
-        if let Some(parquet_format) = inner_format.as_any().downcast_ref::<ParquetFormat>() {
+        if let Some(parquet_format) = inner_format.downcast_ref::<ParquetFormat>() {
             options_mut.inner = parquet_format.options().clone();
             Ok(Arc::new(GeoParquetFormat::new(options_mut)))
         } else {
@@ -132,10 +131,6 @@ impl FileFormatFactory for GeoParquetFormatFactory {
 
     fn default(&self) -> std::sync::Arc<dyn FileFormat> {
         Arc::new(ParquetFormat::default())
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
     }
 }
 
@@ -169,10 +164,6 @@ impl GeoParquetFormat {
 
 #[async_trait]
 impl FileFormat for GeoParquetFormat {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn get_ext(&self) -> String {
         ParquetFormatFactory::new().get_ext()
     }
@@ -224,7 +215,13 @@ impl FileFormat for GeoParquetFormat {
                 }
             })
             .boxed() // Workaround https://github.com/rust-lang/rust/issues/64552
-            .buffered(state.config_options().execution.meta_fetch_concurrency)
+            .buffered(
+                state
+                    .config_options()
+                    .execution
+                    .meta_fetch_concurrency
+                    .into(),
+            )
             .try_collect()
             .await?;
 
@@ -333,7 +330,6 @@ impl FileFormat for GeoParquetFormat {
 
         let mut source = config
             .file_source()
-            .as_any()
             .downcast_ref::<GeoParquetFileSource>()
             .cloned()
             .ok_or_else(|| sedona_internal_datafusion_err!("Expected GeoParquetFileSource"))?;
@@ -440,7 +436,7 @@ pub struct GeoParquetFileSource {
     metadata_size_hint: Option<usize>,
     predicate: Option<Arc<dyn PhysicalExpr>>,
     options: TableGeoParquetOptions,
-    metadata_cache: Option<Arc<dyn FileMetadataCache>>,
+    metadata_cache: Option<Arc<FileMetadataCache>>,
     /// Factory for creating bounders used for spatial pruning
     ///
     /// Enables spatial pruning for both GEOMETRY and GEOGRAPHY columns.
@@ -507,7 +503,7 @@ impl GeoParquetFileSource {
         metadata_size_hint: Option<usize>,
         predicate: Option<Arc<dyn PhysicalExpr>>,
     ) -> Result<Self> {
-        if let Some(parquet_source) = inner.as_any().downcast_ref::<ParquetSource>() {
+        if let Some(parquet_source) = inner.downcast_ref::<ParquetSource>() {
             let parquet_source = parquet_source.clone();
             // Extract the predicate from the existing source if it exists so we can keep a copy of it
             let new_predicate = match (parquet_source.filter(), predicate) {
@@ -586,6 +582,15 @@ impl GeoParquetFileSource {
 }
 
 impl FileSource for GeoParquetFileSource {
+    fn apply_expressions(
+        &self,
+        f: &mut dyn FnMut(
+            &Arc<dyn PhysicalExpr>,
+        ) -> Result<datafusion_common::tree_node::TreeNodeRecursion>,
+    ) -> Result<datafusion_common::tree_node::TreeNodeRecursion> {
+        self.inner.apply_expressions(f)
+    }
+
     fn create_file_opener(
         &self,
         object_store: Arc<dyn ObjectStore>,
@@ -645,10 +650,6 @@ impl FileSource for GeoParquetFileSource {
             }
             None => Ok(inner_result),
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 
     fn with_batch_size(&self, batch_size: usize) -> Arc<dyn FileSource> {
@@ -729,7 +730,7 @@ fn wrap_expr_columns(
     file_schema: &Schema,
 ) -> Result<Arc<dyn PhysicalExpr>> {
     expr.transform_down(|node| {
-        if let Some(column) = node.as_any().downcast_ref::<Column>() {
+        if let Some(column) = node.downcast_ref::<Column>() {
             let index = column.index();
 
             if index >= file_schema.fields().len() {
@@ -1058,10 +1059,7 @@ mod test {
         let dyn_format = format_factory
             .create(&ctx.state(), &HashMap::new())
             .unwrap();
-        assert!(dyn_format
-            .as_any()
-            .downcast_ref::<GeoParquetFormat>()
-            .is_some());
+        assert!(dyn_format.downcast_ref::<GeoParquetFormat>().is_some());
     }
 
     #[tokio::test]
@@ -1086,17 +1084,14 @@ mod test {
             .unwrap();
 
         let data_source_exec = plan
-            .as_any()
             .downcast_ref::<DataSourceExec>()
             .expect("plan root should be DataSourceExec");
         let file_scan_conf = data_source_exec
             .data_source()
-            .as_any()
             .downcast_ref::<FileScanConfig>()
             .expect("data source should be FileScanConfig");
         let geo_source = file_scan_conf
             .file_source()
-            .as_any()
             .downcast_ref::<GeoParquetFileSource>()
             .expect("file source should be GeoParquetFileSource");
         assert!(geo_source.inner.parquet_file_reader_factory().is_some());
@@ -1147,10 +1142,7 @@ mod test {
         let result = wrap_expr_columns(geometry_column, &file_schema).unwrap();
 
         // The result should be wrapped in MetadataPreservingColumn
-        assert!(result
-            .as_any()
-            .downcast_ref::<MetadataPreservingColumn>()
-            .is_some());
+        assert!(result.downcast_ref::<MetadataPreservingColumn>().is_some());
     }
 
     /// Test that columns without extension metadata are not wrapped
@@ -1172,7 +1164,7 @@ mod test {
         let result = wrap_expr_columns(name_column, &file_schema).unwrap();
 
         // The result should NOT be wrapped (still a Column)
-        assert!(result.as_any().downcast_ref::<Column>().is_some());
+        assert!(result.downcast_ref::<Column>().is_some());
     }
 
     /// Test that column index out of file schema bounds returns an error

--- a/rust/sedona-geoparquet/src/metadata.rs
+++ b/rust/sedona-geoparquet/src/metadata.rs
@@ -650,14 +650,16 @@ fn column_from_logical_type(
         let mut column_metadata = GeoParquetColumnMetadata::default();
 
         match logical_type {
-            LogicalType::Geometry { crs } => {
-                column_metadata.crs = geoparquet_crs_from_logical_type(crs.as_ref(), kv_metadata);
+            LogicalType::Geometry(geometry) => {
+                column_metadata.crs =
+                    geoparquet_crs_from_logical_type(geometry.crs.as_ref(), kv_metadata);
                 Ok(Some(column_metadata))
             }
-            LogicalType::Geography { crs, algorithm } => {
-                column_metadata.crs = geoparquet_crs_from_logical_type(crs.as_ref(), kv_metadata);
+            LogicalType::Geography(geography) => {
+                column_metadata.crs =
+                    geoparquet_crs_from_logical_type(geography.crs.as_ref(), kv_metadata);
 
-                let edges = match algorithm {
+                let edges = match geography.algorithm {
                     None | Some(EdgeInterpolationAlgorithm::SPHERICAL) => "spherical",
                     Some(EdgeInterpolationAlgorithm::VINCENTY) => "vincenty",
                     Some(EdgeInterpolationAlgorithm::ANDOYER) => "andoyer",
@@ -803,7 +805,7 @@ mod test {
 
         let schema_additional_parquet_geo = make_parquet_schema(&[
             ("geom_geoparquet", None),
-            ("geom_parquet", Some(LogicalType::Geometry { crs: None })),
+            ("geom_parquet", Some(LogicalType::geometry(None))),
         ]);
         let metadata = GeoParquetMetadata::try_from_parquet_metadata_impl(
             &schema_additional_parquet_geo,
@@ -816,7 +818,7 @@ mod test {
         assert!(metadata.columns.contains_key("geom_parquet"));
 
         let schema_overlapping_columns =
-            make_parquet_schema(&[("geom_geoparquet", Some(LogicalType::Geometry { crs: None }))]);
+            make_parquet_schema(&[("geom_geoparquet", Some(LogicalType::geometry(None)))]);
         let metadata = GeoParquetMetadata::try_from_parquet_metadata_impl(
             &schema_overlapping_columns,
             kv_metadata_with_geo_key.as_ref(),
@@ -834,7 +836,7 @@ mod test {
         );
 
         let schema_only_parquet_geo =
-            make_parquet_schema(&[("geom_parquet", Some(LogicalType::Geometry { crs: None }))]);
+            make_parquet_schema(&[("geom_parquet", Some(LogicalType::geometry(None)))]);
         let metadata = GeoParquetMetadata::try_from_parquet_metadata_impl(
             &schema_only_parquet_geo,
             None, // No key/value metadata
@@ -862,19 +864,17 @@ mod test {
         );
 
         // Geometry logical type
-        let metadata = column_from_logical_type(
-            Some(&LogicalType::Geometry { crs: None }),
-            kv_metadata.as_ref(),
-        )
-        .unwrap()
-        .unwrap();
+        let metadata =
+            column_from_logical_type(Some(&LogicalType::geometry(None)), kv_metadata.as_ref())
+                .unwrap()
+                .unwrap();
         assert_eq!(metadata, GeoParquetColumnMetadata::default());
 
         // Ensure CRS is translated
         let metadata = column_from_logical_type(
-            Some(&LogicalType::Geometry {
-                crs: Some("projjson:some_projjson_key".to_string()),
-            }),
+            Some(&LogicalType::geometry(Some(
+                "projjson:some_projjson_key".to_string(),
+            ))),
             kv_metadata.as_ref(),
         )
         .unwrap()
@@ -886,10 +886,7 @@ mod test {
 
         // Geography logical type
         let metadata = column_from_logical_type(
-            Some(&LogicalType::Geography {
-                crs: None,
-                algorithm: None,
-            }),
+            Some(&LogicalType::geography(None, None)),
             kv_metadata.as_ref(),
         )
         .unwrap()
@@ -898,10 +895,10 @@ mod test {
 
         // Ensure CRS is translated
         let metadata = column_from_logical_type(
-            Some(&LogicalType::Geography {
-                crs: Some("projjson:some_projjson_key".to_string()),
-                algorithm: None,
-            }),
+            Some(&LogicalType::geography(
+                Some("projjson:some_projjson_key".to_string()),
+                None,
+            )),
             kv_metadata.as_ref(),
         )
         .unwrap()
@@ -913,10 +910,10 @@ mod test {
 
         // Ensure algorithm is translated
         let metadata = column_from_logical_type(
-            Some(&LogicalType::Geography {
-                crs: None,
-                algorithm: Some(EdgeInterpolationAlgorithm::VINCENTY),
-            }),
+            Some(&LogicalType::geography(
+                None,
+                Some(EdgeInterpolationAlgorithm::VINCENTY),
+            )),
             kv_metadata.as_ref(),
         )
         .unwrap()

--- a/rust/sedona-geoparquet/src/provider.rs
+++ b/rust/sedona-geoparquet/src/provider.rs
@@ -317,7 +317,7 @@ impl ReadOptions<'_> for GeoParquetReadOptions<'_> {
 
         let mut options = self.inner.to_listing_options(config, table_options);
 
-        if let Some(parquet_format) = options.format.as_any().downcast_ref::<ParquetFormat>() {
+        if let Some(parquet_format) = options.format.downcast_ref::<ParquetFormat>() {
             let mut geoparquet_options =
                 TableGeoParquetOptions::from(parquet_format.options().clone());
             if let Some(geometry_columns) = &self.geometry_columns {

--- a/rust/sedona-geoparquet/src/statistics_accumulator.rs
+++ b/rust/sedona-geoparquet/src/statistics_accumulator.rs
@@ -64,19 +64,21 @@ impl SedonaGeoStatsAccumulatorFactory {
 
 impl GeoStatsAccumulatorFactory for SedonaGeoStatsAccumulatorFactory {
     fn new_accumulator(&self, descr: &ColumnDescPtr) -> Box<dyn GeoStatsAccumulator> {
-        if let Some(LogicalType::Geometry { .. }) = descr.logical_type_ref() {
+        if let Some(LogicalType::Geometry(_)) = descr.logical_type_ref() {
             return Box::new(ParquetGeoStatsAccumulator::default());
         }
 
         // Handle Geography with either no algorithm specified (defaults to spherical)
         // or explicit SPHERICAL algorithm
-        if let Some(LogicalType::Geography {
-            crs: _,
-            algorithm: None | Some(parquet::basic::EdgeInterpolationAlgorithm::SPHERICAL),
-        }) = descr.logical_type_ref()
-        {
-            if let Some(bounder) = self.bounder_factory.bounder_for_edge_type(Edges::Spherical) {
-                return Box::new(GeographyGeoStatsAccumulator::new(bounder));
+        if let Some(LogicalType::Geography(geography)) = descr.logical_type_ref() {
+            if matches!(
+                geography.algorithm,
+                None | Some(parquet::basic::EdgeInterpolationAlgorithm::SPHERICAL)
+            ) {
+                if let Some(bounder) = self.bounder_factory.bounder_for_edge_type(Edges::Spherical)
+                {
+                    return Box::new(GeographyGeoStatsAccumulator::new(bounder));
+                }
             }
         }
 

--- a/rust/sedona-geoparquet/src/writer.rs
+++ b/rust/sedona-geoparquet/src/writer.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::{any::Any, collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 
 use arrow_array::{
     builder::{Float32Builder, NullBufferBuilder},
@@ -239,10 +239,6 @@ impl DisplayAs for GeoParquetSink {
 
 #[async_trait]
 impl DataSink for GeoParquetSink {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> &SchemaRef {
         &self.sink_input_schema
     }
@@ -602,10 +598,6 @@ impl std::hash::Hash for NormalizeForGeoParquet {
 impl Eq for NormalizeForGeoParquet {}
 
 impl ScalarUDFImpl for NormalizeForGeoParquet {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn name(&self) -> &str {
         "normalize_for_geoparquet"
     }
@@ -1231,8 +1223,8 @@ mod test {
         let logical_types = test_dataframe_roundtrip(&ctx, df, options).await;
         let logical_type = logical_types.get("geometry").unwrap().clone().unwrap();
         match logical_type {
-            LogicalType::Geometry { crs } => {
-                assert!(crs.is_none());
+            LogicalType::Geometry(geometry) => {
+                assert!(geometry.crs.is_none());
             }
             unknown => panic!("Unexpected logical type {unknown:?}"),
         }
@@ -1252,11 +1244,14 @@ mod test {
         let logical_types = test_dataframe_roundtrip(&ctx, df, options).await;
         let logical_type = logical_types.get("geometry").unwrap().clone().unwrap();
         match logical_type {
-            LogicalType::Geography { crs, algorithm } => {
-                assert!(crs.is_none());
+            LogicalType::Geography(geography) => {
+                assert!(geography.crs.is_none());
                 assert!(
-                    algorithm.is_none()
-                        || matches!(algorithm.unwrap(), EdgeInterpolationAlgorithm::SPHERICAL)
+                    geography.algorithm.is_none()
+                        || matches!(
+                            geography.algorithm.unwrap(),
+                            EdgeInterpolationAlgorithm::SPHERICAL
+                        )
                 );
             }
             unknown => panic!("Unexpected logical type {unknown:?}"),
@@ -1277,9 +1272,9 @@ mod test {
         let logical_types = test_dataframe_roundtrip(&ctx, df, options).await;
         let logical_type = logical_types.get("geometry").unwrap().clone().unwrap();
         match logical_type {
-            LogicalType::Geometry { crs } => {
-                assert!(crs.as_ref().unwrap().starts_with("{"));
-                let parsed = deserialize_crs(crs.as_ref().unwrap()).unwrap();
+            LogicalType::Geometry(geometry) => {
+                assert!(geometry.crs.as_ref().unwrap().starts_with("{"));
+                let parsed = deserialize_crs(geometry.crs.as_ref().unwrap()).unwrap();
                 assert_eq!(
                     parsed.unwrap().to_authority_code().unwrap(),
                     Some("EPSG:32618".to_string())
@@ -1303,8 +1298,8 @@ mod test {
         let logical_types = test_dataframe_roundtrip(&ctx, df, options).await;
         let logical_type = logical_types.get("geometry").unwrap().clone().unwrap();
         match logical_type {
-            LogicalType::Geometry { crs } => {
-                assert!(crs.is_none());
+            LogicalType::Geometry(geometry) => {
+                assert!(geometry.crs.is_none());
             }
             unknown => panic!("Unexpected logical type {unknown:?}"),
         }

--- a/rust/sedona-pointcloud/src/las/format.rs
+++ b/rust/sedona-pointcloud/src/las/format.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::{any::Any, collections::HashMap, fmt, sync::Arc};
+use std::{collections::HashMap, fmt, sync::Arc};
 
 use arrow_schema::{Schema, SchemaRef};
 use datafusion_catalog::{memory::DataSourceExec, Session};
@@ -106,10 +106,6 @@ impl FileFormatFactory for LasFormatFactory {
     fn default(&self) -> Arc<dyn FileFormat> {
         Arc::new(LasFormat::new(self.extension))
     }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
 }
 
 impl GetExt for LasFormatFactory {
@@ -150,10 +146,6 @@ impl LasFormat {
 
 #[async_trait::async_trait]
 impl FileFormat for LasFormat {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn get_ext(&self) -> String {
         LasFormatFactory::new(self.extension).get_ext()
     }
@@ -235,7 +227,6 @@ impl FileFormat for LasFormat {
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
         let mut source = conf
             .file_source()
-            .as_any()
             .downcast_ref::<LasSource>()
             .cloned()
             .ok_or_else(|| DataFusionError::External("Expected LasSource".into()))?;
@@ -290,14 +281,14 @@ mod test {
         let dyn_format = format_factory
             .create(&ctx.state(), &HashMap::new())
             .unwrap();
-        assert!(dyn_format.as_any().downcast_ref::<LasFormat>().is_some());
+        assert!(dyn_format.downcast_ref::<LasFormat>().is_some());
 
         let ctx = SessionContext::new();
         let format_factory = Arc::new(LasFormatFactory::new(Extension::Laz));
         let dyn_format = format_factory
             .create(&ctx.state(), &HashMap::new())
             .unwrap();
-        assert!(dyn_format.as_any().downcast_ref::<LasFormat>().is_some());
+        assert!(dyn_format.downcast_ref::<LasFormat>().is_some());
     }
 
     #[tokio::test]

--- a/rust/sedona-pointcloud/src/las/metadata.rs
+++ b/rust/sedona-pointcloud/src/las/metadata.rs
@@ -89,7 +89,7 @@ impl FileMetadata for LasMetadata {
 pub struct LasMetadataReader<'a> {
     store: &'a dyn ObjectStore,
     object_meta: &'a ObjectMeta,
-    file_metadata_cache: Option<Arc<dyn FileMetadataCache>>,
+    file_metadata_cache: Option<Arc<FileMetadataCache>>,
     options: LasOptions,
 }
 
@@ -106,7 +106,7 @@ impl<'a> LasMetadataReader<'a> {
     /// set file metadata cache
     pub fn with_file_metadata_cache(
         mut self,
-        file_metadata_cache: Option<Arc<dyn FileMetadataCache>>,
+        file_metadata_cache: Option<Arc<FileMetadataCache>>,
     ) -> Self {
         self.file_metadata_cache = file_metadata_cache;
         self

--- a/rust/sedona-pointcloud/src/las/reader.rs
+++ b/rust/sedona-pointcloud/src/las/reader.rs
@@ -46,14 +46,14 @@ use crate::las::{
 #[derive(Debug)]
 pub struct LasFileReaderFactory {
     store: Arc<dyn ObjectStore>,
-    metadata_cache: Option<Arc<dyn FileMetadataCache>>,
+    metadata_cache: Option<Arc<FileMetadataCache>>,
 }
 
 impl LasFileReaderFactory {
     /// Create a new `LasFileReaderFactory`.
     pub fn new(
         store: Arc<dyn ObjectStore>,
-        metadata_cache: Option<Arc<dyn FileMetadataCache>>,
+        metadata_cache: Option<Arc<FileMetadataCache>>,
     ) -> Self {
         Self {
             store,
@@ -79,7 +79,7 @@ impl LasFileReaderFactory {
 pub struct LasFileReader {
     partitioned_file: PartitionedFile,
     store: Arc<dyn ObjectStore>,
-    metadata_cache: Option<Arc<dyn FileMetadataCache>>,
+    metadata_cache: Option<Arc<FileMetadataCache>>,
     pub options: LasOptions,
 }
 

--- a/rust/sedona-pointcloud/src/las/source.rs
+++ b/rust/sedona-pointcloud/src/las/source.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::{any::Any, iter, sync::Arc};
+use std::{iter, sync::Arc};
 
 use datafusion_common::{config::ConfigOptions, error::DataFusionError};
 use datafusion_datasource::{
@@ -88,6 +88,22 @@ impl LasSource {
 }
 
 impl FileSource for LasSource {
+    fn apply_expressions(
+        &self,
+        f: &mut dyn FnMut(
+            &Arc<dyn PhysicalExpr>,
+        ) -> datafusion_common::Result<
+            datafusion_common::tree_node::TreeNodeRecursion,
+        >,
+    ) -> datafusion_common::Result<datafusion_common::tree_node::TreeNodeRecursion> {
+        datafusion_physical_plan::apply_expression_roots(
+            self.predicate
+                .iter()
+                .chain(self.projection.iter().map(|expr| &expr.expr)),
+            f,
+        )
+    }
+
     fn create_file_opener(
         &self,
         object_store: Arc<dyn ObjectStore>,
@@ -114,10 +130,6 @@ impl FileSource for LasSource {
 
         // Wrap with ProjectionOpener to handle reordering/expressions
         ProjectionOpener::try_new(split_projection, las_opener, table_schema)
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 
     fn table_schema(&self) -> &TableSchema {

--- a/rust/sedona-raster-functions/src/rs_ensure_loaded.rs
+++ b/rust/sedona-raster-functions/src/rs_ensure_loaded.rs
@@ -25,7 +25,6 @@
 //! `data` columns are populated with the loaded bytes. InDb bands pass
 //! through unchanged. Other band/raster metadata is preserved verbatim.
 
-use std::any::Any;
 use std::hash::{Hash, Hasher};
 use std::sync::{Arc, RwLock};
 
@@ -159,10 +158,6 @@ impl Hash for RsEnsureLoaded {
 }
 
 impl ScalarUDFImpl for RsEnsureLoaded {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn name(&self) -> &str {
         "rs_ensureloaded"
     }

--- a/rust/sedona-testing/src/testers.rs
+++ b/rust/sedona-testing/src/testers.rs
@@ -183,7 +183,6 @@ impl AggregateUdfTester {
             state_accumulator.merge_batch(
                 state_batch.columns(),
                 &(0..total_num_groups).collect::<Vec<_>>(),
-                None,
                 total_num_groups,
             )?;
         }


### PR DESCRIPTION
Starts the DataFusion 55 upgrade from #1204, aligning Arrow/Parquet 59.3, object_store 0.13, and adapting expression, aggregate, metadata-cache, and GeoParquet logical-type APIs. GeoParquet compiles and 45/65 tests pass. Remaining reader tests expose the expected Morsel API migration; the workspace also needs GeoArrow/Arrow alignment in sedona-pointcloud and DataFusion trait/protobuf updates in sedona-extension. This draft is intended to make those follow-up changes reviewable in context.