### PR TITLE
test(integration): compare() accepts an optional expected anchor

### DIFF
--- a/integration/spark-parity/test_rs_raster_out.py
+++ b/integration/spark-parity/test_rs_raster_out.py
@@ -47,11 +47,9 @@ BAND_NODATA = {"uint8": 200.0, "int32": -99999.0, "float64": -12345.5}
 # The grid the anchored tests write and reconstruct. Anchors must state the
 # exact raster they expect, so the placement is passed to
 # create_random_raster_view explicitly rather than relying on its defaults
-# staying in sync. GDAL_TRANSFORM is BBOX on the WIDTH x HEIGHT grid — the
-# transform an anchored `DecodedRaster` must decode back to.
+# staying in sync — and the anchors state the same BBOX.
 BANDS, HEIGHT, WIDTH = 2, 6, 7
 BBOX = (100.0, 482.0, 114.0, 500.0)
-GDAL_TRANSFORM = (100.0, 2.0, 0.0, 500.0, 0.0, -3.0)
 
 
 def _anchor(dtype, nodata, *, bands=BANDS, plants=None):
@@ -61,8 +59,8 @@ def _anchor(dtype, nodata, *, bands=BANDS, plants=None):
         random_raster_data(
             dtype, bands=bands, height=HEIGHT, width=WIDTH, plants=plants
         ),
-        GDAL_TRANSFORM,
-        nodata,
+        nodata=nodata,
+        bbox=BBOX,
     )
 
 

--- a/integration/spark-parity/test_rs_raster_out.py
+++ b/integration/spark-parity/test_rs_raster_out.py
@@ -45,9 +45,12 @@ from sedonadb.testing_spark import SedonaSpark
 BAND_NODATA = {"uint8": 200.0, "int32": -99999.0, "float64": -12345.5}
 
 # The grid the anchored tests write and reconstruct. Anchors must state the
-# exact raster they expect, so these are passed to create_random_raster_view
-# explicitly rather than relying on its defaults staying in sync.
+# exact raster they expect, so the placement is passed to
+# create_random_raster_view explicitly rather than relying on its defaults
+# staying in sync. GDAL_TRANSFORM is BBOX on the WIDTH x HEIGHT grid — the
+# transform an anchored `DecodedRaster` must decode back to.
 BANDS, HEIGHT, WIDTH = 2, 6, 7
+BBOX = (100.0, 482.0, 114.0, 500.0)
 GDAL_TRANSFORM = (100.0, 2.0, 0.0, 500.0, 0.0, -3.0)
 
 
@@ -81,7 +84,7 @@ def test_rs_setbandnodata(dtype, tmp_path):
             bands=BANDS,
             height=HEIGHT,
             width=WIDTH,
-            gdal_transform=GDAL_TRANSFORM,
+            bbox=BBOX,
             plants=plants,
         )
 
@@ -107,7 +110,7 @@ def test_rs_setbandnodata_band2(tmp_path):
             bands=BANDS,
             height=HEIGHT,
             width=WIDTH,
-            gdal_transform=GDAL_TRANSFORM,
+            bbox=BBOX,
         )
     sql = "SELECT RS_SetBandNoDataValue(rast, 2, 5.0) FROM band2_src"
     compare(sql, sedona, spark, expected=_anchor("float64", [None, 5.0]))
@@ -124,7 +127,7 @@ def test_rs_setbandnodata_overwrite(tmp_path):
             bands=1,
             height=HEIGHT,
             width=WIDTH,
-            gdal_transform=GDAL_TRANSFORM,
+            bbox=BBOX,
             nodata=7.0,
         )
     for sql, new_nodata in (
@@ -145,7 +148,7 @@ def test_rs_setbandnodata_two_arg_single_band(tmp_path):
             bands=1,
             height=HEIGHT,
             width=WIDTH,
-            gdal_transform=GDAL_TRANSFORM,
+            bbox=BBOX,
         )
     sql = "SELECT RS_SetBandNoDataValue(rast, 5.0) FROM two_arg_src"
     compare(sql, sedona, spark, expected=_anchor("uint8", [5.0], bands=1))

--- a/integration/spark-parity/test_rs_raster_out.py
+++ b/integration/spark-parity/test_rs_raster_out.py
@@ -37,11 +37,30 @@ operation divergence — it isolates the transport. Pixel-transforming ops
 
 import pytest
 
+from sedonadb.raster_testing import DecodedRaster, random_raster_data
 from sedonadb.testing import SedonaDB, compare
 from sedonadb.testing_spark import SedonaSpark
 
 # Each value is representable in its dtype, so it packs into the band exactly.
 BAND_NODATA = {"uint8": 200.0, "int32": -99999.0, "float64": -12345.5}
+
+# The grid the anchored tests write and reconstruct. Anchors must state the
+# exact raster they expect, so these are passed to create_random_raster_view
+# explicitly rather than relying on its defaults staying in sync.
+BANDS, HEIGHT, WIDTH = 2, 6, 7
+GDAL_TRANSFORM = (100.0, 2.0, 0.0, 500.0, 0.0, -3.0)
+
+
+def _anchor(dtype, nodata, *, bands=BANDS, plants=None):
+    """The `DecodedRaster` a pixel-preserving setter must return on the
+    standard grid: the seeded pixels unchanged, with `nodata` per band."""
+    return DecodedRaster(
+        random_raster_data(
+            dtype, bands=bands, height=HEIGHT, width=WIDTH, plants=plants
+        ),
+        GDAL_TRANSFORM,
+        nodata,
+    )
 
 
 @pytest.mark.parametrize("dtype", list(BAND_NODATA))
@@ -50,6 +69,7 @@ def test_rs_setbandnodata(dtype, tmp_path):
     SedonaDB and Sedona Spark must return the same raster: identical pixels and
     geotransform, band 1's nodata set, band 2's still absent."""
     sedona, spark = SedonaDB(), SedonaSpark()
+    plants = {(1, 1): BAND_NODATA[dtype]}
     for eng in (sedona, spark):
         # The new nodata value is also planted into the pixels: setting a
         # band's nodata must not mask or rewrite pixels that happen to hold
@@ -58,11 +78,21 @@ def test_rs_setbandnodata(dtype, tmp_path):
             "src",
             tmp_path / "src.tif",
             dtype=dtype,
-            plants={(1, 1): BAND_NODATA[dtype]},
+            bands=BANDS,
+            height=HEIGHT,
+            width=WIDTH,
+            gdal_transform=GDAL_TRANSFORM,
+            plants=plants,
         )
 
     sql = f"SELECT RS_SetBandNoDataValue(rast, 1, {BAND_NODATA[dtype]}) FROM src"
-    compare(sql, sedona, spark)
+    # Anchored: parity alone would also pass if both engines no-opped.
+    compare(
+        sql,
+        sedona,
+        spark,
+        expected=_anchor(dtype, [BAND_NODATA[dtype], None], plants=plants),
+    )
 
 
 def test_rs_setbandnodata_band2(tmp_path):
@@ -71,10 +101,16 @@ def test_rs_setbandnodata_band2(tmp_path):
     sedona, spark = SedonaDB(), SedonaSpark()
     for eng in (sedona, spark):
         eng.create_random_raster_view(
-            "band2_src", tmp_path / "band2_src.tif", dtype="float64"
+            "band2_src",
+            tmp_path / "band2_src.tif",
+            dtype="float64",
+            bands=BANDS,
+            height=HEIGHT,
+            width=WIDTH,
+            gdal_transform=GDAL_TRANSFORM,
         )
     sql = "SELECT RS_SetBandNoDataValue(rast, 2, 5.0) FROM band2_src"
-    compare(sql, sedona, spark)
+    compare(sql, sedona, spark, expected=_anchor("float64", [None, 5.0]))
 
 
 def test_rs_setbandnodata_overwrite(tmp_path):
@@ -83,13 +119,19 @@ def test_rs_setbandnodata_overwrite(tmp_path):
     sedona, spark = SedonaDB(), SedonaSpark()
     for eng in (sedona, spark):
         eng.create_random_raster_view(
-            "ow_src", tmp_path / "ow_src.tif", bands=1, nodata=7.0
+            "ow_src",
+            tmp_path / "ow_src.tif",
+            bands=1,
+            height=HEIGHT,
+            width=WIDTH,
+            gdal_transform=GDAL_TRANSFORM,
+            nodata=7.0,
         )
-    for sql in (
-        "SELECT RS_SetBandNoDataValue(rast, 1, 9.0) FROM ow_src",
-        "SELECT RS_SetBandNoDataValue(rast, 1, 7.0) FROM ow_src",
+    for sql, new_nodata in (
+        ("SELECT RS_SetBandNoDataValue(rast, 1, 9.0) FROM ow_src", 9.0),
+        ("SELECT RS_SetBandNoDataValue(rast, 1, 7.0) FROM ow_src", 7.0),
     ):
-        compare(sql, sedona, spark)
+        compare(sql, sedona, spark, expected=_anchor("uint8", [new_nodata], bands=1))
 
 
 def test_rs_setbandnodata_two_arg_single_band(tmp_path):
@@ -98,10 +140,15 @@ def test_rs_setbandnodata_two_arg_single_band(tmp_path):
     sedona, spark = SedonaDB(), SedonaSpark()
     for eng in (sedona, spark):
         eng.create_random_raster_view(
-            "two_arg_src", tmp_path / "two_arg_src.tif", bands=1
+            "two_arg_src",
+            tmp_path / "two_arg_src.tif",
+            bands=1,
+            height=HEIGHT,
+            width=WIDTH,
+            gdal_transform=GDAL_TRANSFORM,
         )
     sql = "SELECT RS_SetBandNoDataValue(rast, 5.0) FROM two_arg_src"
-    compare(sql, sedona, spark)
+    compare(sql, sedona, spark, expected=_anchor("uint8", [5.0], bands=1))
 
 
 @pytest.mark.xfail(

--- a/integration/spark-parity/test_rs_scalar.py
+++ b/integration/spark-parity/test_rs_scalar.py
@@ -75,10 +75,15 @@ def test_rs_band_nodata(dtype, tmp_path):
             plants={(2, 3): BAND_NODATA[dtype]},
         )
 
+    # Anchored to the value the fixture wrote (and NULL where none was):
+    # parity alone would also pass if both engines misread the same way.
     for band in (1, 2):
-        for view in ("nd_raster", "nond_raster"):
+        for view, anchor in (
+            ("nd_raster", BAND_NODATA[dtype]),
+            ("nond_raster", [(None,)]),
+        ):
             sql = f"SELECT RS_BandNoDataValue(rast, {band}) FROM {view}"
-            compare(sql, sedona, spark)
+            compare(sql, sedona, spark, expected=anchor)
 
 
 @pytest.mark.parametrize("dtype", ["float32", "float64"])

--- a/python/sedonadb/python/sedonadb/raster_testing.py
+++ b/python/sedonadb/python/sedonadb/raster_testing.py
@@ -36,7 +36,7 @@ then every side carries the same CRS.
 """
 
 import math
-from dataclasses import dataclass
+from dataclasses import InitVar, dataclass
 from typing import Any, List, Mapping, Optional, Tuple
 
 import numpy as np
@@ -46,18 +46,38 @@ import numpy as np
 class DecodedRaster:
     """One raster decoded to plain values.
 
-    `pixels` is `(band, rows, cols)`, `gdal_transform` is GDAL-order
-    `(origin_x, scale_x, skew_x, origin_y, skew_y, scale_y)`, and `nodata`
-    holds one sentinel per band (unpacked in the band's dtype).
+    `pixels` is `(band, rows, cols)` and `nodata` holds one sentinel per band
+    (unpacked in the band's dtype). The grid is stated as exactly one of
+    `gdal_transform` — GDAL-order `(origin_x, scale_x, skew_x, origin_y,
+    skew_y, scale_y)` — or, for a north-up grid, the readable `bbox` spelling
+    `(minx, miny, maxx, maxy)` (pixel size derived from the data's shape),
+    mirroring `write_geotiff`. Either way the instance carries a
+    `gdal_transform`: decoders produce transforms and `assert_decoded_equal`
+    compares them, so `bbox` is construction sugar for anchors, not a second
+    stored representation.
     `compression` is the codec name of the decoded container when one was
     read (GeoTIFF decodes only); it is carried for encoder tests to assert
     on and deliberately not part of `assert_decoded_equal`.
     """
 
     pixels: "np.ndarray"
-    gdal_transform: Tuple[float, ...]
-    nodata: List[Any]
+    gdal_transform: Optional[Tuple[float, ...]] = None
+    nodata: Optional[List[Any]] = None
     compression: Optional[str] = None
+    bbox: InitVar[Optional[Tuple[float, float, float, float]]] = None
+
+    def __post_init__(self, bbox):
+        if self.nodata is None:
+            raise ValueError("nodata is required (one entry per band)")
+        # A plain-transform construction skips _resolve_transform so decoders
+        # (which never pass bbox) stay rasterio-free.
+        if bbox is not None or self.gdal_transform is None:
+            _, height, width = self.pixels.shape
+            self.gdal_transform = tuple(
+                _resolve_transform(
+                    bbox, self.gdal_transform, width=width, height=height
+                ).to_gdal()
+            )
 
 
 def _is_nodata(sampled, nodata) -> bool:

--- a/python/sedonadb/python/sedonadb/raster_testing.py
+++ b/python/sedonadb/python/sedonadb/raster_testing.py
@@ -127,21 +127,15 @@ def decode_geotiff_bytes(data: bytes) -> DecodedRaster:
         )
 
 
-def bbox_geotransform(bbox, *, width, height) -> Tuple[float, ...]:
-    """The north-up GDAL geotransform that lays a `width` x `height` pixel
-    grid over `bbox` (`(minx, miny, maxx, maxy)`) — what rasterio's
-    `transform.from_bounds` computes, in GDAL order."""
-    minx, miny, maxx, maxy = bbox
-    return (minx, (maxx - minx) / width, 0.0, maxy, 0.0, (miny - maxy) / height)
+def _resolve_transform(bbox, gdal_transform, *, width, height):
+    """The rasterio `Affine` from exactly one of `bbox`/`gdal_transform`."""
+    from rasterio.transform import Affine, from_bounds
 
-
-def _resolve_geotransform(bbox, gdal_transform, *, width, height):
-    """The GDAL geotransform from exactly one of `bbox`/`gdal_transform`."""
     if (gdal_transform is None) == (bbox is None):
         raise ValueError("pass exactly one of gdal_transform or bbox")
     if bbox is not None:
-        return bbox_geotransform(bbox, width=width, height=height)
-    return gdal_transform
+        return from_bounds(*bbox, width=width, height=height)
+    return Affine.from_gdal(*gdal_transform)
 
 
 def write_geotiff(
@@ -151,21 +145,17 @@ def write_geotiff(
 
     The grid is placed by exactly one of `bbox` — `(minx, miny, maxx, maxy)`,
     the readable spelling: north-up, no skew, pixel size derived from the
-    data's shape — or `gdal_transform` — GDAL-order `(origin_x, scale_x,
-    skew_x, origin_y, skew_y, scale_y)`, for grids a bbox cannot express
-    (skew, south-up).
+    data's shape (rasterio's `transform.from_bounds`) — or `gdal_transform` —
+    GDAL-order `(origin_x, scale_x, skew_x, origin_y, skew_y, scale_y)`, for
+    grids a bbox cannot express (skew, south-up).
     `nodata` (optional) becomes the per-band nodata of every band. `crs`
     (optional) is any CRS rasterio accepts; parity fixtures stay CRS-less
     unless an engine requires one, and then use the same CRS everywhere so
     nothing reprojects.
     """
     import rasterio
-    from rasterio.transform import Affine
 
     bands, height, width = data.shape
-    gdal_transform = _resolve_geotransform(
-        bbox, gdal_transform, width=width, height=height
-    )
     with rasterio.open(
         str(path),
         "w",
@@ -174,7 +164,7 @@ def write_geotiff(
         width=width,
         count=bands,
         dtype=str(data.dtype),
-        transform=Affine.from_gdal(*gdal_transform),
+        transform=_resolve_transform(bbox, gdal_transform, width=width, height=height),
         nodata=nodata,
         crs=crs,
     ) as dst:

--- a/python/sedonadb/python/sedonadb/raster_testing.py
+++ b/python/sedonadb/python/sedonadb/raster_testing.py
@@ -127,21 +127,45 @@ def decode_geotiff_bytes(data: bytes) -> DecodedRaster:
         )
 
 
+def bbox_geotransform(bbox, *, width, height) -> Tuple[float, ...]:
+    """The north-up GDAL geotransform that lays a `width` x `height` pixel
+    grid over `bbox` (`(minx, miny, maxx, maxy)`) — what rasterio's
+    `transform.from_bounds` computes, in GDAL order."""
+    minx, miny, maxx, maxy = bbox
+    return (minx, (maxx - minx) / width, 0.0, maxy, 0.0, (miny - maxy) / height)
+
+
+def _resolve_geotransform(bbox, gdal_transform, *, width, height):
+    """The GDAL geotransform from exactly one of `bbox`/`gdal_transform`."""
+    if (gdal_transform is None) == (bbox is None):
+        raise ValueError("pass exactly one of gdal_transform or bbox")
+    if bbox is not None:
+        return bbox_geotransform(bbox, width=width, height=height)
+    return gdal_transform
+
+
 def write_geotiff(
-    path, data: "np.ndarray", *, gdal_transform, nodata=None, crs=None
+    path, data: "np.ndarray", *, bbox=None, gdal_transform=None, nodata=None, crs=None
 ) -> None:
     """Write a `(bands, height, width)` array as a GeoTIFF.
 
-    `gdal_transform` is GDAL-order `(origin_x, scale_x, skew_x, origin_y,
-    skew_y, scale_y)`; `nodata` (optional) becomes the per-band nodata of
-    every band. `crs` (optional) is any CRS rasterio accepts; parity fixtures
-    stay CRS-less unless an engine requires one, and then use the same CRS
-    everywhere so nothing reprojects.
+    The grid is placed by exactly one of `bbox` — `(minx, miny, maxx, maxy)`,
+    the readable spelling: north-up, no skew, pixel size derived from the
+    data's shape — or `gdal_transform` — GDAL-order `(origin_x, scale_x,
+    skew_x, origin_y, skew_y, scale_y)`, for grids a bbox cannot express
+    (skew, south-up).
+    `nodata` (optional) becomes the per-band nodata of every band. `crs`
+    (optional) is any CRS rasterio accepts; parity fixtures stay CRS-less
+    unless an engine requires one, and then use the same CRS everywhere so
+    nothing reprojects.
     """
     import rasterio
     from rasterio.transform import Affine
 
     bands, height, width = data.shape
+    gdal_transform = _resolve_geotransform(
+        bbox, gdal_transform, width=width, height=height
+    )
     with rasterio.open(
         str(path),
         "w",
@@ -164,7 +188,8 @@ def write_random_geotiff(
     bands,
     height,
     width,
-    gdal_transform,
+    bbox=None,
+    gdal_transform=None,
     crs=None,
     nodata=None,
     plants=None,
@@ -173,23 +198,28 @@ def write_random_geotiff(
 
     Combines `random_raster_data` (dtype extremes planted in opposite corners)
     with `write_geotiff` — the input-raster fixture shape shared by raster warp
-    parity tests. `gdal_transform`, `crs`, and `nodata` are as `write_geotiff`;
-    `plants` is as `random_raster_data`.
+    parity tests. `bbox`/`gdal_transform` (exactly one), `crs`, and `nodata`
+    are as `write_geotiff`; `plants` is as `random_raster_data`.
     """
     data = random_raster_data(
         dtype, bands=bands, height=height, width=width, plants=plants
     )
-    write_geotiff(path, data, gdal_transform=gdal_transform, nodata=nodata, crs=crs)
+    write_geotiff(
+        path, data, bbox=bbox, gdal_transform=gdal_transform, nodata=nodata, crs=crs
+    )
 
 
-def write_grid_geotiff(path, *, gdal_transform, width, height, crs=None) -> None:
+def write_grid_geotiff(
+    path, *, bbox=None, gdal_transform=None, width, height, crs=None
+) -> None:
     """Write a zeroed single-band GeoTIFF whose only role is to define a grid.
 
     Its pixels are never read — only its extent, resolution, and CRS matter,
-    e.g. as the reference grid for `RS_ReprojectMatch`.
+    e.g. as the reference grid for `RS_ReprojectMatch`. `bbox`/`gdal_transform`
+    (exactly one) are as `write_geotiff`.
     """
     data = np.zeros((1, height, width), dtype="uint8")
-    write_geotiff(path, data, gdal_transform=gdal_transform, crs=crs)
+    write_geotiff(path, data, bbox=bbox, gdal_transform=gdal_transform, crs=crs)
 
 
 def assert_transform_and_nodata(got: DecodedRaster, expected: DecodedRaster) -> None:

--- a/python/sedonadb/python/sedonadb/testing.py
+++ b/python/sedonadb/python/sedonadb/testing.py
@@ -994,7 +994,7 @@ class ArrowSQLCache:
         self._dirty = False
 
 
-def compare(sql, *engines):
+def compare(sql, *engines, expected=None):
     """Assert every engine returns the same result for one shared SQL string.
 
     The cross-engine parity assertion. The first engine is the subject — its
@@ -1013,6 +1013,16 @@ def compare(sql, *engines):
     raster is NULL also counts as agreement. The dispatch asks the subject's
     `result_has_raster`, answered from its lazy result schema, so any engine
     that implements the raster hooks can be the subject.
+
+    `expected` (optional) anchors the comparison to a known value: the subject
+    is asserted against it first, and the references are then anchored
+    transitively. Engines agreeing with each other is not proof that any of
+    them is right — every engine returning the same wrong thing (say, a no-op
+    where an operation was meant to happen) passes the parity claim — so pass
+    an anchor whenever the expected result is easy to state. For table results
+    `expected` is anything `assert_result` accepts (a float, a list of
+    `result_to_tuples` rows, a pandas frame, ...); for raster results it is a
+    `sedonadb.raster_testing.DecodedRaster`.
     """
     if len(engines) < 2:
         raise ValueError("compare() needs at least two engines")
@@ -1022,16 +1032,22 @@ def compare(sql, *engines):
         from sedonadb.raster_testing import assert_decoded_equal
 
         got = subject.decode_raster_result(sql)
-        for reference in references:
-            expected = reference.decode_raster_result(sql)
-            if got is None and expected is None:
-                continue
+        if expected is not None:
             assert_decoded_equal(got, expected, context=sql)
+        for reference in references:
+            reference_raster = reference.decode_raster_result(sql)
+            if got is None and reference_raster is None:
+                continue
+            assert_decoded_equal(got, reference_raster, context=sql)
     else:
         result = subject.execute_and_collect(sql)
-        for reference in references:
-            expected = reference.result_to_tuples(reference.execute_and_collect(sql))
+        if expected is not None:
             subject.assert_result(result, expected)
+        for reference in references:
+            reference_tuples = reference.result_to_tuples(
+                reference.execute_and_collect(sql)
+            )
+            subject.assert_result(result, reference_tuples)
 
 
 def geom_or_null(arg, srid=None):

--- a/python/sedonadb/python/sedonadb/testing.py
+++ b/python/sedonadb/python/sedonadb/testing.py
@@ -196,28 +196,36 @@ class DBEngine:
         bands=2,
         height=6,
         width=7,
-        gdal_transform=(100.0, 2.0, 0.0, 500.0, 0.0, -3.0),
+        bbox=None,
+        gdal_transform=None,
         nodata=None,
         plants=None,
     ) -> "DBEngine":
         """Write a random GeoTIFF at `path` and register it as view `name`
         (see `create_raster_view`).
 
-        The default grid is small and north-up/CRS-less so nothing reprojects
-        and results stay bit-comparable across engines. The pixels come from
-        `sedonadb.raster_testing.random_raster_data` with a fixed seed, so
-        registering the same `path` on several engines rewrites identical
-        bytes and every engine sees the same raster. `nodata` and `plants` are
-        as `write_random_geotiff`.
+        The grid is placed by `bbox` (`(minx, miny, maxx, maxy)`, north-up,
+        no skew) or, for grids a bbox cannot express, a raw GDAL
+        `gdal_transform` — at most one; the default is
+        `bbox=(100, 482, 114, 500)`, whose extent divided by the default 7x6
+        grid gives 2x3 pixels. The grid is small and north-up/CRS-less so
+        nothing reprojects and results stay bit-comparable across engines.
+        The pixels come from `sedonadb.raster_testing.random_raster_data`
+        with a fixed seed, so registering the same `path` on several engines
+        rewrites identical bytes and every engine sees the same raster.
+        `nodata` and `plants` are as `write_random_geotiff`.
         """
         from sedonadb.raster_testing import write_random_geotiff
 
+        if bbox is None and gdal_transform is None:
+            bbox = (100.0, 482.0, 114.0, 500.0)
         write_random_geotiff(
             path,
             dtype,
             bands=bands,
             height=height,
             width=width,
+            bbox=bbox,
             gdal_transform=gdal_transform,
             nodata=nodata,
             plants=plants,

--- a/python/sedonadb/tests/test_raster_testing.py
+++ b/python/sedonadb/tests/test_raster_testing.py
@@ -14,17 +14,19 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Tests for the GeoTIFF fixture writers in `sedonadb.raster_testing`.
+"""Tests for the grid-placement helpers in `sedonadb.raster_testing`.
 
 The bbox spelling of grid placement is only checked here: the parity suite
-compares engines against each other on the same file, so a wrong bbox-derived
-geotransform would agree with itself there.
+compares engines against each other on the same file (and anchors against
+bbox-constructed `DecodedRaster`s), so a wrong bbox-derived geotransform
+would agree with itself there.
 """
 
 import numpy as np
 import pytest
 
 from sedonadb.raster_testing import (
+    DecodedRaster,
     decode_geotiff,
     write_geotiff,
     write_random_geotiff,
@@ -38,6 +40,30 @@ def test_write_geotiff_bbox_places_the_grid(tmp_path):
     path = tmp_path / "bbox.tif"
     write_random_geotiff(path, "uint8", bands=1, height=6, width=7, bbox=BBOX)
     assert decode_geotiff(path).gdal_transform == (100.0, 2.0, 0.0, 500.0, 0.0, -3.0)
+
+
+def test_decoded_raster_bbox_places_the_grid():
+    data = np.zeros((1, 6, 7), dtype="uint8")
+    by_bbox = DecodedRaster(data, nodata=[None], bbox=BBOX)
+    assert by_bbox.gdal_transform == (100.0, 2.0, 0.0, 500.0, 0.0, -3.0)
+
+
+def test_decoded_raster_requires_exactly_one_grid_placement():
+    data = np.zeros((1, 6, 7), dtype="uint8")
+    with pytest.raises(ValueError, match="exactly one"):
+        DecodedRaster(data, nodata=[None])
+    with pytest.raises(ValueError, match="exactly one"):
+        DecodedRaster(
+            data,
+            (100.0, 2.0, 0.0, 500.0, 0.0, -3.0),
+            nodata=[None],
+            bbox=BBOX,
+        )
+
+
+def test_decoded_raster_requires_nodata():
+    with pytest.raises(ValueError, match="nodata"):
+        DecodedRaster(np.zeros((1, 6, 7), dtype="uint8"), bbox=BBOX)
 
 
 def test_write_geotiff_requires_exactly_one_grid_placement(tmp_path):

--- a/python/sedonadb/tests/test_raster_testing.py
+++ b/python/sedonadb/tests/test_raster_testing.py
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for the GeoTIFF fixture writers in `sedonadb.raster_testing`.
+
+The bbox spelling of grid placement is only checked here: the parity suite
+compares engines against each other on the same file, so a wrong bbox-derived
+geotransform would agree with itself there.
+"""
+
+import numpy as np
+import pytest
+
+from sedonadb.raster_testing import (
+    bbox_geotransform,
+    decode_geotiff,
+    write_geotiff,
+    write_random_geotiff,
+)
+
+# The default extent of `DBEngine.create_random_raster_view`.
+BBOX = (100.0, 482.0, 114.0, 500.0)
+
+
+def test_bbox_geotransform_matches_rasterio():
+    from rasterio.transform import from_bounds
+
+    assert (
+        bbox_geotransform(BBOX, width=7, height=6)
+        == from_bounds(*BBOX, width=7, height=6).to_gdal()
+    )
+
+
+def test_write_geotiff_bbox_places_the_grid(tmp_path):
+    path = tmp_path / "bbox.tif"
+    write_random_geotiff(path, "uint8", bands=1, height=6, width=7, bbox=BBOX)
+    assert decode_geotiff(path).gdal_transform == (100.0, 2.0, 0.0, 500.0, 0.0, -3.0)
+
+
+def test_write_geotiff_requires_exactly_one_grid_placement(tmp_path):
+    data = np.zeros((1, 6, 7), dtype="uint8")
+    with pytest.raises(ValueError, match="exactly one"):
+        write_geotiff(tmp_path / "neither.tif", data)
+    with pytest.raises(ValueError, match="exactly one"):
+        write_geotiff(
+            tmp_path / "both.tif",
+            data,
+            bbox=BBOX,
+            gdal_transform=(100.0, 2.0, 0.0, 500.0, 0.0, -3.0),
+        )

--- a/python/sedonadb/tests/test_raster_testing.py
+++ b/python/sedonadb/tests/test_raster_testing.py
@@ -25,7 +25,6 @@ import numpy as np
 import pytest
 
 from sedonadb.raster_testing import (
-    bbox_geotransform,
     decode_geotiff,
     write_geotiff,
     write_random_geotiff,
@@ -33,15 +32,6 @@ from sedonadb.raster_testing import (
 
 # The default extent of `DBEngine.create_random_raster_view`.
 BBOX = (100.0, 482.0, 114.0, 500.0)
-
-
-def test_bbox_geotransform_matches_rasterio():
-    from rasterio.transform import from_bounds
-
-    assert (
-        bbox_geotransform(BBOX, width=7, height=6)
-        == from_bounds(*BBOX, width=7, height=6).to_gdal()
-    )
 
 
 def test_write_geotiff_bbox_places_the_grid(tmp_path):


### PR DESCRIPTION
**Stacked on #1211** (its branch lives on a fork, so the base can't be retargeted onto it — its commits are merged in instead; this diff deduplicates when #1211 lands. Merge #1211 first.)

Implements @paleolimbot's post-merge suggestion on #1203: an optional parameter on `compare()` that lets the reference value be specified, guarding the parity claim against vacuous agreement — every engine returning the same wrong thing passes a pure engine-vs-engine comparison.

### The API

```python
compare(sql, sedona, spark, expected=200.0)        # table path: anything assert_result accepts
compare(sql, sedona, spark, expected=[(None,)])    # e.g. anchoring a NULL
compare(sql, sedona, spark, expected=decoded)      # raster path: a DecodedRaster
```

`expected` is keyword-only and optional. The subject is asserted against the anchor first (clearest failure when all engines agree on a wrong value), then against each reference as before — so the references are anchored transitively. Parity-only remains the default for cases where the reference is hard to state.

### Coverage added

Anchors on every test whose expected value is trivially known:

- `test_rs_band_nodata`: the written nodata for both bands, and `[(None,)]` for the no-nodata fixture.
- All four passing setter tests (`test_rs_setbandnodata`, `_band2`, `_overwrite`, `_two_arg_single_band`): the full `DecodedRaster` — the exact seeded pixels (reconstructible because `random_raster_data` is seeded), the grid (stated explicitly so the anchor and the fixture can't drift apart), and the per-band nodata.

The anchored tests place their grid with `bbox=`, and the anchors state the same BBOX via `DecodedRaster`'s bbox construction (added to #1211) — the instance still carries the derived `gdal_transform`, which is what `assert_decoded_equal` compares.

The setter anchors close a real hole: with parity only, both engines no-opping identically (source nodata unchanged) would have passed every setter test.

### Verification

- Suite: `21 passed, 13 xfailed` locally (pyspark 4.0.4, Sedona 1.9.1), plus #1211's `test_raster_testing.py` (26 passed) in-branch.
- Negative-tested both paths: a wrong scalar anchor and a wrong raster-nodata anchor each raise `AssertionError`; the correct anchors pass.

This suite is not yet wired into CI (#1206 does that), so the counts above are from a local run.
