### PR TITLE
ci(python): run the Sedona Spark raster parity suite in CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -28,6 +28,7 @@ on:
       - 'rust/**'
       - 'c/**'
       - 'python/**'
+      - 'integration/spark-parity/**'
   push:
     branches:
       - main
@@ -163,6 +164,34 @@ jobs:
       - name: Run tests (sedonadb-geopandas)
         run: |
           cd python/sedonadb-geopandas
+          python -m pytest -vv
+
+      - uses: actions/setup-java@v6
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Install Sedona Spark test dependencies
+        run: |
+          pip install "pyspark>=4.0" apache-sedona
+
+      - name: Cache Sedona Spark jars
+        uses: actions/cache@v6
+        with:
+          # Matches SEDONADB_SPARK_IVY_DIR below, which SedonaSpark passes to
+          # spark.jars.ivy so Ivy resolves the jars into a fixed directory
+          # regardless of the Ivy version's default.
+          path: ~/.ivy2-spark-parity
+          # testing_spark.py pins SEDONA_SPARK_VERSION and
+          # GEOTOOLS_WRAPPER_VERSION, so the cache invalidates exactly when
+          # the jar pins change.
+          key: spark-parity-jars-${{ runner.os }}-${{ hashFiles('python/sedonadb/python/sedonadb/testing_spark.py') }}
+
+      - name: Run tests (spark-parity)
+        env:
+          SEDONADB_SPARK_IVY_DIR: /home/runner/.ivy2-spark-parity
+        run: |
+          cd integration/spark-parity
           python -m pytest -vv
 
       - name: Shutdown docker compose services

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -173,7 +173,12 @@ jobs:
 
       - name: Install Sedona Spark test dependencies
         run: |
-          pip install "pyspark>=4.0" apache-sedona
+          # Ceiling tracks the newest Spark minor Sedona publishes a shaded
+          # artifact for (1.9.1 ships 4.0 and 4.1). An unpinned install pulled
+          # pyspark 4.2.0, whose function registry rejects the fallback 4.1
+          # jar at SedonaContext.create. Raise the ceiling when Sedona ships
+          # an artifact for a newer Spark line.
+          pip install "pyspark>=4.0,<4.2" apache-sedona
 
       - name: Cache Sedona Spark jars
         uses: actions/cache@v6

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -173,12 +173,13 @@ jobs:
 
       - name: Install Sedona Spark test dependencies
         run: |
-          # Ceiling tracks the newest Spark minor Sedona publishes a shaded
-          # artifact for (1.9.1 ships 4.0 and 4.1). An unpinned install pulled
-          # pyspark 4.2.0, whose function registry rejects the fallback 4.1
-          # jar at SedonaContext.create. Raise the ceiling when Sedona ships
-          # an artifact for a newer Spark line.
-          pip install "pyspark>=4.0,<4.2" apache-sedona
+          # Pinned to the newest Spark minor Sedona publishes a shaded
+          # artifact for (1.9.1 ships 4.0 and 4.1), so CI runs one known
+          # combination. An unpinned install pulled pyspark 4.2.0, whose
+          # function registry rejects the fallback 4.1 jar at
+          # SedonaContext.create. Bump when Sedona ships an artifact for a
+          # newer Spark line.
+          pip install "pyspark==4.1.*" apache-sedona
 
       - name: Cache Sedona Spark jars
         uses: actions/cache@v6

--- a/integration/spark-parity/README.md
+++ b/integration/spark-parity/README.md
@@ -40,7 +40,8 @@ directory anyway. There is deliberately no opt-in environment variable — each
 test constructs both engines outright, so a missing pyspark, JVM, or jar is a
 failure with a real traceback, not a skip.
 
-This suite is not wired into CI.
+The suite runs in CI as part of the `python` workflow
+(`.github/workflows/python.yml`), after the main sedonadb test steps.
 
 ## Running
 

--- a/integration/spark-parity/README.md
+++ b/integration/spark-parity/README.md
@@ -47,7 +47,7 @@ The suite runs in CI as part of the `python` workflow
 
 ```bash
 pip install -e "python/sedonadb[test]"      # the engine under test
-pip install "pyspark>=4.0" apache-sedona    # the compatibility target
+pip install "pyspark>=4.0,<4.2" apache-sedona    # the compatibility target
 cd integration/spark-parity
 pytest -v
 ```


### PR DESCRIPTION
## What

Wires the `integration/spark-parity` pytest suite (added in #1159) into the `python` workflow, answering the reviewer question on #1203: "Are they running in CI now?" — with this PR, yes.

Changes, all in `.github/workflows/python.yml` plus a one-sentence README update:

- `integration/spark-parity/**` added to the `pull_request` paths filter.
- New steps appended to the existing `test` job, after the current test steps (the job already builds and installs sedonadb editable, which the suite imports):
  - `actions/setup-java@v6` (temurin 17) — the JVM Sedona Spark needs.
  - `pip install "pyspark==4.1.*" apache-sedona` — the newest Spark minor Sedona 1.9.1 ships an artifact for (unpinned resolves pyspark 4.2, whose FunctionRegistry rejects the 4.1 jar).
  - An `actions/cache@v6` step for the Ivy jar directory (`~/.ivy2-spark-parity`).
  - `python -m pytest -vv` run from `integration/spark-parity`, with `SEDONADB_SPARK_IVY_DIR` pointed at the cached directory.
- `integration/spark-parity/README.md`: the "not wired into CI" sentence now says the suite runs in the python workflow.

## Cache design

The cache key is `spark-parity-jars-${{ runner.os }}-${{ hashFiles('python/sedonadb/python/sedonadb/testing_spark.py') }}`. `testing_spark.py` is the file that pins `SEDONA_SPARK_VERSION` and `GEOTOOLS_WRAPPER_VERSION` — the exact Maven coordinates Ivy resolves — so the cache invalidates precisely when the jar pins change and never goes stale on a version bump. `SEDONADB_SPARK_IVY_DIR` is set to the same path the cache step saves, so warm runs skip the Maven download entirely.

## Verification

The workflow triggers on changes to `.github/workflows/python.yml`, so this PR's own CI run exercises the new lane end-to-end.
