### PR TITLE
fix(rust/sedona-raster): align RS_Rotation with Sedona Spark's formula

### DIFF
--- a/integration/spark-parity/test_rs_bandnodatavalue.py
+++ b/integration/spark-parity/test_rs_bandnodatavalue.py
@@ -16,7 +16,6 @@
 # under the License.
 """SedonaDB vs Sedona Spark parity for RS_BandNoDataValue.
 
-The parity suite keeps one module per RS_ function.
 
 Sedona Spark is the compatibility target, so each test runs one shared SQL
 string on both engines and asserts they agree with the harness-level

--- a/integration/spark-parity/test_rs_bandnodatavalue.py
+++ b/integration/spark-parity/test_rs_bandnodatavalue.py
@@ -14,7 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""SedonaDB vs Sedona Spark parity for the scalar raster readers.
+"""SedonaDB vs Sedona Spark parity for RS_BandNoDataValue.
+
+The parity suite keeps one module per RS_ function.
 
 Sedona Spark is the compatibility target, so each test runs one shared SQL
 string on both engines and asserts they agree with the harness-level
@@ -32,8 +34,6 @@ the case `xfail(reason=...)` so the suite doubles as a catalog of what to fix �
 it flips to xpass the day the fix lands. When today's divergence is that one
 engine raises, that error is what trips the xfail.
 """
-
-import math
 
 import pytest
 
@@ -172,108 +172,4 @@ def test_rs_band_nodata_null_band(tmp_path):
     sql = (
         "SELECT RS_BandNoDataValue(rast, CASE WHEN 1 = 0 THEN 1 END) FROM null_band_src"
     )
-    compare(sql, sedona, spark)
-
-
-# --- RS_Rotation -------------------------------------------------------------
-#
-# A rigid rotation by theta of a grid with pixel size (px, py) has the affine
-# R(theta) @ diag(px, -py), i.e. the GDAL transform
-# (ox, px*cos, py*sin, oy, px*sin, -py*cos). SedonaDB computes the angle as
-# atan2(-skewX, scaleX); Sedona Spark as acos(scaleX / hypot(scaleX, skewY)),
-# negated when skewY > 0. The formulas coincide exactly when
-# |skewX| == |skewY| — axis-aligned grids and rigid rotations of square
-# pixels — and separate everywhere else (see the xfails).
-_COS30, _SIN30 = math.cos(math.pi / 6), math.sin(math.pi / 6)
-
-
-def test_rs_rotation_north_up_is_zero(tmp_path):
-    """An axis-aligned raster has zero rotation on both engines. The `+ 0.0`
-    normalizes the zero's sign, which the engines disagree on
-    (test_rs_rotation_zero_sign)."""
-    sedona, spark = SedonaDB(), SedonaSpark()
-    for eng in (sedona, spark):
-        eng.create_random_raster_view("rot_nu", tmp_path / "rot_nu.tif")
-    sql = "SELECT RS_Rotation(rast) + 0.0 FROM rot_nu"
-    compare(sql, sedona, spark, expected=0.0)
-
-
-@pytest.mark.parametrize("theta", [math.pi / 6, -math.pi / 6], ids=["ccw", "cw"])
-def test_rs_rotation_rigid_square_pixels(theta, tmp_path):
-    """A rigid rotation of square 2x2 pixels reads back as -theta from both
-    engines. The raw doubles differ by one ulp across runtimes (Rust's atan2
-    vs the JVM's acos), so the query rounds to 12 digits — the agreement
-    under test is semantic, not bit-level."""
-    transform = (
-        100.0,
-        2 * math.cos(theta),
-        2 * math.sin(theta),
-        500.0,
-        2 * math.sin(theta),
-        -2 * math.cos(theta),
-    )
-    sedona, spark = SedonaDB(), SedonaSpark()
-    for eng in (sedona, spark):
-        eng.create_random_raster_view(
-            "rot_sq", tmp_path / "rot_sq.tif", gdal_transform=transform
-        )
-    sql = "SELECT ROUND(RS_Rotation(rast), 12) FROM rot_sq"
-    compare(sql, sedona, spark, expected=round(-theta, 12))
-
-
-@pytest.mark.parametrize(
-    "transform",
-    [
-        pytest.param((100.0, 2.0, 0.0, 500.0, 0.0, -3.0), id="north-up"),
-        pytest.param((100.0, 2.0, 0.0, 482.0, 0.0, 3.0), id="south-up"),
-    ],
-)
-@pytest.mark.xfail(
-    reason="SedonaDB's atan2(-skewX, scaleX) yields IEEE negative zero for an "
-    "axis-aligned raster; Sedona Spark returns positive zero"
-)
-def test_rs_rotation_zero_sign(transform, tmp_path):
-    """The zero rotation of an axis-aligned raster reads back identically,
-    including the sign of the zero (it stringifies visibly: '-0' vs '0')."""
-    sedona, spark = SedonaDB(), SedonaSpark()
-    for eng in (sedona, spark):
-        eng.create_random_raster_view(
-            "rot_zero", tmp_path / "rot_zero.tif", gdal_transform=transform
-        )
-    sql = "SELECT RS_Rotation(rast) FROM rot_zero"
-    compare(sql, sedona, spark)
-
-
-@pytest.mark.xfail(
-    reason="SedonaDB's atan2(-skewX, scaleX) folds the row axis's skew into the "
-    "reported angle, so a rigid 30-degree rotation of non-square 2x3 pixels "
-    "reads -0.7137 instead of the true -pi/6; Sedona Spark's "
-    "acos(scaleX / hypot(scaleX, skewY)) recovers -pi/6 exactly"
-)
-def test_rs_rotation_rigid_non_square_pixels(tmp_path):
-    """A rigid rotation reads back as -theta regardless of pixel shape."""
-    transform = (100.0, 2 * _COS30, 3 * _SIN30, 500.0, 2 * _SIN30, -3 * _COS30)
-    sedona, spark = SedonaDB(), SedonaSpark()
-    for eng in (sedona, spark):
-        eng.create_random_raster_view(
-            "rot_nsq", tmp_path / "rot_nsq.tif", gdal_transform=transform
-        )
-    sql = "SELECT RS_Rotation(rast) FROM rot_nsq"
-    compare(sql, sedona, spark)
-
-
-@pytest.mark.xfail(
-    reason="under shear the formulas separate: SedonaDB's atan2(-skewX, scaleX) "
-    "gives -0.2915 where Sedona Spark's acos(scaleX / hypot(scaleX, skewY)) "
-    "gives -0.3805; they agree only while |skewX| == |skewY|"
-)
-def test_rs_rotation_shear(tmp_path):
-    """A sheared raster's rotation reads back the same from both engines."""
-    transform = (100.0, 0.2, 0.06, 500.0, 0.08, -0.3)
-    sedona, spark = SedonaDB(), SedonaSpark()
-    for eng in (sedona, spark):
-        eng.create_random_raster_view(
-            "rot_shear", tmp_path / "rot_shear.tif", gdal_transform=transform
-        )
-    sql = "SELECT RS_Rotation(rast) FROM rot_shear"
     compare(sql, sedona, spark)

--- a/integration/spark-parity/test_rs_rotation.py
+++ b/integration/spark-parity/test_rs_rotation.py
@@ -21,10 +21,10 @@ Both engines compute the angle of the grid's column-axis direction
 `skewY > 0`. (SedonaDB previously computed `atan2(-skewX, scaleX)`, which
 agreed only while |skewX| == |skewY| and misreported rigid rotations of
 non-square pixels; it was aligned to Sedona Spark's formula alongside
-these tests.) Axis-aligned grids compare exactly, including the sign of
-the zero; rotated grids can differ by one ulp across runtimes (Rust's
-acos vs the JVM's), so those queries round to 12 digits — the agreement
-under test is semantic, not bit-level.
+these tests.) Axis-aligned grids compare raw and exactly, including the
+sign of the zero; the non-zero-angle queries compare through
+ROUND(..., 12) — see the comment above the rigid tests for the measured
+evidence forcing that.
 """
 
 import math
@@ -66,6 +66,20 @@ def test_rs_rotation_axis_aligned(transform, tmp_path):
     compare("SELECT RS_Rotation(rast) FROM rot_axis", sedona, spark, expected=0.0)
 
 
+# Why the non-zero-angle queries wrap RS_Rotation in ROUND(..., 12): neither
+# runtime promises a bit-exact acos. Java's Math.acos is specified only to
+# within 1 ulp of the correctly rounded result, and Rust's f64::acos delegates
+# to the platform libm with no accuracy contract, so the exact double is an
+# implementation detail that varies by platform and JDK. Measured on macOS
+# (Rust libm vs Temurin 17), sweeping a rigid 2x3-pixel rotation over 72
+# angles: 70 matched bit-for-bit and 2 differed by exactly 1 ulp
+# (e.g. theta=-2.923 read 2.9234264970905017 vs ...13) — and pi/6 below is
+# itself such an angle (-0.5235987755982988 vs ...87). Which angles are
+# unlucky depends on the libm, so a raw comparison would be flaky across
+# platforms rather than strict. ROUND to 12 digits collapses 1-ulp
+# neighbours safely: each anchored constant's 12th-digit remainder sits
+# thousands of ulps from a rounding boundary, so the engines cannot round
+# to different values.
 @pytest.mark.parametrize(
     "pixel", [(2.0, 2.0), (2.0, 3.0)], ids=["square", "non-square"]
 )

--- a/integration/spark-parity/test_rs_rotation.py
+++ b/integration/spark-parity/test_rs_rotation.py
@@ -1,0 +1,132 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_Rotation.
+
+One shared SQL string per case, compared with the harness-level
+`sedonadb.testing.compare` — same conventions as the rest of the parity
+suite (one module per RS_ function, xfail(reason=...) as the catalog of
+known divergences).
+"""
+
+import math
+
+import pytest
+
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+#
+# A rigid rotation by theta of a grid with pixel size (px, py) has the affine
+# R(theta) @ diag(px, -py), i.e. the GDAL transform
+# (ox, px*cos, py*sin, oy, px*sin, -py*cos). SedonaDB computes the angle as
+# atan2(-skewX, scaleX); Sedona Spark as acos(scaleX / hypot(scaleX, skewY)),
+# negated when skewY > 0. The formulas coincide exactly when
+# |skewX| == |skewY| — axis-aligned grids and rigid rotations of square
+# pixels — and separate everywhere else (see the xfails).
+_COS30, _SIN30 = math.cos(math.pi / 6), math.sin(math.pi / 6)
+
+
+def test_rs_rotation_north_up_is_zero(tmp_path):
+    """An axis-aligned raster has zero rotation on both engines. The `+ 0.0`
+    normalizes the zero's sign, which the engines disagree on
+    (test_rs_rotation_zero_sign)."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("rot_nu", tmp_path / "rot_nu.tif")
+    sql = "SELECT RS_Rotation(rast) + 0.0 FROM rot_nu"
+    compare(sql, sedona, spark, expected=0.0)
+
+
+@pytest.mark.parametrize("theta", [math.pi / 6, -math.pi / 6], ids=["ccw", "cw"])
+def test_rs_rotation_rigid_square_pixels(theta, tmp_path):
+    """A rigid rotation of square 2x2 pixels reads back as -theta from both
+    engines. The raw doubles differ by one ulp across runtimes (Rust's atan2
+    vs the JVM's acos), so the query rounds to 12 digits — the agreement
+    under test is semantic, not bit-level."""
+    transform = (
+        100.0,
+        2 * math.cos(theta),
+        2 * math.sin(theta),
+        500.0,
+        2 * math.sin(theta),
+        -2 * math.cos(theta),
+    )
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view(
+            "rot_sq", tmp_path / "rot_sq.tif", gdal_transform=transform
+        )
+    sql = "SELECT ROUND(RS_Rotation(rast), 12) FROM rot_sq"
+    compare(sql, sedona, spark, expected=round(-theta, 12))
+
+
+@pytest.mark.parametrize(
+    "transform",
+    [
+        pytest.param((100.0, 2.0, 0.0, 500.0, 0.0, -3.0), id="north-up"),
+        pytest.param((100.0, 2.0, 0.0, 482.0, 0.0, 3.0), id="south-up"),
+    ],
+)
+@pytest.mark.xfail(
+    reason="SedonaDB's atan2(-skewX, scaleX) yields IEEE negative zero for an "
+    "axis-aligned raster; Sedona Spark returns positive zero"
+)
+def test_rs_rotation_zero_sign(transform, tmp_path):
+    """The zero rotation of an axis-aligned raster reads back identically,
+    including the sign of the zero (it stringifies visibly: '-0' vs '0')."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view(
+            "rot_zero", tmp_path / "rot_zero.tif", gdal_transform=transform
+        )
+    sql = "SELECT RS_Rotation(rast) FROM rot_zero"
+    compare(sql, sedona, spark)
+
+
+@pytest.mark.xfail(
+    reason="SedonaDB's atan2(-skewX, scaleX) folds the row axis's skew into the "
+    "reported angle, so a rigid 30-degree rotation of non-square 2x3 pixels "
+    "reads -0.7137 instead of the true -pi/6; Sedona Spark's "
+    "acos(scaleX / hypot(scaleX, skewY)) recovers -pi/6 exactly"
+)
+def test_rs_rotation_rigid_non_square_pixels(tmp_path):
+    """A rigid rotation reads back as -theta regardless of pixel shape."""
+    transform = (100.0, 2 * _COS30, 3 * _SIN30, 500.0, 2 * _SIN30, -3 * _COS30)
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view(
+            "rot_nsq", tmp_path / "rot_nsq.tif", gdal_transform=transform
+        )
+    sql = "SELECT RS_Rotation(rast) FROM rot_nsq"
+    compare(sql, sedona, spark)
+
+
+@pytest.mark.xfail(
+    reason="under shear the formulas separate: SedonaDB's atan2(-skewX, scaleX) "
+    "gives -0.2915 where Sedona Spark's acos(scaleX / hypot(scaleX, skewY)) "
+    "gives -0.3805; they agree only while |skewX| == |skewY|"
+)
+def test_rs_rotation_shear(tmp_path):
+    """A sheared raster's rotation reads back the same from both engines."""
+    transform = (100.0, 0.2, 0.06, 500.0, 0.08, -0.3)
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view(
+            "rot_shear", tmp_path / "rot_shear.tif", gdal_transform=transform
+        )
+    sql = "SELECT RS_Rotation(rast) FROM rot_shear"
+    compare(sql, sedona, spark)

--- a/integration/spark-parity/test_rs_rotation.py
+++ b/integration/spark-parity/test_rs_rotation.py
@@ -16,10 +16,15 @@
 # under the License.
 """SedonaDB vs Sedona Spark parity for RS_Rotation.
 
-One shared SQL string per case, compared with the harness-level
-`sedonadb.testing.compare` — same conventions as the rest of the parity
-suite (one module per RS_ function, xfail(reason=...) as the catalog of
-known divergences).
+Both engines compute the angle of the grid's column-axis direction
+`(scaleX, skewY)`: `acos(scaleX / hypot(scaleX, skewY))`, negated when
+`skewY > 0`. (SedonaDB previously computed `atan2(-skewX, scaleX)`, which
+agreed only while |skewX| == |skewY| and misreported rigid rotations of
+non-square pixels; it was aligned to Sedona Spark's formula alongside
+these tests.) Axis-aligned grids compare exactly, including the sign of
+the zero; rotated grids can differ by one ulp across runtimes (Rust's
+acos vs the JVM's), so those queries round to 12 digits — the agreement
+under test is semantic, not bit-level.
 """
 
 import math
@@ -29,49 +34,18 @@ import pytest
 from sedonadb.testing import SedonaDB, compare
 from sedonadb.testing_spark import SedonaSpark
 
-#
-# A rigid rotation by theta of a grid with pixel size (px, py) has the affine
-# R(theta) @ diag(px, -py), i.e. the GDAL transform
-# (ox, px*cos, py*sin, oy, px*sin, -py*cos). SedonaDB computes the angle as
-# atan2(-skewX, scaleX); Sedona Spark as acos(scaleX / hypot(scaleX, skewY)),
-# negated when skewY > 0. The formulas coincide exactly when
-# |skewX| == |skewY| — axis-aligned grids and rigid rotations of square
-# pixels — and separate everywhere else (see the xfails).
-_COS30, _SIN30 = math.cos(math.pi / 6), math.sin(math.pi / 6)
 
-
-def test_rs_rotation_north_up_is_zero(tmp_path):
-    """An axis-aligned raster has zero rotation on both engines. The `+ 0.0`
-    normalizes the zero's sign, which the engines disagree on
-    (test_rs_rotation_zero_sign)."""
-    sedona, spark = SedonaDB(), SedonaSpark()
-    for eng in (sedona, spark):
-        eng.create_random_raster_view("rot_nu", tmp_path / "rot_nu.tif")
-    sql = "SELECT RS_Rotation(rast) + 0.0 FROM rot_nu"
-    compare(sql, sedona, spark, expected=0.0)
-
-
-@pytest.mark.parametrize("theta", [math.pi / 6, -math.pi / 6], ids=["ccw", "cw"])
-def test_rs_rotation_rigid_square_pixels(theta, tmp_path):
-    """A rigid rotation of square 2x2 pixels reads back as -theta from both
-    engines. The raw doubles differ by one ulp across runtimes (Rust's atan2
-    vs the JVM's acos), so the query rounds to 12 digits — the agreement
-    under test is semantic, not bit-level."""
-    transform = (
+def _rigid_transform(theta, pixel_x, pixel_y):
+    """The GDAL transform of a north-up grid with pixel (pixel_x, pixel_y)
+    rigidly rotated by theta: R(theta) @ diag(pixel_x, -pixel_y)."""
+    return (
         100.0,
-        2 * math.cos(theta),
-        2 * math.sin(theta),
+        pixel_x * math.cos(theta),
+        pixel_y * math.sin(theta),
         500.0,
-        2 * math.sin(theta),
-        -2 * math.cos(theta),
+        pixel_x * math.sin(theta),
+        -pixel_y * math.cos(theta),
     )
-    sedona, spark = SedonaDB(), SedonaSpark()
-    for eng in (sedona, spark):
-        eng.create_random_raster_view(
-            "rot_sq", tmp_path / "rot_sq.tif", gdal_transform=transform
-        )
-    sql = "SELECT ROUND(RS_Rotation(rast), 12) FROM rot_sq"
-    compare(sql, sedona, spark, expected=round(-theta, 12))
 
 
 @pytest.mark.parametrize(
@@ -81,52 +55,44 @@ def test_rs_rotation_rigid_square_pixels(theta, tmp_path):
         pytest.param((100.0, 2.0, 0.0, 482.0, 0.0, 3.0), id="south-up"),
     ],
 )
-@pytest.mark.xfail(
-    reason="SedonaDB's atan2(-skewX, scaleX) yields IEEE negative zero for an "
-    "axis-aligned raster; Sedona Spark returns positive zero"
-)
-def test_rs_rotation_zero_sign(transform, tmp_path):
-    """The zero rotation of an axis-aligned raster reads back identically,
-    including the sign of the zero (it stringifies visibly: '-0' vs '0')."""
+def test_rs_rotation_axis_aligned(transform, tmp_path):
+    """An axis-aligned raster has exactly zero rotation on both engines —
+    positive zero from both, so even the stringified sign agrees."""
     sedona, spark = SedonaDB(), SedonaSpark()
     for eng in (sedona, spark):
         eng.create_random_raster_view(
-            "rot_zero", tmp_path / "rot_zero.tif", gdal_transform=transform
+            "rot_axis", tmp_path / "rot_axis.tif", gdal_transform=transform
         )
-    sql = "SELECT RS_Rotation(rast) FROM rot_zero"
-    compare(sql, sedona, spark)
+    compare("SELECT RS_Rotation(rast) FROM rot_axis", sedona, spark, expected=0.0)
 
 
-@pytest.mark.xfail(
-    reason="SedonaDB's atan2(-skewX, scaleX) folds the row axis's skew into the "
-    "reported angle, so a rigid 30-degree rotation of non-square 2x3 pixels "
-    "reads -0.7137 instead of the true -pi/6; Sedona Spark's "
-    "acos(scaleX / hypot(scaleX, skewY)) recovers -pi/6 exactly"
+@pytest.mark.parametrize(
+    "pixel", [(2.0, 2.0), (2.0, 3.0)], ids=["square", "non-square"]
 )
-def test_rs_rotation_rigid_non_square_pixels(tmp_path):
-    """A rigid rotation reads back as -theta regardless of pixel shape."""
-    transform = (100.0, 2 * _COS30, 3 * _SIN30, 500.0, 2 * _SIN30, -3 * _COS30)
+@pytest.mark.parametrize("theta", [math.pi / 6, -math.pi / 6], ids=["ccw", "cw"])
+def test_rs_rotation_rigid(theta, pixel, tmp_path):
+    """A rigid rotation by theta reads back as -theta from both engines,
+    regardless of pixel shape."""
     sedona, spark = SedonaDB(), SedonaSpark()
     for eng in (sedona, spark):
         eng.create_random_raster_view(
-            "rot_nsq", tmp_path / "rot_nsq.tif", gdal_transform=transform
+            "rot_rigid",
+            tmp_path / "rot_rigid.tif",
+            gdal_transform=_rigid_transform(theta, *pixel),
         )
-    sql = "SELECT RS_Rotation(rast) FROM rot_nsq"
-    compare(sql, sedona, spark)
+    sql = "SELECT ROUND(RS_Rotation(rast), 12) FROM rot_rigid"
+    compare(sql, sedona, spark, expected=round(-theta, 12))
 
 
-@pytest.mark.xfail(
-    reason="under shear the formulas separate: SedonaDB's atan2(-skewX, scaleX) "
-    "gives -0.2915 where Sedona Spark's acos(scaleX / hypot(scaleX, skewY)) "
-    "gives -0.3805; they agree only while |skewX| == |skewY|"
-)
 def test_rs_rotation_shear(tmp_path):
-    """A sheared raster's rotation reads back the same from both engines."""
+    """Under shear the angle follows the column axis (scaleX, skewY): both
+    engines report -acos(scaleX / hypot(scaleX, skewY))."""
     transform = (100.0, 0.2, 0.06, 500.0, 0.08, -0.3)
     sedona, spark = SedonaDB(), SedonaSpark()
     for eng in (sedona, spark):
         eng.create_random_raster_view(
             "rot_shear", tmp_path / "rot_shear.tif", gdal_transform=transform
         )
-    sql = "SELECT RS_Rotation(rast) FROM rot_shear"
-    compare(sql, sedona, spark)
+    sql = "SELECT ROUND(RS_Rotation(rast), 12) FROM rot_shear"
+    expected = round(-math.acos(0.2 / math.hypot(0.2, 0.08)), 12)
+    compare(sql, sedona, spark, expected=expected)

--- a/integration/spark-parity/test_rs_scalar.py
+++ b/integration/spark-parity/test_rs_scalar.py
@@ -33,6 +33,8 @@ it flips to xpass the day the fix lands. When today's divergence is that one
 engine raises, that error is what trips the xfail.
 """
 
+import math
+
 import pytest
 
 from sedonadb.testing import SedonaDB, compare
@@ -170,4 +172,108 @@ def test_rs_band_nodata_null_band(tmp_path):
     sql = (
         "SELECT RS_BandNoDataValue(rast, CASE WHEN 1 = 0 THEN 1 END) FROM null_band_src"
     )
+    compare(sql, sedona, spark)
+
+
+# --- RS_Rotation -------------------------------------------------------------
+#
+# A rigid rotation by theta of a grid with pixel size (px, py) has the affine
+# R(theta) @ diag(px, -py), i.e. the GDAL transform
+# (ox, px*cos, py*sin, oy, px*sin, -py*cos). SedonaDB computes the angle as
+# atan2(-skewX, scaleX); Sedona Spark as acos(scaleX / hypot(scaleX, skewY)),
+# negated when skewY > 0. The formulas coincide exactly when
+# |skewX| == |skewY| — axis-aligned grids and rigid rotations of square
+# pixels — and separate everywhere else (see the xfails).
+_COS30, _SIN30 = math.cos(math.pi / 6), math.sin(math.pi / 6)
+
+
+def test_rs_rotation_north_up_is_zero(tmp_path):
+    """An axis-aligned raster has zero rotation on both engines. The `+ 0.0`
+    normalizes the zero's sign, which the engines disagree on
+    (test_rs_rotation_zero_sign)."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("rot_nu", tmp_path / "rot_nu.tif")
+    sql = "SELECT RS_Rotation(rast) + 0.0 FROM rot_nu"
+    compare(sql, sedona, spark, expected=0.0)
+
+
+@pytest.mark.parametrize("theta", [math.pi / 6, -math.pi / 6], ids=["ccw", "cw"])
+def test_rs_rotation_rigid_square_pixels(theta, tmp_path):
+    """A rigid rotation of square 2x2 pixels reads back as -theta from both
+    engines. The raw doubles differ by one ulp across runtimes (Rust's atan2
+    vs the JVM's acos), so the query rounds to 12 digits — the agreement
+    under test is semantic, not bit-level."""
+    transform = (
+        100.0,
+        2 * math.cos(theta),
+        2 * math.sin(theta),
+        500.0,
+        2 * math.sin(theta),
+        -2 * math.cos(theta),
+    )
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view(
+            "rot_sq", tmp_path / "rot_sq.tif", gdal_transform=transform
+        )
+    sql = "SELECT ROUND(RS_Rotation(rast), 12) FROM rot_sq"
+    compare(sql, sedona, spark, expected=round(-theta, 12))
+
+
+@pytest.mark.parametrize(
+    "transform",
+    [
+        pytest.param((100.0, 2.0, 0.0, 500.0, 0.0, -3.0), id="north-up"),
+        pytest.param((100.0, 2.0, 0.0, 482.0, 0.0, 3.0), id="south-up"),
+    ],
+)
+@pytest.mark.xfail(
+    reason="SedonaDB's atan2(-skewX, scaleX) yields IEEE negative zero for an "
+    "axis-aligned raster; Sedona Spark returns positive zero"
+)
+def test_rs_rotation_zero_sign(transform, tmp_path):
+    """The zero rotation of an axis-aligned raster reads back identically,
+    including the sign of the zero (it stringifies visibly: '-0' vs '0')."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view(
+            "rot_zero", tmp_path / "rot_zero.tif", gdal_transform=transform
+        )
+    sql = "SELECT RS_Rotation(rast) FROM rot_zero"
+    compare(sql, sedona, spark)
+
+
+@pytest.mark.xfail(
+    reason="SedonaDB's atan2(-skewX, scaleX) folds the row axis's skew into the "
+    "reported angle, so a rigid 30-degree rotation of non-square 2x3 pixels "
+    "reads -0.7137 instead of the true -pi/6; Sedona Spark's "
+    "acos(scaleX / hypot(scaleX, skewY)) recovers -pi/6 exactly"
+)
+def test_rs_rotation_rigid_non_square_pixels(tmp_path):
+    """A rigid rotation reads back as -theta regardless of pixel shape."""
+    transform = (100.0, 2 * _COS30, 3 * _SIN30, 500.0, 2 * _SIN30, -3 * _COS30)
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view(
+            "rot_nsq", tmp_path / "rot_nsq.tif", gdal_transform=transform
+        )
+    sql = "SELECT RS_Rotation(rast) FROM rot_nsq"
+    compare(sql, sedona, spark)
+
+
+@pytest.mark.xfail(
+    reason="under shear the formulas separate: SedonaDB's atan2(-skewX, scaleX) "
+    "gives -0.2915 where Sedona Spark's acos(scaleX / hypot(scaleX, skewY)) "
+    "gives -0.3805; they agree only while |skewX| == |skewY|"
+)
+def test_rs_rotation_shear(tmp_path):
+    """A sheared raster's rotation reads back the same from both engines."""
+    transform = (100.0, 0.2, 0.06, 500.0, 0.08, -0.3)
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view(
+            "rot_shear", tmp_path / "rot_shear.tif", gdal_transform=transform
+        )
+    sql = "SELECT RS_Rotation(rast) FROM rot_shear"
     compare(sql, sedona, spark)

--- a/rust/sedona-raster-functions/src/rs_geotransform.rs
+++ b/rust/sedona-raster-functions/src/rs_geotransform.rs
@@ -112,8 +112,9 @@ pub fn rs_skewy_udf() -> SedonaScalarUDF {
 
 /// RS_Rotation() scalar UDF implementation
 ///
-/// Calculate the uniform rotation of the raster
-/// in radians based on the skew parameters.
+/// Calculate the rotation of the raster in radians: the angle of the grid's
+/// column-axis direction, `acos(scaleX / hypot(scaleX, skewY))` negated when
+/// `skewY > 0` — Sedona Spark's `RS_Rotation` formula.
 pub fn rs_rotation_udf() -> SedonaScalarUDF {
     SedonaScalarUDF::new(
         "rs_rotation",
@@ -242,7 +243,11 @@ mod tests {
 
         let rasters = generate_test_rasters(3, Some(1)).unwrap();
         let expected_values = match g {
-            GeoTransformParam::Rotation => vec![Some(-0.0), None, Some(-0.29145679447786704)],
+            GeoTransformParam::Rotation => {
+                // Spark's formula on the sheared third raster; +0.0 (not -0.0)
+                // for the axis-aligned first.
+                vec![Some(0.0), None, Some(-(0.2f64 / 0.2f64.hypot(0.08)).acos())]
+            }
             GeoTransformParam::ScaleX => vec![Some(0.1), None, Some(0.2)],
             GeoTransformParam::ScaleY => vec![Some(-0.2), None, Some(-0.4)],
             GeoTransformParam::SkewX => vec![Some(0.0), None, Some(0.06)],

--- a/rust/sedona-raster/src/affine_transformation.rs
+++ b/rust/sedona-raster/src/affine_transformation.rs
@@ -70,7 +70,6 @@ mod tests {
     use super::*;
     use crate::traits::BandRef;
     use approx::assert_relative_eq;
-    use std::f64::consts::FRAC_1_SQRT_2;
     use std::f64::consts::PI;
 
     /// Minimal `RasterRef` stub carrying only a geotransform and a spatial
@@ -109,30 +108,39 @@ mod tests {
 
     #[test]
     fn test_rotation() {
-        // 0 degree rotation -> gt[1.0, 0.0, 0.0, -1.0]
+        // Axis-aligned -> exactly +0.0. acos yields the positive zero Sedona
+        // Spark reports; the previous atan2 spelling returned -0.0.
         let raster = rotation_raster(1.0, -1.0, 0.0, 0.0);
         let rot = rotation(&raster);
         assert_eq!(rot, 0.0);
+        assert!(rot.is_sign_positive());
 
-        // pi/2 -> gt[0.0, -1.0, 1.0, 0.0]
-        let raster = rotation_raster(0.0, 0.0, -1.0, 1.0);
-        let rot = rotation(&raster);
-        assert_relative_eq!(rot, PI / 2.0, epsilon = 1e-6); // 90 degrees in radians
+        // A rigid rotation by theta of a north-up grid with pixel (px, py) has
+        // (scale_x, skew_x, skew_y, scale_y) = (px*cos, py*sin, px*sin,
+        // -py*cos), and reads back as -theta.
+        let (sin, cos) = (PI / 6.0).sin_cos();
+        let raster = rotation_raster(cos, -cos, sin, sin);
+        assert_relative_eq!(rotation(&raster), -PI / 6.0, epsilon = 1e-12);
+        let raster = rotation_raster(cos, -cos, -sin, -sin);
+        assert_relative_eq!(rotation(&raster), PI / 6.0, epsilon = 1e-12);
 
-        // pi/4 -> gt[0.70710678, -0.70710678, 0.70710678, 0.70710678]
-        let raster = rotation_raster(FRAC_1_SQRT_2, FRAC_1_SQRT_2, -FRAC_1_SQRT_2, FRAC_1_SQRT_2);
-        let rot = rotation(&raster);
-        assert_relative_eq!(rot, PI / 4.0, epsilon = 1e-6); // 45 degrees in radians
+        // Non-square 2x3 pixels: still exactly -theta — the rigid case the old
+        // atan2(-skew_x, scale_x) misreported (as -0.7137 here).
+        let raster = rotation_raster(2.0 * cos, -3.0 * cos, 3.0 * sin, 2.0 * sin);
+        assert_relative_eq!(rotation(&raster), -PI / 6.0, epsilon = 1e-12);
 
-        // pi/3 -> gt[0.5, -0.866025, 0.866025, 0.5]
-        let raster = rotation_raster(0.5, 0.5, -0.866025, 0.866025);
-        let rot = rotation(&raster);
-        assert_relative_eq!(rot, PI / 3.0, epsilon = 1e-6); // 60 degrees in radians
+        // Under shear the angle follows the column-axis direction
+        // (scale_x, skew_y) — Sedona Spark's convention.
+        let raster = rotation_raster(0.2, -0.3, 0.06, 0.08);
+        assert_relative_eq!(
+            rotation(&raster),
+            -(0.2f64 / 0.2f64.hypot(0.08)).acos(),
+            epsilon = 1e-15
+        );
 
-        // pi -> gt[-1.0, 0.0, 0.0, -1.0]
+        // A mirrored grid (scale_x < 0) reports +pi.
         let raster = rotation_raster(-1.0, -1.0, 0.0, 0.0);
-        let rot = rotation(&raster);
-        assert_relative_eq!(rot, -PI, epsilon = 1e-6); // 180 degrees in radians
+        assert_relative_eq!(rotation(&raster), PI, epsilon = 1e-12);
     }
 
     #[test]

--- a/rust/sedona-raster/src/geo_transform.rs
+++ b/rust/sedona-raster/src/geo_transform.rs
@@ -62,6 +62,13 @@ pub trait GeoTransformEx {
     fn invert(&self) -> Result<GeoTransform, RasterError>;
 
     /// Rotation angle (radians) implied by the coefficients.
+    ///
+    /// Sedona Spark's `RS_Rotation` formula: `acos(scaleX / hypot(scaleX,
+    /// skewY))`, negated when `skewY > 0` — the (clockwise-positive) angle of
+    /// the grid's column-axis direction `(scaleX, skewY)`, which decomposes a
+    /// rigid rotation correctly for any pixel shape. The previous
+    /// `atan2(-skewX, scaleX)` mixed the row axis's skew into the answer and
+    /// misreported rigid rotations of non-square pixels (and shear).
     fn rotation(&self) -> f64;
 
     /// x-coordinate of the upper-left corner of the upper-left pixel (`[0]`).
@@ -130,7 +137,14 @@ impl GeoTransformEx for [f64] {
 
     #[inline]
     fn rotation(&self) -> f64 {
-        (-self.skew_x()).atan2(self.scale_x())
+        // acos rather than atan2 of the same ratio so an axis-aligned grid
+        // reports +0.0 and a mirrored one +pi, matching Sedona Spark exactly.
+        let theta = (self.scale_x() / self.scale_x().hypot(self.skew_y())).acos();
+        if self.skew_y() > 0.0 {
+            -theta
+        } else {
+            theta
+        }
     }
 
     #[inline]
@@ -236,7 +250,7 @@ pub fn geotransform_from_bbox_and_spatial_shape(
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use std::f64::consts::{FRAC_1_SQRT_2, PI};
+    use std::f64::consts::PI;
 
     #[test]
     fn test_apply_no_rotation() {
@@ -323,32 +337,35 @@ mod tests {
 
     #[test]
     fn test_rotation() {
-        // 0 degrees.
+        // Axis-aligned -> exactly +0.0 (acos yields the positive zero Sedona
+        // Spark reports; the previous atan2 spelling returned -0.0).
         let gt: GeoTransform = [0.0, 1.0, 0.0, 0.0, 0.0, -1.0];
         assert_eq!(gt.rotation(), 0.0);
+        assert!(gt.rotation().is_sign_positive());
 
-        // pi/2.
-        let gt: GeoTransform = [0.0, 0.0, -1.0, 0.0, 1.0, 0.0];
-        assert_relative_eq!(gt.rotation(), PI / 2.0, epsilon = 1e-6);
+        // A rigid rotation by theta of a north-up grid with pixel (px, py):
+        // (scale_x, skew_x, skew_y, scale_y) = (px*cos, py*sin, px*sin,
+        // -py*cos); reads back as -theta, for any pixel shape.
+        let (sin, cos) = (PI / 6.0).sin_cos();
+        let gt: GeoTransform = [0.0, cos, sin, 0.0, sin, -cos];
+        assert_relative_eq!(gt.rotation(), -PI / 6.0, epsilon = 1e-12);
+        let gt: GeoTransform = [0.0, cos, -sin, 0.0, -sin, -cos];
+        assert_relative_eq!(gt.rotation(), PI / 6.0, epsilon = 1e-12);
+        let gt: GeoTransform = [0.0, 2.0 * cos, 3.0 * sin, 0.0, 2.0 * sin, -3.0 * cos];
+        assert_relative_eq!(gt.rotation(), -PI / 6.0, epsilon = 1e-12);
 
-        // pi/4.
-        let gt: GeoTransform = [
-            0.0,
-            FRAC_1_SQRT_2,
-            -FRAC_1_SQRT_2,
-            0.0,
-            FRAC_1_SQRT_2,
-            FRAC_1_SQRT_2,
-        ];
-        assert_relative_eq!(gt.rotation(), PI / 4.0, epsilon = 1e-6);
+        // Under shear the angle follows the column-axis direction
+        // (scale_x, skew_y) — Sedona Spark's convention.
+        let gt: GeoTransform = [0.0, 0.2, 0.06, 0.0, 0.08, -0.3];
+        assert_relative_eq!(
+            gt.rotation(),
+            -(0.2f64 / 0.2f64.hypot(0.08)).acos(),
+            epsilon = 1e-15
+        );
 
-        // pi/3.
-        let gt: GeoTransform = [0.0, 0.5, -0.866025, 0.0, 0.866025, 0.5];
-        assert_relative_eq!(gt.rotation(), PI / 3.0, epsilon = 1e-6);
-
-        // pi.
+        // A mirrored grid (scale_x < 0) reports +pi.
         let gt: GeoTransform = [0.0, -1.0, 0.0, 0.0, 0.0, -1.0];
-        assert_relative_eq!(gt.rotation(), -PI, epsilon = 1e-6);
+        assert_relative_eq!(gt.rotation(), PI, epsilon = 1e-12);
     }
 
     #[test]


### PR DESCRIPTION
`RS_Rotation` parity coverage that turned into a kernel fix, in three commits:

1. **Probe-first coverage** of the divergence: SedonaDB computed `atan2(-skewX, scaleX)` where Sedona Spark computes `acos(scaleX / sqrt(scaleX² + skewY²))`, negated when `skewY > 0`. They coincide only while `|skewX| == |skewY|`.
2. **One parity module per RS_ function**: `test_rs_scalar.py` → `test_rs_bandnodatavalue.py`, `RS_Rotation` cases into `test_rs_rotation.py` (the suite's layout convention going forward).
3. **The fix**: `GeoTransformEx::rotation` now uses Spark's formula — the angle of the grid's actual column-axis direction `(scaleX, skewY)`.

### Why align rather than document the divergence

- The old formula didn't just diverge under shear: it misreported a **plain rigid rotation of non-square (2x3) pixels** as −0.7137 for a true −π/6 (the new formula recovers −π/6 exactly, for any pixel shape).
- `RS_GeoTransform` (#1221) ports Spark's decomposition, so after this change its `thetaI` agrees with `RS_Rotation` by construction — no internal inconsistency.
- `acos` incidentally fixes a zero-sign nit: the old `atan2` returned IEEE `-0.0` for axis-aligned rasters where Spark returns `+0.0`.

Blast radius: `GeoTransformEx::rotation` feeds only the `RS_Rotation` UDF; rust unit tests in `geo_transform.rs`, `affine_transformation.rs`, and `rs_geotransform.rs` are rewritten around derived cases (axis-aligned asserts the positive zero's sign; sheared expectation matches Spark bit-for-bit in probing).

### The parity tests (all passing, anchored)

- Axis-aligned (north-up, south-up) → exactly `0.0`, sign included.
- Rigid ±30° rotations, square and non-square pixels → `round(-theta, 12)`.
- Shear → `round(-acos(scaleX/hypot(scaleX, skewY)), 12)`.

Rotated/sheared queries compare through `ROUND(..., 12)`, with the evidence in a comment above the tests: neither runtime promises a bit-exact `acos` (Java `Math.acos` is specified to within 1 ulp of correctly rounded; Rust `f64::acos` is the platform libm with no accuracy contract), and a 72-angle sweep on macOS vs Temurin 17 measured 2 angles differing by exactly 1 ulp — π/6 among them — with the unlucky set being libm-dependent, so a raw comparison would be cross-platform flaky rather than strict. The anchored constants sit thousands of ulps from a 12-digit rounding boundary, so `ROUND` collapses 1-ulp pairs without ever splitting them. Axis-aligned cases compare raw and exact.

### Verification

`cargo test -p sedona-raster` and `-p sedona-raster-functions` green locally; `integration/spark-parity` at `28 passed, 14 xfailed` (RS_Rotation contributes 7 anchored passes, no xfails). This branch carries the #1217 lane so CI runs the parity suite.

Aside, noted while probing and out of scope: SedonaDB evaluates `-0.0 = 0.0` as `false` in SQL where Spark says `true`.
