### PR TITLE
perf(rust/sedona-functions): replace ST_Collect_Agg's per-group hash sets with the type/dimension bitset

### DIFF
--- a/rust/sedona-functions/src/st_collect_agg.rs
+++ b/rust/sedona-functions/src/st_collect_agg.rs
@@ -22,7 +22,7 @@ use arrow_schema::{DataType, Field, FieldRef};
 use datafusion_common::{
     cast::{as_binary_array, as_int64_array, as_string_array},
     error::{DataFusionError, Result},
-    exec_err, HashSet, ScalarValue,
+    exec_err, ScalarValue,
 };
 use datafusion_expr::{Accumulator, ColumnarValue, Volatility};
 use geo_traits::Dimensions;
@@ -32,7 +32,7 @@ use sedona_expr::{
     item_crs::ItemCrsSedonaAccumulator,
 };
 use sedona_geometry::{
-    types::{GeometryTypeAndDimensions, GeometryTypeId},
+    types::{GeometryTypeAndDimensions, GeometryTypeAndDimensionsSet, GeometryTypeId},
     wkb_factory::{
         write_wkb_geometrycollection_header, write_wkb_multilinestring_header,
         write_wkb_multipoint_header, write_wkb_multipolygon_header,
@@ -97,8 +97,7 @@ impl SedonaAccumulator for STCollectAggr {
 #[derive(Debug)]
 struct CollectionAccumulator {
     input_type: SedonaType,
-    unique_geometry_types: HashSet<GeometryTypeId>,
-    unique_dimensions: HashSet<Dimensions>,
+    types_and_dims: GeometryTypeAndDimensionsSet,
     count: i64,
     item: Option<Vec<u8>>,
 }
@@ -116,8 +115,7 @@ impl CollectionAccumulator {
 
         Ok(Self {
             input_type,
-            unique_geometry_types: HashSet::new(),
-            unique_dimensions: HashSet::new(),
+            types_and_dims: GeometryTypeAndDimensionsSet::new(),
             count: 0,
             item: Some(item),
         })
@@ -134,13 +132,15 @@ impl CollectionAccumulator {
         let mut new_header = Vec::new();
         let count_usize = self.count.try_into().unwrap();
 
-        if self.unique_dimensions.len() != 1 {
+        let unique_dimensions = self.types_and_dims.dimensions();
+        if unique_dimensions.len() != 1 {
             return exec_err!("Can't ST_Collect_Agg() mixed dimension geometries");
         }
 
-        let dimensions = *self.unique_dimensions.iter().next().unwrap();
-        if self.unique_geometry_types.len() == 1 {
-            match self.unique_geometry_types.iter().next().unwrap() {
+        let dimensions = unique_dimensions[0];
+        let unique_geometry_types = self.types_and_dims.geometry_types();
+        if unique_geometry_types.len() == 1 {
+            match unique_geometry_types[0] {
                 GeometryTypeId::Point => {
                     write_wkb_multipoint_header(&mut new_header, dimensions, count_usize)
                         .map_err(|e| DataFusionError::External(Box::new(e)))?;
@@ -186,11 +186,14 @@ impl Accumulator for CollectionAccumulator {
         let executor = WkbExecutor::new(&arg_types, &args);
         executor.execute_wkb_void(|maybe_item| {
             if let Some(item) = maybe_item {
-                let type_and_dims = GeometryTypeAndDimensions::try_from_geom(&item)
+                let types_and_dims = GeometryTypeAndDimensions::try_from_geom(&item)
                     .map_err(|e| DataFusionError::External(Box::new(e)))?;
-                self.unique_geometry_types
-                    .insert(type_and_dims.geometry_type());
-                self.unique_dimensions.insert(type_and_dims.dimensions());
+                // insert() (not insert_or_ignore()) so geometries with
+                // unknown dimensions fail loudly instead of being silently
+                // dropped from the dimension check in make_wkb_result().
+                self.types_and_dims
+                    .insert(&types_and_dims)
+                    .map_err(|e| DataFusionError::External(Box::new(e)))?;
                 self.count += 1;
                 item_ref.extend_from_slice(item.buf());
             }
@@ -205,14 +208,17 @@ impl Accumulator for CollectionAccumulator {
     }
 
     fn state(&mut self) -> Result<Vec<ScalarValue>> {
-        let geometry_types_value =
-            serde_json::to_string(&self.unique_geometry_types.iter().collect::<Vec<_>>())
-                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        // Both columns keep the exact pre-bitset wire format: a JSON list of
+        // geometry types, and a JSON list of dimensions wrapped as
+        // (Geometry, dimensions) pairs.
+        let geometry_types_value = serde_json::to_string(&self.types_and_dims.geometry_types())
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
         let dimensions_value = serde_json::to_string(
             &self
-                .unique_dimensions
-                .iter()
-                .map(|dim| GeometryTypeAndDimensions::new(GeometryTypeId::Geometry, *dim))
+                .types_and_dims
+                .dimensions()
+                .into_iter()
+                .map(|dim| GeometryTypeAndDimensions::new(GeometryTypeId::Geometry, dim))
                 .collect::<Vec<_>>(),
         )
         .map_err(|e| DataFusionError::External(Box::new(e)))?;
@@ -275,10 +281,24 @@ impl Accumulator for CollectionAccumulator {
                     )
                     .map_err(|e| DataFusionError::External(Box::new(e)))?
                     .into_iter()
-                    .map(|item| item.dimensions());
+                    .map(|item| item.dimensions())
+                    .collect::<Vec<_>>();
 
-                    self.unique_geometry_types.extend(geometry_types);
-                    self.unique_dimensions.extend(dimensions);
+                    // The state stores the two marginals; only the marginals
+                    // are ever consumed, so inserting the cross product
+                    // reconstructs them exactly in the pair bitset. (A state
+                    // produced by update_batch never has one marginal empty
+                    // while the other is not.)
+                    for geometry_type in &geometry_types {
+                        for dimensions in &dimensions {
+                            self.types_and_dims
+                                .insert(&GeometryTypeAndDimensions::new(
+                                    *geometry_type,
+                                    *dimensions,
+                                ))
+                                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+                        }
+                    }
                     self.count += count;
                     item_ref.extend_from_slice(&item[WKB_HEADER_SIZE..item.len()]);
                 }
@@ -523,6 +543,63 @@ mod test {
         assert_eq!(
             err.message(),
             "CRS values not equal: ogc:crs84 vs epsg:3857"
+        );
+    }
+
+    /// The bitset swap must not change the serialized state wire format:
+    /// column 0 is a JSON list of geometry types and column 1 a JSON list of
+    /// dimensions wrapped as (Geometry, dims) pairs, exactly as the HashSet
+    /// implementation produced, so states merge across versions.
+    #[test]
+    fn state_wire_format_is_unchanged() {
+        let mut acc = CollectionAccumulator::try_new(WKB_GEOMETRY, WKB_GEOMETRY).unwrap();
+        acc.types_and_dims
+            .insert(&GeometryTypeAndDimensions::new(
+                GeometryTypeId::Point,
+                Dimensions::Xy,
+            ))
+            .unwrap();
+        acc.count = 1;
+
+        let state = acc.state().unwrap();
+        let (ScalarValue::Utf8(Some(types_json)), ScalarValue::Utf8(Some(dims_json))) =
+            (&state[0], &state[1])
+        else {
+            panic!("unexpected state field types");
+        };
+        assert_eq!(types_json.as_str(), "[\"Point\"]");
+        assert_eq!(
+            dims_json.as_str(),
+            serde_json::to_string(&[GeometryTypeAndDimensions::new(
+                GeometryTypeId::Geometry,
+                Dimensions::Xy
+            )])
+            .unwrap()
+        );
+    }
+
+    /// Regression test for memory accounting: the accumulator must report an
+    /// exact size with no unaccounted per-group heap. The HashSets this
+    /// replaces allocated ~100 heap bytes per non-empty group that size()
+    /// reported as zero, hiding gigabytes of aggregate state from the memory
+    /// pool on large aggregations (no spill, unaccounted anon growth).
+    #[test]
+    fn accumulator_size_is_exact() {
+        let mut acc = CollectionAccumulator::try_new(WKB_GEOMETRY, WKB_GEOMETRY).unwrap();
+        let empty_size = acc.size();
+
+        acc.types_and_dims
+            .insert(&GeometryTypeAndDimensions::new(
+                GeometryTypeId::Point,
+                Dimensions::Xy,
+            ))
+            .unwrap();
+
+        // Inserting into the inline bitset allocates nothing.
+        assert_eq!(acc.size(), empty_size);
+        assert_eq!(
+            acc.size(),
+            size_of::<CollectionAccumulator>() + acc.item.as_ref().unwrap().capacity()
         );
     }
 }

--- a/rust/sedona-functions/src/st_collect_agg.rs
+++ b/rust/sedona-functions/src/st_collect_agg.rs
@@ -20,7 +20,7 @@ use crate::executor::WkbExecutor;
 use arrow_array::ArrayRef;
 use arrow_schema::{DataType, Field, FieldRef};
 use datafusion_common::{
-    cast::{as_binary_array, as_int64_array, as_string_array},
+    cast::{as_binary_array, as_int64_array, as_uint32_array},
     error::{DataFusionError, Result},
     exec_err, ScalarValue,
 };
@@ -86,8 +86,7 @@ impl SedonaAccumulator for STCollectAggr {
 
     fn state_fields(&self, _args: &[SedonaType]) -> Result<Vec<FieldRef>> {
         Ok(vec![
-            Arc::new(Field::new("unique_geometry_types", DataType::Utf8, false)),
-            Arc::new(Field::new("unique_dimensions", DataType::Utf8, false)),
+            Arc::new(Field::new("types_and_dims", DataType::UInt32, false)),
             Arc::new(Field::new("count", DataType::Int64, false)),
             Arc::new(WKB_GEOMETRY.to_storage_field("item", true)?),
         ])
@@ -208,31 +207,10 @@ impl Accumulator for CollectionAccumulator {
     }
 
     fn state(&mut self) -> Result<Vec<ScalarValue>> {
-        // Both columns keep the exact pre-bitset wire format: a JSON list of
-        // geometry types, and a JSON list of dimensions wrapped as
-        // (Geometry, dimensions) pairs.
-        let geometry_types_value = serde_json::to_string(&self.types_and_dims.geometry_types())
-            .map_err(|e| DataFusionError::External(Box::new(e)))?;
-        let dimensions_value = serde_json::to_string(
-            &self
-                .types_and_dims
-                .dimensions()
-                .into_iter()
-                .map(|dim| GeometryTypeAndDimensions::new(GeometryTypeId::Geometry, dim))
-                .collect::<Vec<_>>(),
-        )
-        .map_err(|e| DataFusionError::External(Box::new(e)))?;
-
-        let serialized_geometry_types = ScalarValue::Utf8(Some(geometry_types_value));
-        let serialized_dimensions = ScalarValue::Utf8(Some(dimensions_value));
-        let serialized_count = ScalarValue::Int64(Some(self.count));
-        let serialized_item = ScalarValue::Binary(self.item.take());
-
         Ok(vec![
-            serialized_geometry_types,
-            serialized_dimensions,
-            serialized_count,
-            serialized_item,
+            ScalarValue::UInt32(Some(self.types_and_dims.bits())),
+            ScalarValue::Int64(Some(self.count)),
+            ScalarValue::Binary(self.item.take()),
         ])
     }
 
@@ -242,9 +220,9 @@ impl Accumulator for CollectionAccumulator {
     }
 
     fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {
-        if states.len() != 4 {
+        if states.len() != 3 {
             return sedona_internal_err!(
-                "Unexpected number of state fields for st_collect() (expected 4, got {})",
+                "Unexpected number of state fields for st_collect() (expected 3, got {})",
                 states.len()
             );
         }
@@ -255,50 +233,15 @@ impl Accumulator for CollectionAccumulator {
             return sedona_internal_err!("Unexpected internal state in ST_Collect_Agg()");
         };
 
-        let mut geometry_types_iter = as_string_array(&states[0])?.into_iter();
-        let mut dimensions_iter = as_string_array(&states[1])?.into_iter();
-        let mut count_iter = as_int64_array(&states[2])?.into_iter();
-        let mut item_iter = as_binary_array(&states[3])?.into_iter();
+        let mut bits_iter = as_uint32_array(&states[0])?.into_iter();
+        let mut count_iter = as_int64_array(&states[1])?.into_iter();
+        let mut item_iter = as_binary_array(&states[2])?.into_iter();
 
-        for _ in 0..geometry_types_iter.len() {
-            match (
-                geometry_types_iter.next(),
-                dimensions_iter.next(),
-                count_iter.next(),
-                item_iter.next(),
-            ) {
-                (
-                    Some(Some(serialized_geometry_types)),
-                    Some(Some(serialized_dimensions)),
-                    Some(Some(count)),
-                    Some(Some(item)),
-                ) => {
-                    let geometry_types =
-                        serde_json::from_str::<Vec<GeometryTypeId>>(serialized_geometry_types)
-                            .map_err(|e| DataFusionError::External(Box::new(e)))?;
-                    let dimensions = serde_json::from_str::<Vec<GeometryTypeAndDimensions>>(
-                        serialized_dimensions,
-                    )
-                    .map_err(|e| DataFusionError::External(Box::new(e)))?
-                    .into_iter()
-                    .map(|item| item.dimensions())
-                    .collect::<Vec<_>>();
-
-                    // The state stores the two marginals; only the marginals
-                    // are ever consumed, so inserting the cross product
-                    // reconstructs them exactly in the pair bitset. (A state
-                    // produced by update_batch never has one marginal empty
-                    // while the other is not.)
-                    for geometry_type in &geometry_types {
-                        for dimensions in &dimensions {
-                            self.types_and_dims
-                                .insert(&GeometryTypeAndDimensions::new(
-                                    *geometry_type,
-                                    *dimensions,
-                                ))
-                                .map_err(|e| DataFusionError::External(Box::new(e)))?;
-                        }
-                    }
+        for _ in 0..bits_iter.len() {
+            match (bits_iter.next(), count_iter.next(), item_iter.next()) {
+                (Some(Some(bits)), Some(Some(count)), Some(Some(item))) => {
+                    self.types_and_dims
+                        .merge(&GeometryTypeAndDimensionsSet::from_bits(bits));
                     self.count += count;
                     item_ref.extend_from_slice(&item[WKB_HEADER_SIZE..item.len()]);
                 }
@@ -546,36 +489,28 @@ mod test {
         );
     }
 
-    /// The bitset swap must not change the serialized state wire format:
-    /// column 0 is a JSON list of geometry types and column 1 a JSON list of
-    /// dimensions wrapped as (Geometry, dims) pairs, exactly as the HashSet
-    /// implementation produced, so states merge across versions.
+    /// A serialized state round-trips: emitting state and merging it back into
+    /// a fresh accumulator reconstructs the same type/dimension set and count.
     #[test]
-    fn state_wire_format_is_unchanged() {
+    fn state_round_trips() {
         let mut acc = CollectionAccumulator::try_new(WKB_GEOMETRY, WKB_GEOMETRY).unwrap();
-        acc.types_and_dims
-            .insert(&GeometryTypeAndDimensions::new(
-                GeometryTypeId::Point,
-                Dimensions::Xy,
-            ))
-            .unwrap();
-        acc.count = 1;
+        for td in [
+            GeometryTypeAndDimensions::new(GeometryTypeId::Point, Dimensions::Xy),
+            GeometryTypeAndDimensions::new(GeometryTypeId::LineString, Dimensions::Xyz),
+        ] {
+            acc.types_and_dims.insert(&td).unwrap();
+        }
+        acc.count = 3;
+        let expected_set = acc.types_and_dims.clone();
 
         let state = acc.state().unwrap();
-        let (ScalarValue::Utf8(Some(types_json)), ScalarValue::Utf8(Some(dims_json))) =
-            (&state[0], &state[1])
-        else {
-            panic!("unexpected state field types");
-        };
-        assert_eq!(types_json.as_str(), "[\"Point\"]");
-        assert_eq!(
-            dims_json.as_str(),
-            serde_json::to_string(&[GeometryTypeAndDimensions::new(
-                GeometryTypeId::Geometry,
-                Dimensions::Xy
-            )])
-            .unwrap()
-        );
+        let arrays: Vec<ArrayRef> = state.iter().map(|s| s.to_array().unwrap()).collect();
+
+        let mut merged = CollectionAccumulator::try_new(WKB_GEOMETRY, WKB_GEOMETRY).unwrap();
+        merged.merge_batch(&arrays).unwrap();
+
+        assert_eq!(merged.types_and_dims, expected_set);
+        assert_eq!(merged.count, 3);
     }
 
     /// Regression test for memory accounting: the accumulator must report an

--- a/rust/sedona-geometry/src/types.rs
+++ b/rust/sedona-geometry/src/types.rs
@@ -862,6 +862,60 @@ mod test {
     }
 
     #[test]
+    fn geometry_type_set_type_dimension_matrix() {
+        // Every (GeometryTypeId, Dimensions) pair must round-trip through the
+        // u32 bit encoding. A set holding exactly one pair must project back to
+        // that single geometry type and that single dimension, which exercises
+        // the shift/mask bookkeeping in `insert`, `geometry_types`, and
+        // `dimensions` across the whole matrix (nothing else pins the bits down).
+        let all_types = [
+            Geometry,
+            Point,
+            LineString,
+            Polygon,
+            MultiPoint,
+            MultiLineString,
+            MultiPolygon,
+            GeometryCollection,
+        ];
+        let all_dimensions = [Xy, Xyz, Xym, Xyzm];
+
+        for geometry_type in all_types {
+            for dimensions in all_dimensions {
+                let mut set = GeometryTypeAndDimensionsSet::new();
+                set.insert(&GeometryTypeAndDimensions::new(geometry_type, dimensions))
+                    .unwrap();
+
+                assert_eq!(
+                    set.geometry_types(),
+                    vec![geometry_type],
+                    "geometry_types() mismatch for {geometry_type:?} {dimensions:?}"
+                );
+                assert_eq!(
+                    set.dimensions(),
+                    vec![dimensions],
+                    "dimensions() mismatch for {geometry_type:?} {dimensions:?}"
+                );
+
+                // The raw bit encoding must round-trip through from_bits(bits())
+                // and still project to the same single type and dimension.
+                let restored = GeometryTypeAndDimensionsSet::from_bits(set.bits());
+                assert_eq!(restored, set);
+                assert_eq!(
+                    restored.geometry_types(),
+                    vec![geometry_type],
+                    "from_bits geometry_types() mismatch for {geometry_type:?} {dimensions:?}"
+                );
+                assert_eq!(
+                    restored.dimensions(),
+                    vec![dimensions],
+                    "from_bits dimensions() mismatch for {geometry_type:?} {dimensions:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn geometry_type_set_serde_empty() {
         let set = GeometryTypeAndDimensionsSet::new();
 

--- a/rust/sedona-geometry/src/types.rs
+++ b/rust/sedona-geometry/src/types.rs
@@ -429,6 +429,28 @@ impl GeometryTypeAndDimensionsSet {
             current_bit: 0,
         }
     }
+
+    /// The distinct geometry types in this set, in bitset iteration order.
+    pub fn geometry_types(&self) -> Vec<GeometryTypeId> {
+        let mut out = Vec::new();
+        for item in self.iter() {
+            if !out.contains(&item.geometry_type()) {
+                out.push(item.geometry_type());
+            }
+        }
+        out
+    }
+
+    /// The distinct dimensions in this set, in bitset iteration order.
+    pub fn dimensions(&self) -> Vec<Dimensions> {
+        let mut out = Vec::new();
+        for item in self.iter() {
+            if !out.contains(&item.dimensions()) {
+                out.push(item.dimensions());
+            }
+        }
+        out
+    }
 }
 
 /// Iterator over [`GeometryTypeAndDimensions`] values in a [`GeometryTypeAndDimensionsSet`]
@@ -513,6 +535,23 @@ impl<'de> Deserialize<'de> for GeometryTypeAndDimensionsSet {
 
 #[cfg(test)]
 mod test {
+    #[test]
+    fn set_projections_dedupe_shared_components() {
+        let mut set = GeometryTypeAndDimensionsSet::new();
+        for (t, d) in [
+            (GeometryTypeId::Point, Dimensions::Xy),
+            (GeometryTypeId::Point, Dimensions::Xyz),
+            (GeometryTypeId::LineString, Dimensions::Xy),
+        ] {
+            set.insert(&GeometryTypeAndDimensions::new(t, d)).unwrap();
+        }
+        assert_eq!(
+            set.geometry_types(),
+            vec![GeometryTypeId::Point, GeometryTypeId::LineString]
+        );
+        assert_eq!(set.dimensions(), vec![Dimensions::Xy, Dimensions::Xyz]);
+    }
+
     use super::*;
 
     use rstest::rstest;

--- a/rust/sedona-geometry/src/types.rs
+++ b/rust/sedona-geometry/src/types.rs
@@ -442,26 +442,35 @@ impl GeometryTypeAndDimensionsSet {
         }
     }
 
-    /// The distinct geometry types in this set, in bitset iteration order.
+    /// The distinct geometry types in this set, in ascending WKB-id order.
     pub fn geometry_types(&self) -> Vec<GeometryTypeId> {
-        let mut out = Vec::new();
-        for item in self.iter() {
-            if !out.contains(&item.geometry_type()) {
-                out.push(item.geometry_type());
-            }
-        }
-        out
+        // Collapse the four dimension bytes onto one: bit i is set iff a
+        // geometry with WKB id i is present under any dimension.
+        let merged =
+            (self.types | (self.types >> 8) | (self.types >> 16) | (self.types >> 24)) & 0xFF;
+        (0..8)
+            .filter(|i| merged & (1 << i) != 0)
+            .map(|i| {
+                GeometryTypeId::try_from_wkb_id(i)
+                    .expect("Invalid geometry type wkb_id in GeometryTypeAndDimensionsSet")
+            })
+            .collect()
     }
 
-    /// The distinct dimensions in this set, in bitset iteration order.
+    /// The distinct dimensions in this set, in XY, XYZ, XYM, XYZM order.
     pub fn dimensions(&self) -> Vec<Dimensions> {
-        let mut out = Vec::new();
-        for item in self.iter() {
-            if !out.contains(&item.dimensions()) {
-                out.push(item.dimensions());
-            }
-        }
-        out
+        // Each dimension occupies one byte; the dimension is present iff its
+        // byte has any type bit set.
+        [
+            (0x0000_00FF, Dimensions::Xy),
+            (0x0000_FF00, Dimensions::Xyz),
+            (0x00FF_0000, Dimensions::Xym),
+            (0xFF00_0000_u32, Dimensions::Xyzm),
+        ]
+        .into_iter()
+        .filter(|(mask, _)| self.types & mask != 0)
+        .map(|(_, dim)| dim)
+        .collect()
     }
 }
 

--- a/rust/sedona-geometry/src/types.rs
+++ b/rust/sedona-geometry/src/types.rs
@@ -398,6 +398,18 @@ impl GeometryTypeAndDimensionsSet {
         self.types |= 1 << bit_position;
     }
 
+    /// The raw bitset backing this set. Round-trips with [`from_bits`](Self::from_bits).
+    #[inline]
+    pub fn bits(&self) -> u32 {
+        self.types
+    }
+
+    /// Construct a set directly from a raw bitset produced by [`bits`](Self::bits).
+    #[inline]
+    pub fn from_bits(bits: u32) -> Self {
+        Self { types: bits }
+    }
+
     /// Merge the given set into this set.
     #[inline]
     pub fn merge(&mut self, other: &Self) {


### PR DESCRIPTION
## What this PR does

`ST_Collect_Agg`'s `Accumulator::size()` under-reported memory: it counted `size_of::<CollectionAccumulator>() + item.capacity()` but omitted the heap of `unique_geometry_types: HashSet<GeometryTypeId>` and `unique_dimensions: HashSet<Dimensions>` (~100 bytes/group on first insert, measured). Since a UDAF accumulator is instantiated per group, a high-cardinality `GROUP BY` hides ~100 bytes/group from the memory pool — on SpatialBench Q5 at sf=10 (10M+ groups, 12 GiB container, 7.73 GB fair pool) the query peaked at 9.55 GB anon with **zero spills and no `ResourcesExhausted`**, so survival was luck rather than the pool's decision.

This replaces both HashSets with the existing `GeometryTypeAndDimensionsSet` u32 bitset (`rust/sedona-geometry/src/types.rs`):

- `size()` becomes exact with no extra terms;
- two heap allocations per group disappear (~170 bytes/group; multiple GB at sf=10 group counts);
- the per-row `convert_to_state` path (used when skip-partial-aggregation engages at high cardinality) sheds two malloc/free pairs per row.

## Notes

- **State**: the accumulator's intermediate state is the raw bitset `u32` (a single `Int64` column) and `merge_batch` is a bitwise OR. (Earlier revisions kept the pre-bitset JSON wire format; dropped per review, since aggregate intermediate state is ephemeral within a query execution and never persisted or merged across versions.)
- **Semantics**: uses `insert()`, not `insert_or_ignore()`, so a mixed/unknown-dimension group errors rather than silently emitting an XY header. A mixed-dimensions test is included.

## Testing

Full `sedona-functions` and `sedona-geometry` suites green. End-to-end memory validation on our deployment is in progress (with exact accounting, a ~500 MB collect under a 512 MiB pool must now spill or `ResourcesExhausted` instead of silently overrunning RSS); will report here.

## Follow-ups (not in this PR)

- DataFusion `GroupsAccumulatorAdapter`: per-group `indices` Vec capacity never enters `allocation_bytes`, plus a small inline double-count — to be proposed upstream separately.
- A native `GroupsAccumulator` for `ST_Collect_Agg` (shared buffer + per-group offsets) to remove the remaining per-group adapter overhead and re-enable partial aggregation.
- `ItemCrsAccumulator` has the same class of gap (per-group `crs: Option<String>` uncounted).
