### PR TITLE
fix(rust): aggregate size() audit — count all per-group heap in ItemCrs, union/intersection, and envelope accumulators

### DIFF
--- a/rust/sedona-expr/src/item_crs.rs
+++ b/rust/sedona-expr/src/item_crs.rs
@@ -323,7 +323,9 @@ impl Accumulator for ItemCrsAccumulator {
     }
 
     fn size(&self) -> usize {
-        self.inner.size() + size_of::<ItemCrsAccumulator>()
+        self.inner.size()
+            + size_of::<ItemCrsAccumulator>()
+            + self.crs.as_ref().map(|s| s.capacity()).unwrap_or(0)
     }
 
     fn state(&mut self) -> Result<Vec<ScalarValue>> {

--- a/rust/sedona-functions/src/st_envelope_agg.rs
+++ b/rust/sedona-functions/src/st_envelope_agg.rs
@@ -454,6 +454,7 @@ impl<T: WkbBounder2D + Default> GroupsAccumulator for BoundsGroupsAccumulator2D<
 
     fn size(&self) -> usize {
         size_of::<BoundsGroupsAccumulator2D<T>>()
+            + (self.bounders.capacity() - self.bounders.len()) * size_of::<T>()
             + self.bounders.iter().map(|b| b.mem_used()).sum::<usize>()
     }
 }

--- a/rust/sedona-geo/src/geometry_mem.rs
+++ b/rust/sedona-geo/src/geometry_mem.rs
@@ -1,0 +1,90 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Heap-size measurement for geo geometries, used by aggregate accumulators
+//! to report their memory use to the memory pool.
+
+use std::mem::size_of;
+
+/// The heap bytes owned by a [geo::Geometry].
+///
+/// The enum itself lives inline in its container; this counts only owned
+/// buffers. Capacity is used where the backing Vec is reachable; interior
+/// rings expose only a slice, so their container overhead is counted by
+/// length, which matches the allocated size for geometries produced by
+/// construction or boolean ops.
+pub(crate) fn geometry_heap_size(geom: &geo::Geometry) -> usize {
+    use geo::Geometry::*;
+    match geom {
+        Point(_) | Line(_) | Rect(_) | Triangle(_) => 0,
+        LineString(ls) => line_string_heap_size(ls),
+        Polygon(p) => polygon_heap_size(p),
+        MultiPoint(mp) => mp.0.capacity() * size_of::<geo::Point>(),
+        MultiLineString(mls) => {
+            mls.0.capacity() * size_of::<geo::LineString>()
+                + mls.0.iter().map(line_string_heap_size).sum::<usize>()
+        }
+        MultiPolygon(mp) => {
+            mp.0.capacity() * size_of::<geo::Polygon>()
+                + mp.0.iter().map(polygon_heap_size).sum::<usize>()
+        }
+        GeometryCollection(gc) => {
+            gc.0.capacity() * size_of::<geo::Geometry>()
+                + gc.0.iter().map(geometry_heap_size).sum::<usize>()
+        }
+    }
+}
+
+fn line_string_heap_size(ls: &geo::LineString) -> usize {
+    ls.0.capacity() * size_of::<geo::Coord>()
+}
+
+fn polygon_heap_size(p: &geo::Polygon) -> usize {
+    line_string_heap_size(p.exterior())
+        + std::mem::size_of_val(p.interiors())
+        + p.interiors()
+            .iter()
+            .map(line_string_heap_size)
+            .sum::<usize>()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn counts_rings_and_container_overhead() {
+        let exterior = geo::LineString::from(vec![(0.0, 0.0), (4.0, 0.0), (4.0, 4.0), (0.0, 0.0)]);
+        let hole = geo::LineString::from(vec![(1.0, 1.0), (2.0, 1.0), (2.0, 2.0), (1.0, 1.0)]);
+        let coords_bytes = (exterior.0.len() + hole.0.len()) * size_of::<geo::Coord>();
+        let poly = geo::Polygon::new(exterior, vec![hole]);
+        let mp = geo::Geometry::MultiPolygon(geo::MultiPolygon(vec![poly]));
+
+        let measured = geometry_heap_size(&mp);
+        assert!(
+            measured >= coords_bytes + size_of::<geo::Polygon>() + size_of::<geo::LineString>()
+        );
+
+        assert_eq!(
+            geometry_heap_size(&geo::Geometry::Point(geo::Point::new(0.0, 0.0))),
+            0
+        );
+
+        let gc = geo::Geometry::GeometryCollection(geo::GeometryCollection(vec![mp]));
+        assert!(geometry_heap_size(&gc) >= measured + size_of::<geo::Geometry>());
+    }
+}

--- a/rust/sedona-geo/src/lib.rs
+++ b/rust/sedona-geo/src/lib.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 pub mod centroid;
+mod geometry_mem;
 pub mod register;
 mod st_area;
 mod st_asgeojson;

--- a/rust/sedona-geo/src/st_intersection_agg.rs
+++ b/rust/sedona-geo/src/st_intersection_agg.rs
@@ -181,22 +181,12 @@ impl Accumulator for IntersectionAccumulator {
     }
 
     fn size(&self) -> usize {
-        let mut size = size_of_val(self);
-
-        // Add size of the geometry data if it exists
-        if let Some(geo::Geometry::MultiPolygon(mp)) = &self.current_intersection {
-            for poly in &mp.0 {
-                // Count exterior ring points
-                size += size_of::<geo::Coord>() * poly.exterior().0.len();
-
-                // Count interior ring points
-                for ring in poly.interiors() {
-                    size += size_of::<geo::Coord>() * ring.0.len();
-                }
-            }
-        }
-
-        size
+        size_of_val(self)
+            + self
+                .current_intersection
+                .as_ref()
+                .map(crate::geometry_mem::geometry_heap_size)
+                .unwrap_or(0)
     }
 
     fn state(&mut self) -> Result<Vec<ScalarValue>> {

--- a/rust/sedona-geo/src/st_union_agg.rs
+++ b/rust/sedona-geo/src/st_union_agg.rs
@@ -175,22 +175,12 @@ impl Accumulator for UnionAccumulator {
     }
 
     fn size(&self) -> usize {
-        let mut size = size_of_val(self);
-
-        // Add size of the geometry data if it exists
-        if let Some(geo::Geometry::MultiPolygon(mp)) = &self.current_union {
-            for poly in &mp.0 {
-                // Count exterior ring points
-                size += size_of::<geo::Coord>() * poly.exterior().0.len();
-
-                // Count interior ring points
-                for ring in poly.interiors() {
-                    size += size_of::<geo::Coord>() * ring.0.len();
-                }
-            }
-        }
-
-        size
+        size_of_val(self)
+            + self
+                .current_union
+                .as_ref()
+                .map(crate::geometry_mem::geometry_heap_size)
+                .unwrap_or(0)
     }
 
     fn state(&mut self) -> Result<Vec<ScalarValue>> {


### PR DESCRIPTION
Follow-up to #1225: after fixing `ST_Collect_Agg`'s memory accounting, we audited every other `Accumulator`/`GroupsAccumulator` `size()` implementation in the repo (enumerated via the trait-required `fn size(&self) -> usize`, cross-checked with a repo-wide sweep for per-group set/collection state). Three more accounting gaps turned up, each small; this PR fixes all three as separate commits. No behavior changes — only what gets reported to the memory pool.

## 1. `ItemCrsAccumulator` (sedona-expr)

`size()` returned `inner.size() + size_of::<ItemCrsAccumulator>()`, omitting the per-group `crs: Option<String>` heap. Since this wrapper multiplies across every aggregate over item-CRS arguments, a high-cardinality `GROUP BY` leaked one uncounted String allocation per group. Fix adds the string's capacity.

## 2. `ST_Union_Agg` / `ST_Intersection_Agg` (sedona-geo)

These accumulators hold a growing `MultiPolygon` (the running union/intersection), yet `size()` counted only the raw coordinate bytes inside it — and by ring `.len()`, not `.capacity()`. Every container that holds those coordinates together went uncounted: the `MultiPolygon`'s own `Vec<Polygon>` buffer, each `Polygon`'s interior-rings `Vec<LineString>` buffer, the per-ring `LineString` headers, and any capacity slack in the coordinate vectors.

For the workload these accumulators exist to serve — dissolving many small polygons into one accumulating `MultiPolygon` — the `Vec<Polygon>` buffer alone scales with the polygon count (each `geo::Polygon` is a ~48-byte struct), so on small features the uncounted structural overhead is comparable to the coordinate bytes that *were* counted: roughly a 40–50% under-report that grows as the union does.

The fix replaces the hand-rolled walk with a shared `geometry_heap_size()` (new crate-private `geometry_mem` module, with tests) that charges for every owned buffer — coordinates by capacity, the polygon and ring vectors, and recursion through nested geometries. As a side benefit the new walk is variant-exhaustive, so it can no longer silently report zero if the held geometry is ever something other than a `MultiPolygon`; that path isn't reachable today (the accumulators maintain a MultiPolygon-or-None invariant), but the walk is robust either way.

## 3. `BoundsGroupsAccumulator2D` (sedona-functions)

The groups accumulator summed per-bounder `mem_used()` over the *live* bounders, missing the `bounders: Vec<T>` doubling slack (capacity beyond len). Smallest of the three — added the slack term.

## Not in scope

`ST_ConvexHull_Agg` and `ST_Analyze_Agg` were audited and are already honest (capacity-based counting and the u32 bitset respectively). The larger `ST_Collect_Agg` follow-ups discussed in #1225 (native `GroupsAccumulator`, DataFusion-side adapter accounting) remain separate work.
