### PR TITLE
chore(rust): upgrade geo to 0.33.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,7 +249,7 @@ dependencies = [
  "snap",
  "strum",
  "strum_macros",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "uuid",
  "zstd",
 ]
@@ -2694,12 +2694,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "earcutr"
-version = "0.4.3"
+name = "earcut"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79127ed59a85d7687c409e9978547cffb7dc79675355ed22da6b66fd5f6ead01"
+checksum = "88459a2a8e3a514b6e6de38cf3aaa9250a894cb098f74a932db77fcc8341b6d0"
 dependencies = [
- "itertools 0.11.0",
  "num-traits",
 ]
 
@@ -3041,31 +3040,32 @@ dependencies = [
 
 [[package]]
 name = "geo"
-version = "0.31.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc1a1678e54befc9b4bcab6cd43b8e7f834ae8ea121118b0fd8c42747675b4a"
+checksum = "30eb1fdc57c1e5cfd11826fe0caec4b9dc7901f3758263bb506228d88c8d9e9a"
 dependencies = [
- "earcutr",
- "float_next_after 1.0.0",
+ "earcut",
+ "float_next_after 2.0.0",
  "geo-types",
  "geographiclib-rs",
- "i_overlay 4.0.7",
+ "i_overlay 4.5.2",
  "log",
  "num-traits",
+ "rand 0.10.1",
+ "rand_pcg",
  "robust",
  "rstar 0.12.2",
+ "sif-itree",
  "spade",
 ]
 
 [[package]]
 name = "geo-index"
 version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310ad245e63f6b5fcf4a7c2663139708eae1374045396eef95ea3badd242d57"
+source = "git+https://github.com/paleolimbot/geo-index.git?rev=a8c8ae19e7a5e3057e40e01d70dfe2d60c0b49ca#a8c8ae19e7a5e3057e40e01d70dfe2d60c0b49ca"
 dependencies = [
  "bytemuck",
  "float_next_after 1.0.0",
- "geo",
  "geo-traits",
  "num-traits",
  "thiserror 1.0.69",
@@ -3083,9 +3083,9 @@ dependencies = [
 
 [[package]]
 name = "geo-types"
-version = "0.7.18"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f8647af4005fa11da47cd56252c6ef030be8fa97bdbf355e7dfb6348f0a82c"
+checksum = "777d18aa0f12f8b285331cd867133ee14422b3f023f6d388034c47d43e28786a"
 dependencies = [
  "approx",
  "num-traits",
@@ -3093,9 +3093,12 @@ dependencies = [
  "rstar 0.10.0",
  "rstar 0.11.0",
  "rstar 0.12.2",
+ "rstar 0.13.0",
  "rstar 0.8.4",
  "rstar 0.9.3",
  "serde",
+ "spade",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3146,7 +3149,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "tinyvec",
 ]
 
@@ -3544,9 +3547,9 @@ dependencies = [
 
 [[package]]
 name = "i_float"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010025c2c532c8d82e42d0b8bb5184afa449fa6f06c709ea9adcb16c49ae405b"
+checksum = "813145bb0ad5b60f55cbbf3c74cdceda1c0a9d253b35c4cc36ae0df7887cb78f"
 dependencies = [
  "libm",
 ]
@@ -3562,9 +3565,12 @@ dependencies = [
 
 [[package]]
 name = "i_key_sort"
-version = "0.6.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9190f86706ca38ac8add223b2aed8b1330002b5cdbbce28fb58b10914d38fc27"
+checksum = "d73d122b937fca067feb0ad74f62388920272b27c356d4df2d0cfdd59e044cf0"
+dependencies = [
+ "rayon",
+]
 
 [[package]]
 name = "i_key_sort"
@@ -3574,14 +3580,14 @@ checksum = "7c6c58d0c60705e66264ce0f788a69a2f21472aeb8188559e7c8c619dbdc10fa"
 
 [[package]]
 name = "i_overlay"
-version = "4.0.7"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413183068e6e0289e18d7d0a1f661b81546e6918d5453a44570b9ab30cbed1b3"
+checksum = "8dd314b4668e2b3a12508f2e125558c82a6c0a8636fa5107a900f79ce414e450"
 dependencies = [
- "i_float 1.15.0",
- "i_key_sort 0.6.0",
- "i_shape 1.14.0",
- "i_tree 0.16.0",
+ "i_float 1.16.0",
+ "i_key_sort 0.10.3",
+ "i_shape 1.18.0",
+ "i_tree 0.18.0",
  "rayon",
 ]
 
@@ -3599,11 +3605,11 @@ dependencies = [
 
 [[package]]
 name = "i_shape"
-version = "1.14.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea154b742f7d43dae2897fcd5ead86bc7b5eefcedd305a7ebf9f69d44d61082"
+checksum = "bfa9eac533d7509a8ab87672b60ac610c17240f9ea4851d26227689fdfe349c8"
 dependencies = [
- "i_float 1.15.0",
+ "i_float 1.16.0",
 ]
 
 [[package]]
@@ -3617,9 +3623,9 @@ dependencies = [
 
 [[package]]
 name = "i_tree"
-version = "0.16.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e6d558e6d4c7b82bc51d9c771e7a927862a161a7d87bf2b0541450e0e20915"
+checksum = "4804bdc1dc124eb7e1aa9e144ecc04096bcf787a10a15fa44af682b51f0f6cce"
 
 [[package]]
 name = "i_tree"
@@ -3838,15 +3844,6 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -3940,7 +3937,7 @@ dependencies = [
  "chrono",
  "log",
  "num-traits",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "uuid",
 ]
 
@@ -3955,7 +3952,7 @@ dependencies = [
  "laz",
  "log",
  "num-traits",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "uuid",
 ]
 
@@ -3967,7 +3964,7 @@ checksum = "249568d517d0dcf0581d1c8241b05cd76559ec1c01e5ded1878645d158cdf594"
 dependencies = [
  "las 0.9.11",
  "log",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4540,7 +4537,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -5018,7 +5015,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -5040,7 +5037,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -5231,7 +5228,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5435,6 +5432,7 @@ checksum = "5912b862fa5ffb462607bfd1e35036c458c537921f508c8235a83d5f3987edfe"
 dependencies = [
  "heapless 0.8.0",
  "num-traits",
+ "serde",
  "smallvec",
 ]
 
@@ -5914,7 +5912,7 @@ dependencies = [
  "libloading 0.9.0",
  "sedona-raster",
  "sedona-testing",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5998,7 +5996,7 @@ dependencies = [
  "sedona-functions",
  "sedona-schema",
  "sedona-testing",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -6013,7 +6011,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "wkb",
  "wkt 0.14.0",
 ]
@@ -6097,7 +6095,7 @@ dependencies = [
  "sedona-geos",
  "sedona-schema",
  "sedona-testing",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "which",
  "wkt 0.14.0",
 ]
@@ -6148,7 +6146,7 @@ dependencies = [
  "proj-sys",
  "sedona-geometry",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "wkb",
 ]
 
@@ -6186,7 +6184,7 @@ dependencies = [
  "sedona-common",
  "sedona-schema",
  "sedona-testing",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "tokio",
 ]
 
@@ -6289,7 +6287,7 @@ dependencies = [
  "sedona-geometry",
  "sedona-schema",
  "sedona-testing",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -6486,7 +6484,7 @@ dependencies = [
  "sedona-functions",
  "sedona-schema",
  "sedona-testing",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "wkb",
 ]
 
@@ -6522,7 +6520,7 @@ dependencies = [
  "sedona-schema",
  "sedona-tg",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "tokio",
 ]
 
@@ -6562,7 +6560,7 @@ dependencies = [
  "sedona-geoparquet",
  "sedona-proj",
  "sedona-schema",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "tokio",
 ]
 
@@ -6732,6 +6730,12 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "sif-itree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7f45b8998ced5134fb1d75732c77842a3e888f19c1ff98481822e8fbfbf930b"
 
 [[package]]
 name = "signal-hook-registry"
@@ -6914,6 +6918,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6989,11 +7004,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -7009,13 +7024,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -8084,7 +8099,7 @@ dependencies = [
  "rayon_iter_concurrent_limit",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "thread_local",
  "unsafe_cell_slice",
  "uuid",
@@ -8109,7 +8124,7 @@ dependencies = [
  "inventory",
  "itertools 0.14.0",
  "rayon",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "tinyvec",
  "zarrs_metadata",
  "zarrs_plugin",
@@ -8141,7 +8156,7 @@ dependencies = [
  "inventory",
  "itertools 0.14.0",
  "rayon",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "unsafe_cell_slice",
  "zarrs_chunk_grid",
  "zarrs_data_type",
@@ -8163,7 +8178,7 @@ dependencies = [
  "paste",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "zarrs_metadata",
  "zarrs_plugin",
 ]
@@ -8181,7 +8196,7 @@ dependencies = [
  "page_size",
  "pathdiff",
  "positioned-io",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "walkdir",
  "zarrs_storage",
 ]
@@ -8197,7 +8212,7 @@ dependencies = [
  "monostate",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8212,7 +8227,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "zarrs_metadata",
 ]
 
@@ -8237,7 +8252,7 @@ dependencies = [
  "paste",
  "regex",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8252,7 +8267,7 @@ dependencies = [
  "derive_more",
  "futures",
  "itertools 0.14.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "unsafe_cell_slice",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,8 +106,8 @@ env_logger = "0.11"
 fastrand = "2.4"
 float_next_after = "2"
 futures = "0.3"
-geo = "0.31.0"
-geo-index = { version = "0.3.4", features = ["use-geo_0_31"] }
+geo = "0.33.1"
+geo-index = { git = "https://github.com/paleolimbot/geo-index.git", rev = "a8c8ae19e7a5e3057e40e01d70dfe2d60c0b49ca" }
 geo-traits = "0.3.0"
 geo-types = "0.7.17"
 geojson = "1.0.0"

--- a/rust/sedona-geo-generic-alg/benches/intersection.rs
+++ b/rust/sedona-geo-generic-alg/benches/intersection.rs
@@ -413,7 +413,7 @@ fn point_triangle_intersection(c: &mut Criterion) {
             }
 
             assert_eq!(intersects, 533);
-            assert_eq!(non_intersects, 5450151);
+            assert_eq!(non_intersects, 5484911);
         });
     });
 

--- a/rust/sedona-geo-generic-alg/src/algorithm/map_coords.rs
+++ b/rust/sedona-geo-generic-alg/src/algorithm/map_coords.rs
@@ -778,7 +778,7 @@ where
 
 impl<T: CoordNum> MapCoordsInPlace<T> for Triangle<T> {
     fn map_coords_in_place(&mut self, func: impl Fn(Coord<T>) -> Coord<T>) {
-        let mut new_triangle = Triangle::new(func(self.0), func(self.1), func(self.2));
+        let mut new_triangle = Triangle::new(func(self.v1()), func(self.v2()), func(self.v3()));
 
         ::std::mem::swap(self, &mut new_triangle);
     }
@@ -787,7 +787,7 @@ impl<T: CoordNum> MapCoordsInPlace<T> for Triangle<T> {
         &mut self,
         func: impl Fn(Coord<T>) -> Result<Coord<T>, E>,
     ) -> Result<(), E> {
-        let mut new_triangle = Triangle::new(func(self.0)?, func(self.1)?, func(self.2)?);
+        let mut new_triangle = Triangle::new(func(self.v1())?, func(self.v2())?, func(self.v3())?);
 
         ::std::mem::swap(self, &mut new_triangle);
 

--- a/rust/sedona-geo-traits-ext/src/triangle.rs
+++ b/rust/sedona-geo-traits-ext/src/triangle.rs
@@ -133,15 +133,15 @@ where
     forward_triangle_trait_ext_funcs!();
 
     fn first_coord(&self) -> Coord<<Self as GeometryTrait>::T> {
-        self.0
+        self.v1()
     }
 
     fn second_coord(&self) -> Coord<<Self as GeometryTrait>::T> {
-        self.1
+        self.v2()
     }
 
     fn third_coord(&self) -> Coord<<Self as GeometryTrait>::T> {
-        self.2
+        self.v3()
     }
 
     fn to_array(&self) -> [Coord<<Self as GeometryTrait>::T>; 3] {
@@ -164,15 +164,15 @@ where
     forward_triangle_trait_ext_funcs!();
 
     fn first_coord(&self) -> Coord<<Self as GeometryTrait>::T> {
-        self.0
+        self.v1()
     }
 
     fn second_coord(&self) -> Coord<<Self as GeometryTrait>::T> {
-        self.1
+        self.v2()
     }
 
     fn third_coord(&self) -> Coord<<Self as GeometryTrait>::T> {
-        self.2
+        self.v3()
     }
 
     fn to_array(&self) -> [Coord<<Self as GeometryTrait>::T>; 3] {

--- a/rust/sedona-geo/src/st_concavehull.rs
+++ b/rust/sedona-geo/src/st_concavehull.rs
@@ -21,6 +21,7 @@ use arrow_array::builder::BinaryBuilder;
 use datafusion_common::error::Result;
 use datafusion_common::{cast::as_float64_array, DataFusionError};
 use datafusion_expr::ColumnarValue;
+use geo::concave_hull::ConcaveHullOptions;
 use geo::{ConcaveHull, CoordsIter, Geometry, GeometryCollection, Point, Polygon};
 use geo_traits::to_geo::{ToGeoGeometry, ToGeoPoint};
 use geo_traits::{GeometryCollectionTrait, GeometryTrait, MultiPointTrait, PointTrait};
@@ -41,6 +42,10 @@ use crate::to_geo::item_to_geometry;
 /// Geo returns a Polygon for every concave hull computation
 /// whereas the Geos implementation returns a MultiPolygon for
 /// certain geometries concave hull computation.
+///
+/// Note that this does *not* match the PostGIS implementation.
+/// In particular, the GEOS/PostGIS "pctconvex" parameter, which extends
+/// from 0..1 does not match this kernel's "concavity" (0..Infinity).
 pub fn st_concavehull_impl() -> Vec<ScalarKernelRef> {
     ItemCrsKernel::wrap_impl(STConcaveHull {})
 }
@@ -84,7 +89,11 @@ fn invoke_batch_impl(arg_types: &[SedonaType], args: &[ColumnarValue]) -> Result
     executor.execute_wkb_void(|maybe_wkb| {
         match (maybe_wkb, pct_convex_iter.next().unwrap()) {
             (Some(wkb), Some(pct_convex)) => {
-                invoke_scalar(wkb, pct_convex, &mut builder)?;
+                let options = ConcaveHullOptions {
+                    concavity: pct_convex,
+                    ..Default::default()
+                };
+                invoke_scalar(wkb, options, &mut builder)?;
                 builder.append_value([]);
             }
             _ => builder.append_null(),
@@ -96,13 +105,17 @@ fn invoke_batch_impl(arg_types: &[SedonaType], args: &[ColumnarValue]) -> Result
     executor.finish(Arc::new(builder.finish()))
 }
 
-fn invoke_scalar(geom: &Wkb, pct_convex: f64, writer: &mut impl std::io::Write) -> Result<()> {
+fn invoke_scalar(
+    geom: &Wkb,
+    options: ConcaveHullOptions<f64>,
+    writer: &mut impl std::io::Write,
+) -> Result<()> {
     if is_empty::is_geometry_empty(geom).map_err(|e| DataFusionError::Execution(e.to_string()))? {
         write_geometry(writer, &Polygon::<f64>::empty(), &write_opts())
             .map_err(|e| DataFusionError::Execution(e.to_string()))?;
         return Ok(());
     }
-    compute_and_write_hull(&normalize_geometry(geom)?, pct_convex, writer)
+    compute_and_write_hull(&normalize_geometry(geom)?, options, writer)
 }
 
 fn write_opts() -> WriteOptions {
@@ -146,7 +159,7 @@ fn normalize_geometry(geom: &Wkb) -> Result<Geometry> {
 
 fn compute_and_write_hull(
     geom: &Geometry,
-    pct_convex: f64,
+    options: ConcaveHullOptions<f64>,
     writer: &mut impl std::io::Write,
 ) -> Result<()> {
     match geom.as_type() {
@@ -160,27 +173,27 @@ fn compute_and_write_hull(
                     .copied()
                     .collect::<Vec<Point>>(),
             )
-            .concave_hull(pct_convex);
+            .concave_hull_with_options(options);
             write_concave_hull(writer, hull)?;
         }
 
         geo_traits::GeometryType::LineString(ls) => {
-            let hull = ls.concave_hull(pct_convex);
+            let hull = ls.concave_hull_with_options(options);
             write_concave_hull(writer, hull)?;
         }
 
         geo_traits::GeometryType::Polygon(pgn) => {
-            let hull = pgn.concave_hull(pct_convex);
+            let hull = pgn.concave_hull_with_options(options);
             write_concave_hull(writer, hull)?;
         }
 
         geo_traits::GeometryType::MultiLineString(mls) => {
-            let hull = mls.concave_hull(pct_convex);
+            let hull = mls.concave_hull_with_options(options);
             write_concave_hull(writer, hull)?;
         }
 
         geo_traits::GeometryType::MultiPolygon(mpgn) => {
-            let hull = mpgn.concave_hull(pct_convex);
+            let hull = mpgn.concave_hull_with_options(options);
             write_concave_hull(writer, hull)?;
         }
 
@@ -194,7 +207,7 @@ fn compute_and_write_hull(
                 coords.into_iter().map(geo_types::Point::from).collect(),
             );
 
-            let hull = multi_point.concave_hull(pct_convex);
+            let hull = multi_point.concave_hull_with_options(options);
             write_concave_hull(writer, hull)?;
         }
 
@@ -327,11 +340,11 @@ mod tests {
             ),
             (
                 "MULTIPOINT ((0 0), (10 0), (0 10), (10 10), (5 5))",
-                "POLYGON ((10 0, 10 10, 0 10, 0 0, 5 5, 10 0))",
+                "POLYGON ((10 0, 10 10, 0 10, 0 0, 10 0))",
             ),
             (
                 "MULTILINESTRING ((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10))",
-                "POLYGON ((20 20, 10 40, 30 30, 40 40, 40 20, 30 10, 10 10, 20 20))",
+                "POLYGON ((30 10, 40 20, 40 40, 10 40, 10 10, 30 10))",
             ),
             (
                 "MULTIPOLYGON (((2 2, 2 5, 5 5, 5 2, 2 2)), ((6 3, 8 3, 8 1, 6 1, 6 3)))",
@@ -359,7 +372,7 @@ mod tests {
                         GEOMETRYCOLLECTION (LINESTRING(6 6,7 7), POLYGON((8 8,9 9,10 10,8 8)))\
                     )\
                 )",
-                "POLYGON ((10 10, 1 1, 3 3, 3 3, 4 4, 5 5, 8 8, 9 9, 10 10))",
+                "POLYGON ((10 10, 1 1, 10 10))",
             ),
         ];
 
@@ -418,12 +431,12 @@ mod tests {
             (
                 "MULTILINESTRING ((50 150, 50 200), (50 50, 50 100))",
                 0.1,
-                "POLYGON ((50 200, 50 50, 50 100, 50 150, 50 200))",
+                "POLYGON ((50 200, 50 50, 50 200))",
             ),
             (
                 "MULTILINESTRING ((50 150, 50 200), (50 50, 50 100))",
                 0.2,
-                "POLYGON ((50 200, 50 50, 50 100, 50 150, 50 200))",
+                "POLYGON ((50 200, 50 50, 50 200))",
             ),
             // Test MULTIPOLYGON with different pctconvex values
             (
@@ -436,7 +449,7 @@ mod tests {
                 "MULTIPOLYGON (((26 125, 26 200, 126 200, 126 125, 26 125 ),\
                     ( 51 150, 101 150, 76 175, 51 150 )), (( 151 100, 151 200, 176 175, 151 100 )))",
                 0.4,
-                "POLYGON((151 100,176 175,151 200,26 200,26 125,151 100))"
+                "POLYGON ((151 100, 176 175, 151 200, 126 200, 26 200, 26 125, 126 125, 151 100))"
             ),
             // Test GEOMETRYCOLLECTION with different pctconvex values
             (
@@ -444,14 +457,14 @@ mod tests {
                     GEOMETRYCOLLECTION(POLYGON((3 3,4 4,5 5,3 3)), \
                     GEOMETRYCOLLECTION(LINESTRING(6 6,7 7), POLYGON((8 8,9 9,10 10,8 8)))))",
                 0.1,
-                "POLYGON ((10 10, 1 1, 3 3, 3 3, 4 4, 5 5, 8 8, 9 9, 10 10))"
+                "POLYGON ((10 10, 1 1, 10 10))"
             ),
             (
                 "GEOMETRYCOLLECTION(LINESTRING(1 1,2 2), \
                     GEOMETRYCOLLECTION(POLYGON((3 3,4 4,5 5,3 3)), \
                     GEOMETRYCOLLECTION(LINESTRING(6 6,7 7), POLYGON((8 8,9 9,10 10,8 8)))))",
                 0.6,
-                "POLYGON ((10 10, 1 1, 3 3, 3 3, 4 4, 5 5, 8 8, 9 9, 10 10))"
+                "POLYGON ((10 10, 1 1, 10 10))"
             ),
         ];
 

--- a/rust/sedona-spatial-join/src/index/default_spatial_index.rs
+++ b/rust/sedona-spatial-join/src/index/default_spatial_index.rs
@@ -28,13 +28,10 @@ use arrow_schema::SchemaRef;
 use datafusion_common::{DataFusionError, Result};
 use datafusion_common_runtime::JoinSet;
 use float_next_after::NextAfter;
-use geo::BoundingRect;
+use geo::{coord, BoundingRect, Distance, Euclidean, Geometry, Rect};
 use geo_index::rtree::{
-    distance::{DistanceMetric, GeometryAccessor},
-    util::f64_box_to_f32,
+    sort::HilbertSort, util::f64_box_to_f32, NeighborsOptions, RTree, RTreeBuilder, RTreeIndex,
 };
-use geo_index::rtree::{sort::HilbertSort, RTree, RTreeBuilder, RTreeIndex};
-use geo_index::IndexableNum;
 use parking_lot::Mutex;
 use sedona_expr::statistics::GeoStatistics;
 use sedona_geo::to_geo::item_to_geometry;
@@ -339,30 +336,32 @@ impl SpatialIndex for DefaultSpatialIndex {
             }
         };
 
-        // Select the appropriate distance metric
-        let distance_metric: &dyn DistanceMetric<f32> = {
-            let Some(knn_components) = self.inner.knn_components.as_ref() else {
-                return sedona_internal_err!(
-                    "knn_components is not initialized when running KNN join"
-                );
-            };
-            if use_spheroid {
-                &knn_components.haversine_metric
-            } else {
-                &knn_components.euclidean_metric
-            }
-        };
-
         // Create geometry accessor for on-demand WKB decoding and caching
         let geometry_accessor = self.create_knn_accessor()?;
 
-        // Use neighbors_geometry to find k nearest neighbors
-        let initial_results = self.inner.rtree.neighbors_geometry(
-            &probe_geom,
-            Some(k as usize),
-            None, // no max_distance filter
-            distance_metric,
-            &geometry_accessor,
+        // Use dependency-free callbacks from geo-index. A zero lower bound is required for
+        // spherical distances because planar longitude/latitude boxes do not provide a valid
+        // Haversine lower bound. Planar queries use the exact geometry-to-rectangle distance.
+        let initial_results = self.inner.rtree.neighbors_with_callbacks(
+            NeighborsOptions {
+                k: Some(k as usize),
+                max_distance: None,
+                include_tie_breakers: false,
+            },
+            |[min_x, min_y, max_x, max_y]| {
+                if use_spheroid {
+                    0.0
+                } else {
+                    let bbox = Geometry::Rect(Rect::new(
+                        coord! { x: min_x as f64, y: min_y as f64 },
+                        coord! { x: max_x as f64, y: max_y as f64 },
+                    ));
+                    Euclidean.distance(&probe_geom, &bbox)
+                }
+            },
+            |item_index, _bbox| {
+                geometry_accessor.distance(&probe_geom, item_index as usize, use_spheroid)
+            },
         );
 
         if initial_results.is_empty() {
@@ -372,7 +371,10 @@ impl SpatialIndex for DefaultSpatialIndex {
             });
         }
 
-        let mut final_results = initial_results;
+        let mut final_results: Vec<u32> = initial_results
+            .into_iter()
+            .map(|(index, _)| index)
+            .collect();
         let mut candidate_count = final_results.len();
 
         // Handle tie-breakers if enabled
@@ -382,11 +384,10 @@ impl SpatialIndex for DefaultSpatialIndex {
 
             for &result_idx in &final_results {
                 if (result_idx as usize) < self.inner.data_id_to_batch_pos.len() {
-                    if let Some(item_geom) = geometry_accessor.get_geometry(result_idx as usize) {
-                        let distance = distance_metric.distance_to_geometry(&probe_geom, item_geom);
-                        if let Some(distance_f64) = distance.to_f64() {
-                            distances_with_indices.push((distance_f64, result_idx));
-                        }
+                    if let Some(distance_f64) =
+                        geometry_accessor.distance(&probe_geom, result_idx as usize, use_spheroid)
+                    {
+                        distances_with_indices.push((distance_f64, result_idx));
                     }
                 }
             }
@@ -437,13 +438,12 @@ impl SpatialIndex for DefaultSpatialIndex {
 
                 for &result_idx in &expanded_results {
                     if (result_idx as usize) < self.inner.data_id_to_batch_pos.len() {
-                        if let Some(item_geom) = geometry_accessor.get_geometry(result_idx as usize)
-                        {
-                            let distance =
-                                distance_metric.distance_to_geometry(&probe_geom, item_geom);
-                            if let Some(distance_f64) = distance.to_f64() {
-                                all_distances_with_indices.push((distance_f64, result_idx));
-                            }
+                        if let Some(distance_f64) = geometry_accessor.distance(
+                            &probe_geom,
+                            result_idx as usize,
+                            use_spheroid,
+                        ) {
+                            all_distances_with_indices.push((distance_f64, result_idx));
                         }
                     }
                 }
@@ -483,13 +483,9 @@ impl SpatialIndex for DefaultSpatialIndex {
                 build_batch_positions.push(self.inner.data_id_to_batch_pos[result_idx as usize]);
 
                 if let Some(dists) = distances.as_mut() {
-                    let mut dist = f64::NAN;
-                    if let Some(item_geom) = geometry_accessor.get_geometry(result_idx as usize) {
-                        dist = distance_metric
-                            .distance_to_geometry(&probe_geom, item_geom)
-                            .to_f64()
-                            .unwrap_or(f64::NAN);
-                    }
+                    let dist = geometry_accessor
+                        .distance(&probe_geom, result_idx as usize, use_spheroid)
+                        .unwrap_or(f64::NAN);
                     dists.push(dist);
                 }
             }

--- a/rust/sedona-spatial-join/src/index/knn_adapter.rs
+++ b/rust/sedona-spatial-join/src/index/knn_adapter.rs
@@ -17,7 +17,7 @@
 
 use once_cell::sync::OnceCell;
 
-use geo_index::rtree::distance::{EuclideanDistance, GeometryAccessor, HaversineDistance};
+use geo::{Centroid, Distance, Euclidean, Haversine};
 use geo_types::Geometry;
 use sedona_expr::statistics::GeoStatistics;
 use sedona_geo::to_geo::item_to_geometry;
@@ -26,8 +26,6 @@ use crate::evaluated_batch::EvaluatedBatch;
 
 /// Shared KNN components that can be reused across queries
 pub(crate) struct KnnComponents {
-    pub euclidean_metric: EuclideanDistance,
-    pub haversine_metric: HaversineDistance,
     /// Pre-allocated vector for geometry cache - lock-free access
     /// Indexed by rtree data index for O(1) access
     geometry_cache: Vec<OnceCell<Geometry<f64>>>,
@@ -50,8 +48,6 @@ impl KnnComponents {
         }
 
         Ok(Self {
-            euclidean_metric: EuclideanDistance,
-            haversine_metric: HaversineDistance::default(),
             geometry_cache,
             estimated_memory_usage: total_wkb_size,
         })
@@ -90,11 +86,9 @@ impl<'a> SedonaKnnAdapter<'a> {
             knn_components,
         }
     }
-}
 
-impl<'a> GeometryAccessor for SedonaKnnAdapter<'a> {
     /// Get geometry for the given item index with lock-free caching
-    fn get_geometry(&self, item_index: usize) -> Option<&Geometry<f64>> {
+    pub fn get_geometry(&self, item_index: usize) -> Option<&Geometry<f64>> {
         let geometry_cache = &self.knn_components.geometry_cache;
 
         // Bounds check
@@ -122,5 +116,21 @@ impl<'a> GeometryAccessor for SedonaKnnAdapter<'a> {
 
         // Failed to decode - don't cache invalid results
         None
+    }
+
+    pub fn distance(
+        &self,
+        probe: &Geometry<f64>,
+        item_index: usize,
+        use_spheroid: bool,
+    ) -> Option<f64> {
+        let item = self.get_geometry(item_index)?;
+        if use_spheroid {
+            let probe_centroid = probe.centroid()?;
+            let item_centroid = item.centroid()?;
+            Some(Haversine.distance(probe_centroid, item_centroid))
+        } else {
+            Some(Euclidean.distance(probe, item))
+        }
     }
 }


### PR DESCRIPTION
Uses the dependency-free ranked-query callbacks from georust/geo-index#161, pinned to its current commit, to remove geo-index's geo 0.31 feature. Upgrades geo to 0.33.1, migrates concave-hull options, updates Triangle accessors, and preserves KNN behavior with conservative spherical pruning.

Closes #455
Closes #491
Replaces #566