### PR TITLE
test(python): skip raster helper tests without rasterio

### DIFF
--- a/python/sedonadb/tests/test_raster_testing.py
+++ b/python/sedonadb/tests/test_raster_testing.py
@@ -37,18 +37,21 @@ BBOX = (100.0, 482.0, 114.0, 500.0)
 
 
 def test_write_geotiff_bbox_places_the_grid(tmp_path):
+    pytest.importorskip("rasterio")
     path = tmp_path / "bbox.tif"
     write_random_geotiff(path, "uint8", bands=1, height=6, width=7, bbox=BBOX)
     assert decode_geotiff(path).gdal_transform == (100.0, 2.0, 0.0, 500.0, 0.0, -3.0)
 
 
 def test_decoded_raster_bbox_places_the_grid():
+    pytest.importorskip("rasterio")
     data = np.zeros((1, 6, 7), dtype="uint8")
     by_bbox = DecodedRaster(data, nodata=[None], bbox=BBOX)
     assert by_bbox.gdal_transform == (100.0, 2.0, 0.0, 500.0, 0.0, -3.0)
 
 
 def test_decoded_raster_requires_exactly_one_grid_placement():
+    pytest.importorskip("rasterio")
     data = np.zeros((1, 6, 7), dtype="uint8")
     with pytest.raises(ValueError, match="exactly one"):
         DecodedRaster(data, nodata=[None])
@@ -67,6 +70,7 @@ def test_decoded_raster_requires_nodata():
 
 
 def test_write_geotiff_requires_exactly_one_grid_placement(tmp_path):
+    pytest.importorskip("rasterio")
     data = np.zeros((1, 6, 7), dtype="uint8")
     with pytest.raises(ValueError, match="exactly one"):
         write_geotiff(tmp_path / "neither.tif", data)


### PR DESCRIPTION
## What

Skip the four raster helper tests that require optional rasterio when it is not installed. Keep test_decoded_raster_requires_nodata running because it does not use rasterio.

## Why

The python-wheels workflow installs a reduced dependency set without rasterio. The tests added in #1211 currently fail after wheel builds complete, causing all five core jobs to fail at the final test marker. Standard Python CI installs the test extra, so these tests still run there.

Failing run: https://github.com/apache/sedona-db/actions/runs/33675876705

## Verification

* Without rasterio: 1 passed, 4 skipped
* With rasterio: 5 passed
* Ruff check and format check
* git diff --check