### PR TITLE
test(integration): metadata accessor parity, one module per RS_ function

### DIFF
--- a/integration/spark-parity/test_rs_bandpixeltype.py
+++ b/integration/spark-parity/test_rs_bandpixeltype.py
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_BandPixelType.
+
+Both engines spell the PostGIS-style pixel type names identically for
+every GeoTIFF-expressible dtype, and the band argument addresses the
+band, not the raster.
+"""
+
+import pytest
+
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+
+@pytest.mark.parametrize(
+    "dtype,name",
+    [
+        ("uint8", "UNSIGNED_8BITS"),
+        ("int16", "SIGNED_16BITS"),
+        ("uint16", "UNSIGNED_16BITS"),
+        ("int32", "SIGNED_32BITS"),
+        ("float32", "REAL_32BITS"),
+        ("float64", "REAL_64BITS"),
+    ],
+)
+def test_rs_bandpixeltype(dtype, name, tmp_path):
+    """Each dtype's pixel-type name reads back identically from both engines."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view(
+            "ptype_src", tmp_path / "ptype_src.tif", bands=1, dtype=dtype
+        )
+    sql = "SELECT RS_BandPixelType(rast, 1) FROM ptype_src"
+    compare(sql, sedona, spark, expected=name)
+
+
+def test_rs_bandpixeltype_band_2(tmp_path):
+    """The band argument resolves on a multi-band raster in both engines."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("ptype2_src", tmp_path / "ptype2_src.tif")
+    sql = "SELECT RS_BandPixelType(rast, 2) FROM ptype2_src"
+    compare(sql, sedona, spark, expected="UNSIGNED_8BITS")

--- a/integration/spark-parity/test_rs_height.py
+++ b/integration/spark-parity/test_rs_height.py
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_Height.
+
+Metadata scalars compare raw and exact — probing showed bit-identical
+values on every fixture. One module per RS_ function, anchored
+`compare()` calls as everywhere in this suite.
+"""
+
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+
+def test_rs_height(tmp_path):
+    """The standard 7x6 grid reads back 6 rows from both engines."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("height_src", tmp_path / "height_src.tif")
+    compare("SELECT RS_Height(rast) FROM height_src", sedona, spark, expected=6)

--- a/integration/spark-parity/test_rs_numbands.py
+++ b/integration/spark-parity/test_rs_numbands.py
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_NumBands.
+
+Metadata scalars compare raw and exact — probing showed bit-identical
+values on every fixture. One module per RS_ function, anchored
+`compare()` calls as everywhere in this suite.
+"""
+
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+
+def test_rs_numbands(tmp_path):
+    """Band counts read back exactly for multi- and single-band rasters."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("nb_two_src", tmp_path / "nb_two_src.tif")
+        eng.create_random_raster_view(
+            "nb_one_src", tmp_path / "nb_one_src.tif", bands=1
+        )
+    compare("SELECT RS_NumBands(rast) FROM nb_two_src", sedona, spark, expected=2)
+    compare("SELECT RS_NumBands(rast) FROM nb_one_src", sedona, spark, expected=1)

--- a/integration/spark-parity/test_rs_scalex.py
+++ b/integration/spark-parity/test_rs_scalex.py
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_ScaleX.
+
+Metadata scalars compare raw and exact — probing showed bit-identical
+values on every fixture. One module per RS_ function, anchored
+`compare()` calls as everywhere in this suite.
+"""
+
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+
+def test_rs_scalex(tmp_path):
+    """The standard grid's 2-unit pixel width reads back from both engines."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("scalex_src", tmp_path / "scalex_src.tif")
+    compare("SELECT RS_ScaleX(rast) FROM scalex_src", sedona, spark, expected=2.0)

--- a/integration/spark-parity/test_rs_scaley.py
+++ b/integration/spark-parity/test_rs_scaley.py
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_ScaleY.
+
+Metadata scalars compare raw and exact — probing showed bit-identical
+values on every fixture. One module per RS_ function, anchored
+`compare()` calls as everywhere in this suite.
+"""
+
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+
+def test_rs_scaley(tmp_path):
+    """North-up reads the negative scale, bottom-up the positive one."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("scaley_src", tmp_path / "scaley_src.tif")
+        eng.create_random_raster_view(
+            "scaley_south_src",
+            tmp_path / "scaley_south_src.tif",
+            gdal_transform=(100.0, 2.0, 0.0, 482.0, 0.0, 3.0),
+        )
+    compare("SELECT RS_ScaleY(rast) FROM scaley_src", sedona, spark, expected=-3.0)
+    compare("SELECT RS_ScaleY(rast) FROM scaley_south_src", sedona, spark, expected=3.0)

--- a/integration/spark-parity/test_rs_skewx.py
+++ b/integration/spark-parity/test_rs_skewx.py
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_SkewX.
+
+Metadata scalars compare raw and exact — probing showed bit-identical
+values on every fixture. One module per RS_ function, anchored
+`compare()` calls as everywhere in this suite.
+"""
+
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+
+def test_rs_skewx(tmp_path):
+    """Zero on the standard grid; the sheared grid's 0.5 reads back exactly."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("skewx_src", tmp_path / "skewx_src.tif")
+        eng.create_random_raster_view(
+            "skewx_rot_src",
+            tmp_path / "skewx_rot_src.tif",
+            gdal_transform=(100.0, 2.0, 0.5, 500.0, 0.25, -3.0),
+        )
+    compare("SELECT RS_SkewX(rast) FROM skewx_src", sedona, spark, expected=0.0)
+    compare("SELECT RS_SkewX(rast) FROM skewx_rot_src", sedona, spark, expected=0.5)

--- a/integration/spark-parity/test_rs_skewy.py
+++ b/integration/spark-parity/test_rs_skewy.py
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_SkewY.
+
+Metadata scalars compare raw and exact — probing showed bit-identical
+values on every fixture. One module per RS_ function, anchored
+`compare()` calls as everywhere in this suite.
+"""
+
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+
+def test_rs_skewy(tmp_path):
+    """Zero on the standard grid; the sheared grid's 0.25 reads back exactly."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("skewy_src", tmp_path / "skewy_src.tif")
+        eng.create_random_raster_view(
+            "skewy_rot_src",
+            tmp_path / "skewy_rot_src.tif",
+            gdal_transform=(100.0, 2.0, 0.5, 500.0, 0.25, -3.0),
+        )
+    compare("SELECT RS_SkewY(rast) FROM skewy_src", sedona, spark, expected=0.0)
+    compare("SELECT RS_SkewY(rast) FROM skewy_rot_src", sedona, spark, expected=0.25)

--- a/integration/spark-parity/test_rs_srid.py
+++ b/integration/spark-parity/test_rs_srid.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_SRID.
+
+Metadata scalars compare raw and exact — probing showed bit-identical
+values on every fixture. One module per RS_ function, anchored
+`compare()` calls as everywhere in this suite.
+"""
+
+from sedonadb.raster_testing import write_random_geotiff
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+
+def test_rs_srid(tmp_path):
+    """A CRS-less raster reads SRID 0; an EPSG:3857 raster reads 3857."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("srid_none_src", tmp_path / "srid_none_src.tif")
+    path = tmp_path / "srid_3857_src.tif"
+    write_random_geotiff(
+        path,
+        "uint8",
+        bands=1,
+        height=6,
+        width=7,
+        bbox=(100.0, 482.0, 114.0, 500.0),
+        crs="EPSG:3857",
+    )
+    for eng in (sedona, spark):
+        eng.create_raster_view("srid_3857_src", path)
+    compare("SELECT RS_SRID(rast) FROM srid_none_src", sedona, spark, expected=0)
+    compare("SELECT RS_SRID(rast) FROM srid_3857_src", sedona, spark, expected=3857)

--- a/integration/spark-parity/test_rs_upperleftx.py
+++ b/integration/spark-parity/test_rs_upperleftx.py
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_UpperLeftX.
+
+Metadata scalars compare raw and exact — probing showed bit-identical
+values on every fixture. One module per RS_ function, anchored
+`compare()` calls as everywhere in this suite.
+"""
+
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+
+def test_rs_upperleftx(tmp_path):
+    """The standard grid's origin x reads back from both engines."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("ulx_src", tmp_path / "ulx_src.tif")
+    compare("SELECT RS_UpperLeftX(rast) FROM ulx_src", sedona, spark, expected=100.0)

--- a/integration/spark-parity/test_rs_upperlefty.py
+++ b/integration/spark-parity/test_rs_upperlefty.py
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_UpperLeftY.
+
+Metadata scalars compare raw and exact — probing showed bit-identical
+values on every fixture. One module per RS_ function, anchored
+`compare()` calls as everywhere in this suite.
+"""
+
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+
+def test_rs_upperlefty(tmp_path):
+    """North-up anchors the top edge (500); bottom-up the bottom edge (482)."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("uly_src", tmp_path / "uly_src.tif")
+        eng.create_random_raster_view(
+            "uly_south_src",
+            tmp_path / "uly_south_src.tif",
+            gdal_transform=(100.0, 2.0, 0.0, 482.0, 0.0, 3.0),
+        )
+    compare("SELECT RS_UpperLeftY(rast) FROM uly_src", sedona, spark, expected=500.0)
+    compare(
+        "SELECT RS_UpperLeftY(rast) FROM uly_south_src", sedona, spark, expected=482.0
+    )

--- a/integration/spark-parity/test_rs_width.py
+++ b/integration/spark-parity/test_rs_width.py
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_Width.
+
+Metadata scalars compare raw and exact — probing showed bit-identical
+values on every fixture. One module per RS_ function, anchored
+`compare()` calls as everywhere in this suite.
+"""
+
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+
+def test_rs_width(tmp_path):
+    """The standard 7x6 grid reads back 7 columns from both engines."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("width_src", tmp_path / "width_src.tif")
+    compare("SELECT RS_Width(rast) FROM width_src", sedona, spark, expected=7)


### PR DESCRIPTION
Probe-first parity for the eleven metadata scalar accessors (RS_Width, RS_Height, RS_NumBands, RS_ScaleX/Y, RS_SkewX/Y, RS_UpperLeftX/Y, RS_SRID, RS_BandPixelType), one module per function, RS-only SQL. Every value probed bit-identical across engines — standard, sheared (raw-transform), bottom-up, and EPSG:3857 fixtures; pixel-type names identical for all six GeoTIFF dtypes; band addressing checked on band 2. `17 passed`, all anchored, no xfails or tolerances. Locally verified with pyspark 4.0.4 + Sedona 1.9.1; CI runs the parity lane.