### PR TITLE
test(integration): coordinate mapper parity, a pure divergence catalog

### DIFF
--- a/integration/spark-parity/test_rs_rastertoworldcoordx.py
+++ b/integration/spark-parity/test_rs_rastertoworldcoordx.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_RasterToWorldCoordX.
+
+Every case is a cataloged divergence: SedonaDB treats pixel coordinates
+as 0-based where Sedona Spark (following PostGIS, and SedonaDB's own
+RS_PixelAs* functions) is 1-based, so results are exactly one pixel
+apart everywhere, extrapolation included (apache/sedona-db#1235). The
+geometry-returning combined form is deferred until the harness can
+compare geometry columns without ST_ wrappers.
+"""
+
+import pytest
+
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+
+@pytest.mark.parametrize(
+    "px,py",
+    [pytest.param(1, 1, id="origin"), pytest.param(9, 9, id="outside")],
+)
+@pytest.mark.xfail(
+    reason="SedonaDB maps pixel coordinates 0-based (returns 102 for pixel "
+    "(1, 1)); Sedona Spark is 1-based (returns 100) — apache/sedona-db#1235"
+)
+def test_rs_rastertoworldcoordx(px, py, tmp_path):
+    """Pixel (1, 1) is the upper-left corner on both engines."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("r2wx_src", tmp_path / "r2wx_src.tif")
+    sql = f"SELECT RS_RasterToWorldCoordX(rast, {px}, {py}) FROM r2wx_src"
+    compare(sql, sedona, spark)

--- a/integration/spark-parity/test_rs_rastertoworldcoordy.py
+++ b/integration/spark-parity/test_rs_rastertoworldcoordy.py
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_RasterToWorldCoordY.
+
+Every case is a cataloged divergence: SedonaDB treats pixel coordinates
+as 0-based where Sedona Spark (following PostGIS, and SedonaDB's own
+RS_PixelAs* functions) is 1-based, so results are exactly one pixel
+apart everywhere, extrapolation included (apache/sedona-db#1235). The
+geometry-returning combined form is deferred until the harness can
+compare geometry columns without ST_ wrappers.
+"""
+
+import pytest
+
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+
+@pytest.mark.xfail(
+    reason="SedonaDB maps pixel coordinates 0-based (returns 497 for pixel "
+    "(1, 1)); Sedona Spark is 1-based (returns 500) — apache/sedona-db#1235"
+)
+def test_rs_rastertoworldcoordy(tmp_path):
+    """Pixel (1, 1) is the upper-left corner on both engines."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("r2wy_src", tmp_path / "r2wy_src.tif")
+    sql = "SELECT RS_RasterToWorldCoordY(rast, 1, 1) FROM r2wy_src"
+    compare(sql, sedona, spark)

--- a/integration/spark-parity/test_rs_worldtorastercoordx.py
+++ b/integration/spark-parity/test_rs_worldtorastercoordx.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_WorldToRasterCoordX.
+
+Every case is a cataloged divergence: SedonaDB treats pixel coordinates
+as 0-based where Sedona Spark (following PostGIS, and SedonaDB's own
+RS_PixelAs* functions) is 1-based, so results are exactly one pixel
+apart everywhere, extrapolation included (apache/sedona-db#1235). The
+geometry-returning combined form is deferred until the harness can
+compare geometry columns without ST_ wrappers.
+"""
+
+import pytest
+
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+
+@pytest.mark.parametrize(
+    "x,y",
+    [pytest.param(100.0, 500.0, id="origin"), pytest.param(90.0, 505.0, id="outside")],
+)
+@pytest.mark.xfail(
+    reason="SedonaDB maps pixel coordinates 0-based (the origin is column 0); "
+    "Sedona Spark is 1-based (column 1) — apache/sedona-db#1235"
+)
+def test_rs_worldtorastercoordx(x, y, tmp_path):
+    """The origin corner maps to the first column on both engines."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("w2rx_src", tmp_path / "w2rx_src.tif")
+    sql = f"SELECT RS_WorldToRasterCoordX(rast, {x}, {y}) FROM w2rx_src"
+    compare(sql, sedona, spark)

--- a/integration/spark-parity/test_rs_worldtorastercoordy.py
+++ b/integration/spark-parity/test_rs_worldtorastercoordy.py
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_WorldToRasterCoordY.
+
+Every case is a cataloged divergence: SedonaDB treats pixel coordinates
+as 0-based where Sedona Spark (following PostGIS, and SedonaDB's own
+RS_PixelAs* functions) is 1-based, so results are exactly one pixel
+apart everywhere, extrapolation included (apache/sedona-db#1235). The
+geometry-returning combined form is deferred until the harness can
+compare geometry columns without ST_ wrappers.
+"""
+
+import pytest
+
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+
+@pytest.mark.xfail(
+    reason="SedonaDB maps pixel coordinates 0-based (the origin is row 0); "
+    "Sedona Spark is 1-based (row 1) — apache/sedona-db#1235"
+)
+def test_rs_worldtorastercoordy(tmp_path):
+    """The origin corner maps to the first row on both engines."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("w2ry_src", tmp_path / "w2ry_src.tif")
+    sql = "SELECT RS_WorldToRasterCoordY(rast, 100.0, 500.0) FROM w2ry_src"
+    compare(sql, sedona, spark)


### PR DESCRIPTION
Probe-first coverage for RS_RasterToWorldCoordX/Y and RS_WorldToRasterCoordX/Y, one module per function — and every case is a cataloged xfail: SedonaDB maps pixel coordinates 0-based where Sedona Spark (following PostGIS, and consistent with SedonaDB's own 1-based RS_PixelAs*) is 1-based, so every result sits exactly one pixel apart, extrapolation outside the grid included. #1235 tracks the decision (align to 1-based, or document 0-basing loudly); when it resolves these xfails flip to anchored passing tests. `6 xfailed`, nothing passes by design; CI runs the parity lane.