### PR TITLE
test(integration): RS_SetSRID, RS_SetGeoReference, RS_SetCRS, and RS_CRS parity

### DIFF
--- a/integration/spark-parity/test_rs_crs.py
+++ b/integration/spark-parity/test_rs_crs.py
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_CRS.
+
+A pure divergence catalog: the engines serialize a CRS differently by
+design (SedonaDB emits PROJJSON, or a short authority code for an
+SRID-set raster; Sedona Spark emits GeoTools' JSON), and they disagree
+on the CRS-less answer, so every case is an xfail stating both observed
+behaviors.
+"""
+
+import pytest
+
+from sedonadb.raster_testing import write_random_geotiff
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+
+@pytest.mark.xfail(
+    reason="a CRS-less raster reads '0' from SedonaDB and NULL from Sedona Spark"
+)
+def test_rs_crs_crsless(tmp_path):
+    """A CRS-less raster reads the same from both engines."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("crs_none_src", tmp_path / "crs_none_src.tif")
+    compare("SELECT RS_CRS(rast) FROM crs_none_src", sedona, spark)
+
+
+@pytest.mark.xfail(
+    reason="the serializations differ by design: SedonaDB emits PROJJSON "
+    "where Sedona Spark emits GeoTools' JSON"
+)
+def test_rs_crs_projected(tmp_path):
+    """An EPSG:3857 raster's CRS reads the same from both engines."""
+    path = tmp_path / "crs_3857_src.tif"
+    write_random_geotiff(
+        path,
+        "uint8",
+        bands=1,
+        height=6,
+        width=7,
+        bbox=(100.0, 482.0, 114.0, 500.0),
+        crs="EPSG:3857",
+    )
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_raster_view("crs_3857_src", path)
+    compare("SELECT RS_CRS(rast) FROM crs_3857_src", sedona, spark)
+
+
+@pytest.mark.xfail(
+    reason="after RS_SetSRID(4326) SedonaDB reads back the short authority "
+    "code 'OGC:CRS84' where Sedona Spark emits GeoTools' JSON for EPSG:4326"
+)
+def test_rs_crs_after_setsrid(tmp_path):
+    """The CRS set through RS_SetSRID reads back the same from both engines."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("crs_set_src", tmp_path / "crs_set_src.tif")
+    compare("SELECT RS_CRS(RS_SetSRID(rast, 4326)) FROM crs_set_src", sedona, spark)

--- a/integration/spark-parity/test_rs_setcrs.py
+++ b/integration/spark-parity/test_rs_setcrs.py
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_SetCRS.
+
+The authority-code form resolves identically on both engines — pinned
+through RS_SRID, since RS_CRS's serializations differ by design (see
+test_rs_crs.py) — and the raster passes through untouched.
+"""
+
+from sedonadb.raster_testing import DecodedRaster
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+
+def test_rs_setcrs(tmp_path):
+    """Setting a CRS by authority code reads back the same SRID from both
+    engines, and the raster passes through untouched."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("setcrs_src", tmp_path / "setcrs_src.tif")
+    compare(
+        "SELECT RS_SRID(RS_SetCRS(rast, 'EPSG:4326')) FROM setcrs_src",
+        sedona,
+        spark,
+        expected=4326,
+    )
+    compare(
+        "SELECT RS_SetCRS(rast, 'EPSG:4326') FROM setcrs_src",
+        sedona,
+        spark,
+        expected=DecodedRaster.random(),
+    )

--- a/integration/spark-parity/test_rs_setcrs.py
+++ b/integration/spark-parity/test_rs_setcrs.py
@@ -21,6 +21,8 @@ through RS_SRID, since RS_CRS's serializations differ by design (see
 test_rs_crs.py) — and the raster passes through untouched.
 """
 
+import pytest
+
 from sedonadb.raster_testing import DecodedRaster
 from sedonadb.testing import SedonaDB, compare
 from sedonadb.testing_spark import SedonaSpark
@@ -44,3 +46,100 @@ def test_rs_setcrs(tmp_path):
         spark,
         expected=DecodedRaster.random(),
     )
+
+
+# CRS WKT inputs: WKT1 and WKT2 spellings of EPSG:4326 carrying an authority
+# identifier, the same WKT1 stripped of every AUTHORITY, and a custom CRS no
+# authority could describe.
+WKT1_AUTHORITY = (
+    'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,'
+    '298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],'
+    'PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",'
+    '0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]'
+)
+WKT2_ID = (
+    'GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID['
+    '"WGS 84",6378137,298.257223563]],CS[ellipsoidal,2],AXIS["latitude",'
+    'north],AXIS["longitude",east],ANGLEUNIT["degree",0.0174532925199433],'
+    'ID["EPSG",4326]]'
+)
+WKT1_NO_AUTHORITY = (
+    'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,'
+    '298.257223563]],PRIMEM["Greenwich",0],UNIT["degree",'
+    "0.0174532925199433]]"
+)
+WKT1_CUSTOM = (
+    'GEOGCS["Custom Sphere",DATUM["Custom",SPHEROID["Sphere",6371000,0]],'
+    'PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]]'
+)
+
+
+def _engines(name, tmp_path):
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view(name, tmp_path / f"{name}.tif")
+    return sedona, spark
+
+
+@pytest.mark.parametrize(
+    "wkt",
+    [
+        pytest.param(WKT1_AUTHORITY, id="wkt1-authority"),
+        pytest.param(WKT2_ID, id="wkt2-id"),
+    ],
+)
+def test_rs_setcrs_wkt_with_authority(wkt, tmp_path):
+    """A CRS WKT carrying an authority identifier — WKT1 AUTHORITY or WKT2
+    ID — resolves to the same SRID on both engines."""
+    sedona, spark = _engines("setcrs_wkt_src", tmp_path)
+    sql = f"SELECT RS_SRID(RS_SetCRS(rast, '{wkt}')) FROM setcrs_wkt_src"
+    compare(sql, sedona, spark, expected=4326)
+
+
+@pytest.mark.parametrize(
+    "wkt",
+    [
+        pytest.param(WKT1_NO_AUTHORITY, id="no-authority"),
+        pytest.param(WKT1_CUSTOM, id="custom"),
+    ],
+)
+@pytest.mark.xfail(
+    reason="an authority-less CRS reads back through RS_SRID as an error on "
+    "SedonaDB ('Can't extract SRID from item-level CRS') and as 0 on "
+    "Sedona Spark"
+)
+def test_rs_setcrs_wkt_without_authority_srid(wkt, tmp_path):
+    """A CRS WKT without an authority reads back the same SRID from both
+    engines."""
+    sedona, spark = _engines("setcrs_noauth_src", tmp_path)
+    sql = f"SELECT RS_SRID(RS_SetCRS(rast, '{wkt}')) FROM setcrs_noauth_src"
+    compare(sql, sedona, spark)
+
+
+@pytest.mark.parametrize(
+    "wkt",
+    [
+        pytest.param(WKT1_AUTHORITY, id="authority"),
+        pytest.param(WKT1_CUSTOM, id="custom"),
+    ],
+)
+@pytest.mark.xfail(
+    reason="the RS_CRS serializations differ by design: SedonaDB echoes the "
+    "stored WKT1 verbatim (authority-less CRSs included) where Sedona Spark "
+    "re-serializes as GeoTools' JSON — see test_rs_crs.py"
+)
+def test_rs_setcrs_wkt_crs_readback(wkt, tmp_path):
+    """A WKT-set CRS reads back through RS_CRS the same from both engines."""
+    sedona, spark = _engines("setcrs_crsrb_src", tmp_path)
+    sql = f"SELECT RS_CRS(RS_SetCRS(rast, '{wkt}')) FROM setcrs_crsrb_src"
+    compare(sql, sedona, spark)
+
+
+def test_rs_setcrs_garbage_rejected(tmp_path):
+    """Both engines refuse a string that is no CRS at all. Parity on
+    refusal."""
+    sedona, spark = _engines("setcrs_bad_src", tmp_path)
+    sql = "SELECT RS_SRID(RS_SetCRS(rast, 'NOT A CRS')) FROM setcrs_bad_src"
+    for eng in (sedona, spark):
+        with pytest.raises(Exception):
+            eng.result_to_tuples(eng.execute_and_collect(sql))

--- a/integration/spark-parity/test_rs_setgeoreference.py
+++ b/integration/spark-parity/test_rs_setgeoreference.py
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_SetGeoReference.
+
+The georeference string is `scaleX skewY skewX scaleY upperLeftX
+upperLeftY` (world-file order). Both engines parse the 2-argument form,
+the explicit GDAL format, and the ESRI format (which reads the origin as
+the centre of the upper-left pixel, shifting it by half a pixel)
+identically, and pixels pass through untouched — anchored with the full
+decoded raster.
+"""
+
+import pytest
+
+from sedonadb.raster_testing import DecodedRaster, random_raster_data
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+# "3 0 0 -4 90 480": 3x4 pixels, origin (90, 480).
+GEOREF = "3 0 0 -4 90 480"
+
+
+@pytest.mark.parametrize(
+    "args,transform",
+    [
+        pytest.param("", (90.0, 3.0, 0.0, 480.0, 0.0, -4.0), id="2-arg"),
+        pytest.param(", 'GDAL'", (90.0, 3.0, 0.0, 480.0, 0.0, -4.0), id="gdal"),
+        # ESRI reads the origin as the centre of the upper-left pixel, so the
+        # corner shifts back by half a pixel: (90 - 3/2, 480 - (-4)/2).
+        pytest.param(", 'ESRI'", (88.5, 3.0, 0.0, 482.0, 0.0, -4.0), id="esri"),
+    ],
+)
+def test_rs_setgeoreference(args, transform, tmp_path):
+    """Every format spelling re-grids the raster identically on both engines,
+    pixels untouched."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("geo_set_src", tmp_path / "geo_set_src.tif")
+    sql = f"SELECT RS_SetGeoReference(rast, '{GEOREF}'{args}) FROM geo_set_src"
+    anchor = DecodedRaster(
+        random_raster_data("uint8", bands=2, height=6, width=7),
+        gdal_transform=transform,
+        nodata=[None, None],
+    )
+    compare(sql, sedona, spark, expected=anchor)

--- a/integration/spark-parity/test_rs_setgeoreference.py
+++ b/integration/spark-parity/test_rs_setgeoreference.py
@@ -57,3 +57,66 @@ def test_rs_setgeoreference(args, transform, tmp_path):
         nodata=[None, None],
     )
     compare(sql, sedona, spark, expected=anchor)
+
+
+# World-file order with skew: scaleX=2, skewY=0.25, skewX=0.5, scaleY=-3.
+SKEWED = "2 0.25 0.5 -3 100 500"
+
+
+@pytest.mark.parametrize(
+    "args", [pytest.param("", id="2-arg"), pytest.param(", 'GDAL'", id="gdal")]
+)
+def test_rs_setgeoreference_skew(args, tmp_path):
+    """Skew terms land in the right transform slots on both engines."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("geo_skew_src", tmp_path / "geo_skew_src.tif")
+    sql = f"SELECT RS_SetGeoReference(rast, '{SKEWED}'{args}) FROM geo_skew_src"
+    anchor = DecodedRaster(
+        random_raster_data("uint8", bands=2, height=6, width=7),
+        gdal_transform=(100.0, 2.0, 0.5, 500.0, 0.25, -3.0),
+        nodata=[None, None],
+    )
+    compare(sql, sedona, spark, expected=anchor)
+
+
+@pytest.mark.xfail(
+    reason="the ESRI centre-to-corner shift diverges under skew: SedonaDB "
+    "applies the full affine half-pixel offset (corner 98.75, 501.375 — "
+    "centre minus half of scale AND skew); Sedona Spark shifts by the scale "
+    "terms only (99, 501.5)"
+)
+def test_rs_setgeoreference_esri_skew(tmp_path):
+    """The ESRI format re-grids a skewed georeference identically on both
+    engines."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("geo_es_src", tmp_path / "geo_es_src.tif")
+    sql = f"SELECT RS_SetGeoReference(rast, '{SKEWED}', 'ESRI') FROM geo_es_src"
+    compare(sql, sedona, spark)
+
+
+@pytest.mark.xfail(
+    reason="a malformed georeference string is rejected by SedonaDB "
+    "('expected 6 whitespace-separated values') but returns NULL from "
+    "Sedona Spark"
+)
+def test_rs_setgeoreference_malformed_string(tmp_path):
+    """A georeference string with the wrong token count gets the same
+    treatment from both engines."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("geo_bad_src", tmp_path / "geo_bad_src.tif")
+    sql = "SELECT RS_ScaleX(RS_SetGeoReference(rast, '1 2 3')) FROM geo_bad_src"
+    compare(sql, sedona, spark)
+
+
+def test_rs_setgeoreference_unknown_format_rejected(tmp_path):
+    """Both engines refuse an unknown format name. Parity on refusal."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("geo_fmt_src", tmp_path / "geo_fmt_src.tif")
+    sql = f"SELECT RS_ScaleX(RS_SetGeoReference(rast, '{SKEWED}', 'WORLD')) FROM geo_fmt_src"
+    for eng in (sedona, spark):
+        with pytest.raises(Exception):
+            eng.result_to_tuples(eng.execute_and_collect(sql))

--- a/integration/spark-parity/test_rs_setsrid.py
+++ b/integration/spark-parity/test_rs_setsrid.py
@@ -21,6 +21,8 @@ to 0), and the raster's pixels, grid, and nodata pass through untouched
 — anchored with the standard raster the fixture registers.
 """
 
+import pytest
+
 from sedonadb.raster_testing import DecodedRaster
 from sedonadb.testing import SedonaDB, compare
 from sedonadb.testing_spark import SedonaSpark
@@ -55,3 +57,42 @@ def test_rs_setsrid_passes_raster_through(tmp_path):
         eng.create_random_raster_view("srid_pt_src", tmp_path / "srid_pt_src.tif")
     sql = "SELECT RS_SetSRID(rast, 4326) FROM srid_pt_src"
     compare(sql, sedona, spark, expected=DecodedRaster.random())
+
+
+def test_rs_setsrid_null_srid_is_null(tmp_path):
+    """A NULL SRID yields a NULL raster (read through RS_SRID as NULL) on
+    both engines."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("srid_null_src", tmp_path / "srid_null_src.tif")
+    sql = "SELECT RS_SRID(RS_SetSRID(rast, CAST(NULL AS INT))) FROM srid_null_src"
+    compare(sql, sedona, spark, expected=[(None,)])
+
+
+def test_rs_setsrid_invalid_srid_rejected(tmp_path):
+    """Both engines refuse a negative SRID. Error types and messages differ,
+    so parity here is parity on refusal."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("srid_neg_src", tmp_path / "srid_neg_src.tif")
+    sql = "SELECT RS_SRID(RS_SetSRID(rast, -5)) FROM srid_neg_src"
+    for eng in (sedona, spark):
+        with pytest.raises(Exception):
+            eng.result_to_tuples(eng.execute_and_collect(sql))
+
+
+@pytest.mark.xfail(
+    reason="the CASE that types the NULL loses the raster extension type in "
+    "SedonaDB, so no kernel matches; Sedona Spark returns NULL"
+)
+def test_rs_setsrid_null_raster(tmp_path):
+    """NULL raster in, NULL out — phrased through CASE because neither
+    dialect types a bare NULL literal as a raster."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("srid_nr_src", tmp_path / "srid_nr_src.tif")
+    sql = (
+        "SELECT RS_SRID(RS_SetSRID(CASE WHEN 1 = 0 THEN rast END, 4326)) "
+        "FROM srid_nr_src"
+    )
+    compare(sql, sedona, spark)

--- a/integration/spark-parity/test_rs_setsrid.py
+++ b/integration/spark-parity/test_rs_setsrid.py
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_SetSRID.
+
+The set SRID reads back through RS_SRID identically (including clearing
+to 0), and the raster's pixels, grid, and nodata pass through untouched
+— anchored with the standard raster the fixture registers.
+"""
+
+from sedonadb.raster_testing import DecodedRaster
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+
+def test_rs_setsrid(tmp_path):
+    """Setting and clearing the SRID reads back through RS_SRID from both
+    engines."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("srid_set_src", tmp_path / "srid_set_src.tif")
+    compare(
+        "SELECT RS_SRID(RS_SetSRID(rast, 4326)) FROM srid_set_src",
+        sedona,
+        spark,
+        expected=4326,
+    )
+    compare(
+        "SELECT RS_SRID(RS_SetSRID(rast, 0)) FROM srid_set_src",
+        sedona,
+        spark,
+        expected=0,
+    )
+
+
+def test_rs_setsrid_passes_raster_through(tmp_path):
+    """RS_SetSRID changes only the CRS: pixels, grid, and nodata come back
+    unchanged. (The decoded comparison carries no CRS — the transport stamps
+    one — so the SRID itself is pinned by the RS_SRID test above.)"""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("srid_pt_src", tmp_path / "srid_pt_src.tif")
+    sql = "SELECT RS_SetSRID(rast, 4326) FROM srid_pt_src"
+    compare(sql, sedona, spark, expected=DecodedRaster.random())


### PR DESCRIPTION
Probe-first parity for the two metadata setters, one module each. RS_SetSRID: set and clear read back through RS_SRID identically, and the raster passes through untouched (anchored with DecodedRaster.random — the CRS itself is pinned by the scalar composition since decoded comparisons carry no CRS). RS_SetGeoReference: the world-file-order string parses identically in the 2-arg, explicit GDAL, and ESRI formats — including ESRI's half-pixel centre-origin shift (88.5/482 from '3 0 0 -4 90 480') — anchored with the full re-gridded DecodedRaster. `5 passed`, no xfails. CI runs the parity lane.

### Skew, NULL, and RS_CRS / RS_SetCRS (per review)

- **Skewed georeferences** (`'2 0.25 0.5 -3 100 500'`): the 2-arg and GDAL forms land every term in the right transform slot on both engines, anchored with the full re-gridded `DecodedRaster`. Two new xfails: the **ESRI centre-to-corner shift diverges under skew** — SedonaDB applies the full affine half-pixel offset (corner `98.75, 501.375`), Sedona Spark shifts by the scale terms only (`99, 501.5`) — and a **malformed string** (wrong token count) is rejected by SedonaDB but returns NULL from Spark. An unknown format name is refused by both (parity-on-refusal).
- **RS_SetSRID NULL cases**: a NULL SRID yields NULL on both (anchored); a negative SRID is refused by both; the NULL-raster-via-CASE case is the suite's known planner xfail.
- **RS_SetCRS** (new module): authority codes resolve identically — pinned through `RS_SRID`, since `RS_CRS`'s serializations differ by design — and the raster passes through untouched, anchored with `DecodedRaster.random`.
- **RS_CRS** (new module): a pure divergence catalog — SedonaDB emits PROJJSON (or the short authority code after `RS_SetSRID`) where Spark emits GeoTools' JSON, and a CRS-less raster reads `'0'` vs NULL.

Now `11 passed, 6 xfailed` across the four modules.

### WKT CRS inputs, with and without an authority (per review)

- **With an authority**: WKT1 (`AUTHORITY["EPSG","4326"]`) and WKT2 (`ID["EPSG",4326]`) both resolve to SRID 4326 on both engines — anchored. (GeoTools parses WKT2 fine.)
- **Without an authority** (the same WKT1 stripped of AUTHORITY clauses, and a custom sphere no authority describes): two xfails, read back through both accessors per review — `RS_SRID` errors on SedonaDB ("Can't extract SRID from item-level CRS") vs 0 on Spark, and `RS_CRS` shows SedonaDB echoing the stored WKT1 verbatim (authority-less included) vs Spark's GeoTools re-serialization.
- A non-CRS string is refused by both (parity-on-refusal).

Now `14 passed, 10 xfailed` across the four modules.