### PR TITLE
feat(python/sedonadb-geopandas): add dissolve

### DIFF
--- a/python/sedonadb-geopandas/README.md
+++ b/python/sedonadb-geopandas/README.md
@@ -34,7 +34,10 @@ big = gdf[gdf["pop"] > 1_000_000]          # boolean-mask filter
 gdf["surveyed"] = True                     # broadcast a scalar column
 gdf["centers"] = gdf.geometry.centroid     # assign a computed column
 web = gdf.to_crs("EPSG:3857")              # reproject (CRS tracked through)
-result = web.to_geopandas()                # back to a real GeoDataFrame
+
+zones = gdf.dissolve(by="region")          # group and union geometry
+
+result = zones.to_geopandas()               # back to a real GeoDataFrame
 ```
 
 ## Intentional differences from GeoPandas
@@ -45,7 +48,9 @@ deliberately *not* identical to GeoPandas:
 - **Lazy, not eager**: operations build a query; data materializes on
   `to_geopandas()` / `to_pandas()` / display.
 - **No row index / alignment**: there is no pandas `Index`; joins and filters
-  are positional/relational, not index-aligned.
+  are positional/relational, not index-aligned. Consequently `dissolve()`
+  leaves the group keys as ordinary columns instead of moving them into the
+  index.
 - **Immutable under the hood**: "in-place" style operations return a new frame.
   A `Series` read from a frame stays usable across assignments that only *add*
   columns (so `g = gdf.geometry` can supply `g.area`, `g.length`, ... in turn),
@@ -61,6 +66,18 @@ deliberately *not* identical to GeoPandas:
   against the destination and silently write the wrong values. Assign a `Series`
   read from the same frame, or a scalar (a geometry included). For anything the
   wrapper does not cover, drop to the SedonaDB `DataFrame` API directly.
+
+`dissolve()` aggregates non-geometry columns with `"first"`, which is an
+unordered aggregate: it returns *some* value from the group rather than the one
+from the first row, and unlike GeoPandas it does not skip missing values, so a
+group containing a null or NaN may aggregate to that. Dissolving an empty frame
+without a group key returns one row — empty geometry collection, null attribute
+values — rather than zero rows, because that is what a grouping-free SQL
+aggregate produces, and a group mixing 2D and 3D geometries raises rather than
+being promoted to 3D. Grouping is observed-only: unused categories of a
+categorical key do not produce empty groups the way GeoPandas' default
+`observed=False` does, because the category domain does not survive a relational
+aggregation.
 
 See the SedonaDB "Migrating from GeoPandas" guide for the relational model that
 underlies each method.

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
@@ -553,17 +553,26 @@ class GeoDataFrame:
                 )
 
         source = self._df
+        # "Missing" has to cover IEEE NaN as well as SQL null: a float column
+        # read from pandas carries NaN, and grouping treats it as an ordinary
+        # value, so a key column holding both would form two missing groups
+        # (and dropna would drop only one of them). NaN is normalized to null
+        # first, in both modes, so the two representations group as one
+        # missing key the way they do in pandas. The gate is null where the
+        # key is NaN and zero elsewhere, and adding it keeps real values and
+        # null keys unchanged.
+        floating = {
+            key: source[key]
+            + source[key].funcs.isnan().funcs.nullif(lit(True)).cast(pa.float64())
+            for key in keys
+            if _is_floating(source, key)
+        }
+        if floating:
+            source = source.mutate(**floating)
         if keys and dropna:
-            # GeoPandas drops rows with a missing group key by default. "Missing"
-            # has to cover IEEE NaN as well as SQL null: a float column read from
-            # pandas carries NaN, and grouping treats it as an ordinary value, so
-            # filtering nulls alone would leave it as its own group.
+            # GeoPandas drops rows with a missing group key by default.
             for key in keys:
-                column = source[key]
-                keep = column.is_not_null()
-                if _is_floating(source, key):
-                    keep = keep & ~column.funcs.isnan()
-                source = source.filter(keep)
+                source = source.filter(source[key].is_not_null())
 
         # Collect each group into one geometry and union it afterwards, rather than
         # using ST_Union_Agg: that aggregate only initializes for polygonal input,

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
@@ -35,6 +35,24 @@ def _geometry_column_names(df):
     return {names[i] for i in df.schema.geometry_column_indices}
 
 
+def _is_floating(df, name):
+    """Whether column `name` holds scalar floating-point values, so it can hold NaN.
+
+    The Arrow datatype is checked rather than its string form: a rendered type such
+    as `list<item: double>` or `struct<x: double>` contains "float"/"double" while
+    being nothing `isnan()` can be applied to, and passing one to `isnan()` fails
+    at planning time. Dictionary encoding is unwrapped — a
+    `dictionary<values=double>` column is floating for NaN purposes, and `isnan()`
+    handles it.
+    """
+    import pyarrow as pa
+
+    dtype = pa.schema(df.schema).field(name).type
+    if pa.types.is_dictionary(dtype):
+        dtype = dtype.value_type
+    return pa.types.is_floating(dtype)
+
+
 def _expr_crs(df, expr):
     """The CRS carried by `expr`, read from a projected schema (a plan build)."""
     field = df.select(expr.alias("x")).schema.field("x")
@@ -461,6 +479,131 @@ class GeoDataFrame:
         transformed = self._df[self._geometry_name].geo.transform(lit(crs))
         new_df = self._df.mutate(**{self._geometry_name: transformed})
         return GeoDataFrame(new_df, self._geometry_name)
+
+    def dissolve(self, by=None, aggfunc="first", dropna=True):
+        """Group rows and union each group's geometry.
+
+        Args:
+            by: Column name, or list of names, to group on. With `None`, every
+                row is dissolved into one.
+            aggfunc: How to aggregate the remaining non-geometry columns.
+                Only `"first"` is currently supported.
+            dropna: Drop rows whose group key is missing, as GeoPandas does.
+
+        Returns:
+            A `GeoDataFrame` with one row per group. Unlike GeoPandas, the group
+            keys stay ordinary columns rather than becoming the index.
+
+        Three remaining differences from GeoPandas:
+
+        - `aggfunc="first"` is an unordered aggregate: it returns *some* value from
+          the group, not necessarily the one from the first row, and it does not
+          skip missing values the way GeoPandas' `first` does. A group containing a
+          null or NaN may therefore aggregate to that value.
+        - Dissolving an empty frame with `by=None` yields one row — empty geometry
+          collection, null attribute values — rather than zero rows, because that
+          is what a grouping-free SQL aggregate returns. Detecting emptiness would
+          require executing the query first.
+        - A group mixing 2D and 3D geometries raises, because the collect step
+          rejects mixed coordinate dimensions; GeoPandas promotes to 3D with NaN.
+          Normalize the dimension first if a group can contain both.
+        - Grouping is observed-only: a categorical key contributes one group per
+          value actually present. GeoPandas defaults to `observed=False` and also
+          emits empty groups for unused categories, but the category domain does
+          not survive a relational aggregation, so those groups cannot be
+          reconstructed here.
+        """
+        if self._geometry_name is None:
+            raise ValueError("dissolve() requires an active geometry column")
+        if aggfunc != "first":
+            raise NotImplementedError(
+                f"dissolve() currently supports aggfunc='first' only, got "
+                f"{aggfunc!r}. Aggregate explicitly with group_by/agg on the "
+                f"underlying SedonaDB DataFrame if you need something else."
+            )
+
+        if by is None:
+            keys = []
+        elif isinstance(by, str):
+            keys = [by]
+        else:
+            keys = list(by)
+            if not keys:
+                # Matches GeoPandas: an explicit empty iterable is almost
+                # certainly a bug, unlike by=None which means dissolve-all.
+                raise ValueError("No group keys passed!")
+
+        unknown = [k for k in keys if k not in self.columns]
+        if unknown:
+            raise KeyError(f"Column(s) {unknown} not found. Columns: {self.columns}")
+
+        import pyarrow as pa
+
+        schema = pa.schema(self._df.schema)
+        for key in keys:
+            ktype = schema.field(key).type
+            if pa.types.is_duration(ktype) or pa.types.is_timestamp(ktype):
+                # pandas missing values arrive from numpy-backed frames as a
+                # sentinel tick that must group as missing, not as a value;
+                # that needs the dedicated temporal handling that arrives as
+                # its own change.
+                raise NotImplementedError(
+                    "dissolve() by a temporal key is not supported yet; "
+                    "temporal support arrives in a follow-up change"
+                )
+
+        source = self._df
+        if keys and dropna:
+            # GeoPandas drops rows with a missing group key by default. "Missing"
+            # has to cover IEEE NaN as well as SQL null: a float column read from
+            # pandas carries NaN, and grouping treats it as an ordinary value, so
+            # filtering nulls alone would leave it as its own group.
+            for key in keys:
+                column = source[key]
+                keep = column.is_not_null()
+                if _is_floating(source, key):
+                    keep = keep & ~column.funcs.isnan()
+                source = source.filter(keep)
+
+        # Collect each group into one geometry and union it afterwards, rather than
+        # using ST_Union_Agg: that aggregate only initializes for polygonal input,
+        # so a group of points or linestrings dissolves to NULL
+        # (apache/sedona-db#1093). Collect-then-unary-union is geometry-general and
+        # also produces the geometry types GeoPandas produces.
+        #
+        # The union is a separate projection because a scalar function wrapped
+        # around an aggregate is not a valid aggregate expression.
+        aggregates = [
+            source[self._geometry_name].geo.collect_agg().alias(self._geometry_name)
+        ]
+        for name in self.columns:
+            if name == self._geometry_name or name in keys:
+                continue
+            aggregates.append(source[name].funcs.first_value().alias(name))
+
+        if keys:
+            collected = source.group_by(*keys).agg(*aggregates)
+        else:
+            collected = source.agg(*aggregates)
+
+        # A group whose geometries are all null unions to null; GeoPandas yields an
+        # empty geometry collection, which behaves differently for isna, is_empty,
+        # predicates, and serialization. Coalescing loses the geometry type, so the
+        # result is re-typed and the source column's CRS re-applied.
+        ctx = self._df._ctx
+        crs = self._df.schema.field(self._geometry_name).type.crs
+        empty = ctx.lit("GEOMETRYCOLLECTION EMPTY").funcs.st_geomfromwkt()
+        geometry_expr = (
+            collected[self._geometry_name]
+            .geo.unary_union()
+            .funcs.coalesce(empty)
+            .funcs.st_geomfromwkb()
+        )
+        if crs is not None:
+            geometry_expr = geometry_expr.funcs.st_setcrs(ctx.lit(crs.to_json()))
+
+        unioned = collected.mutate(**{self._geometry_name: geometry_expr})
+        return GeoDataFrame(unioned, self._geometry_name)
 
     def to_geopandas(self):
         """Execute and return a `geopandas.GeoDataFrame` (or plain DataFrame).

--- a/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
+++ b/python/sedonadb-geopandas/python/sedonadb_geopandas/_frame.py
@@ -280,7 +280,9 @@ class GeoDataFrame:
             self._ancestors = []
         else:
             self._ancestors.append(self._df)
-        self._df = self._df.mutate(**{key: expr})
+        # Positional alias rather than a keyword: a column named "self"
+        # would collide with mutate's own first parameter.
+        self._df = self._df.mutate(expr.alias(key))
 
         # Assignment can change whether the active geometry column is still a
         # geometry: replacing it with a number leaves nothing to be active, and
@@ -477,7 +479,7 @@ class GeoDataFrame:
         if self._geometry_name is None:
             raise ValueError("to_crs() requires an active geometry column")
         transformed = self._df[self._geometry_name].geo.transform(lit(crs))
-        new_df = self._df.mutate(**{self._geometry_name: transformed})
+        new_df = self._df.mutate(transformed.alias(self._geometry_name))
         return GeoDataFrame(new_df, self._geometry_name)
 
     def dissolve(self, by=None, aggfunc="first", dropna=True):
@@ -561,14 +563,21 @@ class GeoDataFrame:
         # missing key the way they do in pandas. The gate is null where the
         # key is NaN and zero elsewhere, and adding it keeps real values and
         # null keys unchanged.
-        floating = {
-            key: source[key]
-            + source[key].funcs.isnan().funcs.nullif(lit(True)).cast(pa.float64())
-            for key in keys
-            if _is_floating(source, key)
-        }
-        if floating:
-            source = source.mutate(**floating)
+        schema = pa.schema(source.schema)
+        normalized = []
+        for key in keys:
+            if _is_floating(source, key):
+                # The gate takes the key's own float type, so a Float32 key
+                # stays Float32 rather than being widened by the addition.
+                ktype = schema.field(key).type
+                if pa.types.is_dictionary(ktype):
+                    ktype = ktype.value_type
+                gate = source[key].funcs.isnan().funcs.nullif(lit(True)).cast(ktype)
+                normalized.append((source[key] + gate).alias(key))
+        if normalized:
+            # Positional aliases rather than keywords: a key named "self"
+            # would collide with mutate's own first parameter.
+            source = source.mutate(*normalized)
         if keys and dropna:
             # GeoPandas drops rows with a missing group key by default.
             for key in keys:
@@ -611,7 +620,7 @@ class GeoDataFrame:
         if crs is not None:
             geometry_expr = geometry_expr.funcs.st_setcrs(ctx.lit(crs.to_json()))
 
-        unioned = collected.mutate(**{self._geometry_name: geometry_expr})
+        unioned = collected.mutate(geometry_expr.alias(self._geometry_name))
         return GeoDataFrame(unioned, self._geometry_name)
 
     def to_geopandas(self):

--- a/python/sedonadb-geopandas/tests/test_geopandas_compat.py
+++ b/python/sedonadb-geopandas/tests/test_geopandas_compat.py
@@ -1489,6 +1489,43 @@ def test_dissolve_groups_null_and_nan_keys_together():
     assert dropped["k"].tolist() == [1.0]
 
 
+def test_dissolve_float32_keys_keep_their_type():
+    # The NaN gate was built as Float64, so adding it widened every Float32
+    # key column, missing values or not; the gate now takes the key's type.
+    tbl = pa.table(
+        {
+            "k": pa.array([1.0, 1.0, float("nan")], pa.float32()),
+            "geometry": ga.as_wkb(["POINT (0 0)", "POINT (1 1)", "POINT (2 2)"]),
+        }
+    )
+    gdf = GeoDataFrame(sgpd.default_context().create_data_frame(tbl))
+    out = gdf.dissolve(by="k", dropna=False)
+    assert pa.schema(out._df.schema).field("k").type == pa.float32()
+    assert len(out.to_geopandas()) == 2
+
+
+def test_columns_named_self_work_everywhere():
+    # Keyword-form mutate(**{name: expr}) collides with mutate's own first
+    # parameter when the column is named "self"; every site now passes a
+    # positional alias. Covers assignment, reprojection, and dissolve keys.
+    tbl = pa.table(
+        {
+            "self": pa.array([1.0, 1.0], pa.float64()),
+            "geometry": ga.as_wkb(["POINT (0 0)", "POINT (1 1)"]),
+        }
+    )
+    gdf = GeoDataFrame(sgpd.default_context().create_data_frame(tbl))
+    gdf["self"] = gdf["self"]
+    assert len(gdf.dissolve(by="self").to_geopandas()) == 1
+    reproj = GeoDataFrame(
+        sgpd.default_context().sql(
+            "SELECT ST_SetSRID(ST_Point(0.0, 0.0), 4326) AS self"
+        ),
+        geometry="self",
+    ).to_crs("EPSG:3857")
+    assert "3857" in str(reproj.crs)
+
+
 def test_dissolve_by_nested_float_column():
     # _is_floating used to match the rendered type string, so `list<item: double>`
     # looked like a float column and dropna called isnan() on it, failing at

--- a/python/sedonadb-geopandas/tests/test_geopandas_compat.py
+++ b/python/sedonadb-geopandas/tests/test_geopandas_compat.py
@@ -1310,3 +1310,244 @@ def test_nat_assigns_as_datetime_missing():
     gdf["geometry"] = pd.NaT
     assert gdf._geometry_name == "geometry"
     assert gdf.to_geopandas()["geometry"].isna().all()
+
+
+def points():
+    """A small frame in a projected CRS, shared across the tests."""
+    return gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.GeoSeries.from_wkt(["POINT (0 0)", "POINT (5 5)", "POINT (9 9)"]),
+        crs="EPSG:3857",
+    )
+
+
+def parcels():
+    """Overlapping polygons per zone, so a dissolve has something to union."""
+    return gpd.GeoDataFrame(
+        {"zone": ["A", "A", "B"], "v": [1, 2, 3]},
+        geometry=gpd.GeoSeries.from_wkt(
+            [
+                "POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))",
+                "POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1))",
+                "POLYGON ((5 5, 7 5, 7 7, 5 7, 5 5))",
+            ]
+        ),
+        crs="EPSG:3857",
+    )
+
+
+def test_dissolve_matches_geopandas():
+    parcels = gpd.GeoDataFrame(
+        {"zone": ["A", "A", "B"], "v": [1, 2, 3]},
+        geometry=gpd.GeoSeries.from_wkt(
+            [
+                "POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))",
+                "POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1))",
+                "POLYGON ((5 5, 7 5, 7 7, 5 7, 5 5))",
+            ]
+        ),
+        crs="EPSG:3857",
+    )
+    got = (
+        sgpd.from_geopandas(parcels)
+        .dissolve(by="zone")
+        .to_geopandas()
+        .sort_values("zone")
+    )
+    expected = parcels.dissolve(by="zone")
+    # Unioned geometry per group, and non-geometry columns aggregated as "first",
+    # both matching GeoPandas.
+    assert got.area.round(6).tolist() == expected.area.round(6).tolist()
+    assert got["v"].tolist() == expected["v"].tolist()
+    # The group key stays a column here rather than becoming the index.
+    assert "zone" in got.columns
+
+
+def test_dissolve_without_by():
+    parcels = gpd.GeoDataFrame(
+        {"zone": ["A", "A", "B"], "v": [1, 2, 3]},
+        geometry=gpd.GeoSeries.from_wkt(
+            [
+                "POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))",
+                "POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1))",
+                "POLYGON ((5 5, 7 5, 7 7, 5 7, 5 5))",
+            ]
+        ),
+        crs="EPSG:3857",
+    )
+    got = sgpd.from_geopandas(parcels).dissolve().to_geopandas()
+    assert len(got) == len(parcels.dissolve()) == 1
+
+
+def test_dissolve_multiple_keys():
+    parcels = gpd.GeoDataFrame(
+        {"zone": ["A", "A", "B"], "v": [1, 2, 3]},
+        geometry=gpd.GeoSeries.from_wkt(
+            [
+                "POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))",
+                "POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1))",
+                "POLYGON ((5 5, 7 5, 7 7, 5 7, 5 5))",
+            ]
+        ),
+        crs="EPSG:3857",
+    )
+    got = sgpd.from_geopandas(parcels).dissolve(by=["zone"]).to_geopandas()
+    assert sorted(got["zone"]) == ["A", "B"]
+
+
+def test_dissolve_validation():
+    parcels = gpd.GeoDataFrame(
+        {"zone": ["A", "A", "B"], "v": [1, 2, 3]},
+        geometry=gpd.GeoSeries.from_wkt(
+            [
+                "POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))",
+                "POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1))",
+                "POLYGON ((5 5, 7 5, 7 7, 5 7, 5 5))",
+            ]
+        ),
+        crs="EPSG:3857",
+    )
+    gdf = sgpd.from_geopandas(parcels)
+    with pytest.raises(NotImplementedError, match="aggfunc"):
+        gdf.dissolve(by="zone", aggfunc="sum")
+    with pytest.raises(KeyError, match="not found"):
+        gdf.dissolve(by="nope")
+    with pytest.raises(ValueError, match="active geometry"):
+        gdf[["zone", "v"]].dissolve(by="zone")
+
+
+@pytest.mark.parametrize(
+    "wkts",
+    [
+        ["POINT (0 0)", "POINT (1 1)"],
+        ["LINESTRING (0 0, 1 1)", "LINESTRING (1 1, 2 2)"],
+        ["POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))", "POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1))"],
+    ],
+    ids=["points", "lines", "polygons"],
+)
+def test_dissolve_handles_every_geometry_type(wkts):
+    # ST_Union_Agg only initializes for polygonal input, so points and linestrings
+    # used to dissolve to NULL geometry.
+    g = gpd.GeoDataFrame(
+        {"zone": ["A", "A"]},
+        geometry=gpd.GeoSeries.from_wkt(wkts),
+        crs="EPSG:3857",
+    )
+    got = sgpd.from_geopandas(g).dissolve(by="zone").to_geopandas()
+    expected = g.dissolve(by="zone")
+    assert got.geometry.iloc[0] is not None
+    assert got.geometry.iloc[0].geom_type == expected.geometry.iloc[0].geom_type
+    assert got.geometry.iloc[0].equals(expected.geometry.iloc[0])
+
+
+def test_dissolve_dropna_matches_geopandas():
+    g = gpd.GeoDataFrame(
+        {"zone": ["A", None], "v": [1, 2]},
+        geometry=gpd.GeoSeries.from_wkt(
+            [
+                "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))",
+                "POLYGON ((2 2, 3 2, 3 3, 2 3, 2 2))",
+            ]
+        ),
+        crs="EPSG:3857",
+    )
+    gdf = sgpd.from_geopandas(g)
+    # GeoPandas drops the missing key by default; dropna=False keeps it.
+    assert len(gdf.dissolve(by="zone").to_geopandas()) == len(g.dissolve(by="zone"))
+    assert len(gdf.dissolve(by="zone", dropna=False).to_geopandas()) == 2
+
+
+def test_dissolve_drops_nan_group_keys():
+    # dropna has to cover IEEE NaN as well as SQL null: a float key read from
+    # pandas carries NaN, which grouping otherwise treats as its own group.
+    df = sgpd.default_context().sql(
+        "SELECT CAST('NaN' AS DOUBLE) k, ST_Point(0.0, 0.0) geometry "
+        "UNION ALL SELECT 1.0, ST_Point(1.0, 1.0)"
+    )
+    assert len(GeoDataFrame(df).dissolve(by="k").to_geopandas()) == 1
+    assert len(GeoDataFrame(df).dissolve(by="k", dropna=False).to_geopandas()) == 2
+
+
+def test_dissolve_by_nested_float_column():
+    # _is_floating used to match the rendered type string, so `list<item: double>`
+    # looked like a float column and dropna called isnan() on it, failing at
+    # planning time.
+    df = sgpd.default_context().sql(
+        "SELECT [1.0, 2.0] AS k, ST_Point(0.0, 0.0) AS geometry"
+    )
+    got = GeoDataFrame(df).dissolve(by="k").to_geopandas()
+    assert len(got) == 1
+
+
+def test_dissolve_all_null_group_is_empty_geometry():
+    # GeoPandas returns GEOMETRYCOLLECTION EMPTY rather than None, which behaves
+    # differently for isna, is_empty, predicates and serialization.
+    df = sgpd.default_context().sql(
+        "SELECT 'A' AS z, "
+        "ST_SetSRID(ST_GeomFromText(CAST(NULL AS VARCHAR)), 3857) AS geometry "
+        "UNION ALL SELECT 'A', "
+        "ST_SetSRID(ST_GeomFromText(CAST(NULL AS VARCHAR)), 3857)"
+    )
+    got = GeoDataFrame(df).dissolve(by="z").to_geopandas()
+    expected = gpd.GeoDataFrame(
+        {"z": ["A", "A"]},
+        geometry=gpd.GeoSeries.from_wkt([None, None]),
+        crs="EPSG:3857",
+    ).dissolve(by="z")
+    assert got.geometry.iloc[0].equals(expected.geometry.iloc[0])
+    assert got.geometry.iloc[0].is_empty
+    assert not got.geometry.isna().any()
+
+
+def test_dissolve_rejects_empty_key_list():
+    # Matches GeoPandas: an explicit empty iterable is an error, unlike by=None.
+    points = gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "v": [1, 2, 3]},
+        geometry=gpd.points_from_xy([0, 5, 9], [0, 5, 9]),
+        crs=3857,
+    )
+    gdf = sgpd.from_geopandas(points)
+    with pytest.raises(ValueError, match="No group keys"):
+        gdf.dissolve(by=[])
+    assert len(gdf.dissolve().to_geopandas()) == 1
+
+
+def test_dissolve_categorical_is_observed_only():
+    # Documented divergence: unused categories do not produce empty groups (the
+    # category domain does not survive a relational aggregation).
+
+    cat = gpd.GeoDataFrame(
+        {"z": pd.Categorical(["A"], categories=["A", "B"])},
+        geometry=gpd.GeoSeries.from_wkt(["POINT (0 0)"]),
+        crs="EPSG:3857",
+    )
+    assert len(cat.dissolve(by="z")) == 2  # GeoPandas observed=False default
+    assert len(sgpd.from_geopandas(cat).dissolve(by="z").to_geopandas()) == 1
+
+
+def test_is_floating_unwraps_dictionary_encoding():
+    from sedonadb_geopandas._frame import _is_floating
+
+    tbl = pa.table(
+        {
+            "k": pa.DictionaryArray.from_arrays(
+                pa.array([0, 1], type=pa.int8()), pa.array([1.0, float("nan")])
+            ),
+            "x": [1, 2],
+        }
+    )
+    df = sgpd.default_context().create_data_frame(tbl)
+    assert _is_floating(df, "k")
+
+
+def test_dissolve_temporal_keys_are_deferred():
+    # pandas missing values arrive from numpy-backed frames as a sentinel
+    # tick that must group as missing rather than as a value; temporal keys
+    # are rejected until the dedicated temporal handling lands.
+    gdf = GeoDataFrame(
+        sgpd.default_context().sql(
+            "SELECT TIMESTAMP '2026-01-01' AS ts, ST_Point(0.0, 0.0) AS geometry"
+        )
+    )
+    with pytest.raises(NotImplementedError, match="not supported yet"):
+        gdf.dissolve(by="ts")

--- a/python/sedonadb-geopandas/tests/test_geopandas_compat.py
+++ b/python/sedonadb-geopandas/tests/test_geopandas_compat.py
@@ -1468,6 +1468,27 @@ def test_dissolve_drops_nan_group_keys():
     assert len(GeoDataFrame(df).dissolve(by="k", dropna=False).to_geopandas()) == 2
 
 
+def test_dissolve_groups_null_and_nan_keys_together():
+    # Missing-key handling only ran with dropna=True, so with dropna=False a
+    # SQL NULL and an IEEE NaN in the same float key column formed two
+    # missing groups where pandas forms one. NaN is normalized to null before
+    # grouping, in both modes.
+    tbl = pa.table(
+        {
+            "k": pa.array([None, float("nan"), 1.0], pa.float64()),
+            "geometry": ga.as_wkb(["POINT (0 0)", "POINT (1 1)", "POINT (2 2)"]),
+        }
+    )
+    gdf = GeoDataFrame(sgpd.default_context().create_data_frame(tbl))
+    kept = gdf.dissolve(by="k", dropna=False).to_geopandas()
+    assert len(kept) == 2
+    assert kept["k"].isna().sum() == 1
+    missing = kept[kept["k"].isna()].geometry.iloc[0]
+    assert missing.geom_type == "MultiPoint" and len(missing.geoms) == 2
+    dropped = gdf.dissolve(by="k").to_geopandas()
+    assert dropped["k"].tolist() == [1.0]
+
+
 def test_dissolve_by_nested_float_column():
     # _is_floating used to match the rendered type string, so `list<item: double>`
     # looked like a float column and dropna called isnan() on it, failing at


### PR DESCRIPTION
## What changes

Second slice of the series that started with #1195 (column assignment). This one adds `GeoDataFrame.dissolve()` to the experimental `sedonadb-geopandas` package: group rows on one or more key columns (or on nothing, to dissolve everything into one row) and union each group's geometry.

- **Geometry aggregation** goes through `ST_Collect_Agg` followed by a `ST_UnaryUnion` in a separate projection. `ST_Union_Agg` only initializes for polygonal input (#1093), so a group of points or lines would dissolve to NULL; collect-then-union is geometry-general and yields the geometry types GeoPandas yields. The union sits in its own projection because a scalar function wrapped around an aggregate is not a valid aggregate expression. A group whose geometries are all null coalesces to an empty geometry collection re-typed back to geometry, matching GeoPandas.
- **Missing keys** follow pandas: IEEE NaN in a floating-point key is normalized to null before grouping, in both `dropna` modes, so a column holding both representations forms one missing group rather than two (and `dropna=True` drops both). Floating-ness is decided from the Arrow type, dictionary encoding unwrapped, rather than from the type's string form, so a `list<double>` column is not mistaken for something `isnan()` can be applied to.
- **Validation** matches GeoPandas: `by=[]` raises (unlike `by=None`), unknown keys raise `KeyError`, and only `aggfunc="first"` is supported for now with an error that points at the SedonaDB `DataFrame` API for anything else.
- **Temporal group keys are rejected for now.** Numpy-backed pandas delivers a missing timestamp or duration as an `INT64_MIN` tick, which must group (and `dropna`) as missing rather than as a value; that handling arrives with the temporal follow-up.

Documented differences from GeoPandas (also in the README): group keys stay ordinary columns rather than becoming the index; `"first"` is an unordered aggregate that does not skip missing values; dissolving an empty frame without keys yields one row rather than zero; a group mixing 2D and 3D geometries raises rather than being promoted to 3D; and grouping is observed-only for categorical keys, since the category domain does not survive a relational aggregation.

## Testing

18 new tests (136 in the package), including a corpus over every geometry type, GeoPandas parity for `dropna`, nested-float and dictionary-encoded keys, the all-null group, and the categorical case; run with warnings promoted to errors against both a source-built current main and the released sedonadb 0.4.1 in a clean environment (pandas 2 and 3). Ruff lint/format clean.


