### PR TITLE
chore(rust): remove obsolete dead code allowance

### DIFF
--- a/rust/sedona-raster-gdal/src/lib.rs
+++ b/rust/sedona-raster-gdal/src/lib.rs
@@ -28,8 +28,6 @@
 pub mod register;
 
 mod gdal_common;
-// Temporary until https://github.com/apache/sedona-db/issues/804 is resolved.
-#[allow(dead_code)]
 mod gdal_dataset_provider;
 
 mod mask;


### PR DESCRIPTION
Removes the temporary dead_code allowance from gdal_dataset_provider now that the module is used by GDAL-backed raster functions. The remaining allow attribute in the crate is still required.

Closes #804

Tests: cargo clippy -p sedona-raster-gdal --all-targets -- -D warnings; cargo test -p sedona-raster-gdal --lib