### PR TITLE
chore(rust/sedona-schema): migrate to Rust 2024 edition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
       - id: fmt
         name: rustfmt
         args: ["--all", "--"]
+        pass_filenames: false
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13

--- a/rust/sedona-schema/Cargo.toml
+++ b/rust/sedona-schema/Cargo.toml
@@ -24,7 +24,7 @@ homepage.workspace = true
 repository.workspace = true
 description.workspace = true
 readme.workspace = true
-edition.workspace = true
+edition = "2024"
 rust-version.workspace = true
 
 [lints.clippy]

--- a/rust/sedona-schema/benches/crs_benchmarks.rs
+++ b/rust/sedona-schema/benches/crs_benchmarks.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use sedona_schema::crs::deserialize_crs;
 use std::hint::black_box;
 

--- a/rust/sedona-schema/src/crs.rs
+++ b/rust/sedona-schema/src/crs.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 use datafusion_common::{
-    exec_err, plan_datafusion_err, plan_err, DataFusionError, HashMap, Result,
+    DataFusionError, HashMap, Result, exec_err, plan_datafusion_err, plan_err,
 };
 use lru::LruCache;
 use std::cell::RefCell;
@@ -765,7 +765,7 @@ impl<'a> WktParser<'a> {
             None => {
                 return Err(DataFusionError::Execution(
                     "unexpected end of WKT CRS string".into(),
-                ))
+                ));
             }
         }
         // A keyword or bare token runs until a structural character.
@@ -797,7 +797,7 @@ impl<'a> WktParser<'a> {
                         None => {
                             return Err(DataFusionError::Execution(
                                 "WKT CRS string has an unterminated bracket".into(),
-                            ))
+                            ));
                         }
                     }
                 }
@@ -1053,10 +1053,12 @@ mod test {
         assert!(projjson.crs_equals(&projjson));
 
         let projjson_without_identifier = "{}".parse::<ProjJSON>().unwrap();
-        assert!(projjson_without_identifier
-            .to_authority_code()
-            .unwrap()
-            .is_none());
+        assert!(
+            projjson_without_identifier
+                .to_authority_code()
+                .unwrap()
+                .is_none()
+        );
         assert!(!projjson.crs_equals(&projjson_without_identifier));
 
         let projjson = EPSG_6318_PROJJSON.parse::<ProjJSON>().unwrap();

--- a/rust/sedona-schema/src/datatypes.rs
+++ b/rust/sedona-schema/src/datatypes.rs
@@ -24,7 +24,7 @@ use std::sync::LazyLock;
 /// Re-export for external crates that depended on this enum in this crate
 pub use sedona_geometry::types::Edges;
 
-use crate::crs::{deserialize_crs, deserialize_crs_from_obj, lnglat, Crs};
+use crate::crs::{Crs, deserialize_crs, deserialize_crs_from_obj, lnglat};
 use crate::extension_type::ExtensionType;
 use crate::raster::RasterSchema;
 
@@ -718,37 +718,45 @@ mod tests {
     fn geoarrow_deserialize_invalid() {
         let bad_json =
             ExtensionType::new("geoarrow.wkb", DataType::Binary, Some(r#"{"#.to_string()));
-        assert!(SedonaType::from_extension_type(bad_json)
-            .unwrap_err()
-            .message()
-            .contains("Error deserializing GeoArrow metadata"));
+        assert!(
+            SedonaType::from_extension_type(bad_json)
+                .unwrap_err()
+                .message()
+                .contains("Error deserializing GeoArrow metadata")
+        );
 
         let bad_type =
             ExtensionType::new("geoarrow.wkb", DataType::Binary, Some(r#"[]"#.to_string()));
-        assert!(SedonaType::from_extension_type(bad_type)
-            .unwrap_err()
-            .message()
-            .contains("Expected GeoArrow metadata as JSON object"));
+        assert!(
+            SedonaType::from_extension_type(bad_type)
+                .unwrap_err()
+                .message()
+                .contains("Expected GeoArrow metadata as JSON object")
+        );
 
         let bad_edges_type = ExtensionType::new(
             "geoarrow.wkb",
             DataType::Binary,
             Some(r#"{"edges": []}"#.to_string()),
         );
-        assert!(SedonaType::from_extension_type(bad_edges_type)
-            .unwrap_err()
-            .message()
-            .contains("Unsupported edges JSON type"));
+        assert!(
+            SedonaType::from_extension_type(bad_edges_type)
+                .unwrap_err()
+                .message()
+                .contains("Unsupported edges JSON type")
+        );
 
         let bad_edges_value = ExtensionType::new(
             "geoarrow.wkb",
             DataType::Binary,
             Some(r#"{"edges": "gazornenplat"}"#.to_string()),
         );
-        assert!(SedonaType::from_extension_type(bad_edges_value)
-            .unwrap_err()
-            .message()
-            .contains("Unsupported edges value"));
+        assert!(
+            SedonaType::from_extension_type(bad_edges_value)
+                .unwrap_err()
+                .message()
+                .contains("Unsupported edges value")
+        );
     }
 
     /// An extension name this crate has no built-in support for -- a

--- a/rust/sedona-schema/src/matchers.rs
+++ b/rust/sedona-schema/src/matchers.rs
@@ -18,11 +18,11 @@
 use std::{fmt::Debug, iter::zip, sync::Arc};
 
 use arrow_schema::DataType;
-use datafusion_common::{plan_err, Result};
+use datafusion_common::{Result, plan_err};
 use sedona_common::sedona_internal_err;
 use sedona_geometry::types::Edges;
 
-use crate::datatypes::{SedonaType, RASTER, WKB_GEOGRAPHY, WKB_GEOMETRY};
+use crate::datatypes::{RASTER, SedonaType, WKB_GEOGRAPHY, WKB_GEOMETRY};
 
 /// Helper to match arguments and compute return types
 #[derive(Debug)]
@@ -654,12 +654,16 @@ mod tests {
 
     #[test]
     fn matchers() {
-        assert!(ArgMatcher::is_arrow(DataType::Null).match_type(&SedonaType::Arrow(DataType::Null)));
+        assert!(
+            ArgMatcher::is_arrow(DataType::Null).match_type(&SedonaType::Arrow(DataType::Null))
+        );
 
         assert!(ArgMatcher::is_geometry_or_geography().match_type(&WKB_GEOMETRY));
         assert!(ArgMatcher::is_geometry_or_geography().match_type(&WKB_GEOGRAPHY));
-        assert!(!ArgMatcher::is_geometry_or_geography()
-            .match_type(&SedonaType::Arrow(DataType::Binary)));
+        assert!(
+            !ArgMatcher::is_geometry_or_geography()
+                .match_type(&SedonaType::Arrow(DataType::Binary))
+        );
         assert_eq!(ArgMatcher::is_geometry_or_geography().type_if_null(), None);
 
         assert!(ArgMatcher::is_geometry().match_type(&WKB_GEOMETRY));

--- a/rust/sedona-schema/src/schema.rs
+++ b/rust/sedona-schema/src/schema.rs
@@ -223,9 +223,11 @@ mod test {
         assert_eq!(schema.primary_geometry_column_index().unwrap(), Some(1));
 
         // ...but should still detect a column without a special name
-        let schema = Schema::new(vec![WKB_GEOMETRY
-            .to_storage_field("name_not_special_cased", true)
-            .unwrap()]);
+        let schema = Schema::new(vec![
+            WKB_GEOMETRY
+                .to_storage_field("name_not_special_cased", true)
+                .unwrap(),
+        ]);
         assert_eq!(schema.geometry_column_indices().unwrap(), vec![0]);
         assert_eq!(schema.primary_geometry_column_index().unwrap(), Some(0));
     }
@@ -261,9 +263,9 @@ mod test {
         );
 
         // A plain top-level geometry column is still reported.
-        let schema = Schema::new(vec![WKB_GEOMETRY
-            .to_storage_field("geometry", true)
-            .unwrap()]);
+        let schema = Schema::new(vec![
+            WKB_GEOMETRY.to_storage_field("geometry", true).unwrap(),
+        ]);
         assert_eq!(schema.geometry_column_indices_recursive().unwrap(), vec![0]);
     }
 }


### PR DESCRIPTION
Begins #258 by migrating `sedona-schema` independently to Rust 2024 and applying the standard Rust 2024 formatter output for that crate.

Validated with `cargo fmt --all --check`, `cargo check -p sedona-schema --all-targets`, `cargo test -p sedona-schema`, and Clippy with warnings denied.