### PR TITLE
test(integration): xfail-catalog missing overloads, skewed resample, and NaN zonal stats

### DIFF
--- a/integration/spark-parity/test_rs_crs.py
+++ b/integration/spark-parity/test_rs_crs.py
@@ -18,9 +18,10 @@
 
 A pure divergence catalog: the engines serialize a CRS differently by
 design (SedonaDB emits PROJJSON, or a short authority code for an
-SRID-set raster; Sedona Spark emits GeoTools' JSON), and they disagree
-on the CRS-less answer, so every case is an xfail stating both observed
-behaviors.
+SRID-set raster; Sedona Spark emits GeoTools' JSON), they disagree on
+the CRS-less answer, and Sedona Spark's format-selecting 2-argument
+overload has no SedonaDB counterpart — so every case is an xfail
+stating both observed behaviors.
 """
 
 import pytest
@@ -73,3 +74,28 @@ def test_rs_crs_after_setsrid(tmp_path):
     for eng in (sedona, spark):
         eng.create_random_raster_view("crs_set_src", tmp_path / "crs_set_src.tif")
     compare("SELECT RS_CRS(RS_SetSRID(rast, 4326)) FROM crs_set_src", sedona, spark)
+
+
+@pytest.mark.parametrize("fmt", ["wkt", "projjson"])
+@pytest.mark.xfail(
+    reason="SedonaDB has no format overload of RS_CRS (it raises 'No kernel "
+    "matching arguments'); Sedona Spark serializes to the requested format "
+    "('wkt' emits WKT1, 'projjson' emits PROJJSON)"
+)
+def test_rs_crs_format_overload(fmt, tmp_path):
+    """RS_CRS(raster, format) serializes the CRS the same from both
+    engines."""
+    path = tmp_path / "crs_fmt_src.tif"
+    write_random_geotiff(
+        path,
+        "uint8",
+        bands=1,
+        height=6,
+        width=7,
+        bbox=(100.0, 482.0, 114.0, 500.0),
+        crs="EPSG:3857",
+    )
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_raster_view("crs_fmt_src", path)
+    compare(f"SELECT RS_CRS(rast, '{fmt}') FROM crs_fmt_src", sedona, spark)

--- a/integration/spark-parity/test_rs_resample.py
+++ b/integration/spark-parity/test_rs_resample.py
@@ -35,6 +35,11 @@ rejects unknown names. Even where both engines really interpolate (Bilinear,
 Bicubic) the kernels differ pixel-wise. All of that is `xfail`-cataloged, same
 policy as the other suites: the reason states both engines' observed behavior,
 and where one engine raises, that error is what trips the xfail.
+
+Skewed sources are their own divergence family (also `xfail`-cataloged):
+SedonaDB refuses a scale change or grid snap on a skewed raster outright,
+and even the extent-preserving dimension change both engines accept agrees
+only on the output geotransform, not the pixels.
 """
 
 import numpy as np
@@ -47,6 +52,7 @@ from sedonadb.raster_testing import (
     RANDOM_GRID_WIDTH as WIDTH,
     DecodedRaster,
     random_raster_data,
+    write_geotiff,
     write_grid_geotiff,
 )
 from sedonadb.testing import SedonaDB, compare
@@ -318,5 +324,63 @@ def test_rs_resample_grid_snap_edge_centres(tmp_path):
     sql = (
         "SELECT RS_Resample(rast, 2.0, -3.0, 99.0, 501.0, true, 'NearestNeighbor') "
         "FROM edge_src"
+    )
+    compare(sql, sedona, spark)
+
+
+# A skewed source for the skew divergence family: 4x3 pixels on transform
+# (100, 2, 0.5, 500, 0.3, -3).
+SKEW_TRANSFORM = (100.0, 2.0, 0.5, 500.0, 0.3, -3.0)
+
+
+def _register_skewed(name, tmp_path):
+    """Both engines with a skewed single-band raster registered as `name`."""
+    path = tmp_path / f"{name}.tif"
+    write_geotiff(
+        path,
+        random_raster_data("uint8", bands=1, height=3, width=4),
+        gdal_transform=SKEW_TRANSFORM,
+    )
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_raster_view(name, path)
+    return sedona, spark
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        pytest.param("1.0, -1.5, true", id="scale"),
+        pytest.param("1.0, -1.5, 99.0, 501.0, true", id="grid-snap"),
+    ],
+)
+@pytest.mark.xfail(
+    reason="a scale change or grid snap on a skewed raster is rejected by "
+    "SedonaDB ('not supported'); Sedona Spark silently regrids as if the "
+    "grid were north-up, keeping the skew terms in the output transform and "
+    "growing the canvas with zero fill"
+)
+def test_rs_resample_skewed_scale(args, tmp_path):
+    """A scale change (and a grid snap) on a skewed raster gets the same
+    treatment from both engines."""
+    sedona, spark = _register_skewed("skew_scale_src", tmp_path)
+    sql = f"SELECT RS_Resample(rast, {args}, 'NearestNeighbor') FROM skew_scale_src"
+    compare(sql, sedona, spark)
+
+
+@pytest.mark.xfail(
+    reason="dimension mode on a skewed raster: the engines agree on the "
+    "output geotransform (pixel size scaled from the skewed envelope, skew "
+    "carried through) but not the pixels — SedonaDB regrids in index space, "
+    "so a 2x upsample is block replication; Sedona Spark samples through "
+    "the envelope transform, shifting content and zero-filling the last "
+    "row and trailing columns"
+)
+def test_rs_resample_skewed_dimensions(tmp_path):
+    """An extent-preserving width/height change on a skewed raster produces
+    the same pixels from both engines."""
+    sedona, spark = _register_skewed("skew_dim_src", tmp_path)
+    sql = (
+        "SELECT RS_Resample(rast, 8.0, 6.0, false, 'NearestNeighbor') FROM skew_dim_src"
     )
     compare(sql, sedona, spark)

--- a/integration/spark-parity/test_rs_setgeoreference.py
+++ b/integration/spark-parity/test_rs_setgeoreference.py
@@ -21,7 +21,8 @@ upperLeftY` (world-file order). Both engines parse the 2-argument form,
 the explicit GDAL format, and the ESRI format (which reads the origin as
 the centre of the upper-left pixel, shifting it by half a pixel)
 identically, and pixels pass through untouched — anchored with the full
-decoded raster.
+decoded raster. Sedona Spark's numeric 7-argument overload has no
+SedonaDB counterpart (xfail below).
 """
 
 import pytest
@@ -75,6 +76,29 @@ def test_rs_setgeoreference_skew(args, tmp_path):
     anchor = DecodedRaster(
         random_raster_data("uint8", bands=2, height=6, width=7),
         gdal_transform=(100.0, 2.0, 0.5, 500.0, 0.25, -3.0),
+        nodata=[None, None],
+    )
+    compare(sql, sedona, spark, expected=anchor)
+
+
+@pytest.mark.xfail(
+    reason="SedonaDB has no numeric 7-argument overload of RS_SetGeoReference "
+    "(it raises 'No kernel matching arguments'); Sedona Spark re-grids from "
+    "(upperLeftX, upperLeftY, scaleX, scaleY, skewX, skewY)"
+)
+def test_rs_setgeoreference_numeric_overload(tmp_path):
+    """The numeric argument form re-grids the raster identically on both
+    engines, pixels untouched."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("geo_num_src", tmp_path / "geo_num_src.tif")
+    sql = (
+        "SELECT RS_SetGeoReference(rast, 10.0, 20.0, 2.0, -2.0, 0.1, 0.2) "
+        "FROM geo_num_src"
+    )
+    anchor = DecodedRaster(
+        random_raster_data("uint8", bands=2, height=6, width=7),
+        gdal_transform=(10.0, 2.0, 0.1, 20.0, 0.2, -2.0),
         nodata=[None, None],
     )
     compare(sql, sedona, spark, expected=anchor)

--- a/integration/spark-parity/test_rs_worldtorastercoordx.py
+++ b/integration/spark-parity/test_rs_worldtorastercoordx.py
@@ -19,9 +19,11 @@
 Every case is a cataloged divergence: SedonaDB treats pixel coordinates
 as 0-based where Sedona Spark (following PostGIS, and SedonaDB's own
 RS_PixelAs* functions) is 1-based, so results are exactly one pixel
-apart everywhere, extrapolation included (apache/sedona-db#1235). The
-geometry-returning combined form is deferred until the harness can
-compare geometry columns without ST_ wrappers.
+apart everywhere, extrapolation included (apache/sedona-db#1235). Sedona
+Spark also accepts a point geometry in place of the (x, y) pair, an
+overload SedonaDB lacks entirely. The geometry-returning combined form
+is deferred until the harness can compare geometry columns without ST_
+wrappers.
 """
 
 import pytest
@@ -44,4 +46,23 @@ def test_rs_worldtorastercoordx(x, y, tmp_path):
     for eng in (sedona, spark):
         eng.create_random_raster_view("w2rx_src", tmp_path / "w2rx_src.tif")
     sql = f"SELECT RS_WorldToRasterCoordX(rast, {x}, {y}) FROM w2rx_src"
+    compare(sql, sedona, spark)
+
+
+@pytest.mark.xfail(
+    reason="SedonaDB has no point-geometry overload of RS_WorldToRasterCoordX "
+    "(it raises 'No kernel matching arguments'); Sedona Spark accepts "
+    "(raster, point) and answers 1-based, so once the overload exists the "
+    "0- vs 1-based divergence (apache/sedona-db#1235) still applies"
+)
+def test_rs_worldtorastercoordx_point_overload(tmp_path):
+    """The point-geometry form maps the interior point (104 494) to the
+    same column on both engines."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("w2rxp_src", tmp_path / "w2rxp_src.tif")
+    sql = (
+        "SELECT RS_WorldToRasterCoordX(rast, ST_GeomFromWKT('POINT (104 494)')) "
+        "FROM w2rxp_src"
+    )
     compare(sql, sedona, spark)

--- a/integration/spark-parity/test_rs_worldtorastercoordy.py
+++ b/integration/spark-parity/test_rs_worldtorastercoordy.py
@@ -19,9 +19,11 @@
 Every case is a cataloged divergence: SedonaDB treats pixel coordinates
 as 0-based where Sedona Spark (following PostGIS, and SedonaDB's own
 RS_PixelAs* functions) is 1-based, so results are exactly one pixel
-apart everywhere, extrapolation included (apache/sedona-db#1235). The
-geometry-returning combined form is deferred until the harness can
-compare geometry columns without ST_ wrappers.
+apart everywhere, extrapolation included (apache/sedona-db#1235). Sedona
+Spark also accepts a point geometry in place of the (x, y) pair, an
+overload SedonaDB lacks entirely. The geometry-returning combined form
+is deferred until the harness can compare geometry columns without ST_
+wrappers.
 """
 
 import pytest
@@ -40,4 +42,23 @@ def test_rs_worldtorastercoordy(tmp_path):
     for eng in (sedona, spark):
         eng.create_random_raster_view("w2ry_src", tmp_path / "w2ry_src.tif")
     sql = "SELECT RS_WorldToRasterCoordY(rast, 100.0, 500.0) FROM w2ry_src"
+    compare(sql, sedona, spark)
+
+
+@pytest.mark.xfail(
+    reason="SedonaDB has no point-geometry overload of RS_WorldToRasterCoordY "
+    "(it raises 'No kernel matching arguments'); Sedona Spark accepts "
+    "(raster, point) and answers 1-based, so once the overload exists the "
+    "0- vs 1-based divergence (apache/sedona-db#1235) still applies"
+)
+def test_rs_worldtorastercoordy_point_overload(tmp_path):
+    """The point-geometry form maps the interior point (104 494) to the
+    same row on both engines."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("w2ryp_src", tmp_path / "w2ryp_src.tif")
+    sql = (
+        "SELECT RS_WorldToRasterCoordY(rast, ST_GeomFromWKT('POINT (104 494)')) "
+        "FROM w2ryp_src"
+    )
     compare(sql, sedona, spark)

--- a/integration/spark-parity/test_rs_zonalstats.py
+++ b/integration/spark-parity/test_rs_zonalstats.py
@@ -34,7 +34,12 @@ y in (485, 497) selects the 4x4 block rows 1-4 x cols 1-4 of the standard
 import numpy as np
 import pytest
 
-from sedonadb.raster_testing import random_raster_data, write_random_geotiff
+from sedonadb.raster_testing import (
+    RANDOM_GRID_BBOX,
+    random_raster_data,
+    write_geotiff,
+    write_random_geotiff,
+)
 from sedonadb.testing import SedonaDB, compare
 from sedonadb.testing_spark import SedonaSpark
 
@@ -410,3 +415,57 @@ def test_rs_zonalstats_coastline_counts(tmp_path):
         spark,
         expected=1842,
     )
+
+
+# ---------------------------------------------------------------------------
+# NaN pixels. A float band can hold NaN as ordinary data (no nodata is
+# declared here, so nodata exclusion is not in play). SedonaDB deliberately
+# NaN-poisons every statistic — one NaN member makes every reduction NaN,
+# numpy semantics — where Sedona Spark varies per statistic. count and sum
+# agree today and are pinned as plain parity tests; the rest are the xfail
+# catalog.
+
+
+def _nan_engines(name, tmp_path):
+    """A float32 band with one NaN pixel inside RECT, no nodata declared."""
+    data = random_raster_data("float32", bands=1, height=6, width=7)
+    data[0, 2, 3] = np.nan
+    path = tmp_path / f"{name}.tif"
+    write_geotiff(path, data, bbox=RANDOM_GRID_BBOX)
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_raster_view(name, path)
+    return sedona, spark
+
+
+@pytest.mark.parametrize("stat", ["count", "sum"])
+def test_rs_zonalstats_nan_pixel_agreeing_stats(stat, tmp_path):
+    """Both engines count the NaN pixel as a zone member (16, not 15) and
+    let it poison the sum to NaN. Whether counting it is the right policy
+    is open — GDAL and rasterio treat any NaN as nodata — so this pins
+    parity, not correctness."""
+    sedona, spark = _nan_engines("zs_nan_src", tmp_path)
+    sql = (
+        f"SELECT RS_ZonalStats(rast, ST_GeomFromWKT('{RECT}'), 1, '{stat}') "
+        "FROM zs_nan_src"
+    )
+    compare(sql, sedona, spark)
+
+
+@pytest.mark.parametrize(
+    "stat", ["mean", "min", "max", "median", "mode", "stddev", "variance"]
+)
+@pytest.mark.xfail(
+    reason="a NaN pixel in the zone: SedonaDB reports NaN for every "
+    "statistic; Sedona Spark reports NULL for mean, stddev, and variance "
+    "and computes min, max, median, and mode over the 15 non-NaN pixels"
+)
+def test_rs_zonalstats_nan_pixel_diverging_stats(stat, tmp_path):
+    """Each statistic treats a NaN zone member the same way on both
+    engines."""
+    sedona, spark = _nan_engines("zs_nan_div_src", tmp_path)
+    sql = (
+        f"SELECT RS_ZonalStats(rast, ST_GeomFromWKT('{RECT}'), 1, '{stat}') "
+        "FROM zs_nan_div_src"
+    )
+    compare(sql, sedona, spark)


### PR DESCRIPTION
Extends the spark-parity xfail catalog with divergences that existed in code but had no capture — a regression in any of them would previously have gone unnoticed. Every case was probed on both engines first; each reason states both observed behaviors.

## Missing overloads (SedonaDB raises "No kernel matching arguments", Sedona Spark computes)

- **RS_SetGeoReference(raster, ulX, ulY, scaleX, scaleY, skewX, skewY)** — the numeric 7-argument form. Anchored with the full decoded raster (probe: Spark re-grids to exactly that transform, pixels untouched), so the test flips green only when SedonaDB adds the kernel and matches.
- **RS_WorldToRasterCoordX/Y(raster, point)** — the point-geometry input form. Spark answers 1-based (`3` for the interior point (104 494) on the standard grid), so once the overload exists the 0- vs 1-based divergence (apache/sedona-db#1235) still applies; the reason says so.
- **RS_CRS(raster, format)** — the format-selecting form, parametrized over `'wkt'` (Spark emits WKT1) and `'projjson'` (Spark emits PROJJSON).

## RS_Resample on skewed rasters

- **Scale change and grid snap**: SedonaDB rejects them outright ("not supported"); Sedona Spark silently regrids as if the grid were north-up, keeping the skew terms in the output transform and growing the canvas with zero fill.
- **Dimension mode** (new finding): both engines accept it and agree on the output geotransform — pixel size scaled from the skewed *envelope* (9.5/8 = 1.1875 on x for the fixture), skew carried through — but not on the pixels. SedonaDB regrids in index space, so the 2x upsample is exact block replication; Spark samples through the envelope transform, shifting content and zero-filling the last row and trailing columns.

## RS_ZonalStats with a NaN pixel in the zone

A float32 band holding one NaN as ordinary data (no nodata declared):

| stat | SedonaDB | Sedona Spark |
|---|---|---|
| count | 16 | 16 |
| sum | NaN | NaN |
| mean, stddev, variance | NaN | NULL |
| min, max, median, mode | NaN | computed over the 15 non-NaN pixels |

count and sum agree and are pinned as plain parity tests (parity, not correctness — GDAL/rasterio would treat the NaN as nodata, and neither engine has a stated policy). The rest are xfails. The "over the 15 non-NaN pixels" claim is verified against numpy: Spark's min/max/median match the non-NaN selection exactly, and mode is its largest value per the suite's documented ties-toward-higher convention.

## Probed but deliberately not included

- **RS_Values coordinate-array overload**: there is no SQL spelling both engines parse — Spark only accepts `array(1, 2)` (SedonaDB: "Invalid function 'array'"), SedonaDB only accepts `[1, 2]` (Spark: PARSE_SYNTAX_ERROR) — so a shared-SQL parity test cannot exist until the harness grows dialect handling for array literals.

Local run of the six touched files: `52 passed, 41 xfailed`.
