### PR TITLE
chore(rust): scope datafusion "sql" feature to the engine crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ datafusion-proto = { version = "54.1.0", default-features = false }
 datafusion-datasource = { version = "54.1.0", default-features = false }
 datafusion-datasource-parquet = { version = "54.1.0" }
 datafusion-execution = { version = "54.1.0", default-features = false }
-datafusion-expr = { version = "54.1.0" }
+datafusion-expr = { version = "54.1.0", default-features = false }
 datafusion-ffi = {  version = "54.1.0" }
 datafusion-optimizer = { version = "54.1.0" }
 datafusion-physical-expr = { version = "54.1.0" }

--- a/rust/sedona-functions/Cargo.toml
+++ b/rust/sedona-functions/Cargo.toml
@@ -36,7 +36,7 @@ criterion = { workspace = true }
 rstest = { workspace = true }
 sedona-proj = { workspace = true, features = ["proj-sys"] }
 sedona-testing = { workspace = true, features = ["criterion"] }
-datafusion = { workspace = true, features = ["sql"] }
+datafusion = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
 
 [dependencies]

--- a/rust/sedona-geoparquet/Cargo.toml
+++ b/rust/sedona-geoparquet/Cargo.toml
@@ -52,7 +52,7 @@ arrow-schema = { workspace = true }
 arrow-array = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
-datafusion = { workspace = true, features = ["parquet", "sql"] }
+datafusion = { workspace = true, features = ["parquet"] }
 datafusion-catalog = { workspace = true }
 datafusion-common = { workspace = true }
 datafusion-datasource = { workspace = true }

--- a/rust/sedona-query-planner/Cargo.toml
+++ b/rust/sedona-query-planner/Cargo.toml
@@ -42,6 +42,6 @@ sedona-schema = { workspace = true }
 
 [dev-dependencies]
 arrow = { workspace = true }
-datafusion = { workspace = true, features = ["nested_expressions", "sql"] }
+datafusion = { workspace = true, features = ["nested_expressions"] }
 sedona-schema = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/rust/sedona-spatial-join/Cargo.toml
+++ b/rust/sedona-spatial-join/Cargo.toml
@@ -73,7 +73,7 @@ log = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
-datafusion = { workspace = true, features = ["sql"] }
+datafusion = { workspace = true }
 rstest = { workspace = true }
 sedona-testing = { workspace = true }
 wkt = { workspace = true }

--- a/rust/sedona/Cargo.toml
+++ b/rust/sedona/Cargo.toml
@@ -64,7 +64,7 @@ comfy-table = { workspace = true }
 datafusion = { workspace = true, default_features = false, features = ["sql", "parquet", "nested_expressions"] }
 datafusion-catalog = { workspace = true }
 datafusion-common = { workspace = true }
-datafusion-expr = { workspace = true }
+datafusion-expr = { workspace = true, features = ["sql"] }
 datafusion-ffi = { workspace = true }
 datafusion-optimizer = { workspace = true }
 datafusion-session = { workspace = true }


### PR DESCRIPTION
## What
Scope DataFusion's `sql` feature to the `sedona` engine crate instead of enabling it workspace-wide.

## Why
`datafusion-expr`'s default features include `sql`, which pulls `sqlparser`, switches `RawBinaryExpr.op` / `RenameSelectItem` to sqlparser types, and gates `datafusion-functions-nested`'s sql planner. Only the `sedona` engine crate uses that surface (`RawBinaryExpr` / `sqlparser`); the function, spatial-join, query-planner and geoparquet crates never do. Enabling it workspace-wide (via `datafusion-expr`'s defaults) forces every downstream consumer onto the sql-gated `datafusion-expr`, which breaks non-sql embedders such as my Sail fork (whose resolver depends on the `not(sql)` forms and cannot compile the sql-gated nested planner).

## Change
- `datafusion-expr` → `default-features = false` in the workspace; the `sedona` engine crate opts into `features = ["sql"]`.
- Drop the unused `sql` feature from `sedona-functions`, `sedona-spatial-join`, `sedona-query-planner`, `sedona-geoparquet`.
