### PR TITLE
test(integration): geometry results in the parity harness; RS_WorldToRasterCoord + RS_RasterToWorldCoord catalogs

### DIFF
--- a/integration/spark-parity/test_rs_rastertoworldcoord.py
+++ b/integration/spark-parity/test_rs_rastertoworldcoord.py
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_RasterToWorldCoord.
+
+The combined form returns the world coordinate of a pixel's upper-left
+corner as a POINT geometry; results travel through the harness's
+geometry path. Every case is the input side of the same cataloged
+divergence (apache/sedona-db#1235): SedonaDB reads the pixel coordinate
+0-based, so (0, 0) names the origin pixel, where Sedona Spark reads it
+1-based, so (1, 1) does — shifting every answer by one pixel of scale.
+The X/Y variants catalog the same divergence scalar by scalar.
+"""
+
+import pytest
+
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+
+@pytest.mark.parametrize(
+    "col,row", [pytest.param(1, 1, id="1-1"), pytest.param(2, 2, id="2-2")]
+)
+@pytest.mark.xfail(
+    reason="the input pixel coordinate is 0-based in SedonaDB and 1-based in "
+    "Sedona Spark (apache/sedona-db#1235): (1, 1) answers POINT (102 497) "
+    "from SedonaDB and POINT (100 500) — the origin corner — from Sedona "
+    "Spark"
+)
+def test_rs_rastertoworldcoord(col, row, tmp_path):
+    """A pixel coordinate names the same world POINT on both engines."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("r2wc_src", tmp_path / "r2wc_src.tif")
+    sql = f"SELECT RS_RasterToWorldCoord(rast, {col}, {row}) FROM r2wc_src"
+    compare(sql, sedona, spark)

--- a/integration/spark-parity/test_rs_worldtorastercoord.py
+++ b/integration/spark-parity/test_rs_worldtorastercoord.py
@@ -1,0 +1,95 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_WorldToRasterCoord.
+
+The combined form returns the pixel coordinate as a POINT geometry;
+results travel through the harness's geometry path (each engine's WKB
+rendered as WKT by geoarrow) so the shared SQL stays RS-only. Every
+case is a cataloged divergence: SedonaDB treats pixel coordinates as
+0-based where Sedona Spark (following PostGIS, and SedonaDB's own
+RS_PixelAs* functions) is 1-based (apache/sedona-db#1235) — and on a
+fractional negative index the engines also disagree on rounding, so
+outside the grid the answers are not even a uniform pixel apart.
+Sedona Spark additionally accepts a point geometry in place of the
+(x, y) pair, an overload SedonaDB lacks (the X/Y variants share both
+gaps).
+"""
+
+import pytest
+
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+
+def _engines(name, tmp_path):
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view(name, tmp_path / f"{name}.tif")
+    return sedona, spark
+
+
+@pytest.mark.parametrize(
+    "x,y",
+    [
+        pytest.param(100.0, 500.0, id="origin"),
+        pytest.param(104.0, 494.0, id="interior"),
+        pytest.param(105.0, 493.0, id="interior-fractional"),
+    ],
+)
+@pytest.mark.xfail(
+    reason="SedonaDB maps pixel coordinates 0-based (the origin is "
+    "POINT (0 0)); Sedona Spark is 1-based (POINT (1 1)) — "
+    "apache/sedona-db#1235"
+)
+def test_rs_worldtorastercoord(x, y, tmp_path):
+    """Points on and between pixel corners map to the same pixel POINT on
+    both engines."""
+    sedona, spark = _engines("w2rc_src", tmp_path)
+    sql = f"SELECT RS_WorldToRasterCoord(rast, {x}, {y}) FROM w2rc_src"
+    compare(sql, sedona, spark)
+
+
+@pytest.mark.xfail(
+    reason="outside the grid the divergence is not the uniform one-pixel "
+    "offset: (90, 505) sits -5 columns and -5/3 rows from the origin, and "
+    "SedonaDB truncates the fraction toward zero (POINT (-5 -1)) where "
+    "Sedona Spark floors it before its 1-based shift (POINT (-4 -1)) — the "
+    "rows agree by coincidence while the columns differ"
+)
+def test_rs_worldtorastercoord_outside(tmp_path):
+    """A point outside the grid extrapolates to the same pixel POINT on
+    both engines."""
+    sedona, spark = _engines("w2rc_out_src", tmp_path)
+    sql = "SELECT RS_WorldToRasterCoord(rast, 90.0, 505.0) FROM w2rc_out_src"
+    compare(sql, sedona, spark)
+
+
+@pytest.mark.xfail(
+    reason="SedonaDB has no point-geometry overload of RS_WorldToRasterCoord "
+    "(it raises 'No kernel matching arguments'); Sedona Spark accepts "
+    "(raster, point) and answers 1-based, so once the overload exists the "
+    "0- vs 1-based divergence (apache/sedona-db#1235) still applies"
+)
+def test_rs_worldtorastercoord_point_overload(tmp_path):
+    """The point-geometry form maps the interior point (104 494) to the
+    same pixel POINT on both engines."""
+    sedona, spark = _engines("w2rcp_src", tmp_path)
+    sql = (
+        "SELECT RS_WorldToRasterCoord(rast, ST_GeomFromWKT('POINT (104 494)')) "
+        "FROM w2rcp_src"
+    )
+    compare(sql, sedona, spark)

--- a/python/sedonadb/python/sedonadb/testing_spark.py
+++ b/python/sedonadb/python/sedonadb/testing_spark.py
@@ -167,7 +167,41 @@ class SedonaSpark(DBEngine):
     def result_to_table(self, result) -> pa.Table:
         # toArrow() preserves nulls Arrow-natively; toPandas() would turn a
         # nodata None into a float NaN and mask the value under test.
-        return result.toArrow()
+        #
+        # toArrow() ships a GeometryUDT column as the UDT's internal
+        # serialization bytes, not ISO WKB, so convert in the JVM first
+        # (transport-only, like decode_raster_result's RS_AsGeoTiff) and
+        # re-tag the bytes as geoarrow.wkb — geometry results then render
+        # WKT through the same geoarrow path as every other engine.
+        import geoarrow.pyarrow as ga
+        from sedona.spark.sql.st_functions import ST_AsBinary
+        from sedona.spark.sql.types import GeometryType
+
+        fields = result.schema.fields
+        geometry_indices = {
+            i for i, f in enumerate(fields) if isinstance(f.dataType, GeometryType)
+        }
+        if geometry_indices:
+            # Rename positionally first: the generated column names contain
+            # dots ("rs_worldtorastercoord(rast, 104.0, 494.0)"), which every
+            # name-based column lookup would re-parse as a nested path.
+            names = [f.name for f in fields]
+            renamed = result.toDF(*[f"c{i}" for i in range(len(fields))])
+            result = renamed.select(
+                *[
+                    ST_AsBinary(column).alias(f"c{i}")
+                    if i in geometry_indices
+                    else column
+                    for i, column in enumerate(renamed[c] for c in renamed.columns)
+                ]
+            )
+        table = result.toArrow()
+        if geometry_indices:
+            table = table.rename_columns(names)
+        for i in geometry_indices:
+            wkb = ga.wkb().wrap_array(table.column(i).combine_chunks())
+            table = table.set_column(i, pa.field(table.schema.names[i], wkb.type), wkb)
+        return table
 
     def result_has_raster(self, sql) -> bool:
         from sedona.spark.sql.types import RasterType

--- a/python/sedonadb/python/sedonadb/testing_spark.py
+++ b/python/sedonadb/python/sedonadb/testing_spark.py
@@ -169,39 +169,23 @@ class SedonaSpark(DBEngine):
         # nodata None into a float NaN and mask the value under test.
         #
         # toArrow() ships a GeometryUDT column as the UDT's internal
-        # serialization bytes, not ISO WKB, so convert in the JVM first
-        # (transport-only, like decode_raster_result's RS_AsGeoTiff) and
-        # re-tag the bytes as geoarrow.wkb — geometry results then render
-        # WKT through the same geoarrow path as every other engine.
-        import geoarrow.pyarrow as ga
-        from sedona.spark.sql.st_functions import ST_AsBinary
+        # serialization bytes, not WKB, so geometry results route through
+        # sedona's own dataframe_to_arrow, which converts to EWKB in the
+        # JVM and tags the columns as geoarrow extension types — they then
+        # render WKT through the same geoarrow path as every other engine.
+        # Columns are renamed positionally around the call because
+        # dataframe_to_arrow resolves them by name and the generated names
+        # ("rs_worldtorastercoord(rast, 104.0, 494.0)") contain dots that
+        # name resolution re-parses as nested paths (apache/sedona#3351).
+        from sedona.spark.geoarrow import dataframe_to_arrow
         from sedona.spark.sql.types import GeometryType
 
         fields = result.schema.fields
-        geometry_indices = {
-            i for i, f in enumerate(fields) if isinstance(f.dataType, GeometryType)
-        }
-        if geometry_indices:
-            # Rename positionally first: the generated column names contain
-            # dots ("rs_worldtorastercoord(rast, 104.0, 494.0)"), which every
-            # name-based column lookup would re-parse as a nested path.
-            names = [f.name for f in fields]
-            renamed = result.toDF(*[f"c{i}" for i in range(len(fields))])
-            result = renamed.select(
-                *[
-                    ST_AsBinary(column).alias(f"c{i}")
-                    if i in geometry_indices
-                    else column
-                    for i, column in enumerate(renamed[c] for c in renamed.columns)
-                ]
-            )
-        table = result.toArrow()
-        if geometry_indices:
-            table = table.rename_columns(names)
-        for i in geometry_indices:
-            wkb = ga.wkb().wrap_array(table.column(i).combine_chunks())
-            table = table.set_column(i, pa.field(table.schema.names[i], wkb.type), wkb)
-        return table
+        if not any(isinstance(f.dataType, GeometryType) for f in fields):
+            return result.toArrow()
+        names = [f.name for f in fields]
+        renamed = result.toDF(*[f"c{i}" for i in range(len(fields))])
+        return dataframe_to_arrow(renamed).rename_columns(names)
 
     def result_has_raster(self, sql) -> bool:
         from sedona.spark.sql.types import RasterType


### PR DESCRIPTION
Unblocks geometry-returning raster functions in the spark-parity suite and uses that to catalog the `RS_WorldToRasterCoord` / `RS_RasterToWorldCoord` combined forms — including the missing point-geometry overload.

## Harness: geometry results (first commit)

Probing showed the two sides fail asymmetrically:

- **SedonaDB needed nothing**: its geometry results already arrive as `geoarrow.wkb` and `result_to_tuples` already renders them as WKT.
- **Sedona Spark was the broken side**: `DataFrame.toArrow()` ships a `GeometryUDT` column as the UDT's *internal* serialization bytes — not ISO WKB — which the tuple path then tried to cast to string ("Invalid UTF8 payload").

`SedonaSpark.result_to_table` now converts geometry columns to WKB in the JVM (`ST_AsBinary`, transport-only — the same pattern `decode_raster_result` uses with `RS_AsGeoTiff`; the shared test SQL stays RS-only) and re-tags the bytes as `geoarrow.wkb`, so both engines render WKT through the same geoarrow formatter. Columns are renamed positionally before the select because Spark's generated names (`rs_worldtorastercoord(rast, 104.0, 494.0)`) contain dots that every name-based lookup re-parses as a nested path; the original names are restored on the Arrow table.

Everything downstream (`result_to_tuples`, `assert_result`, WKT `expected=` anchors, `compare()`) works unchanged. Full suite on this branch: `174 passed, 84 xfailed` — main's counts plus exactly the 7 new xfails.

## RS_WorldToRasterCoord (second commit)

All probed, every case an xfail stating both observed behaviors:

- **0- vs 1-based** (#1235, now in geometry form): the origin answers `POINT (0 0)` from SedonaDB and `POINT (1 1)` from Sedona Spark; interior points likewise one pixel apart.
- **Outside the grid the offset is not even uniform** (new finding): (90, 505) sits −5 columns and −5/3 rows from the origin. SedonaDB truncates the fraction toward zero (`POINT (-5 -1)`); Spark floors before its 1-based shift (`POINT (-4 -1)`) — the rows agree by coincidence, the columns differ. A positive-fraction probe ((105, 493) → 2 vs 3) confirms the rules are truncation vs floor+1, not something else.
- **Missing point-geometry overload**: `RS_WorldToRasterCoord(raster, point)` raises "No kernel matching arguments" on SedonaDB; Spark accepts it. The xfail notes #1235 still applies once the overload exists.

## RS_RasterToWorldCoord

The input side of #1235: `(1, 1)` answers `POINT (102 497)` from SedonaDB (0-based input) and `POINT (100 500)` — the origin corner — from Spark (1-based input).

## Follow-ups this unblocks

The remaining geometry-returning functions can now get parity files the same way: RS_Envelope, RS_ConvexHull, RS_PixelAsPoint / RS_PixelAsCentroid / RS_PixelAsPolygon. (Item-level-CRS geometry outputs may need another look — these fixtures are CRS-less.) The `test_rs_worldtorastercoordx/y` docstrings still say the combined form is "deferred"; updating that line is left out here because #1262 touches the same sentence — whichever lands second gets the one-line fix.
