### PR TITLE
fix(python/sedonadb): avoid expr dependency in dataframe test

### DIFF
--- a/python/sedonadb/tests/test_dataframe.py
+++ b/python/sedonadb/tests/test_dataframe.py
@@ -190,7 +190,9 @@ def test_columns(con):
 def test_select_struct_field_after_unnest_st_dump(con):
     # Regression for https://github.com/apache/sedona-db/issues/1232.
     multi = con.sql("SELECT ST_GeomFromText('MULTIPOINT (0 0, 1 1)') AS geometry")
-    dumped = multi.select(multi["geometry"].geo.dump().alias("dump")).unnest("dump")
+    dumped = multi.select(multi["geometry"].funcs.st_dump().alias("dump")).unnest(
+        "dump"
+    )
     result = dumped.select(dumped["dump"]["geom"].alias("geometry"))
 
     assert result.to_arrow_table().num_rows == 2


### PR DESCRIPTION
Use the built-in funcs expression accessor for ST_Dump in the unnest regression test. This keeps the wheel test independent of the optional sedonadb-expr package and fixes the ModuleNotFoundError seen in CI.