### PR TITLE
chore(rust/sedona-raster): migrate to Rust 2024 edition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
       - id: fmt
         name: rustfmt
         args: ["--all", "--"]
+        pass_filenames: false
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13

--- a/rust/sedona-raster/Cargo.toml
+++ b/rust/sedona-raster/Cargo.toml
@@ -24,7 +24,7 @@ homepage.workspace = true
 repository.workspace = true
 description.workspace = true
 readme.workspace = true
-edition.workspace = true
+edition = "2024"
 rust-version.workspace = true
 
 [lints.clippy]

--- a/rust/sedona-raster/src/affine_transformation.rs
+++ b/rust/sedona-raster/src/affine_transformation.rs
@@ -198,11 +198,13 @@ mod tests {
         };
         let result = to_raster_coordinate(&bad_raster, 100.0, 200.0);
         assert!(result.is_err());
-        assert!(result
-            .err()
-            .unwrap()
-            .to_string()
-            .contains("determinant is zero."));
+        assert!(
+            result
+                .err()
+                .unwrap()
+                .to_string()
+                .contains("determinant is zero.")
+        );
     }
 
     fn rotation_raster(scale_x: f64, scale_y: f64, skew_x: f64, skew_y: f64) -> TestRaster {

--- a/rust/sedona-raster/src/array.rs
+++ b/rust/sedona-raster/src/array.rs
@@ -16,8 +16,8 @@
 // under the License.
 
 use arrow_array::{
-    new_null_array, Array, ArrayRef, BinaryArray, BinaryViewArray, Float64Array, Int64Array,
-    ListArray, StringArray, StringViewArray, StructArray, UInt32Array,
+    Array, ArrayRef, BinaryArray, BinaryViewArray, Float64Array, Int64Array, ListArray,
+    StringArray, StringViewArray, StructArray, UInt32Array, new_null_array,
 };
 use arrow_buffer::NullBuffer;
 use arrow_schema::DataType;
@@ -31,7 +31,7 @@ use crate::error::RasterError;
 use crate::traits::{BandRef, NdBuffer, Override, RasterRef};
 use crate::view_entries::{ViewEntries, ViewEntry};
 use sedona_schema::raster::{
-    band_indices, band_view_indices, raster_indices, BandDataType, RasterSchema,
+    BandDataType, RasterSchema, band_indices, band_view_indices, raster_indices,
 };
 
 /// Arrow-backed implementation of BandRef for a single band within a raster.
@@ -472,7 +472,7 @@ pub fn with_column_overrides(
             return Err(RasterError::Invalid(format!(
                 "with_column_overrides: input nulls have {} rows, expected {num_rows} or 1",
                 nulls.len()
-            )))
+            )));
         }
         None => None,
     };
@@ -942,7 +942,7 @@ mod tests {
     use arrow_array::{ArrayRef, ListArray, StructArray, UInt32Array};
     use arrow_buffer::{Buffer, NullBuffer, OffsetBuffer, ScalarBuffer};
     use arrow_schema::{DataType, Field, Fields};
-    use sedona_schema::raster::{band_indices, raster_indices, BandDataType, RasterSchema};
+    use sedona_schema::raster::{BandDataType, RasterSchema, band_indices, raster_indices};
     use sedona_testing::rasters::generate_test_rasters;
     use std::sync::Arc;
 
@@ -1262,13 +1262,14 @@ mod tests {
         for i in 0..3 {
             let band = raster.band(i).unwrap();
             let expected_value = i as u8;
-            assert!(band
-                .nd_buffer()
-                .unwrap()
-                .as_contiguous()
-                .unwrap()
-                .iter()
-                .all(|&x| x == expected_value));
+            assert!(
+                band.nd_buffer()
+                    .unwrap()
+                    .as_contiguous()
+                    .unwrap()
+                    .iter()
+                    .all(|&x| x == expected_value)
+            );
         }
 
         // Test array
@@ -2040,8 +2041,8 @@ mod tests {
         // the data buffer so the NdBuffer.offset invariant holds — a view whose
         // offset runs past the buffer end must error even though it's empty.
         let array = build_explicit_view_raster(); // source_shape [8], 8 data bytes
-                                                  // start=100 with steps=0: validate skips the start bound for empty axes,
-                                                  // so this composes byte_offset=100 over the 8-byte buffer.
+        // start=100 with steps=0: validate skips the start bound for empty axes,
+        // so this composes byte_offset=100 over the 8-byte buffer.
         let escaping_view = make_band_view_list(vec![vec![(0, 100, 1, 0)]], None);
         let mutated = replace_band_column(&array, band_indices::VIEW, escaping_view);
         let rasters = RasterStructArray::try_new(&mutated).unwrap();

--- a/rust/sedona-raster/src/band_builder.rs
+++ b/rust/sedona-raster/src/band_builder.rs
@@ -19,11 +19,11 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow_array::{
+    ArrayRef, BinaryViewArray, ListArray, StructArray,
     builder::{
         ArrayBuilder, BinaryBuilder, BinaryViewBuilder, Int64Builder, StringBuilder,
         StringViewBuilder, UInt32Builder,
     },
-    ArrayRef, BinaryViewArray, ListArray, StructArray,
 };
 use arrow_buffer::{Buffer, NullBuffer, OffsetBuffer, ScalarBuffer};
 use arrow_schema::DataType;
@@ -364,12 +364,10 @@ impl BandArrayBuilder {
     pub fn finish_band(&mut self) -> Result<(), RasterError> {
         let current_count = self.data.len();
         if current_count != self.data_count_at_start + 1 {
-            return Err(RasterError::Invalid(
-                format!(
-                    "Expected exactly one band data value per band, but got {} appended since start_band()",
-                    current_count - self.data_count_at_start
-                ),
-            ));
+            return Err(RasterError::Invalid(format!(
+                "Expected exactly one band data value per band, but got {} appended since start_band()",
+                current_count - self.data_count_at_start
+            )));
         }
         Ok(())
     }
@@ -522,7 +520,7 @@ mod tests {
     use crate::builder::RasterBuilder;
     use crate::traits::{BandOverrides, RasterRef};
     use arrow_array::{Array, BinaryViewArray, StringArray, UInt32Array};
-    use sedona_schema::raster::{band_indices, BandDataType};
+    use sedona_schema::raster::{BandDataType, band_indices};
 
     /// The point of this whole refactor: a bare `BandArrayBuilder`, with no
     /// enclosing `RasterBuilder`/raster envelope at all, builds a real band

--- a/rust/sedona-raster/src/builder.rs
+++ b/rust/sedona-raster/src/builder.rs
@@ -16,8 +16,8 @@
 // under the License.
 
 use arrow_array::{
-    builder::{BinaryViewBuilder, BooleanBuilder, Float64Builder, Int64Builder, StringViewBuilder},
     Array, ArrayRef, BinaryViewArray, ListArray, StructArray,
+    builder::{BinaryViewBuilder, BooleanBuilder, Float64Builder, Int64Builder, StringViewBuilder},
 };
 use arrow_buffer::{Buffer, OffsetBuffer, ScalarBuffer};
 use arrow_schema::DataType;
@@ -785,13 +785,14 @@ mod tests {
         for i in 0..3 {
             let band = raster.band(i).unwrap();
             let expected_value = i as u8;
-            assert!(band
-                .nd_buffer()
-                .unwrap()
-                .as_contiguous()
-                .unwrap()
-                .iter()
-                .all(|&x| x == expected_value));
+            assert!(
+                band.nd_buffer()
+                    .unwrap()
+                    .as_contiguous()
+                    .unwrap()
+                    .iter()
+                    .all(|&x| x == expected_value)
+            );
         }
 
         // Test iterator
@@ -895,7 +896,7 @@ mod tests {
 
     #[test]
     fn copy_raster_from_overrides_transform_and_preserves_bands() {
-        use sedona_testing::raster_spec::{assert_rasters_equal, RasterSpec};
+        use sedona_testing::raster_spec::{RasterSpec, assert_rasters_equal};
 
         // Source: a CRS, a nodata sentinel, and pixel values to preserve.
         let source = RasterSpec::d2(2, 1)

--- a/rust/sedona-raster/src/error.rs
+++ b/rust/sedona-raster/src/error.rs
@@ -43,7 +43,7 @@
 //! directly — same as `sedona-geometry`, which has no internal variant.
 
 use arrow_schema::ArrowError;
-use datafusion_common::{exec_datafusion_err, DataFusionError};
+use datafusion_common::{DataFusionError, exec_datafusion_err};
 use thiserror::Error;
 
 /// Error type for the raster crates.

--- a/rust/sedona-raster/src/geo_transform.rs
+++ b/rust/sedona-raster/src/geo_transform.rs
@@ -140,11 +140,7 @@ impl GeoTransformEx for [f64] {
         // acos rather than atan2 of the same ratio so an axis-aligned grid
         // reports +0.0 and a mirrored one +pi, matching Sedona Spark exactly.
         let theta = (self.scale_x() / self.scale_x().hypot(self.skew_y())).acos();
-        if self.skew_y() > 0.0 {
-            -theta
-        } else {
-            theta
-        }
+        if self.skew_y() > 0.0 { -theta } else { theta }
     }
 
     #[inline]
@@ -239,7 +235,7 @@ pub fn geotransform_from_bbox_and_spatial_shape(
         other => {
             return Err(RasterError::Invalid(format!(
                 "registration must be \"pixel\" or \"node\"; got {other:?}"
-            )))
+            )));
         }
     };
 

--- a/rust/sedona-raster/src/raster_loader.rs
+++ b/rust/sedona-raster/src/raster_loader.rs
@@ -34,7 +34,7 @@ use arrow_schema::ArrowError;
 use datafusion_common::config::{
     ConfigEntry, ConfigExtension, ConfigField, ExtensionOptions, Visit,
 };
-use datafusion_common::{config_err, Result as DFResult};
+use datafusion_common::{Result as DFResult, config_err};
 use sedona_schema::raster::BandDataType;
 
 use crate::view_entries::ViewEntries;

--- a/rust/sedona-raster/src/traits.rs
+++ b/rust/sedona-raster/src/traits.rs
@@ -142,15 +142,15 @@ impl<'a> NdBuffer<'a> {
 /// This is the shared convention consumers use to recover the source path and
 /// band from a band's `outdb_uri()`.
 pub fn split_outdb_band_fragment(uri: &str) -> Result<(String, u32), RasterError> {
-    if let Some((prefix, fragment)) = uri.rsplit_once('#') {
-        if let Some(band_str) = fragment.strip_prefix("band=") {
-            return match band_str.parse::<u32>() {
-                Ok(band) if band >= 1 => Ok((prefix.to_string(), band)),
-                _ => Err(RasterError::Invalid(format!(
-                    "Invalid band index in outdb URI fragment '#band={band_str}': expected a positive integer in 1..=u32::MAX"
-                ))),
-            };
-        }
+    if let Some((prefix, fragment)) = uri.rsplit_once('#')
+        && let Some(band_str) = fragment.strip_prefix("band=")
+    {
+        return match band_str.parse::<u32>() {
+            Ok(band) if band >= 1 => Ok((prefix.to_string(), band)),
+            _ => Err(RasterError::Invalid(format!(
+                "Invalid band index in outdb URI fragment '#band={band_str}': expected a positive integer in 1..=u32::MAX"
+            ))),
+        };
     }
     Ok((uri.to_string(), 1))
 }


### PR DESCRIPTION
Migrates sedona-raster independently to Rust 2024 as part of #258, applies standard formatter output, and adopts a Rust 2024 let-chain required by Clippy. Validated with 190 package tests, all-target checks, and Clippy with warnings denied.