### PR TITLE
chore(c/sedona-geoarrow-c): migrate to Rust 2024 edition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
       - id: fmt
         name: rustfmt
         args: ["--all", "--"]
+        pass_filenames: false
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13

--- a/c/sedona-geoarrow-c/Cargo.toml
+++ b/c/sedona-geoarrow-c/Cargo.toml
@@ -25,7 +25,7 @@ homepage.workspace = true
 repository.workspace = true
 description.workspace = true
 readme.workspace = true
-edition.workspace = true
+edition = "2024"
 rust-version.workspace = true
 
 [build-dependencies]
@@ -35,7 +35,7 @@ cc = { version = "1" }
 criterion = { workspace = true }
 rstest = { workspace = true }
 sedona = { workspace = true }
-sedona-testing = { workspace = true }
+sedona-testing = { workspace = true, features = ["criterion"] }
 
 [dependencies]
 arrow-schema = { workspace = true }

--- a/c/sedona-geoarrow-c/benches/geoarrow_c-functions.rs
+++ b/c/sedona-geoarrow-c/benches/geoarrow_c-functions.rs
@@ -14,9 +14,9 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use datafusion_expr::ScalarUDF;
-use sedona_testing::benchmark_util::{benchmark, BenchmarkArgSpec::*};
+use sedona_testing::benchmark_util::{BenchmarkArgSpec::*, benchmark};
 
 fn criterion_benchmark(c: &mut Criterion) {
     let mut f = sedona_functions::register::default_function_set();

--- a/c/sedona-geoarrow-c/src/geoarrow_c.rs
+++ b/c/sedona-geoarrow-c/src/geoarrow_c.rs
@@ -16,7 +16,7 @@
 // under the License.
 use std::{ffi::CStr, fmt::Display, mem::transmute, ptr};
 
-use arrow_array::{ffi::FFI_ArrowArray, make_array, ArrayRef};
+use arrow_array::{ArrayRef, ffi::FFI_ArrowArray, make_array};
 use arrow_schema::DataType;
 use sedona_schema::datatypes::SedonaType;
 
@@ -284,12 +284,12 @@ fn geoarrow_type_id(sedona_type: &SedonaType) -> Result<GeoArrowType, GeoArrowCE
         SedonaType::Raster => {
             return Err(GeoArrowCError::Invalid(
                 "GeoArrow does not support Raster types".to_string(),
-            ))
+            ));
         }
         SedonaType::UnrecognizedExtension(_) => {
             return Err(GeoArrowCError::Invalid(
                 "GeoArrow does not support user-defined extension types".to_string(),
-            ))
+            ));
         }
     };
 
@@ -307,7 +307,7 @@ fn arrow_storage_type(type_id: GeoArrowType) -> Result<DataType, GeoArrowCError>
         _ => {
             return Err(GeoArrowCError::Invalid(format!(
                 "Can't guess Arrow type from GeoArrowType with ID {type_id:?}"
-            )))
+            )));
         }
     })
 }


### PR DESCRIPTION
Migrates sedona-geoarrow-c independently to Rust 2024 as part of #258 and applies standard formatter output. Also enables the sedona-testing criterion feature explicitly so standalone all-target checks include the benchmark helper without workspace feature unification. Validated with package tests, all-target checks, and Clippy with warnings denied.