### PR TITLE
chore(c/sedona-s2geography): migrate to Rust 2024 edition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
       - id: fmt
         name: rustfmt
         args: ["--all", "--"]
+        pass_filenames: false
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13

--- a/c/sedona-s2geography/Cargo.toml
+++ b/c/sedona-s2geography/Cargo.toml
@@ -25,7 +25,7 @@ homepage.workspace = true
 repository.workspace = true
 description.workspace = true
 readme.workspace = true
-edition.workspace = true
+edition = "2024"
 rust-version.workspace = true
 
 [build-dependencies]

--- a/c/sedona-s2geography/benches/s2geography-functions.rs
+++ b/c/sedona-s2geography/benches/s2geography-functions.rs
@@ -16,14 +16,14 @@
 // under the License.
 use std::sync::Arc;
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use datafusion_expr::ScalarUDF;
 use sedona_expr::{
     function_set::FunctionSet,
     scalar_udf::{SedonaScalarUDF, SimpleSedonaScalarKernel},
 };
 use sedona_schema::{datatypes::WKB_GEOGRAPHY, matchers::ArgMatcher};
-use sedona_testing::benchmark_util::{benchmark, BenchmarkArgSpec::*, BenchmarkArgs};
+use sedona_testing::benchmark_util::{BenchmarkArgSpec::*, BenchmarkArgs, benchmark};
 
 fn criterion_benchmark(c: &mut Criterion) {
     let mut f = FunctionSet::new();

--- a/c/sedona-s2geography/src/operator.rs
+++ b/c/sedona-s2geography/src/operator.rs
@@ -226,11 +226,13 @@ mod tests {
 
         let mut op = Op::new(OpType::DWithin);
         assert_eq!(op.name(), "distance_within");
-        assert!(!op
-            .eval_binary_distance_predicate(&geog1, &geog2, 100000.0)
-            .unwrap());
-        assert!(op
-            .eval_binary_distance_predicate(&geog1, &geog2, 200000.0)
-            .unwrap());
+        assert!(
+            !op.eval_binary_distance_predicate(&geog1, &geog2, 100000.0)
+                .unwrap()
+        );
+        assert!(
+            op.eval_binary_distance_predicate(&geog1, &geog2, 200000.0)
+                .unwrap()
+        );
     }
 }

--- a/c/sedona-s2geography/tests/bounding_functions.rs
+++ b/c/sedona-s2geography/tests/bounding_functions.rs
@@ -145,7 +145,7 @@ mod st_envelope {
 }
 
 mod st_xy_minmax {
-    use arrow_array::{create_array, ArrayRef};
+    use arrow_array::{ArrayRef, create_array};
     use arrow_schema::DataType;
     use datafusion_common::ScalarValue;
     use rstest::rstest;


### PR DESCRIPTION
Migrates sedona-s2geography independently to Rust 2024 as part of #258 and applies standard formatter output. Validated with 65 package tests, all-target checks, and Clippy with warnings denied.