### PR TITLE
chore(rust/sedona-geometry): migrate to Rust 2024 edition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
       - id: fmt
         name: rustfmt
         args: ["--all", "--"]
+        pass_filenames: false
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13

--- a/rust/sedona-geometry/Cargo.toml
+++ b/rust/sedona-geometry/Cargo.toml
@@ -24,7 +24,7 @@ homepage.workspace = true
 repository.workspace = true
 description.workspace = true
 readme.workspace = true
-edition.workspace = true
+edition = "2024"
 rust-version.workspace = true
 
 [lints.clippy]

--- a/rust/sedona-geometry/src/bounds.rs
+++ b/rust/sedona-geometry/src/bounds.rs
@@ -306,7 +306,7 @@ pub fn visit_xy_coords(
         _ => {
             return Err(SedonaGeometryError::Invalid(
                 "GeometryType not supported for coordinate visiting".to_string(),
-            ))
+            ));
         }
     }
 
@@ -375,7 +375,7 @@ pub fn geo_traits_update_dimension_bounds(
         _ => {
             return Err(SedonaGeometryError::Invalid(
                 "GeometryType not supported for dimension bounds".to_string(),
-            ))
+            ));
         }
     }
 
@@ -403,7 +403,7 @@ mod test {
     use super::*;
     use rstest::rstest;
     use std::{iter::zip, str::FromStr};
-    use wkb::{writer::WriteOptions, Endianness};
+    use wkb::{Endianness, writer::WriteOptions};
     use wkt::Wkt;
 
     pub fn wkt_bounds_xy(wkt_value: &str) -> Result<BoundingBox, SedonaGeometryError> {

--- a/rust/sedona-geometry/src/ewkb_factory.rs
+++ b/rust/sedona-geometry/src/ewkb_factory.rs
@@ -228,7 +228,7 @@ fn write_geometry_type_and_srid(
 mod test {
 
     use rstest::rstest;
-    use wkb::{writer::WriteOptions, Endianness};
+    use wkb::{Endianness, writer::WriteOptions};
 
     use super::*;
 

--- a/rust/sedona-geometry/src/interval.rs
+++ b/rust/sedona-geometry/src/interval.rs
@@ -538,11 +538,14 @@ impl IntervalTrait for WraparoundInterval {
             (false, true) => {
                 let inner = self.inner;
                 let (left, right) = other.split();
-                match (inner.intersects_interval(&left), inner.intersects_interval(&right)) {
+                match (
+                    inner.intersects_interval(&left),
+                    inner.intersects_interval(&right),
+                ) {
                     // Intersects both the left and right intervals
-                    (true, true) => {
-                        Err(SedonaGeometryError::Invalid(format!("Can't represent the intersection of {self:?} and {other:?} as a single WraparoundInterval")))
-                    },
+                    (true, true) => Err(SedonaGeometryError::Invalid(format!(
+                        "Can't represent the intersection of {self:?} and {other:?} as a single WraparoundInterval"
+                    ))),
                     // Intersects only the left interval
                     (true, false) => Ok(inner.intersection(&left)?.into()),
                     // Intersects only the right interval
@@ -570,7 +573,9 @@ impl IntervalTrait for WraparoundInterval {
                         excluded_union.lo(),
                     ))
                 } else {
-                    Err(SedonaGeometryError::Invalid(format!("Can't represent the intersection of {self:?} and {other:?} as a single WraparoundInterval")))
+                    Err(SedonaGeometryError::Invalid(format!(
+                        "Can't represent the intersection of {self:?} and {other:?} as a single WraparoundInterval"
+                    )))
                 }
             }
         }
@@ -1329,8 +1334,9 @@ mod test {
 
         // Can't convert a wraparound interval that actually wraps around to an Interval
         let err = Interval::try_from(wraparound).unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("Can't convert wraparound interval"));
+        assert!(
+            err.to_string()
+                .contains("Can't convert wraparound interval")
+        );
     }
 }

--- a/rust/sedona-geometry/src/is_empty.rs
+++ b/rust/sedona-geometry/src/is_empty.rs
@@ -50,9 +50,9 @@ pub fn is_geometry_empty<G: GeometryTrait<T = f64>>(
 mod tests {
     use super::*;
     use std::str::FromStr;
-    use wkb::reader::read_wkb;
-    use wkb::writer::{write_geometry, WriteOptions};
     use wkb::Endianness;
+    use wkb::reader::read_wkb;
+    use wkb::writer::{WriteOptions, write_geometry};
     use wkt::Wkt;
 
     fn create_wkb_bytes_from_wkt(wkt_str: &str) -> Vec<u8> {

--- a/rust/sedona-geometry/src/transform.rs
+++ b/rust/sedona-geometry/src/transform.rs
@@ -393,7 +393,7 @@ pub fn transform(
         _ => {
             return Err(SedonaGeometryError::Invalid(
                 "GeometryType not supported for transform".to_string(),
-            ))
+            ));
         }
     }
 

--- a/rust/sedona-geometry/src/types.rs
+++ b/rust/sedona-geometry/src/types.rs
@@ -191,7 +191,7 @@ impl GeometryTypeAndDimensions {
             _ => {
                 return Err(SedonaGeometryError::Invalid(
                     "Unsupported geometry type".to_string(),
-                ))
+                ));
             }
         };
 
@@ -218,7 +218,7 @@ impl GeometryTypeAndDimensions {
             _ => {
                 return Err(SedonaGeometryError::Invalid(format!(
                     "Unknown dimensions in ISO WKB geometry type: {wkb_id}"
-                )))
+                )));
             }
         };
 
@@ -291,7 +291,7 @@ impl FromStr for GeometryTypeAndDimensions {
             None => {
                 return Err(SedonaGeometryError::Invalid(format!(
                     "Invalid geometry type string: '{value}'"
-                )))
+                )));
             }
         };
 
@@ -303,7 +303,7 @@ impl FromStr for GeometryTypeAndDimensions {
                 _ => {
                     return Err(SedonaGeometryError::Invalid(format!(
                         "invalid geometry type string: '{value}'"
-                    )))
+                    )));
                 }
             },
             None => Dimensions::Xy,
@@ -575,9 +575,9 @@ mod test {
 
     use super::*;
 
-    use rstest::rstest;
     use Dimensions::*;
     use GeometryTypeId::*;
+    use rstest::rstest;
 
     #[rstest]
     fn geometry_type_wkb_id_roundtrip(

--- a/rust/sedona-geometry/src/wkb_factory.rs
+++ b/rust/sedona-geometry/src/wkb_factory.rs
@@ -531,9 +531,9 @@ fn count_to_u32(count: usize) -> Result<u32, SedonaGeometryError> {
 #[cfg(test)]
 mod test {
     use std::str::FromStr;
-    use wkb::reader::read_wkb;
-    use wkb::writer::{write_geometry, WriteOptions};
     use wkb::Endianness;
+    use wkb::reader::read_wkb;
+    use wkb::writer::{WriteOptions, write_geometry};
     use wkt::Wkt;
 
     use super::*;

--- a/rust/sedona-geometry/src/wkb_header.rs
+++ b/rust/sedona-geometry/src/wkb_header.rs
@@ -185,7 +185,7 @@ impl WkbPointLayout {
             _ => {
                 return Err(SedonaGeometryError::Invalid(
                     "WKB: missing or invalid byte order".to_string(),
-                ))
+                ));
             }
         };
 
@@ -397,7 +397,7 @@ impl<'a> WkbBuffer<'a> {
             other => {
                 return Err(SedonaGeometryError::Invalid(format!(
                     "Unexpected byte order: {other:?}"
-                )))
+                )));
             }
         };
         self.remaining -= 4;
@@ -440,7 +440,7 @@ impl<'a> WkbBuffer<'a> {
             other => {
                 return Err(SedonaGeometryError::Invalid(format!(
                     "Unexpected byte order: {other:?}"
-                )))
+                )));
             }
         };
         self.remaining -= 8;
@@ -490,7 +490,7 @@ mod tests {
     use super::*;
     use sedona_testing::fixtures::*;
     use std::str::FromStr;
-    use wkb::writer::{write_geometry, WriteOptions};
+    use wkb::writer::{WriteOptions, write_geometry};
     use wkt::Wkt;
 
     fn make_wkb(wkt_value: &'static str) -> Vec<u8> {
@@ -588,7 +588,9 @@ mod tests {
         let header = WkbHeader::try_new(&wkb).unwrap();
         assert_eq!(header.size(), 1);
 
-        let wkb = make_wkb("GEOMETRYCOLLECTION (POINT (1 2), LINESTRING (1 2, 3 4), POLYGON ((0 0, 0 1, 1 0, 0 0)))");
+        let wkb = make_wkb(
+            "GEOMETRYCOLLECTION (POINT (1 2), LINESTRING (1 2, 3 4), POLYGON ((0 0, 0 1, 1 0, 0 0)))",
+        );
         let header = WkbHeader::try_new(&wkb).unwrap();
         assert_eq!(header.size(), 3);
     }
@@ -805,7 +807,9 @@ mod tests {
         let header = WkbHeader::try_new(&wkb).unwrap();
         assert_eq!(header.first_xy(), (1.0, 2.0));
 
-        let wkb = make_wkb("GEOMETRYCOLLECTION (POINT (1 2), LINESTRING (1 2, 3 4), POLYGON ((0 0, 0 1, 1 0, 0 0)))");
+        let wkb = make_wkb(
+            "GEOMETRYCOLLECTION (POINT (1 2), LINESTRING (1 2, 3 4), POLYGON ((0 0, 0 1, 1 0, 0 0)))",
+        );
         let header = WkbHeader::try_new(&wkb).unwrap();
         assert_eq!(header.first_xy(), (1.0, 2.0));
     }


### PR DESCRIPTION
Migrates sedona-geometry independently to Rust 2024 as part of #258 and applies standard formatter output. Validated with package tests, all-target checks, and Clippy with warnings denied.