### PR TITLE
chore(rust/sedona-common): migrate to Rust 2024 edition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
       - id: fmt
         name: rustfmt
         args: ["--all", "--"]
+        pass_filenames: false
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13

--- a/rust/sedona-common/Cargo.toml
+++ b/rust/sedona-common/Cargo.toml
@@ -24,7 +24,7 @@ homepage.workspace = true
 repository.workspace = true
 description.workspace = true
 readme.workspace = true
-edition.workspace = true
+edition = "2024"
 rust-version.workspace = true
 
 [dependencies]

--- a/rust/sedona-common/src/option.rs
+++ b/rust/sedona-common/src/option.rs
@@ -18,10 +18,10 @@ use std::fmt::Display;
 use std::rc::Rc;
 use std::sync::Arc;
 
+use datafusion_common::Result;
 use datafusion_common::config::{
     ConfigEntry, ConfigExtension, ConfigField, ConfigOptions, ExtensionOptions, Visit,
 };
-use datafusion_common::Result;
 use datafusion_common::{config_err, config_namespace};
 use regex::Regex;
 use sedona_geometry::bounding_box::BoundingBox;
@@ -350,9 +350,9 @@ impl ConfigField for ExecutionMode {
                     };
                     ExecutionMode::Speculative(n)
                 } else {
-                    return Err(datafusion_common::DataFusionError::Configuration(
-                        format!("Unknown execution mode: {value}. Expected formats: prepare_none, prepare_build, prepare_probe, auto, auto[number]")
-                    ));
+                    return Err(datafusion_common::DataFusionError::Configuration(format!(
+                        "Unknown execution mode: {value}. Expected formats: prepare_none, prepare_build, prepare_probe, auto, auto[number]"
+                    )));
                 }
             }
         };


### PR DESCRIPTION
Migrates sedona-common independently to Rust 2024 as part of #258 and applies standard formatter output. Validated with package tests, all-target checks, and Clippy with warnings denied.