### PR TITLE
chore(c/sedona-libgpuspatial): migrate to Rust 2024 edition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
       - id: fmt
         name: rustfmt
         args: ["--all", "--"]
+        pass_filenames: false
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13

--- a/c/sedona-libgpuspatial/Cargo.toml
+++ b/c/sedona-libgpuspatial/Cargo.toml
@@ -23,7 +23,7 @@ homepage.workspace = true
 repository.workspace = true
 description = "GPU spatial operations wrapper for libgpuspatial"
 readme.workspace = true
-edition.workspace = true
+edition = "2024"
 rust-version.workspace = true
 
 [features]

--- a/c/sedona-libgpuspatial/build.rs
+++ b/c/sedona-libgpuspatial/build.rs
@@ -122,8 +122,12 @@ fn main() {
     // Check if libgpuspatial submodule exists
     let libgpuspatial_path = std::path::Path::new("./libgpuspatial/CMakeLists.txt");
     if !libgpuspatial_path.exists() {
-        println!("cargo:warning=libgpuspatial submodule not found. GPU functionality will not be available.");
-        println!("cargo:warning=To enable GPU support, initialize the submodule: git submodule update --init --recursive");
+        println!(
+            "cargo:warning=libgpuspatial submodule not found. GPU functionality will not be available."
+        );
+        println!(
+            "cargo:warning=To enable GPU support, initialize the submodule: git submodule update --init --recursive"
+        );
 
         // Create empty bindings file so the build doesn't fail
         let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
@@ -236,7 +240,9 @@ fn main() {
                 driver_lib_path.display()
             ); // CUDA driver
         } else {
-            panic!("CUDA libcuda.so is not found. Please ensure NVIDIA drivers are installed and in a standard location, or set LD_LIBRARY_PATH or CUDA_HOME.");
+            panic!(
+                "CUDA libcuda.so is not found. Please ensure NVIDIA drivers are installed and in a standard location, or set LD_LIBRARY_PATH or CUDA_HOME."
+            );
         }
 
         println!("cargo:rustc-link-lib=static=gpuspatial_c");

--- a/c/sedona-libgpuspatial/src/libgpuspatial.rs
+++ b/c/sedona-libgpuspatial/src/libgpuspatial.rs
@@ -20,11 +20,11 @@ use crate::error::GpuSpatialError;
 use crate::libgpuspatial_glue_bindgen::*;
 use crate::predicate::GpuSpatialRelationPredicate;
 use arrow_array::{Array, ArrayRef};
-use arrow_schema::ffi::FFI_ArrowSchema;
 use arrow_schema::DataType;
+use arrow_schema::ffi::FFI_ArrowSchema;
 use std::cell::UnsafeCell;
 use std::convert::TryFrom;
-use std::ffi::{c_void, CStr, CString};
+use std::ffi::{CStr, CString, c_void};
 use std::os::raw::c_char;
 use std::sync::Arc;
 


### PR DESCRIPTION
Migrates sedona-libgpuspatial independently to Rust 2024 as part of #258 and applies standard formatter output. Validated with package tests, all-target checks, and Clippy with warnings denied.