### PR TITLE
chore(c/sedona-tg): migrate to Rust 2024 edition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
       - id: fmt
         name: rustfmt
         args: ["--all", "--"]
+        pass_filenames: false
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13

--- a/c/sedona-tg/Cargo.toml
+++ b/c/sedona-tg/Cargo.toml
@@ -25,7 +25,7 @@ homepage.workspace = true
 repository.workspace = true
 description.workspace = true
 readme.workspace = true
-edition.workspace = true
+edition = "2024"
 rust-version.workspace = true
 
 [build-dependencies]

--- a/c/sedona-tg/benches/parse-wkb.rs
+++ b/c/sedona-tg/benches/parse-wkb.rs
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use geo::{LineString, Point};
 use sedona_tg::tg::Geom;
 

--- a/c/sedona-tg/benches/tg-functions.rs
+++ b/c/sedona-tg/benches/tg-functions.rs
@@ -14,9 +14,9 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use sedona_expr::function_set::FunctionSet;
-use sedona_testing::benchmark_util::{benchmark, BenchmarkArgSpec::*, BenchmarkArgs::*};
+use sedona_testing::benchmark_util::{BenchmarkArgSpec::*, BenchmarkArgs::*, benchmark};
 
 fn criterion_benchmark(c: &mut Criterion) {
     let mut f = FunctionSet::new();

--- a/c/sedona-tg/src/binary_predicate.rs
+++ b/c/sedona-tg/src/binary_predicate.rs
@@ -105,7 +105,7 @@ impl<Op: tg::BinaryPredicate + Send + Sync> SedonaScalarKernel for TgPredicate<O
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::{create_array, ArrayRef};
+    use arrow_array::{ArrayRef, create_array};
     use datafusion_common::scalar::ScalarValue;
     use rstest::rstest;
     use sedona_expr::scalar_udf::SedonaScalarUDF;

--- a/c/sedona-tg/src/tg.rs
+++ b/c/sedona-tg/src/tg.rs
@@ -92,12 +92,12 @@ impl Geom {
         }
 
         let geom = Self { inner };
-        let err = tg_geom_error(geom.inner);
+        let err = unsafe { tg_geom_error(geom.inner) };
         if err.is_null() {
             return Ok(geom);
         }
 
-        let c_str = std::ffi::CStr::from_ptr(err);
+        let c_str = unsafe { std::ffi::CStr::from_ptr(err) };
         Err(TgError::Invalid(c_str.to_string_lossy().into_owned()))
     }
 
@@ -258,7 +258,7 @@ pub unsafe fn set_allocator(
     static ALLOCATOR_SET: OnceLock<()> = OnceLock::new();
 
     if ALLOCATOR_SET.set(()).is_ok() {
-        tg_env_set_allocator(Some(malloc), Some(realloc), Some(free));
+        unsafe { tg_env_set_allocator(Some(malloc), Some(realloc), Some(free)) };
         Ok(())
     } else {
         Err(TgError::Invalid("Allocator already set".to_string()))


### PR DESCRIPTION
Migrates sedona-tg independently to Rust 2024 as part of #258, applies standard formatter output, and scopes unsafe operations explicitly inside unsafe functions. Validated with 14 package tests, all-target checks, and Clippy with warnings denied.