### PR TITLE
chore(rust/sedona-geo-traits-ext): migrate to Rust 2024 edition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
       - id: fmt
         name: rustfmt
         args: ["--all", "--"]
+        pass_filenames: false
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13

--- a/rust/sedona-geo-traits-ext/Cargo.toml
+++ b/rust/sedona-geo-traits-ext/Cargo.toml
@@ -24,7 +24,7 @@ homepage.workspace = true
 repository.workspace = true
 description.workspace = true
 readme.workspace = true
-edition.workspace = true
+edition = "2024"
 rust-version.workspace = true
 
 [dependencies]

--- a/rust/sedona-geo-traits-ext/src/geometry.rs
+++ b/rust/sedona-geo-traits-ext/src/geometry.rs
@@ -283,10 +283,12 @@ where
     }
 
     unsafe fn geometry_unchecked_ext(&self, i: usize) -> &Geometry<T> {
-        let GeometryType::GeometryCollection(gc) = self.as_type() else {
-            panic!("Not a GeometryCollection");
-        };
-        gc.geometry_unchecked(i)
+        unsafe {
+            let GeometryType::GeometryCollection(gc) = self.as_type() else {
+                panic!("Not a GeometryCollection");
+            };
+            gc.geometry_unchecked(i)
+        }
     }
 
     fn geometries_ext(&self) -> impl Iterator<Item = &Geometry<T>> {
@@ -318,8 +320,10 @@ where
     }
 
     unsafe fn geometry_unchecked_ext(&self, i: usize) -> &'a Geometry<T> {
-        let g = *self;
-        g.geometry_unchecked_ext(i)
+        unsafe {
+            let g = *self;
+            g.geometry_unchecked_ext(i)
+        }
     }
 
     fn geometries_ext(&self) -> impl Iterator<Item = &'a Geometry<T>> {

--- a/rust/sedona-geo-traits-ext/src/line_string.rs
+++ b/rust/sedona-geo-traits-ext/src/line_string.rs
@@ -51,7 +51,7 @@ where
     /// Otherwise, this function may cause undefined behavior.
     #[inline]
     unsafe fn geo_coord_unchecked(&self, i: usize) -> Coord<Self::T> {
-        self.coord_unchecked_ext(i).geo_coord()
+        unsafe { self.coord_unchecked_ext(i).geo_coord() }
     }
 
     /// Return an iterator yielding one [`Line`] for each line segment
@@ -136,7 +136,7 @@ macro_rules! forward_line_string_trait_ext_funcs {
 
         #[inline]
         unsafe fn coord_unchecked_ext(&self, i: usize) -> Self::CoordTypeExt<'_> {
-            <Self as LineStringTrait>::coord_unchecked(self, i)
+            unsafe { <Self as LineStringTrait>::coord_unchecked(self, i) }
         }
 
         #[inline]
@@ -153,7 +153,7 @@ where
     forward_line_string_trait_ext_funcs!();
 
     unsafe fn geo_coord_unchecked(&self, i: usize) -> Coord<Self::T> {
-        *self.0.get_unchecked(i)
+        unsafe { *self.0.get_unchecked(i) }
     }
 
     // Delegate to the `geo-types` implementation for less performance overhead
@@ -191,7 +191,7 @@ where
     forward_line_string_trait_ext_funcs!();
 
     unsafe fn geo_coord_unchecked(&self, i: usize) -> Coord<Self::T> {
-        *self.0.get_unchecked(i)
+        unsafe { *self.0.get_unchecked(i) }
     }
 
     // Delegate to the `geo-types` implementation for less performance overhead

--- a/rust/sedona-geo-traits-ext/src/multi_line_string.rs
+++ b/rust/sedona-geo-traits-ext/src/multi_line_string.rs
@@ -79,7 +79,7 @@ macro_rules! forward_multi_line_string_trait_ext_funcs {
 
         #[inline]
         unsafe fn line_string_unchecked_ext(&self, i: usize) -> Self::LineStringTypeExt<'_> {
-            <Self as MultiLineStringTrait>::line_string_unchecked(self, i)
+            unsafe { <Self as MultiLineStringTrait>::line_string_unchecked(self, i) }
         }
 
         #[inline]

--- a/rust/sedona-geo-traits-ext/src/multi_point.rs
+++ b/rust/sedona-geo-traits-ext/src/multi_point.rs
@@ -104,7 +104,7 @@ macro_rules! forward_multi_point_trait_ext_funcs {
 
         #[inline]
         unsafe fn point_unchecked_ext(&self, i: usize) -> Self::PointTypeExt<'_> {
-            <Self as MultiPointTrait>::point_unchecked(self, i)
+            unsafe { <Self as MultiPointTrait>::point_unchecked(self, i) }
         }
 
         #[inline]
@@ -122,7 +122,7 @@ where
 
     /// Specialized coordinate accessor for `geo_types::MultiPoint`.
     unsafe fn geo_coord_unchecked(&self, i: usize) -> Option<Coord<T>> {
-        Some(self.0.get_unchecked(i).0)
+        unsafe { Some(self.0.get_unchecked(i).0) }
     }
 
     // Specialized implementation for geo_types::MultiPoint to reduce performance overhead
@@ -143,7 +143,7 @@ where
 
     /// Specialized coordinate accessor for `&geo_types::MultiPoint`.
     unsafe fn geo_coord_unchecked(&self, i: usize) -> Option<Coord<T>> {
-        Some(self.0.get_unchecked(i).0)
+        unsafe { Some(self.0.get_unchecked(i).0) }
     }
 
     // Specialized implementation for geo_types::MultiPoint to reduce performance overhead

--- a/rust/sedona-geo-traits-ext/src/multi_polygon.rs
+++ b/rust/sedona-geo-traits-ext/src/multi_polygon.rs
@@ -69,7 +69,7 @@ macro_rules! forward_multi_polygon_trait_ext_funcs {
 
         #[inline]
         unsafe fn polygon_unchecked_ext(&self, i: usize) -> Self::PolygonTypeExt<'_> {
-            <Self as MultiPolygonTrait>::polygon_unchecked(self, i)
+            unsafe { <Self as MultiPolygonTrait>::polygon_unchecked(self, i) }
         }
 
         #[inline]
@@ -95,7 +95,7 @@ where
 
     #[inline]
     unsafe fn polygon_unchecked_ext(&self, i: usize) -> Self::PolygonTypeExt<'_> {
-        self.0.get_unchecked(i)
+        unsafe { self.0.get_unchecked(i) }
     }
 
     #[inline]
@@ -124,7 +124,7 @@ where
 
     #[inline]
     unsafe fn polygon_unchecked_ext(&self, i: usize) -> Self::PolygonTypeExt<'_> {
-        self.0.get_unchecked(i)
+        unsafe { self.0.get_unchecked(i) }
     }
 
     #[inline]

--- a/rust/sedona-geo-traits-ext/src/polygon.rs
+++ b/rust/sedona-geo-traits-ext/src/polygon.rs
@@ -86,7 +86,7 @@ macro_rules! forward_polygon_trait_ext_funcs {
 
         #[inline]
         unsafe fn interior_unchecked_ext(&self, i: usize) -> Self::RingTypeExt<'_> {
-            <Self as PolygonTrait>::interior_unchecked(self, i)
+            unsafe { <Self as PolygonTrait>::interior_unchecked(self, i) }
         }
     };
 }

--- a/rust/sedona-geo-traits-ext/src/rect.rs
+++ b/rust/sedona-geo-traits-ext/src/rect.rs
@@ -17,7 +17,7 @@
 // Extend RectTrait traits for the `geo-traits` crate
 
 use geo_traits::{CoordTrait, GeometryTrait, RectTrait, UnimplementedRect};
-use geo_types::{coord, Coord, CoordFloat, CoordNum, Line, LineString, Polygon, Rect};
+use geo_types::{Coord, CoordFloat, CoordNum, Line, LineString, Polygon, Rect, coord};
 use num_traits::One;
 
 use crate::{CoordTraitExt, GeoTraitExtWithTypeTag, RectTag};

--- a/rust/sedona-geo-traits-ext/src/triangle.rs
+++ b/rust/sedona-geo-traits-ext/src/triangle.rs
@@ -17,7 +17,7 @@
 // Extend TriangleTrait traits for the `geo-traits` crate
 
 use geo_traits::{GeometryTrait, TriangleTrait, UnimplementedTriangle};
-use geo_types::{polygon, Coord, CoordNum, Line, Polygon, Triangle};
+use geo_types::{Coord, CoordNum, Line, Polygon, Triangle, polygon};
 
 use crate::{CoordTraitExt, GeoTraitExtWithTypeTag, TriangleTag};
 

--- a/rust/sedona-geo-traits-ext/src/wkb_ext.rs
+++ b/rust/sedona-geo-traits-ext/src/wkb_ext.rs
@@ -23,11 +23,11 @@ use geo_traits::{
     MultiPointTrait, MultiPolygonTrait, PointTrait, PolygonTrait,
 };
 use geo_types::{Coord as GeoCoord, Line};
+use wkb::Endianness;
 use wkb::reader::{
     Coord, Dimension, GeometryCollection, LineString, LinearRing, MultiLineString, MultiPoint,
     MultiPolygon, Point, Polygon, Wkb,
 };
-use wkb::Endianness;
 
 // ┌──────────────────────────────────────────────────────────┐
 // │ Coord                                                    │
@@ -323,10 +323,12 @@ impl<'a> GeometryTraitExt for Wkb<'a> {
 
     #[inline]
     unsafe fn geometry_unchecked_ext(&self, i: usize) -> Self::InnerGeometryRef<'_> {
-        let GeometryType::GeometryCollection(gc) = self.as_type() else {
-            panic!("Called geometry_unchecked_ext on a non-GeometryCollection geometry");
-        };
-        gc.geometry_unchecked(i)
+        unsafe {
+            let GeometryType::GeometryCollection(gc) = self.as_type() else {
+                panic!("Called geometry_unchecked_ext on a non-GeometryCollection geometry");
+            };
+            gc.geometry_unchecked(i)
+        }
     }
 
     #[inline]
@@ -356,7 +358,7 @@ where
 
     #[inline]
     unsafe fn geometry_unchecked_ext(&self, i: usize) -> Self::InnerGeometryRef<'_> {
-        (*self).geometry_unchecked_ext(i)
+        unsafe { (*self).geometry_unchecked_ext(i) }
     }
 
     #[inline]

--- a/rust/sedona-geo-traits-ext/tests/wkb_ext_tests.rs
+++ b/rust/sedona-geo-traits-ext/tests/wkb_ext_tests.rs
@@ -21,7 +21,7 @@ use geo_traits::GeometryTrait;
 use rstest::rstest;
 use sedona_geo_traits_ext::*;
 use std::str::FromStr;
-use wkb::{reader::Wkb, Endianness};
+use wkb::{Endianness, reader::Wkb};
 use wkt::Wkt;
 
 /// Helper to create WKB from WKT string using the wkb writer


### PR DESCRIPTION
Migrates sedona-geo-traits-ext independently to Rust 2024 as part of #258, applies standard formatter output, and adds explicit unsafe scopes required by the new edition. Validated with package tests, all-target checks, and Clippy with warnings denied.