### PR TITLE
chore(rust/sedona-geo-generic-alg): migrate to Rust 2024 edition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
       - id: fmt
         name: rustfmt
         args: ["--all", "--"]
+        pass_filenames: false
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13

--- a/rust/sedona-geo-generic-alg/Cargo.toml
+++ b/rust/sedona-geo-generic-alg/Cargo.toml
@@ -24,7 +24,7 @@ homepage.workspace = true
 repository.workspace = true
 description.workspace = true
 readme.workspace = true
-edition.workspace = true
+edition = "2024"
 rust-version.workspace = true
 
 [dependencies]

--- a/rust/sedona-geo-generic-alg/benches/area.rs
+++ b/rust/sedona-geo-generic-alg/benches/area.rs
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use geo_traits::to_geo::ToGeoGeometry;
 use sedona_geo_generic_alg::Area;
 use sedona_geo_generic_alg::Polygon;

--- a/rust/sedona-geo-generic-alg/benches/centroid.rs
+++ b/rust/sedona-geo-generic-alg/benches/centroid.rs
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use geo_traits::to_geo::ToGeoGeometry;
 use sedona_geo_generic_alg::Centroid;
 use sedona_geo_generic_alg::Polygon;

--- a/rust/sedona-geo-generic-alg/benches/distance.rs
+++ b/rust/sedona-geo-generic-alg/benches/distance.rs
@@ -14,10 +14,10 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use geo::{Distance as GeoDistance, Euclidean};
 use sedona_geo_generic_alg::algorithm::line_measures::DistanceExt;
-use sedona_geo_generic_alg::{coord, LineString, MultiPolygon, Point, Polygon};
+use sedona_geo_generic_alg::{LineString, MultiPolygon, Point, Polygon, coord};
 
 #[path = "utils/wkb_util.rs"]
 mod wkb_util;

--- a/rust/sedona-geo-generic-alg/benches/intersection.rs
+++ b/rust/sedona-geo-generic-alg/benches/intersection.rs
@@ -14,12 +14,12 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use geo::Triangle;
 use geo_traits::to_geo::ToGeoGeometry;
 use geo_types::Geometry;
 use sedona_geo_generic_alg::MultiPolygon;
-use sedona_geo_generic_alg::{intersects::Intersects, Centroid};
+use sedona_geo_generic_alg::{Centroid, intersects::Intersects};
 
 #[path = "utils/wkb_util.rs"]
 mod wkb_util;
@@ -320,8 +320,8 @@ fn point_polygon_intersection_wkb_conv(c: &mut Criterion) {
 }
 
 fn rect_intersection(c: &mut Criterion) {
-    use sedona_geo_generic_alg::algorithm::BoundingRect;
     use sedona_geo_generic_alg::Rect;
+    use sedona_geo_generic_alg::algorithm::BoundingRect;
     let plot_bbox: Vec<Rect> = sedona_testing::fixtures::nl_plots_wgs84()
         .iter()
         .map(|plot| plot.bounding_rect().unwrap())
@@ -437,7 +437,7 @@ fn point_triangle_intersection(c: &mut Criterion) {
 }
 
 fn linestring_polygon_intersection(c: &mut Criterion) {
-    use geo::{coord, line_string, LineString, Polygon, Rect};
+    use geo::{LineString, Polygon, Rect, coord, line_string};
     c.bench_function("LineString above Polygon", |bencher| {
         let ls = line_string![
             coord! {x:0., y:1.},

--- a/rust/sedona-geo-generic-alg/benches/length.rs
+++ b/rust/sedona-geo-generic-alg/benches/length.rs
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use geo_traits::to_geo::ToGeoGeometry;
 use sedona_geo_generic_alg::algorithm::line_measures::{Euclidean, LengthMeasurableExt};
 

--- a/rust/sedona-geo-generic-alg/benches/perimeter.rs
+++ b/rust/sedona-geo-generic-alg/benches/perimeter.rs
@@ -14,10 +14,10 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use geo_traits::to_geo::ToGeoGeometry;
-use sedona_geo_generic_alg::algorithm::line_measures::{Euclidean, LengthMeasurableExt};
 use sedona_geo_generic_alg::Polygon;
+use sedona_geo_generic_alg::algorithm::line_measures::{Euclidean, LengthMeasurableExt};
 
 #[path = "utils/wkb_util.rs"]
 mod wkb_util;

--- a/rust/sedona-geo-generic-alg/src/algorithm/area.rs
+++ b/rust/sedona-geo-generic-alg/src/algorithm/area.rs
@@ -189,11 +189,7 @@ where
                     total - get_linestring_area(&next).abs()
                 });
 
-                if is_negative {
-                    -area
-                } else {
-                    area
-                }
+                if is_negative { -area } else { area }
             }
             None => T::zero(),
         }
@@ -347,7 +343,7 @@ where
 #[cfg(test)]
 mod test {
     use crate::Area;
-    use crate::{coord, polygon, wkt, Line, MultiPolygon, Polygon, Rect, Triangle};
+    use crate::{Line, MultiPolygon, Polygon, Rect, Triangle, coord, polygon, wkt};
 
     // Area of the polygon
     #[test]

--- a/rust/sedona-geo-generic-alg/src/algorithm/bounding_rect.rs
+++ b/rust/sedona-geo-generic-alg/src/algorithm/bounding_rect.rs
@@ -20,7 +20,7 @@
 //! <https://github.com/georust/geo/blob/5d667f844716a3d0a17aa60bc0a58528cb5808c3/geo/src/algorithm/bounding_rect.rs>.
 //! Original code is dual-licensed under Apache-2.0 or MIT; used here under Apache-2.0.
 use crate::utils::{partial_max, partial_min};
-use crate::{coord, geometry::*, CoordNum};
+use crate::{CoordNum, coord, geometry::*};
 use core::borrow::Borrow;
 use geo_types::private_utils::get_bounding_rect;
 use sedona_geo_traits_ext::*;
@@ -285,15 +285,15 @@ fn bounding_rect_merge<T: CoordNum>(a: Rect<T>, b: Rect<T>) -> Rect<T> {
 mod test {
     use core::f64;
 
-    use wkb::writer::WriteOptions;
     use wkb::Endianness;
+    use wkb::writer::WriteOptions;
 
     use super::bounding_rect_merge;
-    use crate::line_string;
     use crate::BoundingRect;
+    use crate::line_string;
     use crate::{
-        coord, point, polygon, Geometry, GeometryCollection, Line, LineString, MultiLineString,
-        MultiPoint, MultiPolygon, Polygon, Rect,
+        Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint, MultiPolygon,
+        Polygon, Rect, coord, point, polygon,
     };
 
     #[test]

--- a/rust/sedona-geo-generic-alg/src/algorithm/centroid.rs
+++ b/rust/sedona-geo-generic-alg/src/algorithm/centroid.rs
@@ -24,12 +24,12 @@ use std::cmp::Ordering;
 
 use sedona_geo_traits_ext::*;
 
-use crate::area::{get_linestring_area, Area};
+use crate::GeoFloat;
+use crate::area::{Area, get_linestring_area};
 use crate::dimensions::{Dimensions, Dimensions::*, HasDimensions};
 use crate::geometry::*;
-use crate::line_measures::metric_spaces::euclidean::Euclidean;
 use crate::line_measures::LengthMeasurableExt;
-use crate::GeoFloat;
+use crate::line_measures::metric_spaces::euclidean::Euclidean;
 
 /// Calculation of the centroid.
 /// The centroid is the arithmetic mean position of all points in the shape.

--- a/rust/sedona-geo-generic-alg/src/algorithm/coordinate_position.rs
+++ b/rust/sedona-geo-generic-alg/src/algorithm/coordinate_position.rs
@@ -22,10 +22,10 @@
 use core::borrow::Borrow;
 use std::cmp::Ordering;
 
+use crate::GeoNum;
 use crate::geometry::*;
 use crate::intersects::{point_in_rect, value_in_between};
 use crate::kernels::*;
-use crate::GeoNum;
 use crate::{BoundingRect, HasDimensions, Intersects};
 use sedona_geo_traits_ext::*;
 
@@ -149,10 +149,10 @@ where
         is_inside: &mut bool,
         _boundary_count: &mut usize,
     ) {
-        if let Some(point_coord) = self.geo_coord() {
-            if &point_coord == coord {
-                *is_inside = true;
-            }
+        if let Some(point_coord) = self.geo_coord()
+            && &point_coord == coord
+        {
+            *is_inside = true;
         }
     }
 }

--- a/rust/sedona-geo-generic-alg/src/algorithm/euclidean_length.rs
+++ b/rust/sedona-geo-generic-alg/src/algorithm/euclidean_length.rs
@@ -224,10 +224,10 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::line_string;
     #[allow(deprecated)]
     use crate::EuclideanLength;
-    use crate::{coord, Line, MultiLineString};
+    use crate::line_string;
+    use crate::{Line, MultiLineString, coord};
 
     #[allow(deprecated)]
     #[test]
@@ -285,7 +285,7 @@ mod test {
     #[allow(deprecated)]
     #[test]
     fn polygon_returns_zero_test() {
-        use crate::{polygon, Polygon};
+        use crate::{Polygon, polygon};
         let polygon: Polygon<f64> = polygon![
             (x: 0., y: 0.),
             (x: 4., y: 0.),
@@ -309,10 +309,10 @@ mod test {
     #[allow(deprecated)]
     #[test]
     fn comprehensive_test_scenarios() {
-        use crate::{line_string, polygon};
         use crate::{
             Geometry, GeometryCollection, MultiLineString, MultiPoint, MultiPolygon, Point,
         };
+        use crate::{line_string, polygon};
 
         // Test cases matching the Python pytest scenarios
 
@@ -486,7 +486,7 @@ mod test {
     #[test]
     fn test_multipolygon_double_unit_squares() {
         // MULTIPOLYGON (((0 0, 1 0, 1 1, 0 1, 0 0)), ((0 0, 1 0, 1 1, 0 1, 0 0))) -> 0
-        use crate::{polygon, MultiPolygon};
+        use crate::{MultiPolygon, polygon};
         let multipolygon = MultiPolygon::new(vec![
             polygon![
                 (x: 0., y: 0.),
@@ -511,7 +511,7 @@ mod test {
     fn test_geometrycollection_mixed() {
         // GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1), POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)), LINESTRING (0 0, 1 1))
         // Expected: 2.8284271247461903 (only linestrings contribute)
-        use crate::{polygon, Geometry, GeometryCollection};
+        use crate::{Geometry, GeometryCollection, polygon};
         let collection = GeometryCollection::new_from(vec![
             Geometry::LineString(line_string![(x: 0., y: 0.), (x: 1., y: 1.)]), // sqrt(2) ≈ 1.4142135623730951
             Geometry::Polygon(polygon![
@@ -544,7 +544,7 @@ mod test {
         // Exact match for the Python pytest scenario:
         // GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1), POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)), LINESTRING (0 0, 1 1))
         // Expected: 2.8284271247461903
-        use crate::{polygon, Geometry, GeometryCollection};
+        use crate::{Geometry, GeometryCollection, polygon};
 
         let collection = GeometryCollection::new_from(vec![
             // LINESTRING (0 0, 1 1) - length = sqrt(2) ≈ 1.4142135623730951

--- a/rust/sedona-geo-generic-alg/src/algorithm/intersects/collections.rs
+++ b/rust/sedona-geo-generic-alg/src/algorithm/intersects/collections.rs
@@ -22,8 +22,8 @@
 use core::borrow::Borrow;
 use sedona_geo_traits_ext::*;
 
-use super::has_disjoint_bboxes;
 use super::IntersectsTrait;
+use super::has_disjoint_bboxes;
 use crate::GeoNum;
 
 macro_rules! impl_intersects_geometry {

--- a/rust/sedona-geo-generic-alg/src/algorithm/intersects/line.rs
+++ b/rust/sedona-geo-generic-alg/src/algorithm/intersects/line.rs
@@ -21,7 +21,7 @@
 //! Original code is dual-licensed under Apache-2.0 or MIT; used here under Apache-2.0.
 use sedona_geo_traits_ext::*;
 
-use super::{point_in_rect, IntersectsTrait};
+use super::{IntersectsTrait, point_in_rect};
 use crate::*;
 
 impl<T, LHS, RHS> IntersectsTrait<LineTag, CoordTag, RHS> for LHS

--- a/rust/sedona-geo-generic-alg/src/algorithm/intersects/line_string.rs
+++ b/rust/sedona-geo-generic-alg/src/algorithm/intersects/line_string.rs
@@ -21,7 +21,7 @@
 //! Original code is dual-licensed under Apache-2.0 or MIT; used here under Apache-2.0.
 use sedona_geo_traits_ext::*;
 
-use super::{has_disjoint_bboxes, IntersectsTrait};
+use super::{IntersectsTrait, has_disjoint_bboxes};
 use crate::*;
 
 // Generate implementations for LineString<T> by delegating to Line<T>

--- a/rust/sedona-geo-generic-alg/src/algorithm/intersects/mod.rs
+++ b/rust/sedona-geo-generic-alg/src/algorithm/intersects/mod.rs
@@ -145,12 +145,11 @@ where
     B: BoundingRect<T>,
 {
     let mut disjoint_bbox = false;
-    if let Some(a_bbox) = a.bounding_rect().into() {
-        if let Some(b_bbox) = b.bounding_rect().into() {
-            if !a_bbox.intersects(&b_bbox) {
-                disjoint_bbox = true;
-            }
-        }
+    if let Some(a_bbox) = a.bounding_rect().into()
+        && let Some(b_bbox) = b.bounding_rect().into()
+        && !a_bbox.intersects(&b_bbox)
+    {
+        disjoint_bbox = true;
     }
     disjoint_bbox
 }
@@ -161,8 +160,8 @@ mod test {
 
     use crate::Intersects;
     use crate::{
-        coord, line_string, polygon, Geometry, Line, LineString, MultiLineString, MultiPoint,
-        MultiPolygon, Point, Polygon, Rect,
+        Geometry, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
+        Rect, coord, line_string, polygon,
     };
 
     /// Tests: intersection LineString and LineString
@@ -428,27 +427,35 @@ mod test {
 
         assert!(bounding_rect_xl.to_polygon().intersects(&bounding_rect_sm));
         assert!(bounding_rect_xl.intersects(&bounding_rect_sm.to_polygon()));
-        assert!(bounding_rect_xl
-            .to_polygon()
-            .intersects(&bounding_rect_sm.to_polygon()));
+        assert!(
+            bounding_rect_xl
+                .to_polygon()
+                .intersects(&bounding_rect_sm.to_polygon())
+        );
 
         assert!(bounding_rect_sm.to_polygon().intersects(&bounding_rect_xl));
         assert!(bounding_rect_sm.intersects(&bounding_rect_xl.to_polygon()));
-        assert!(bounding_rect_sm
-            .to_polygon()
-            .intersects(&bounding_rect_xl.to_polygon()));
+        assert!(
+            bounding_rect_sm
+                .to_polygon()
+                .intersects(&bounding_rect_xl.to_polygon())
+        );
 
         assert!(bounding_rect_sm.to_polygon().intersects(&bounding_rect_s2));
         assert!(bounding_rect_sm.intersects(&bounding_rect_s2.to_polygon()));
-        assert!(bounding_rect_sm
-            .to_polygon()
-            .intersects(&bounding_rect_s2.to_polygon()));
+        assert!(
+            bounding_rect_sm
+                .to_polygon()
+                .intersects(&bounding_rect_s2.to_polygon())
+        );
 
         assert!(bounding_rect_s2.to_polygon().intersects(&bounding_rect_sm));
         assert!(bounding_rect_s2.intersects(&bounding_rect_sm.to_polygon()));
-        assert!(bounding_rect_s2
-            .to_polygon()
-            .intersects(&bounding_rect_sm.to_polygon()));
+        assert!(
+            bounding_rect_s2
+                .to_polygon()
+                .intersects(&bounding_rect_sm.to_polygon())
+        );
     }
     #[test]
     fn point_intersects_line_test() {

--- a/rust/sedona-geo-generic-alg/src/algorithm/intersects/polygon.rs
+++ b/rust/sedona-geo-generic-alg/src/algorithm/intersects/polygon.rs
@@ -19,10 +19,10 @@
 //! Ported (and contains copied code) from `geo::algorithm::intersects::polygon`:
 //! <https://github.com/georust/geo/blob/f2326a3dd1fa9ff39d3e65618eb7ca2bacad2c0c/geo/src/algorithm/intersects/polygon.rs>.
 //! Original code is dual-licensed under Apache-2.0 or MIT; used here under Apache-2.0.
-use super::{has_disjoint_bboxes, IntersectsTrait};
-use crate::coordinate_position::CoordPos;
+use super::{IntersectsTrait, has_disjoint_bboxes};
 use crate::CoordinatePosition;
 use crate::GeoNum;
+use crate::coordinate_position::CoordPos;
 use sedona_geo_traits_ext::*;
 
 impl<T, LHS, RHS> IntersectsTrait<PolygonTag, CoordTag, RHS> for LHS

--- a/rust/sedona-geo-generic-alg/src/algorithm/kernels/mod.rs
+++ b/rust/sedona-geo-generic-alg/src/algorithm/kernels/mod.rs
@@ -21,7 +21,7 @@
 //! Original code is dual-licensed under Apache-2.0 or MIT; used here under Apache-2.0.
 use num_traits::Zero;
 
-use crate::{coord, Coord, CoordNum};
+use crate::{Coord, CoordNum, coord};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub enum Orientation {

--- a/rust/sedona-geo-generic-alg/src/algorithm/kernels/robust.rs
+++ b/rust/sedona-geo-generic-alg/src/algorithm/kernels/robust.rs
@@ -37,7 +37,7 @@ where
     T: CoordNum + Float,
 {
     fn orient2d(p: Coord<T>, q: Coord<T>, r: Coord<T>) -> Orientation {
-        use robust::{orient2d, Coord};
+        use robust::{Coord, orient2d};
 
         let orientation = orient2d(
             Coord {

--- a/rust/sedona-geo-generic-alg/src/algorithm/line_measures/length.rs
+++ b/rust/sedona-geo-generic-alg/src/algorithm/line_measures/length.rs
@@ -384,8 +384,8 @@ mod tests {
 
         use super::*;
         use crate::{
-            coord, line_string, polygon, Geometry, GeometryCollection, Line, MultiLineString,
-            MultiPoint, MultiPolygon, Point, Polygon,
+            Geometry, GeometryCollection, Line, MultiLineString, MultiPoint, MultiPolygon, Point,
+            Polygon, coord, line_string, polygon,
         };
 
         #[test]

--- a/rust/sedona-geo-generic-alg/src/algorithm/line_measures/metric_spaces/euclidean/utils.rs
+++ b/rust/sedona-geo-generic-alg/src/algorithm/line_measures/metric_spaces/euclidean/utils.rs
@@ -20,7 +20,7 @@
 //! <https://github.com/georust/geo/blob/5d667f844716a3d0a17aa60bc0a58528cb5808c3/geo/src/algorithm/line_measures/metric_spaces/euclidean/utils.rs>.
 //! Original code is dual-licensed under Apache-2.0 or MIT; used here under Apache-2.0.
 use crate::algorithm::Intersects;
-use crate::coordinate_position::{coord_pos_relative_to_ring, CoordPos};
+use crate::coordinate_position::{CoordPos, coord_pos_relative_to_ring};
 use crate::geometry::*;
 use crate::{CoordFloat, GeoFloat, GeoNum};
 use geo_traits::{CoordTrait, LineStringTrait};
@@ -586,68 +586,64 @@ where
 
         // Symmetric containment logic matching concrete implementation exactly
         // Check if polygon_b is contained within polygon_a (has holes)
-        if has_interiors1 {
-            if let Some(first_coord_b) = ext2.coords_ext().next() {
-                let ext1_ls = LineString::from(
-                    ext1.coords_ext()
-                        .map(|c| (c.x(), c.y()))
-                        .collect::<Vec<_>>(),
-                );
+        if has_interiors1 && let Some(first_coord_b) = ext2.coords_ext().next() {
+            let ext1_ls = LineString::from(
+                ext1.coords_ext()
+                    .map(|c| (c.x(), c.y()))
+                    .collect::<Vec<_>>(),
+            );
 
-                let coord_b = Coord::from((first_coord_b.x(), first_coord_b.y()));
-                if ring_contains_coord(&ext1_ls, coord_b) {
-                    // polygon_b is inside polygon_a: check distance to polygon_a's holes
-                    let ext2_concrete = LineString::from(
-                        ext2.coords_ext()
-                            .map(|c| (c.x(), c.y()))
-                            .collect::<Vec<_>>(),
-                    );
-
-                    let mut mindist: F = Float::max_value();
-                    for ring in polygon1.interiors_ext() {
-                        let ring_concrete = LineString::from(
-                            ring.coords_ext()
-                                .map(|c| (c.x(), c.y()))
-                                .collect::<Vec<_>>(),
-                        );
-                        mindist =
-                            mindist.min(nearest_neighbour_distance(&ext2_concrete, &ring_concrete));
-                    }
-                    return mindist;
-                }
-            }
-        }
-
-        // Check if polygon_a is contained within polygon_b (has holes)
-        if has_interiors2 {
-            if let Some(first_coord_a) = ext1.coords_ext().next() {
-                let ext2_ls = LineString::from(
+            let coord_b = Coord::from((first_coord_b.x(), first_coord_b.y()));
+            if ring_contains_coord(&ext1_ls, coord_b) {
+                // polygon_b is inside polygon_a: check distance to polygon_a's holes
+                let ext2_concrete = LineString::from(
                     ext2.coords_ext()
                         .map(|c| (c.x(), c.y()))
                         .collect::<Vec<_>>(),
                 );
 
-                let coord_a = Coord::from((first_coord_a.x(), first_coord_a.y()));
-                if ring_contains_coord(&ext2_ls, coord_a) {
-                    // polygon_a is inside polygon_b: check distance to polygon_b's holes
-                    let ext1_concrete = LineString::from(
-                        ext1.coords_ext()
+                let mut mindist: F = Float::max_value();
+                for ring in polygon1.interiors_ext() {
+                    let ring_concrete = LineString::from(
+                        ring.coords_ext()
                             .map(|c| (c.x(), c.y()))
                             .collect::<Vec<_>>(),
                     );
-
-                    let mut mindist: F = Float::max_value();
-                    for ring in polygon2.interiors_ext() {
-                        let ring_concrete = LineString::from(
-                            ring.coords_ext()
-                                .map(|c| (c.x(), c.y()))
-                                .collect::<Vec<_>>(),
-                        );
-                        mindist =
-                            mindist.min(nearest_neighbour_distance(&ext1_concrete, &ring_concrete));
-                    }
-                    return mindist;
+                    mindist =
+                        mindist.min(nearest_neighbour_distance(&ext2_concrete, &ring_concrete));
                 }
+                return mindist;
+            }
+        }
+
+        // Check if polygon_a is contained within polygon_b (has holes)
+        if has_interiors2 && let Some(first_coord_a) = ext1.coords_ext().next() {
+            let ext2_ls = LineString::from(
+                ext2.coords_ext()
+                    .map(|c| (c.x(), c.y()))
+                    .collect::<Vec<_>>(),
+            );
+
+            let coord_a = Coord::from((first_coord_a.x(), first_coord_a.y()));
+            if ring_contains_coord(&ext2_ls, coord_a) {
+                // polygon_a is inside polygon_b: check distance to polygon_b's holes
+                let ext1_concrete = LineString::from(
+                    ext1.coords_ext()
+                        .map(|c| (c.x(), c.y()))
+                        .collect::<Vec<_>>(),
+                );
+
+                let mut mindist: F = Float::max_value();
+                for ring in polygon2.interiors_ext() {
+                    let ring_concrete = LineString::from(
+                        ring.coords_ext()
+                            .map(|c| (c.x(), c.y()))
+                            .collect::<Vec<_>>(),
+                    );
+                    mindist =
+                        mindist.min(nearest_neighbour_distance(&ext1_concrete, &ring_concrete));
+                }
+                return mindist;
             }
         }
 
@@ -737,7 +733,7 @@ symmetric_distance_generic_impl!(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{coord, Line, LineString, Point, Polygon, Triangle};
+    use crate::{Line, LineString, Point, Polygon, Triangle, coord};
     use approx::assert_relative_eq;
     use geo::algorithm::line_measures::{Distance, Euclidean};
 
@@ -2321,7 +2317,7 @@ mod tests {
     #[test]
     fn test_line_segment_distance_algorithm_equivalence() {
         // Test that the updated generic algorithm produces identical results to concrete
-        use geo_types::{coord, Line, Point};
+        use geo_types::{Line, Point, coord};
 
         // Test cases covering different scenarios
         let test_cases = vec![

--- a/rust/sedona-geo-generic-alg/src/algorithm/map_coords.rs
+++ b/rust/sedona-geo-generic-alg/src/algorithm/map_coords.rs
@@ -19,12 +19,12 @@
 //! Ported (and contains copied code) from `geo::algorithm::map_coords`:
 //! <https://github.com/georust/geo/blob/f2326a3dd1fa9ff39d3e65618eb7ca2bacad2c0c/geo/src/algorithm/map_coords.rs>.
 //! Original code is dual-licensed under Apache-2.0 or MIT; used here under Apache-2.0.
-pub(crate) use crate::geometry::*;
 pub(crate) use crate::CoordNum;
+pub(crate) use crate::geometry::*;
 
+use Coord;
 use core::borrow::Borrow;
 use sedona_geo_traits_ext::*;
-use Coord;
 
 /// Map a function over all the coordinates in an object, returning a new one
 pub trait MapCoords<T: CoordNum, NT: CoordNum> {
@@ -799,8 +799,8 @@ impl<T: CoordNum> MapCoordsInPlace<T> for Triangle<T> {
 mod test {
     use super::{MapCoords, MapCoordsInPlace};
     use crate::{
-        coord, polygon, Coord, Geometry, GeometryCollection, Line, LineString, MultiLineString,
-        MultiPoint, MultiPolygon, Point, Polygon, Rect,
+        Coord, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
+        MultiPolygon, Point, Polygon, Rect, coord, polygon,
     };
 
     #[test]

--- a/rust/sedona-geo-generic-alg/src/lib.rs
+++ b/rust/sedona-geo-generic-alg/src/lib.rs
@@ -26,7 +26,7 @@
 pub use crate::algorithm::*;
 use std::cmp::Ordering;
 
-pub use geo_types::{coord, line_string, point, polygon, wkt, CoordFloat, CoordNum};
+pub use geo_types::{CoordFloat, CoordNum, coord, line_string, point, polygon, wkt};
 
 pub mod geometry;
 pub use geometry::*;

--- a/rust/sedona-geo-generic-alg/src/utils.rs
+++ b/rust/sedona-geo-generic-alg/src/utils.rs
@@ -24,20 +24,12 @@
 
 // The Rust standard library has `max` for `Ord`, but not for `PartialOrd`
 pub fn partial_max<T: PartialOrd>(a: T, b: T) -> T {
-    if a > b {
-        a
-    } else {
-        b
-    }
+    if a > b { a } else { b }
 }
 
 // The Rust standard library has `min` for `Ord`, but not for `PartialOrd`
 pub fn partial_min<T: PartialOrd>(a: T, b: T) -> T {
-    if a < b {
-        a
-    } else {
-        b
-    }
+    if a < b { a } else { b }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Migrates sedona-geo-generic-alg independently to Rust 2024 as part of #258, applies standard formatter output, and adopts Rust 2024 let-chains required by Clippy. Validated with package tests, all-target checks, and Clippy with warnings denied.