### PR TITLE
chore(rust/sedona-adbc): migrate to Rust 2024 edition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
       - id: fmt
         name: rustfmt
         args: ["--all", "--"]
+        pass_filenames: false
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13

--- a/rust/sedona-adbc/Cargo.toml
+++ b/rust/sedona-adbc/Cargo.toml
@@ -24,7 +24,7 @@ homepage.workspace = true
 repository.workspace = true
 description.workspace = true
 readme.workspace = true
-edition.workspace = true
+edition = "2024"
 rust-version.workspace = true
 
 [lints.clippy]

--- a/rust/sedona-adbc/src/connection.rs
+++ b/rust/sedona-adbc/src/connection.rs
@@ -20,8 +20,8 @@
 #![allow(refining_impl_trait)]
 
 use adbc_core::{
-    options::{InfoCode, ObjectDepth},
     Connection,
+    options::{InfoCode, ObjectDepth},
 };
 use arrow_array::RecordBatchReader;
 use sedona::context::SedonaContext;
@@ -29,14 +29,14 @@ use sedona_extension::runtime::RuntimeHandle;
 use std::sync::Arc;
 
 use adbc_core::{
+    Optionable,
     error::{Error, Result, Status},
     options::{OptionConnection, OptionValue},
-    Optionable,
 };
 
 use crate::{
     err_not_implemented, err_unrecognized_option, statement::SedonaStatement,
-    utils::from_datafusion_error, utils::OptionValueExt,
+    utils::OptionValueExt, utils::from_datafusion_error,
 };
 
 pub struct SedonaConnection {

--- a/rust/sedona-adbc/src/database.rs
+++ b/rust/sedona-adbc/src/database.rs
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 use adbc_core::{
+    Database, Optionable,
     error::{Error, Result, Status},
     options::{OptionConnection, OptionDatabase, OptionValue},
-    Database, Optionable,
 };
 
 use crate::{connection::SedonaConnection, err_unrecognized_option};

--- a/rust/sedona-adbc/src/driver.rs
+++ b/rust/sedona-adbc/src/driver.rs
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 use adbc_core::{
+    Driver, Optionable,
     error::Result,
     options::{OptionDatabase, OptionValue},
-    Driver, Optionable,
 };
 
 use crate::database::SedonaDatabase;

--- a/rust/sedona-adbc/src/statement.rs
+++ b/rust/sedona-adbc/src/statement.rs
@@ -23,9 +23,9 @@ use sedona_extension::streaming::StreamingRecordBatchReader;
 use std::sync::Arc;
 
 use adbc_core::{
+    Optionable, Statement,
     error::{Error, Result, Status},
     options::{OptionStatement, OptionValue},
-    Optionable, Statement,
 };
 
 use crate::{err_not_implemented, err_unrecognized_option, utils::from_datafusion_error};


### PR DESCRIPTION
Migrates sedona-adbc to the Rust 2024 edition as part of #258. Applies standard Rust 2024 formatting without compatibility overrides. Validated with cargo check, Clippy with warnings denied, and package tests.