### PR TITLE
chore(rust/sedona-datasource): migrate to Rust 2024 edition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
       - id: fmt
         name: rustfmt
         args: ["--all", "--"]
+        pass_filenames: false
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13

--- a/rust/sedona-datasource/Cargo.toml
+++ b/rust/sedona-datasource/Cargo.toml
@@ -25,7 +25,7 @@ homepage.workspace = true
 repository.workspace = true
 description.workspace = true
 readme.workspace = true
-edition.workspace = true
+edition = "2024"
 rust-version.workspace = true
 
 [features]

--- a/rust/sedona-datasource/src/format.rs
+++ b/rust/sedona-datasource/src/format.rs
@@ -23,7 +23,7 @@ use async_trait::async_trait;
 use datafusion::{
     config::ConfigOptions,
     datasource::{
-        file_format::{file_compression_type::FileCompressionType, FileFormat, FileFormatFactory},
+        file_format::{FileFormat, FileFormatFactory, file_compression_type::FileCompressionType},
         listing::PartitionedFile,
         physical_plan::{
             FileGroupPartitioner, FileOpenFuture, FileOpener, FileScanConfig, FileSinkConfig,
@@ -32,20 +32,20 @@ use datafusion::{
         table_schema::TableSchema,
     },
 };
-use datafusion_catalog::{memory::DataSourceExec, Session};
-use datafusion_common::{not_impl_err, plan_err, DataFusionError, GetExt, Result, Statistics};
+use datafusion_catalog::{Session, memory::DataSourceExec};
+use datafusion_common::{DataFusionError, GetExt, Result, Statistics, not_impl_err, plan_err};
 use datafusion_datasource::projection::{ProjectionOpener, SplitProjection};
 use datafusion_physical_expr::{
-    projection::ProjectionExprs, LexOrdering, LexRequirement, PhysicalExpr,
+    LexOrdering, LexRequirement, PhysicalExpr, projection::ProjectionExprs,
 };
 use datafusion_physical_plan::{
+    ExecutionPlan,
     filter_pushdown::{FilterPushdownPropagation, PushedDown},
     metrics::ExecutionPlanMetricsSet,
-    ExecutionPlan,
 };
 use futures::{
-    lock::{Mutex, OwnedMutexGuard},
     StreamExt, TryStreamExt,
+    lock::{Mutex, OwnedMutexGuard},
 };
 use object_store::{ObjectMeta, ObjectStore};
 
@@ -464,7 +464,7 @@ mod test {
     use datafusion::{
         assert_batches_eq,
         datasource::listing::ListingTableUrl,
-        prelude::{col, SessionConfig, SessionContext},
+        prelude::{SessionConfig, SessionContext, col},
     };
     use datafusion_common::plan_err;
     use std::{
@@ -822,9 +822,10 @@ mod test {
         .await
         .unwrap_err();
 
-        assert!(err
-            .message()
-            .ends_with("does not match the expected extension 'echospec'"));
+        assert!(
+            err.message()
+                .ends_with("does not match the expected extension 'echospec'")
+        );
 
         // ...but we should be able to turn off the error
         external_table(

--- a/rust/sedona-datasource/src/provider.rs
+++ b/rust/sedona-datasource/src/provider.rs
@@ -23,24 +23,24 @@ use datafusion::{
     catalog::TableProvider,
     config::TableOptions,
     datasource::{
+        TableType,
         file_format::FileFormat,
         listing::{ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl},
         physical_plan::FileScanConfig,
-        TableType,
     },
-    execution::{options::ReadOptions, SessionState},
+    execution::{SessionState, options::ReadOptions},
     logical_expr::Expr,
     physical_plan::ExecutionPlan,
     prelude::{SessionConfig, SessionContext},
 };
-use datafusion_catalog::{memory::DataSourceExec, Session};
-use datafusion_common::{exec_err, extensions::Extensions, Result, TableReference};
+use datafusion_catalog::{Session, memory::DataSourceExec};
+use datafusion_common::{Result, TableReference, exec_err, extensions::Extensions};
 use datafusion_datasource::{
-    file_groups::FileGroup, file_scan_config::FileScanConfigBuilder, table_schema::TableSchema,
-    PartitionedFile,
+    PartitionedFile, file_groups::FileGroup, file_scan_config::FileScanConfigBuilder,
+    table_schema::TableSchema,
 };
 use datafusion_execution::object_store::ObjectStoreUrl;
-use object_store::{path::Path as ObjectPath, ObjectMeta};
+use object_store::{ObjectMeta, path::Path as ObjectPath};
 
 use crate::{
     format::ExternalFileFormat,
@@ -107,8 +107,8 @@ async fn listing_table_provider(
             let file_path = path.as_str();
             if !file_path.ends_with(option_extension.clone().as_str()) && !path.is_collection() {
                 return exec_err!(
-                        "File path '{file_path}' does not match the expected extension '{option_extension}'"
-                    );
+                    "File path '{file_path}' does not match the expected extension '{option_extension}'"
+                );
             }
         }
     }

--- a/rust/sedona-datasource/src/spec.rs
+++ b/rust/sedona-datasource/src/spec.rs
@@ -54,7 +54,7 @@ pub trait ExternalFormatSpec: Debug + Send + Sync {
     /// The implementation must handle the `file_projection`; however,
     /// need not handle the `filters` (but may use them for pruning).
     async fn open_reader(&self, args: &OpenReaderArgs)
-        -> Result<Box<dyn RecordBatchReader + Send>>;
+    -> Result<Box<dyn RecordBatchReader + Send>>;
 
     /// Compute a clone of self but with the key/value options specified
     ///

--- a/rust/sedona-datasource/src/utility.rs
+++ b/rust/sedona-datasource/src/utility.rs
@@ -83,7 +83,7 @@ impl Iterator for ProjectedRecordBatchReader {
 #[cfg(test)]
 mod test {
 
-    use arrow_array::{create_array, ArrayRef, RecordBatchIterator};
+    use arrow_array::{ArrayRef, RecordBatchIterator, create_array};
     use datafusion::assert_batches_eq;
 
     use super::*;


### PR DESCRIPTION
Migrates sedona-datasource independently to Rust 2024 as part of #258 and applies standard formatter output. Validated with package tests, all-target checks, and Clippy with warnings denied.