### PR TITLE
chore(rust/sedona-expr): migrate to Rust 2024 edition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
       - id: fmt
         name: rustfmt
         args: ["--all", "--"]
+        pass_filenames: false
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13

--- a/rust/sedona-expr/Cargo.toml
+++ b/rust/sedona-expr/Cargo.toml
@@ -24,7 +24,7 @@ homepage.workspace = true
 repository.workspace = true
 description.workspace = true
 readme.workspace = true
-edition.workspace = true
+edition = "2024"
 rust-version.workspace = true
 
 [lints.clippy]

--- a/rust/sedona-expr/src/aggregate_udf.rs
+++ b/rust/sedona-expr/src/aggregate_udf.rs
@@ -17,10 +17,10 @@
 use std::{fmt::Debug, sync::Arc};
 
 use arrow_schema::{DataType, FieldRef};
-use datafusion_common::{not_impl_err, Result};
+use datafusion_common::{Result, not_impl_err};
 use datafusion_expr::{
-    function::{AccumulatorArgs, StateFieldsArgs},
     Accumulator, AggregateUDFImpl, Documentation, GroupsAccumulator, Signature, Volatility,
+    function::{AccumulatorArgs, StateFieldsArgs},
 };
 use sedona_common::sedona_internal_err;
 use sedona_schema::datatypes::SedonaType;
@@ -189,10 +189,10 @@ impl AggregateUDFImpl for SedonaAggregateUDF {
     }
 
     fn groups_accumulator_supported(&self, args: AccumulatorArgs) -> bool {
-        if let Ok(arg_types) = Self::accumulator_arg_types(&args) {
-            if let Ok((accumulator, _)) = self.dispatch_impl(&arg_types) {
-                return accumulator.groups_accumulator_supported(&arg_types);
-            }
+        if let Ok(arg_types) = Self::accumulator_arg_types(&args)
+            && let Ok((accumulator, _)) = self.dispatch_impl(&arg_types)
+        {
+            return accumulator.groups_accumulator_supported(&arg_types);
         }
 
         false

--- a/rust/sedona-expr/src/item_crs.rs
+++ b/rust/sedona-expr/src/item_crs.rs
@@ -22,8 +22,9 @@ use arrow_buffer::NullBuffer;
 use arrow_schema::{DataType, Field, FieldRef};
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::{
+    DataFusionError, Result, ScalarValue,
     cast::{as_string_view_array, as_struct_array},
-    exec_err, DataFusionError, Result, ScalarValue,
+    exec_err,
 };
 use datafusion_expr::{Accumulator, ColumnarValue};
 use sedona_common::sedona_internal_err;

--- a/rust/sedona-expr/src/metadata_preserving_column.rs
+++ b/rust/sedona-expr/src/metadata_preserving_column.rs
@@ -34,7 +34,7 @@ use arrow_array::RecordBatch;
 use arrow_schema::{DataType, FieldRef, Schema};
 use datafusion_common::Result;
 use datafusion_expr::ColumnarValue;
-use datafusion_physical_expr::{expressions::Column, PhysicalExpr};
+use datafusion_physical_expr::{PhysicalExpr, expressions::Column};
 use sedona_common::sedona_internal_err;
 
 /// A wrapper around [`Column`] that preserves field metadata in `return_field()`.
@@ -159,9 +159,11 @@ mod tests {
 
         // return_field should return the stored field with metadata, not the input schema's field
         let returned_field = wrapper.return_field(&input_schema).unwrap();
-        assert!(returned_field
-            .metadata()
-            .contains_key("ARROW:extension:name"));
+        assert!(
+            returned_field
+                .metadata()
+                .contains_key("ARROW:extension:name")
+        );
         assert_eq!(
             returned_field.metadata().get("ARROW:extension:name"),
             Some(&"geoarrow.wkb".to_string())

--- a/rust/sedona-expr/src/placeholder_udf.rs
+++ b/rust/sedona-expr/src/placeholder_udf.rs
@@ -30,16 +30,16 @@ use std::{
 
 use arrow_schema::{DataType, Field};
 use datafusion_common::{
-    tree_node::{Transformed, TreeNode, TreeNodeRecursion},
     Result,
+    tree_node::{Transformed, TreeNode, TreeNodeRecursion},
 };
 use datafusion_execution::FunctionRegistry;
 use datafusion_expr::{
-    expr::ScalarFunction,
-    function::{AccumulatorArgs, PartitionEvaluatorArgs, WindowUDFFieldArgs},
     Accumulator, AggregateUDF, AggregateUDFImpl, Expr, HigherOrderUDF, PartitionEvaluator,
     ScalarUDF, ScalarUDFImpl, Signature, Volatility, WindowFunctionDefinition, WindowUDF,
     WindowUDFImpl,
+    expr::ScalarFunction,
+    function::{AccumulatorArgs, PartitionEvaluatorArgs, WindowUDFFieldArgs},
 };
 use sedona_common::sedona_internal_err;
 
@@ -55,11 +55,11 @@ impl PlaceholderRegistry {
     pub fn expr_contains_placeholder(expr: &Expr) -> bool {
         let mut found = false;
         expr.apply(|e| {
-            if let Expr::ScalarFunction(func) = e {
-                if func.func.inner().downcast_ref::<PlaceholderUDF>().is_some() {
-                    found = true;
-                    return Ok(TreeNodeRecursion::Stop);
-                }
+            if let Expr::ScalarFunction(func) = e
+                && func.func.inner().downcast_ref::<PlaceholderUDF>().is_some()
+            {
+                found = true;
+                return Ok(TreeNodeRecursion::Stop);
             }
             Ok(TreeNodeRecursion::Continue)
         })
@@ -90,11 +90,11 @@ impl PlaceholderRegistry {
                     }
                 }
                 Expr::WindowFunction(func) => {
-                    if let WindowFunctionDefinition::WindowUDF(ref udf) = func.fun {
-                        if udf.inner().downcast_ref::<PlaceholderUDWF>().is_some() {
-                            found = true;
-                            return Ok(TreeNodeRecursion::Stop);
-                        }
+                    if let WindowFunctionDefinition::WindowUDF(ref udf) = func.fun
+                        && udf.inner().downcast_ref::<PlaceholderUDWF>().is_some()
+                    {
+                        found = true;
+                        return Ok(TreeNodeRecursion::Stop);
                     }
                 }
                 _ => {}
@@ -143,17 +143,16 @@ impl PlaceholderRegistry {
                     }
                 }
                 Expr::WindowFunction(func) => {
-                    if let WindowFunctionDefinition::WindowUDF(ref udf) = func.fun {
-                        if udf.inner().downcast_ref::<PlaceholderUDWF>().is_some() {
-                            let real_udwf = registry.udwf(udf.name())?;
-                            let replaced = Expr::WindowFunction(Box::new(
-                                datafusion_expr::expr::WindowFunction {
-                                    fun: WindowFunctionDefinition::WindowUDF(real_udwf),
-                                    params: func.params.clone(),
-                                },
-                            ));
-                            return Ok(Transformed::yes(replaced));
-                        }
+                    if let WindowFunctionDefinition::WindowUDF(ref udf) = func.fun
+                        && udf.inner().downcast_ref::<PlaceholderUDWF>().is_some()
+                    {
+                        let real_udwf = registry.udwf(udf.name())?;
+                        let replaced =
+                            Expr::WindowFunction(Box::new(datafusion_expr::expr::WindowFunction {
+                                fun: WindowFunctionDefinition::WindowUDF(real_udwf),
+                                params: func.params.clone(),
+                            }));
+                        return Ok(Transformed::yes(replaced));
                     }
                 }
                 _ => {}
@@ -350,7 +349,7 @@ impl WindowUDFImpl for PlaceholderUDWF {
 mod tests {
     use super::*;
     use datafusion_common::ScalarValue;
-    use datafusion_expr::{col, lit, SimpleScalarUDF};
+    use datafusion_expr::{SimpleScalarUDF, col, lit};
 
     #[test]
     fn test_placeholder_registry_returns_empty_function_sets() {

--- a/rust/sedona-expr/src/scalar_udf.rs
+++ b/rust/sedona-expr/src/scalar_udf.rs
@@ -18,7 +18,7 @@ use std::{collections::HashMap, fmt::Debug, sync::Arc};
 
 use arrow_schema::{DataType, FieldRef};
 use datafusion_common::config::ConfigOptions;
-use datafusion_common::{not_impl_err, Result, ScalarValue};
+use datafusion_common::{Result, ScalarValue, not_impl_err};
 use datafusion_expr::{
     ColumnarValue, Documentation, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl, Signature,
     Volatility,
@@ -357,10 +357,10 @@ impl ScalarUDFImpl for SedonaScalarUDF {
 #[cfg(test)]
 mod tests {
 
-    use datafusion_common::{scalar::ScalarValue, DFSchema};
+    use datafusion_common::{DFSchema, scalar::ScalarValue};
     use sedona_testing::testers::ScalarUdfTester;
 
-    use datafusion_expr::{lit, ExprSchemable, ScalarUDF};
+    use datafusion_expr::{ExprSchemable, ScalarUDF, lit};
     use sedona_geometry::types::Edges;
     use sedona_schema::{crs::lnglat, datatypes::WKB_GEOMETRY};
 

--- a/rust/sedona-expr/src/spatial_filter.rs
+++ b/rust/sedona-expr/src/spatial_filter.rs
@@ -18,11 +18,11 @@ use std::{collections::HashMap, fmt::Debug, sync::Arc};
 
 use arrow_schema::{DataType, Field, Schema};
 use datafusion_common::config::ConfigOptions;
-use datafusion_common::{exec_datafusion_err, DataFusionError, Result, ScalarValue};
+use datafusion_common::{DataFusionError, Result, ScalarValue, exec_datafusion_err};
 use datafusion_expr::{Expr, Operator};
 use datafusion_physical_expr::{
-    expressions::{BinaryExpr, Column, Literal},
     PhysicalExpr, ScalarFunctionExpr,
+    expressions::{BinaryExpr, Column, Literal},
 };
 use geo_traits::Dimensions;
 use sedona_common::sedona_internal_err;
@@ -36,7 +36,7 @@ use sedona_schema::{datatypes::SedonaType, schema::SedonaSchema};
 use crate::{
     metadata_preserving_column::MetadataPreservingColumn,
     statistics::GeoStatistics,
-    utils::{parse_distance_predicate, ParsedDistancePredicate},
+    utils::{ParsedDistancePredicate, parse_distance_predicate},
 };
 
 /// Simplified parsed spatial filter
@@ -96,7 +96,7 @@ impl SpatialFilter {
                 return bounds;
             }
             SpatialFilter::LiteralFalse => {
-                return BoundingBox::xy(Interval::empty(), Interval::empty())
+                return BoundingBox::xy(Interval::empty(), Interval::empty());
             }
             SpatialFilter::HasZ(_) | SpatialFilter::Unknown => {}
         }
@@ -146,12 +146,11 @@ impl SpatialFilter {
     }
 
     fn evaluate_has_z(column_stats: &GeoStatistics) -> bool {
-        if let Some(bbox) = column_stats.bbox() {
-            if let Some(z) = bbox.z() {
-                if z.is_empty() {
-                    return false;
-                }
-            }
+        if let Some(bbox) = column_stats.bbox()
+            && let Some(z) = bbox.z()
+            && z.is_empty()
+        {
+            return false;
         }
 
         if let Some(geometry_types) = column_stats.geometry_types() {
@@ -461,7 +460,7 @@ impl SpatialFilterFactory {
             _ => {
                 return sedona_internal_err!(
                     "Unexpected scalar type in filter expression ({sedona_type:?})"
-                )
+                );
             }
         };
 
@@ -480,7 +479,7 @@ impl SpatialFilterFactory {
             _ => {
                 return sedona_internal_err!(
                     "Unexpected scalar type in filter expression ({sedona_type:?})"
-                )
+                );
             }
         };
 
@@ -683,7 +682,7 @@ mod test {
     use arrow_schema::{DataType, Field};
     use datafusion_common::config::ConfigOptions;
     use datafusion_expr::{
-        expr::ScalarFunction, ScalarUDF, Signature, SimpleScalarUDF, Volatility,
+        ScalarUDF, Signature, SimpleScalarUDF, Volatility, expr::ScalarFunction,
     };
     use rstest::rstest;
     use sedona_geometry::{bounding_box::BoundingBox, interval::Interval};
@@ -738,21 +737,27 @@ mod test {
         );
         let col0 = Column::new("col0", 0);
 
-        assert!(SpatialFilter::Intersects(col0.clone(), bounds.clone())
-            .evaluate(&stats_no_info)
-            .unwrap());
-        assert!(SpatialFilter::Intersects(col0.clone(), bounds.clone())
-            .evaluate(&stats_intersecting)
-            .unwrap());
+        assert!(
+            SpatialFilter::Intersects(col0.clone(), bounds.clone())
+                .evaluate(&stats_no_info)
+                .unwrap()
+        );
+        assert!(
+            SpatialFilter::Intersects(col0.clone(), bounds.clone())
+                .evaluate(&stats_intersecting)
+                .unwrap()
+        );
 
         let stats_empty_bbox = TableGeoStatistics::from(
             GeoStatistics::unspecified()
                 .with_bbox(Some(BoundingBox::xy(Interval::empty(), Interval::empty()))),
         );
 
-        assert!(!SpatialFilter::Intersects(col0.clone(), bounds.clone())
-            .evaluate(&stats_empty_bbox)
-            .unwrap());
+        assert!(
+            !SpatialFilter::Intersects(col0.clone(), bounds.clone())
+                .evaluate(&stats_empty_bbox)
+                .unwrap()
+        );
 
         let unrelated_literal = Literal::new(ScalarValue::Null);
 
@@ -787,15 +792,21 @@ mod test {
         let col0 = Column::new("col0", 0);
 
         // Covers should return true when column bbox is fully contained in literal bounds
-        assert!(SpatialFilter::Covers(col0.clone(), bounds.clone())
-            .evaluate(&stats_no_info)
-            .unwrap());
-        assert!(SpatialFilter::Covers(col0.clone(), bounds.clone())
-            .evaluate(&stats_covered)
-            .unwrap());
-        assert!(!SpatialFilter::Covers(col0.clone(), bounds.clone())
-            .evaluate(&stats_not_covered)
-            .unwrap());
+        assert!(
+            SpatialFilter::Covers(col0.clone(), bounds.clone())
+                .evaluate(&stats_no_info)
+                .unwrap()
+        );
+        assert!(
+            SpatialFilter::Covers(col0.clone(), bounds.clone())
+                .evaluate(&stats_covered)
+                .unwrap()
+        );
+        assert!(
+            !SpatialFilter::Covers(col0.clone(), bounds.clone())
+                .evaluate(&stats_not_covered)
+                .unwrap()
+        );
     }
 
     #[test]
@@ -833,47 +844,61 @@ mod test {
 
     #[test]
     fn predicate_other() {
-        assert!(!SpatialFilter::LiteralFalse
+        assert!(
+            !SpatialFilter::LiteralFalse
+                .evaluate(&TableGeoStatistics::empty())
+                .unwrap()
+        );
+        assert!(
+            SpatialFilter::Unknown
+                .evaluate(&TableGeoStatistics::empty())
+                .unwrap()
+        );
+
+        assert!(
+            SpatialFilter::And(
+                Box::new(SpatialFilter::Unknown),
+                Box::new(SpatialFilter::Unknown)
+            )
             .evaluate(&TableGeoStatistics::empty())
-            .unwrap());
-        assert!(SpatialFilter::Unknown
+            .unwrap()
+        );
+
+        assert!(
+            !SpatialFilter::And(
+                Box::new(SpatialFilter::Unknown),
+                Box::new(SpatialFilter::LiteralFalse)
+            )
             .evaluate(&TableGeoStatistics::empty())
-            .unwrap());
+            .unwrap()
+        );
 
-        assert!(SpatialFilter::And(
-            Box::new(SpatialFilter::Unknown),
-            Box::new(SpatialFilter::Unknown)
-        )
-        .evaluate(&TableGeoStatistics::empty())
-        .unwrap());
+        assert!(
+            SpatialFilter::Or(
+                Box::new(SpatialFilter::Unknown),
+                Box::new(SpatialFilter::Unknown)
+            )
+            .evaluate(&TableGeoStatistics::empty())
+            .unwrap()
+        );
 
-        assert!(!SpatialFilter::And(
-            Box::new(SpatialFilter::Unknown),
-            Box::new(SpatialFilter::LiteralFalse)
-        )
-        .evaluate(&TableGeoStatistics::empty())
-        .unwrap());
+        assert!(
+            SpatialFilter::Or(
+                Box::new(SpatialFilter::Unknown),
+                Box::new(SpatialFilter::LiteralFalse)
+            )
+            .evaluate(&TableGeoStatistics::empty())
+            .unwrap()
+        );
 
-        assert!(SpatialFilter::Or(
-            Box::new(SpatialFilter::Unknown),
-            Box::new(SpatialFilter::Unknown)
-        )
-        .evaluate(&TableGeoStatistics::empty())
-        .unwrap());
-
-        assert!(SpatialFilter::Or(
-            Box::new(SpatialFilter::Unknown),
-            Box::new(SpatialFilter::LiteralFalse)
-        )
-        .evaluate(&TableGeoStatistics::empty())
-        .unwrap());
-
-        assert!(!SpatialFilter::Or(
-            Box::new(SpatialFilter::LiteralFalse),
-            Box::new(SpatialFilter::LiteralFalse)
-        )
-        .evaluate(&TableGeoStatistics::empty())
-        .unwrap());
+        assert!(
+            !SpatialFilter::Or(
+                Box::new(SpatialFilter::LiteralFalse),
+                Box::new(SpatialFilter::LiteralFalse)
+            )
+            .evaluate(&TableGeoStatistics::empty())
+            .unwrap()
+        );
     }
 
     #[test]
@@ -1265,11 +1290,13 @@ mod test {
             Arc::new(Field::new("", DataType::Boolean, true)),
             Arc::new(ConfigOptions::default()),
         ));
-        assert!(factory
-            .try_from_expr(&expr_no_args)
-            .unwrap_err()
-            .message()
-            .contains("unexpected argument count"));
+        assert!(
+            factory
+                .try_from_expr(&expr_no_args)
+                .unwrap_err()
+                .message()
+                .contains("unexpected argument count")
+        );
 
         // Unsupported arg types
         let expr_wrong_types: Arc<dyn PhysicalExpr> = Arc::new(ScalarFunctionExpr::new(
@@ -1428,11 +1455,13 @@ mod test {
             Arc::new(Field::new("", DataType::Boolean, true)),
             Arc::new(ConfigOptions::default()),
         ));
-        assert!(factory
-            .try_from_expr(&expr_no_args)
-            .unwrap_err()
-            .message()
-            .contains("unexpected argument count"));
+        assert!(
+            factory
+                .try_from_expr(&expr_no_args)
+                .unwrap_err()
+                .message()
+                .contains("unexpected argument count")
+        );
 
         // Wrong arg types
         let expr_wrong_types: Arc<dyn PhysicalExpr> = Arc::new(ScalarFunctionExpr::new(

--- a/rust/sedona-expr/src/statistics.rs
+++ b/rust/sedona-expr/src/statistics.rs
@@ -16,7 +16,7 @@
 // under the License.
 use std::str::FromStr;
 
-use datafusion_common::{stats::Precision, ColumnStatistics, DataFusionError, Result, ScalarValue};
+use datafusion_common::{ColumnStatistics, DataFusionError, Result, ScalarValue, stats::Precision};
 use sedona_common::sedona_internal_datafusion_err;
 use sedona_geometry::interval::{Interval, IntervalTrait};
 use sedona_geometry::{
@@ -526,16 +526,20 @@ mod test {
     fn from_non_geometry_stats() {
         // Can't make geo stats from unknown
         let stats = ColumnStatistics::new_unknown();
-        assert!(GeoStatistics::try_from_column_statistics(&stats)
-            .unwrap()
-            .is_none());
+        assert!(
+            GeoStatistics::try_from_column_statistics(&stats)
+                .unwrap()
+                .is_none()
+        );
 
         // Can't make geo stats from binary null
         let stats = ColumnStatistics::new_unknown()
             .with_sum_value(Precision::Exact(ScalarValue::Binary(None)));
-        assert!(GeoStatistics::try_from_column_statistics(&stats)
-            .unwrap()
-            .is_none());
+        assert!(
+            GeoStatistics::try_from_column_statistics(&stats)
+                .unwrap()
+                .is_none()
+        );
 
         // Can't make geo stats from binary null
         let stats = ColumnStatistics::new_unknown()

--- a/rust/sedona-expr/src/utils.rs
+++ b/rust/sedona-expr/src/utils.rs
@@ -18,7 +18,7 @@
 use std::sync::Arc;
 
 use datafusion_expr::Operator;
-use datafusion_physical_expr::{expressions::BinaryExpr, PhysicalExpr, ScalarFunctionExpr};
+use datafusion_physical_expr::{PhysicalExpr, ScalarFunctionExpr, expressions::BinaryExpr};
 
 /// Represents a parsed distance predicate with its constituent parts.
 ///


### PR DESCRIPTION
Migrates sedona-expr independently to Rust 2024 as part of #258. Applies standard formatter output and Rust 2024 let chains. Validated with 101 package tests, all-target checks, and Clippy with warnings denied.