### PR TITLE
chore(rust/sedona-functions): migrate to Rust 2024 edition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
       - id: fmt
         name: rustfmt
         args: ["--all", "--"]
+        pass_filenames: false
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13

--- a/rust/sedona-functions/Cargo.toml
+++ b/rust/sedona-functions/Cargo.toml
@@ -24,7 +24,7 @@ homepage.workspace = true
 repository.workspace = true
 description.workspace = true
 readme.workspace = true
-edition.workspace = true
+edition = "2024"
 rust-version.workspace = true
 
 [lints.clippy]

--- a/rust/sedona-functions/benches/native-functions.rs
+++ b/rust/sedona-functions/benches/native-functions.rs
@@ -14,9 +14,9 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use datafusion_expr::ScalarUDF;
-use sedona_testing::benchmark_util::{benchmark, BenchmarkArgSpec::*, BenchmarkArgs};
+use sedona_testing::benchmark_util::{BenchmarkArgSpec::*, BenchmarkArgs, benchmark};
 
 fn criterion_benchmark(c: &mut Criterion) {
     let f = sedona_functions::register::default_function_set();

--- a/rust/sedona-functions/benches/proj-functions.rs
+++ b/rust/sedona-functions/benches/proj-functions.rs
@@ -16,10 +16,10 @@
 // under the License.
 use std::sync::Arc;
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use sedona_functions::register::default_function_set;
 use sedona_proj::transform::LazyProjEngine;
-use sedona_testing::benchmark_util::{benchmark, BenchmarkArgSpec::*, BenchmarkArgs};
+use sedona_testing::benchmark_util::{BenchmarkArgSpec::*, BenchmarkArgs, benchmark};
 
 fn criterion_benchmark(c: &mut Criterion) {
     let f = default_function_set();

--- a/rust/sedona-functions/src/executor.rs
+++ b/rust/sedona-functions/src/executor.rs
@@ -26,7 +26,7 @@ use datafusion_expr::ColumnarValue;
 use sedona_common::{option::SedonaOptions, sedona_internal_err};
 use sedona_geometry::{bounds::WkbBounder2D, types::Edges, wkb_header::WkbPointLayout};
 use sedona_schema::datatypes::SedonaType;
-use wkb::reader::{read_wkb, Wkb};
+use wkb::reader::{Wkb, read_wkb};
 
 /// Resolve the session bounder for a geometry/geography argument.
 pub(crate) fn bounder_for_arg_type(
@@ -329,10 +329,10 @@ impl GeometryFactory for PointXYGeometryFactory {
     fn try_from_wkb<'a>(&self, wkb_bytes: &'a [u8]) -> Result<Self::Geom<'a>> {
         // A finite Point: read its coordinate from the fixed offset, no parse.
         // POINT EMPTY (NaN/NaN) and any header error fall through to the parser.
-        if let Ok(Some(layout)) = WkbPointLayout::try_from_wkb(wkb_bytes) {
-            if let Ok(Some((x, y))) = layout.read_xy(wkb_bytes) {
-                return Ok(PointOrWkb::Point(x, y));
-            }
+        if let Ok(Some(layout)) = WkbPointLayout::try_from_wkb(wkb_bytes)
+            && let Ok(Some((x, y))) = layout.read_xy(wkb_bytes)
+        {
+            return Ok(PointOrWkb::Point(x, y));
         }
         let wkb = read_wkb(wkb_bytes).map_err(|e| DataFusionError::External(Box::new(e)))?;
         Ok(PointOrWkb::Other(wkb))
@@ -808,9 +808,10 @@ mod tests {
                 |_| unreachable!(),
             )
             .unwrap_err();
-        assert!(err
-            .message()
-            .contains("Expected 1000000 items but got Array with 3 items"));
+        assert!(
+            err.message()
+                .contains("Expected 1000000 items but got Array with 3 items")
+        );
 
         let factory0 = WkbGeometryFactory::default();
         let factory1 = WkbGeometryFactory::default();
@@ -833,10 +834,12 @@ mod tests {
     #[test]
     fn wkb_scalar() {
         let factory = WkbGeometryFactory::default();
-        assert!(ScalarValue::Binary(None)
-            .scalar_from_factory(&factory)
-            .unwrap()
-            .is_none());
+        assert!(
+            ScalarValue::Binary(None)
+                .scalar_from_factory(&factory)
+                .unwrap()
+                .is_none()
+        );
 
         let mut wkt_out = String::new();
         let binary_scalar = ScalarValue::Binary(Some(POINT.to_vec()));

--- a/rust/sedona-functions/src/sd_format.rs
+++ b/rust/sedona-functions/src/sd_format.rs
@@ -18,13 +18,14 @@ use std::{fmt::Write, sync::Arc, vec};
 
 use crate::executor::WkbExecutor;
 use arrow_array::{
-    builder::StringBuilder, cast::AsArray, Array, GenericListArray, GenericListViewArray,
-    OffsetSizeTrait, StructArray,
+    Array, GenericListArray, GenericListViewArray, OffsetSizeTrait, StructArray,
+    builder::StringBuilder, cast::AsArray,
 };
 use arrow_schema::{DataType, Field, Fields};
 use datafusion_common::{
+    ScalarValue,
     error::{DataFusionError, Result},
-    internal_err, ScalarValue,
+    internal_err,
 };
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
@@ -71,22 +72,21 @@ impl SedonaScalarKernel for SDFormatDefault {
         args: &[ColumnarValue],
     ) -> Result<ColumnarValue> {
         let mut maybe_width_hint: Option<usize> = None;
-        if args.len() >= 2 {
-            if let ColumnarValue::Scalar(ScalarValue::Utf8(Some(options_value))) =
+        if args.len() >= 2
+            && let ColumnarValue::Scalar(ScalarValue::Utf8(Some(options_value))) =
                 args[1].cast_to(&DataType::Utf8, None)?
+        {
+            let options: serde_json::Value = options_value
+                .parse()
+                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+            if let Some(width_hint_value) = options.get("width_hint")
+                && let Some(width_hint_i64) = width_hint_value.as_i64()
             {
-                let options: serde_json::Value = options_value
-                    .parse()
-                    .map_err(|e| DataFusionError::External(Box::new(e)))?;
-                if let Some(width_hint_value) = options.get("width_hint") {
-                    if let Some(width_hint_i64) = width_hint_value.as_i64() {
-                        maybe_width_hint = Some(
-                            width_hint_i64
-                                .try_into()
-                                .map_err(|e| DataFusionError::External(Box::new(e)))?,
-                        );
-                    }
-                }
+                maybe_width_hint = Some(
+                    width_hint_i64
+                        .try_into()
+                        .map_err(|e| DataFusionError::External(Box::new(e)))?,
+                );
             }
         }
 
@@ -418,8 +418,8 @@ impl<'a, T: std::fmt::Write> std::fmt::Write for LimitedSizeOutput<'a, T> {
 #[cfg(test)]
 mod tests {
     use arrow_array::{
-        create_array, ArrayRef, Float64Array, Int32Array, ListArray, ListViewArray, StringArray,
-        StructArray,
+        ArrayRef, Float64Array, Int32Array, ListArray, ListViewArray, StringArray, StructArray,
+        create_array,
     };
     use arrow_schema::{DataType, Field};
     use datafusion::arrow::buffer::{OffsetBuffer, ScalarBuffer};

--- a/rust/sedona-functions/src/sd_order.rs
+++ b/rust/sedona-functions/src/sd_order.rs
@@ -62,7 +62,7 @@ impl SedonaScalarKernel for SDOrderDefault {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_array::{create_array, ArrayRef};
+    use arrow_array::{ArrayRef, create_array};
     use arrow_schema::DataType;
     use datafusion_common::ScalarValue;
     use datafusion_expr::ScalarUDF;

--- a/rust/sedona-functions/src/sd_order_lnglat.rs
+++ b/rust/sedona-functions/src/sd_order_lnglat.rs
@@ -148,7 +148,7 @@ impl<F: Fn((f64, f64)) -> u64 + Send + Sync> SedonaScalarKernel for OrderLngLat<
 #[cfg(test)]
 mod test {
 
-    use arrow_array::{create_array, ArrayRef};
+    use arrow_array::{ArrayRef, create_array};
     use sedona_expr::scalar_udf::SedonaScalarUDF;
     use sedona_geometry::types::Edges;
     use sedona_schema::datatypes::WKB_GEOMETRY;

--- a/rust/sedona-functions/src/sd_simplifystorage.rs
+++ b/rust/sedona-functions/src/sd_simplifystorage.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use arrow_array::ArrayRef;
 use arrow_schema::{DataType, FieldRef, UnionFields};
-use datafusion_common::{config::ConfigOptions, datatype::DataTypeExt, Result, ScalarValue};
+use datafusion_common::{Result, ScalarValue, config::ConfigOptions, datatype::DataTypeExt};
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_common::sedona_internal_err;
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
@@ -275,8 +275,7 @@ mod tests {
             let tester = ScalarUdfTester::new(udf.clone().into(), vec![initial_type.clone()]);
             let return_type = tester.return_type().unwrap();
             assert_eq!(
-                return_type,
-                simplified_type,
+                return_type, simplified_type,
                 "expected {initial_type:?} to simplify to {simplified_type:?} but got {return_type:?}"
             );
 

--- a/rust/sedona-functions/src/st_affine.rs
+++ b/rust/sedona-functions/src/st_affine.rs
@@ -14,9 +14,9 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-use arrow_array::{builder::BinaryBuilder, Array};
+use arrow_array::{Array, builder::BinaryBuilder};
 use arrow_schema::DataType;
-use datafusion_common::{error::Result, DataFusionError};
+use datafusion_common::{DataFusionError, error::Result};
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_expr::{
     item_crs::ItemCrsKernel,

--- a/rust/sedona-functions/src/st_affine_helpers.rs
+++ b/rust/sedona-functions/src/st_affine_helpers.rs
@@ -14,9 +14,9 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-use arrow_array::types::Float64Type;
 use arrow_array::Array;
 use arrow_array::PrimitiveArray;
+use arrow_array::types::Float64Type;
 use datafusion_common::cast::as_float64_array;
 use datafusion_common::error::Result;
 use geo_traits::Dimensions;

--- a/rust/sedona-functions/src/st_analyze_agg.rs
+++ b/rust/sedona-functions/src/st_analyze_agg.rs
@@ -19,15 +19,16 @@ use std::vec;
 
 use std::{mem::size_of_val, sync::Arc};
 
+use arrow_array::StructArray;
 use arrow_array::builder::Float64Builder;
 use arrow_array::builder::Int64Builder;
-use arrow_array::StructArray;
 use arrow_array::{Array, ArrayRef, Float64Array, Int64Array};
 use arrow_schema::{DataType, Field, FieldRef};
 use datafusion_common::{
+    ScalarValue,
     cast::as_binary_array,
     error::{DataFusionError, Result},
-    exec_datafusion_err, ScalarValue,
+    exec_datafusion_err,
 };
 use datafusion_expr::Volatility;
 use datafusion_expr::{Accumulator, ColumnarValue};
@@ -35,7 +36,7 @@ use sedona_common::{sedona_internal_datafusion_err, sedona_internal_err};
 use sedona_expr::aggregate_udf::{SedonaAccumulatorRef, SedonaAggregateUDF};
 use sedona_expr::item_crs::ItemCrsSedonaAccumulator;
 use sedona_expr::{aggregate_udf::SedonaAccumulator, statistics::GeoStatistics};
-use sedona_geometry::analyze::{analyze_wkb, GeometrySummary};
+use sedona_geometry::analyze::{GeometrySummary, analyze_wkb};
 use sedona_geometry::bounding_box::BoundingBox;
 use sedona_geometry::bounds::{WkbBounder2D, WkbGeometryBounder};
 use sedona_geometry::interval::IntervalTrait;
@@ -234,9 +235,9 @@ impl<T> STAnalyzeAgg<T> {
             Arc::new(Int64Array::from(vec![stats.puntal_count().unwrap_or(0)])) as ArrayRef,
             Arc::new(Int64Array::from(vec![stats.lineal_count().unwrap_or(0)])) as ArrayRef,
             Arc::new(Int64Array::from(vec![stats.polygonal_count().unwrap_or(0)])) as ArrayRef,
-            Arc::new(Int64Array::from(vec![stats
-                .collection_count()
-                .unwrap_or(0)])) as ArrayRef,
+            Arc::new(Int64Array::from(vec![
+                stats.collection_count().unwrap_or(0),
+            ])) as ArrayRef,
             Arc::new(Self::create_float64_array(mean_envelope_width)) as ArrayRef,
             Arc::new(Self::create_float64_array(mean_envelope_height)) as ArrayRef,
             Arc::new(Self::create_float64_array(mean_envelope_area)) as ArrayRef,

--- a/rust/sedona-functions/src/st_asbinary.rs
+++ b/rust/sedona-functions/src/st_asbinary.rs
@@ -43,10 +43,10 @@ struct STAsBinary {}
 impl SedonaScalarKernel for STAsBinary {
     fn return_type(&self, args: &[SedonaType]) -> Result<Option<SedonaType>> {
         // If we have WkbView input, return BinaryView to avoid a cast
-        if args.len() == 1 {
-            if let SedonaType::WkbView(_, _) = args[0] {
-                return Ok(Some(SedonaType::Arrow(DataType::BinaryView)));
-            }
+        if args.len() == 1
+            && let SedonaType::WkbView(_, _) = args[0]
+        {
+            return Ok(Some(SedonaType::Arrow(DataType::BinaryView)));
         }
 
         let matcher = ArgMatcher::new(

--- a/rust/sedona-functions/src/st_asewkb.rs
+++ b/rust/sedona-functions/src/st_asewkb.rs
@@ -19,9 +19,10 @@ use std::{sync::Arc, vec};
 use arrow_array::builder::BinaryBuilder;
 use arrow_schema::DataType;
 use datafusion_common::{
+    ScalarValue,
     cast::{as_string_view_array, as_struct_array},
     error::Result,
-    exec_datafusion_err, exec_err, ScalarValue,
+    exec_datafusion_err, exec_err,
 };
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_common::sedona_internal_err;

--- a/rust/sedona-functions/src/st_astext.rs
+++ b/rust/sedona-functions/src/st_astext.rs
@@ -88,7 +88,7 @@ impl SedonaScalarKernel for STAsText {
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::{create_array, ArrayRef};
+    use arrow_array::{ArrayRef, create_array};
     use datafusion_common::scalar::ScalarValue;
     use datafusion_expr::ScalarUDF;
     use rstest::rstest;

--- a/rust/sedona-functions/src/st_collect_agg.rs
+++ b/rust/sedona-functions/src/st_collect_agg.rs
@@ -20,9 +20,10 @@ use crate::executor::WkbExecutor;
 use arrow_array::ArrayRef;
 use arrow_schema::{DataType, Field, FieldRef};
 use datafusion_common::{
+    ScalarValue,
     cast::{as_binary_array, as_int64_array, as_uint32_array},
     error::{DataFusionError, Result},
-    exec_err, ScalarValue,
+    exec_err,
 };
 use datafusion_expr::{Accumulator, ColumnarValue, Volatility};
 use geo_traits::Dimensions;
@@ -248,7 +249,7 @@ impl Accumulator for CollectionAccumulator {
                 _ => {
                     return sedona_internal_err!(
                         "unexpected nulls in st_collect() serialized state"
-                    )
+                    );
                 }
             }
         }

--- a/rust/sedona-functions/src/st_dimension.rs
+++ b/rust/sedona-functions/src/st_dimension.rs
@@ -91,7 +91,7 @@ fn invoke_scalar(item: &Wkb) -> Result<i8> {
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::{create_array as arrow_array, ArrayRef};
+    use arrow_array::{ArrayRef, create_array as arrow_array};
     use datafusion_common::ScalarValue;
     use datafusion_expr::ScalarUDF;
     use rstest::rstest;
@@ -141,7 +141,9 @@ mod tests {
             Some("GEOMETRYCOLLECTION EMPTY"),
             Some("GEOMETRYCOLLECTION (POINT (1 2))"),
             Some("GEOMETRYCOLLECTION (POINT (1 2), LINESTRING EMPTY)"),
-            Some("GEOMETRYCOLLECTION (POINT (1 2), LINESTRING (1 2, 2 2), POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)))"),
+            Some(
+                "GEOMETRYCOLLECTION (POINT (1 2), LINESTRING (1 2, 2 2), POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)))",
+            ),
             Some("GEOMETRYCOLLECTION (POINT (1 2), GEOMETRYCOLLECTION (LINESTRING (1 2, 2 2)))"),
         ];
         let expected: ArrayRef = arrow_array!(

--- a/rust/sedona-functions/src/st_dump.rs
+++ b/rust/sedona-functions/src/st_dump.rs
@@ -15,11 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 use arrow_array::{
-    builder::{BinaryBuilder, NullBufferBuilder, OffsetBufferBuilder, UInt32Builder},
     ListArray, StructArray,
+    builder::{BinaryBuilder, NullBufferBuilder, OffsetBufferBuilder, UInt32Builder},
 };
 use arrow_schema::{DataType, Field, Fields};
-use datafusion_common::{config::ConfigOptions, Result};
+use datafusion_common::{Result, config::ConfigOptions};
 use datafusion_expr::{ColumnarValue, Volatility};
 use geo_traits::{
     GeometryCollectionTrait, GeometryTrait, GeometryType, MultiLineStringTrait, MultiPointTrait,
@@ -305,8 +305,12 @@ mod tests {
                 Some("MULTIPOINT (1 1, 2 2)"),
                 Some("MULTILINESTRING ((1 1, 2 2), EMPTY, (3 3, 4 4))"),
                 Some("MULTIPOLYGON (((1 1, 2 2, 2 1, 1 1)), EMPTY, ((3 3, 4 4, 4 3, 3 3)))"),
-                Some("GEOMETRYCOLLECTION (POINT (1 2), MULTILINESTRING ((1 1, 2 2), EMPTY, (3 3, 4 4)), LINESTRING (1 1, 2 2))"),
-                Some("GEOMETRYCOLLECTION (POINT (1 2), GEOMETRYCOLLECTION (MULTILINESTRING ((1 1, 2 2), EMPTY, (3 3, 4 4)), LINESTRING (1 1, 2 2)))"),
+                Some(
+                    "GEOMETRYCOLLECTION (POINT (1 2), MULTILINESTRING ((1 1, 2 2), EMPTY, (3 3, 4 4)), LINESTRING (1 1, 2 2))",
+                ),
+                Some(
+                    "GEOMETRYCOLLECTION (POINT (1 2), GEOMETRYCOLLECTION (MULTILINESTRING ((1 1, 2 2), EMPTY, (3 3, 4 4)), LINESTRING (1 1, 2 2)))",
+                ),
             ],
             &sedona_type,
         );

--- a/rust/sedona-functions/src/st_envelope.rs
+++ b/rust/sedona-functions/src/st_envelope.rs
@@ -16,7 +16,7 @@
 // under the License.
 use std::{sync::Arc, vec};
 
-use crate::executor::{bounder_for_arg_type, WkbBytesExecutor};
+use crate::executor::{WkbBytesExecutor, bounder_for_arg_type};
 use arrow_array::builder::BinaryBuilder;
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::{
@@ -34,10 +34,11 @@ use sedona_geometry::{
     bounds::WkbBounder2D,
     interval::{Interval, IntervalTrait, WraparoundInterval},
     wkb_factory::{
-        write_wkb_empty_point, write_wkb_geometrycollection_header, write_wkb_linestring,
-        write_wkb_linestring_header, write_wkb_multilinestring, write_wkb_multilinestring_header,
-        write_wkb_multipoint_header, write_wkb_multipolygon, write_wkb_multipolygon_header,
-        write_wkb_point, write_wkb_polygon, write_wkb_polygon_header, WKB_MIN_PROBABLE_BYTES,
+        WKB_MIN_PROBABLE_BYTES, write_wkb_empty_point, write_wkb_geometrycollection_header,
+        write_wkb_linestring, write_wkb_linestring_header, write_wkb_multilinestring,
+        write_wkb_multilinestring_header, write_wkb_multipoint_header, write_wkb_multipolygon,
+        write_wkb_multipolygon_header, write_wkb_point, write_wkb_polygon,
+        write_wkb_polygon_header,
     },
 };
 use sedona_schema::{
@@ -408,7 +409,9 @@ mod tests {
         assert!(result);
         assert_scalar_equal_wkb_geometry(
             &ScalarValue::Binary(Some(buf)),
-            Some("MULTIPOLYGON(((170 -10,170 10,180 10,180 -10,170 -10)),((-180 -10,-180 10,-170 10,-170 -10,-180 -10)))"),
+            Some(
+                "MULTIPOLYGON(((170 -10,170 10,180 10,180 -10,170 -10)),((-180 -10,-180 10,-170 10,-170 -10,-180 -10)))",
+            ),
         );
     }
 

--- a/rust/sedona-functions/src/st_envelope_agg.rs
+++ b/rust/sedona-functions/src/st_envelope_agg.rs
@@ -18,13 +18,13 @@ use std::{marker::PhantomData, sync::Arc, vec};
 
 use crate::executor::WkbBytesExecutor;
 use crate::st_envelope::write_envelope;
-use arrow_array::{builder::BinaryBuilder, Array, ArrayRef, BooleanArray};
+use arrow_array::{Array, ArrayRef, BooleanArray, builder::BinaryBuilder};
 use arrow_schema::{DataType, Field, FieldRef};
 use datafusion_common::exec_datafusion_err;
 use datafusion_common::{
+    ScalarValue,
     cast::as_float64_array,
     error::{DataFusionError, Result},
-    ScalarValue,
 };
 use datafusion_expr::{Accumulator, ColumnarValue, EmitTo, GroupsAccumulator, Volatility};
 use sedona_common::sedona_internal_err;
@@ -136,11 +136,7 @@ impl<T: std::fmt::Debug + WkbBounder2D + Default> BoundsAccumulator2D<T> {
         let mut wkb = Vec::new();
         let (x, y) = self.bounder.finish();
         let written = write_envelope(&x, &y, &mut wkb)?;
-        if written {
-            Ok(Some(wkb))
-        } else {
-            Ok(None)
-        }
+        if written { Ok(Some(wkb)) } else { Ok(None) }
     }
 
     // Check the input length for update methods.

--- a/rust/sedona-functions/src/st_flipcoordinates.rs
+++ b/rust/sedona-functions/src/st_flipcoordinates.rs
@@ -26,7 +26,7 @@ use sedona_expr::{
 };
 use sedona_geometry::{
     error::SedonaGeometryError,
-    transform::{transform, CrsTransform},
+    transform::{CrsTransform, transform},
     wkb_factory::WKB_MIN_PROBABLE_BYTES,
 };
 

--- a/rust/sedona-functions/src/st_force_dim.rs
+++ b/rust/sedona-functions/src/st_force_dim.rs
@@ -17,9 +17,9 @@
 
 use std::sync::Arc;
 
-use arrow_array::{builder::BinaryBuilder, Float64Array};
+use arrow_array::{Float64Array, builder::BinaryBuilder};
 use arrow_schema::DataType;
-use datafusion_common::{cast::as_float64_array, error::Result, DataFusionError};
+use datafusion_common::{DataFusionError, cast::as_float64_array, error::Result};
 use datafusion_expr::{ColumnarValue, Volatility};
 use geo_traits::Dimensions;
 use sedona_expr::{
@@ -28,7 +28,7 @@ use sedona_expr::{
 };
 use sedona_geometry::{
     error::SedonaGeometryError,
-    transform::{transform, CrsTransform},
+    transform::{CrsTransform, transform},
     wkb_factory::WKB_MIN_PROBABLE_BYTES,
 };
 use sedona_schema::{

--- a/rust/sedona-functions/src/st_geohash.rs
+++ b/rust/sedona-functions/src/st_geohash.rs
@@ -18,13 +18,14 @@
 use std::{collections::HashMap, iter::zip, sync::Arc};
 
 use crate::executor::WkbExecutor;
-use arrow_array::{builder::StringBuilder, Array, ArrayRef, Int64Array};
+use arrow_array::{Array, ArrayRef, Int64Array, builder::StringBuilder};
 use arrow_schema::DataType;
 use datafusion_common::{
+    ScalarValue,
     cast::{as_int64_array, as_string_view_array, as_struct_array, as_uint64_array},
     config::ConfigOptions,
     error::{DataFusionError, Result},
-    exec_err, plan_err, ScalarValue,
+    exec_err, plan_err,
 };
 use datafusion_expr::{ColumnarValue, Volatility};
 use geo_traits::{GeometryTrait, GeometryType};
@@ -198,7 +199,7 @@ fn bounder_for_arg_type(
         _ => {
             return sedona_internal_err!(
                 "Expected geometry or geography argument but got {arg_type:?}"
-            )
+            );
         }
     };
 
@@ -809,7 +810,7 @@ fn geohash_encode(lon: f64, lat: f64, precision: i64) -> String {
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::{create_array, ArrayRef, UInt32Array, UInt64Array};
+    use arrow_array::{ArrayRef, UInt32Array, UInt64Array, create_array};
     use arrow_schema::Field;
     use datafusion_common::ScalarValue;
     use datafusion_expr::ScalarUDF;
@@ -1474,8 +1475,12 @@ mod tests {
                 Some("LINESTRING (30 10, 10 30, 40 40)"),
                 Some("POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10), (20 30, 35 35, 30 20, 20 30))"),
                 Some("MULTIPOINT ((10 40), (40 30), (20 20), (30 10))"),
-                Some("MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)), ((15 5, 40 10, 10 20, 5 10, 15 5)))"),
-                Some("GEOMETRYCOLLECTION (POINT (40 10), LINESTRING (10 10, 20 20, 10 40), POLYGON ((40 40, 20 45, 45 30, 40 40)))"),
+                Some(
+                    "MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)), ((15 5, 40 10, 10 20, 5 10, 15 5)))",
+                ),
+                Some(
+                    "GEOMETRYCOLLECTION (POINT (40 10), LINESTRING (10 10, 20 20, 10 40), POLYGON ((40 40, 20 45, 45 30, 40 40)))",
+                ),
                 None,
             ],
             &sedona_type,

--- a/rust/sedona-functions/src/st_geometryn.rs
+++ b/rust/sedona-functions/src/st_geometryn.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use crate::executor::WkbExecutor;
 use arrow_array::builder::BinaryBuilder;
-use datafusion_common::{cast::as_int64_array, Result};
+use datafusion_common::{Result, cast::as_int64_array};
 use datafusion_expr::{ColumnarValue, Volatility};
 use geo_traits::{
     GeometryCollectionTrait, GeometryTrait, MultiLineStringTrait, MultiPointTrait,
@@ -175,12 +175,16 @@ mod tests {
                 Some("MULTILINESTRING((1 1, 2 2), (3 3, 4 4))"), //  n=2 (Valid)
                 // 6. MULTIPOLYGON
                 Some("MULTIPOLYGON(((0 0, 1 1, 0 1, 0 0)), ((5 5, 6 6, 5 6, 5 5)))"), //   n=2 (Valid) - Original
-                Some("MULTIPOLYGON(((0 0, 1 1, 0 1, 0 0)))"),                          //  n=2 (OOB) - Original
+                Some("MULTIPOLYGON(((0 0, 1 1, 0 1, 0 0)))"), //  n=2 (OOB) - Original
                 Some("MULTIPOLYGON(((0 0, 1 1, 0 1, 0 0)), ((5 5, 6 6, 5 6, 5 5)))"), //  n=1 (Valid)
-                Some("MULTIPOLYGON EMPTY"),                                            //  Empty Multi (n=1)
+                Some("MULTIPOLYGON EMPTY"), //  Empty Multi (n=1)
                 // 7. GEOMETRYCOLLECTION (7 cases)
-                Some("GEOMETRYCOLLECTION(POINT(10 10), LINESTRING(20 20, 30 30), POLYGON((1 1, 2 2, 1 2, 1 1)))"), //  n=1 (Point) - Original
-                Some("GEOMETRYCOLLECTION(POINT(10 10), LINESTRING(20 20, 30 30), POLYGON((1 1, 2 2, 1 2, 1 1)))"), //  n=2 (LineString) - Original
+                Some(
+                    "GEOMETRYCOLLECTION(POINT(10 10), LINESTRING(20 20, 30 30), POLYGON((1 1, 2 2, 1 2, 1 1)))",
+                ), //  n=1 (Point) - Original
+                Some(
+                    "GEOMETRYCOLLECTION(POINT(10 10), LINESTRING(20 20, 30 30), POLYGON((1 1, 2 2, 1 2, 1 1)))",
+                ), //  n=2 (LineString) - Original
                 Some("GEOMETRYCOLLECTION(POINT(10 10))"), //  n=2 (OOB) - Original
                 Some("GEOMETRYCOLLECTION(POINT(1 1), GEOMETRYCOLLECTION(LINESTRING(2 2, 3 3)))"), //  n=1 (Nested: Point)
                 Some("GEOMETRYCOLLECTION(POINT(1 1), GEOMETRYCOLLECTION(LINESTRING(2 2, 3 3)))"), //  n=2 (Nested: GC)

--- a/rust/sedona-functions/src/st_geometrytype.rs
+++ b/rust/sedona-functions/src/st_geometrytype.rs
@@ -106,7 +106,7 @@ fn infer_geometry_type_name(buf: &[u8]) -> Result<&'static str> {
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::{create_array, ArrayRef};
+    use arrow_array::{ArrayRef, create_array};
     use datafusion_common::ScalarValue;
     use datafusion_expr::ScalarUDF;
     use rstest::rstest;

--- a/rust/sedona-functions/src/st_geomfromewkb.rs
+++ b/rust/sedona-functions/src/st_geomfromewkb.rs
@@ -18,7 +18,7 @@ use std::{sync::Arc, vec};
 
 use arrow_array::builder::{BinaryBuilder, StringViewBuilder};
 use arrow_schema::DataType;
-use datafusion_common::{error::Result, exec_datafusion_err, ScalarValue};
+use datafusion_common::{ScalarValue, error::Result, exec_datafusion_err};
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_common::sedona_internal_err;
 use sedona_expr::{
@@ -67,11 +67,11 @@ impl SedonaScalarKernel for STGeomFromEWKB {
                 _ => {
                     return sedona_internal_err!(
                         "Unexpected arguments to invoke_batch: {arg_types:?}"
-                    )
+                    );
                 }
             },
             _ => {
-                return sedona_internal_err!("Unexpected arguments to invoke_batch: {arg_types:?}")
+                return sedona_internal_err!("Unexpected arguments to invoke_batch: {arg_types:?}");
             }
         };
 

--- a/rust/sedona-functions/src/st_geomfromwkb.rs
+++ b/rust/sedona-functions/src/st_geomfromwkb.rs
@@ -123,7 +123,7 @@ impl SedonaScalarKernel for STGeomFromWKB {
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::{create_array, ArrayRef, BinaryArray, BinaryViewArray};
+    use arrow_array::{ArrayRef, BinaryArray, BinaryViewArray, create_array};
     use datafusion_common::scalar::ScalarValue;
     use datafusion_expr::ScalarUDF;
     use rstest::rstest;

--- a/rust/sedona-functions/src/st_geomfromwkt.rs
+++ b/rust/sedona-functions/src/st_geomfromwkt.rs
@@ -31,8 +31,8 @@ use sedona_schema::{
     datatypes::{SedonaType, WKB_GEOGRAPHY, WKB_GEOGRAPHY_WGS84, WKB_GEOMETRY},
     matchers::ArgMatcher,
 };
-use wkb::writer::{write_geometry, WriteOptions};
 use wkb::Endianness;
+use wkb::writer::{WriteOptions, write_geometry};
 use wkt::Wkt;
 
 use sedona_geometry::types::GeometryTypeId;
@@ -320,7 +320,7 @@ fn invoke_scalar_with_srid(
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::{create_array, ArrayRef};
+    use arrow_array::{ArrayRef, create_array};
     use arrow_schema::DataType;
     use datafusion_common::scalar::ScalarValue;
     use datafusion_expr::{Literal, ScalarUDF};

--- a/rust/sedona-functions/src/st_haszm.rs
+++ b/rust/sedona-functions/src/st_haszm.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use crate::executor::WkbBytesExecutor;
 use arrow_array::builder::BooleanBuilder;
 use arrow_schema::DataType;
-use datafusion_common::{error::Result, DataFusionError};
+use datafusion_common::{DataFusionError, error::Result};
 use datafusion_expr::{ColumnarValue, Volatility};
 use geo_traits::Dimensions;
 use sedona_expr::{

--- a/rust/sedona-functions/src/st_interiorringn.rs
+++ b/rust/sedona-functions/src/st_interiorringn.rs
@@ -24,7 +24,7 @@ use geo_traits::{GeometryTrait, LineStringTrait, PolygonTrait};
 use sedona_expr::item_crs::ItemCrsKernel;
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_geometry::wkb_factory::{
-    write_wkb_coord_trait, write_wkb_linestring_header, WKB_MIN_PROBABLE_BYTES,
+    WKB_MIN_PROBABLE_BYTES, write_wkb_coord_trait, write_wkb_linestring_header,
 };
 use sedona_schema::datatypes::SedonaType;
 use sedona_schema::{
@@ -233,12 +233,18 @@ mod tests {
 
         let input_wkt = create_array(
             &[
-                Some("POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))"),                                  // Single hole, n=1
-                Some("POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))"),                                  // Single hole, n=1
-                Some("POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))"),                                  // Single hole, n=2 (too high)
-                Some("POLYGON ((0 0, 6 0, 6 6, 0 6, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1), (4 4, 4 5, 5 5, 5 4, 4 4))"),       // Two holes, n=1
-                Some("POLYGON ((0 0, 6 0, 6 6, 0 6, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1), (4 4, 4 5, 5 5, 5 4, 4 4))"),       // Two holes, n=2
-                Some("POLYGON ((0 0, 6 0, 6 6, 0 6, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1), (4 4, 4 5, 5 5, 5 4, 4 4))"),       // Two holes, n=3 (too high)
+                Some("POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))"), // Single hole, n=1
+                Some("POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))"), // Single hole, n=1
+                Some("POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))"), // Single hole, n=2 (too high)
+                Some(
+                    "POLYGON ((0 0, 6 0, 6 6, 0 6, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1), (4 4, 4 5, 5 5, 5 4, 4 4))",
+                ), // Two holes, n=1
+                Some(
+                    "POLYGON ((0 0, 6 0, 6 6, 0 6, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1), (4 4, 4 5, 5 5, 5 4, 4 4))",
+                ), // Two holes, n=2
+                Some(
+                    "POLYGON ((0 0, 6 0, 6 6, 0 6, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1), (4 4, 4 5, 5 5, 5 4, 4 4))",
+                ), // Two holes, n=3 (too high)
             ],
             &sedona_type,
         );
@@ -273,9 +279,11 @@ mod tests {
 
         let input_wkt = create_array(
             &[
-                Some("POLYGON ((0 0, 1 0, 1 1))"),                                                            // Unclosed/Malformed WKT
-                Some("POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0), (5 5, 5 6, 6 6, 6 5, 5 5))"),                       // External hole
-                Some("POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 1 3, 3 3, 3 1, 1 1), (2 2, 2 2.5, 2.5 2.5, 2.5 2, 2 2))"), // Intersecting holes
+                Some("POLYGON ((0 0, 1 0, 1 1))"), // Unclosed/Malformed WKT
+                Some("POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0), (5 5, 5 6, 6 6, 6 5, 5 5))"), // External hole
+                Some(
+                    "POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 1 3, 3 3, 3 1, 1 1), (2 2, 2 2.5, 2.5 2.5, 2.5 2, 2 2))",
+                ), // Intersecting holes
             ],
             &sedona_type,
         );
@@ -304,13 +312,15 @@ mod tests {
         let input_wkt = create_array(
             &[
                 // Valid Polygon Z extraction
-                Some("POLYGON Z ((0 0 10, 4 0 10, 4 4 10, 0 4 10, 0 0 10), (1 1 5, 1 2 5, 2 2 5, 2 1 5, 1 1 5))"),
+                Some(
+                    "POLYGON Z ((0 0 10, 4 0 10, 4 4 10, 0 4 10, 0 0 10), (1 1 5, 1 2 5, 2 2 5, 2 1 5, 1 1 5))",
+                ),
                 // Non-Polygon Z (Should be NULL)
                 Some("POINT Z (1 1 5)"),
                 // Polygon Z with no hole (Should be NULL)
                 Some("POLYGON Z ((0 0 10, 4 0 10, 4 4 10, 0 4 10, 0 0 10))"),
             ],
-            &sedona_type
+            &sedona_type,
         );
         let integers = arrow_array::create_array!(Int64, [Some(1), Some(1), Some(1)]);
         let expected = create_array(
@@ -337,13 +347,15 @@ mod tests {
         let input_wkt = create_array(
             &[
                 // Valid Polygon M extraction
-                Some("POLYGON M ((0 0 1, 4 0 2, 4 4 3, 0 4 4, 0 0 5), (1 1 6, 1 2 7, 2 2 8, 2 1 9, 1 1 10))"),
+                Some(
+                    "POLYGON M ((0 0 1, 4 0 2, 4 4 3, 0 4 4, 0 0 5), (1 1 6, 1 2 7, 2 2 8, 2 1 9, 1 1 10))",
+                ),
                 // Non-Polygon M (Should be NULL)
                 Some("LINESTRING M (0 0 1, 1 1 2)"),
                 // Polygon M with no hole (Should be NULL)
                 Some("POLYGON M ((0 0 1, 4 0 2, 4 4 3, 0 4 4, 0 0 5))"),
             ],
-            &sedona_type
+            &sedona_type,
         );
         let integers = arrow_array::create_array!(Int64, [Some(1), Some(1), Some(1)]);
         let expected = create_array(
@@ -370,13 +382,17 @@ mod tests {
         let input_wkt = create_array(
             &[
                 // Valid Polygon ZM extraction (n=1)
-                Some("POLYGON ZM ((0 0 10 1, 4 0 10 2, 4 4 10 3, 0 4 10 4, 0 0 10 5), (1 1 5 6, 1 2 5 7, 2 2 5 8, 2 1 5 9, 1 1 5 10))"),
+                Some(
+                    "POLYGON ZM ((0 0 10 1, 4 0 10 2, 4 4 10 3, 0 4 10 4, 0 0 10 5), (1 1 5 6, 1 2 5 7, 2 2 5 8, 2 1 5 9, 1 1 5 10))",
+                ),
                 // Index too high (n=2)
-                Some("POLYGON ZM ((0 0 10 1, 4 0 10 2, 4 4 10 3, 0 4 10 4, 0 0 10 5), (1 1 5 6, 1 2 5 7, 2 2 5 8, 2 1 5 9, 1 1 5 10))"),
+                Some(
+                    "POLYGON ZM ((0 0 10 1, 4 0 10 2, 4 4 10 3, 0 4 10 4, 0 0 10 5), (1 1 5 6, 1 2 5 7, 2 2 5 8, 2 1 5 9, 1 1 5 10))",
+                ),
                 // POLYGON ZM EMPTY (Should be NULL)
                 Some("POLYGON ZM EMPTY"),
             ],
-            &sedona_type
+            &sedona_type,
         );
         let integers = arrow_array::create_array!(Int64, [Some(1), Some(2), Some(1)]);
         let expected = create_array(

--- a/rust/sedona-functions/src/st_isclosed.rs
+++ b/rust/sedona-functions/src/st_isclosed.rs
@@ -23,8 +23,8 @@ use datafusion_common::error::Result;
 use datafusion_expr::Volatility;
 use geo_traits::GeometryCollectionTrait;
 use geo_traits::{
-    to_geo::{ToGeoLineString, ToGeoMultiLineString},
     GeometryTrait,
+    to_geo::{ToGeoLineString, ToGeoMultiLineString},
 };
 use sedona_common::sedona_internal_err;
 use sedona_expr::item_crs::ItemCrsKernel;
@@ -112,7 +112,7 @@ fn is_geometry_closed(item: &Wkb) -> Result<bool> {
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::{create_array as arrow_array, ArrayRef};
+    use arrow_array::{ArrayRef, create_array as arrow_array};
     use datafusion_common::ScalarValue;
     use datafusion_expr::ScalarUDF;
     use rstest::rstest;

--- a/rust/sedona-functions/src/st_iscollection.rs
+++ b/rust/sedona-functions/src/st_iscollection.rs
@@ -92,7 +92,7 @@ fn invoke_scalar(buf: &[u8]) -> Result<bool> {
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::{create_array as arrow_array, ArrayRef};
+    use arrow_array::{ArrayRef, create_array as arrow_array};
     use datafusion_common::ScalarValue;
     use datafusion_expr::ScalarUDF;
     use rstest::rstest;

--- a/rust/sedona-functions/src/st_isempty.rs
+++ b/rust/sedona-functions/src/st_isempty.rs
@@ -82,7 +82,7 @@ fn invoke_scalar(item: &Wkb) -> Result<bool> {
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::{create_array as arrow_array, ArrayRef};
+    use arrow_array::{ArrayRef, create_array as arrow_array};
     use datafusion_common::ScalarValue;
     use datafusion_expr::ScalarUDF;
     use rstest::rstest;

--- a/rust/sedona-functions/src/st_linesubstring.rs
+++ b/rust/sedona-functions/src/st_linesubstring.rs
@@ -15,8 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 use crate::executor::WkbExecutor;
-use arrow_array::builder::BinaryBuilder;
 use arrow_array::Array;
+use arrow_array::builder::BinaryBuilder;
 use arrow_schema::DataType;
 use datafusion_common::{error::Result, exec_datafusion_err, exec_err};
 use datafusion_expr::{ColumnarValue, Volatility};
@@ -246,11 +246,13 @@ unsafe fn interpolate<C: CoordTrait<T = f64>>(
     dim: Dimensions,
     buf: &mut impl Write,
 ) -> Result<(), SedonaGeometryError> {
-    for i in 0..dim.size() {
-        let v = p1.nth_unchecked(i) + (p2.nth_unchecked(i) - p1.nth_unchecked(i)) * fraction;
-        buf.write_all(&v.to_le_bytes())?;
+    unsafe {
+        for i in 0..dim.size() {
+            let v = p1.nth_unchecked(i) + (p2.nth_unchecked(i) - p1.nth_unchecked(i)) * fraction;
+            buf.write_all(&v.to_le_bytes())?;
+        }
+        Ok(())
     }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/rust/sedona-functions/src/st_makeenvelope.rs
+++ b/rust/sedona-functions/src/st_makeenvelope.rs
@@ -19,7 +19,7 @@ use std::{iter::zip, sync::Arc};
 
 use arrow_array::builder::BinaryBuilder;
 use arrow_schema::DataType;
-use datafusion_common::{cast::as_float64_array, error::Result, ScalarValue};
+use datafusion_common::{ScalarValue, cast::as_float64_array, error::Result};
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_schema::{

--- a/rust/sedona-functions/src/st_makeline.rs
+++ b/rust/sedona-functions/src/st_makeline.rs
@@ -17,9 +17,9 @@
 use std::{io::Write, sync::Arc, vec};
 
 use arrow_array::builder::BinaryBuilder;
+use datafusion_common::DataFusionError;
 use datafusion_common::error::Result;
 use datafusion_common::exec_err;
-use datafusion_common::DataFusionError;
 use datafusion_expr::{ColumnarValue, Volatility};
 use geo_traits::{CoordTrait, GeometryTrait, LineStringTrait, MultiPointTrait, PointTrait};
 use sedona_common::sedona_internal_err;
@@ -185,7 +185,7 @@ fn add_coords(
         _ => {
             return exec_err!(
                 "ST_MakeLine() only supports Point, LineString, and MultiPoint as input"
-            )
+            );
         }
     }
 

--- a/rust/sedona-functions/src/st_max_distance.rs
+++ b/rust/sedona-functions/src/st_max_distance.rs
@@ -169,7 +169,7 @@ fn collect_line_string<LS: LineStringTrait<T = f64>>(
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::{create_array as arrow_array, ArrayRef};
+    use arrow_array::{ArrayRef, create_array as arrow_array};
     use datafusion_common::ScalarValue;
     use rstest::rstest;
     use sedona_schema::datatypes::{WKB_GEOMETRY, WKB_GEOMETRY_ITEM_CRS, WKB_VIEW_GEOMETRY};

--- a/rust/sedona-functions/src/st_numgeometries.rs
+++ b/rust/sedona-functions/src/st_numgeometries.rs
@@ -102,7 +102,7 @@ fn invoke_scalar(buf: &[u8]) -> Result<u32> {
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::{create_array as arrow_array, ArrayRef};
+    use arrow_array::{ArrayRef, create_array as arrow_array};
     use datafusion_common::ScalarValue;
     use datafusion_expr::ScalarUDF;
     use rstest::rstest;

--- a/rust/sedona-functions/src/st_point.rs
+++ b/rust/sedona-functions/src/st_point.rs
@@ -147,8 +147,8 @@ fn populate_wkb_item(item: &mut [u8], x: &f64, y: &f64) {
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::create_array;
     use arrow_array::ArrayRef;
+    use arrow_array::create_array;
     use arrow_schema::DataType;
     use datafusion_expr::Literal;
     use datafusion_expr::ScalarUDF;

--- a/rust/sedona-functions/src/st_pointn.rs
+++ b/rust/sedona-functions/src/st_pointn.rs
@@ -16,7 +16,7 @@
 // under the License.
 use arrow_array::builder::BinaryBuilder;
 use arrow_schema::DataType;
-use datafusion_common::{error::Result, ScalarValue};
+use datafusion_common::{ScalarValue, error::Result};
 use datafusion_expr::{ColumnarValue, Volatility};
 use geo_traits::{CoordTrait, GeometryTrait, LineStringTrait};
 use sedona_common::sedona_internal_err;
@@ -26,7 +26,7 @@ use sedona_expr::{
 };
 use sedona_geometry::{
     error::SedonaGeometryError,
-    wkb_factory::{write_wkb_coord_trait, write_wkb_point_header, WKB_MIN_PROBABLE_BYTES},
+    wkb_factory::{WKB_MIN_PROBABLE_BYTES, write_wkb_coord_trait, write_wkb_point_header},
 };
 use sedona_schema::{
     datatypes::{SedonaType, WKB_GEOGRAPHY, WKB_GEOMETRY},
@@ -96,26 +96,26 @@ impl SedonaScalarKernel for STPointN {
                 }
             };
 
-            if let Some(wkb) = maybe_wkb {
-                if let geo_traits::GeometryType::LineString(line_string) = wkb.as_type() {
-                    let num_coords = line_string.num_coords() as i64;
+            if let Some(wkb) = maybe_wkb
+                && let geo_traits::GeometryType::LineString(line_string) = wkb.as_type()
+            {
+                let num_coords = line_string.num_coords() as i64;
 
-                    // if n is out of the range, return NULL
-                    if n.abs() > num_coords {
-                        builder.append_null();
-                        return Ok(());
-                    }
+                // if n is out of the range, return NULL
+                if n.abs() > num_coords {
+                    builder.append_null();
+                    return Ok(());
+                }
 
-                    // Negative values are counted backwards from the end
-                    let n = if n > 0 { n - 1 } else { num_coords + n } as usize;
+                // Negative values are counted backwards from the end
+                let n = if n > 0 { n - 1 } else { num_coords + n } as usize;
 
-                    if let Some(coord) = line_string.coord(n) {
-                        if write_wkb_point_from_coord(&mut builder, coord).is_err() {
-                            return sedona_internal_err!("Failed to write WKB point");
-                        };
-                        builder.append_value([]);
-                        return Ok(());
-                    }
+                if let Some(coord) = line_string.coord(n) {
+                    if write_wkb_point_from_coord(&mut builder, coord).is_err() {
+                        return sedona_internal_err!("Failed to write WKB point");
+                    };
+                    builder.append_value([]);
+                    return Ok(());
                 }
             }
 

--- a/rust/sedona-functions/src/st_points.rs
+++ b/rust/sedona-functions/src/st_points.rs
@@ -30,8 +30,8 @@ use sedona_expr::{
 use sedona_geometry::{
     error::SedonaGeometryError,
     wkb_factory::{
-        write_wkb_coord_trait, write_wkb_multipoint_header, write_wkb_point_header,
-        WKB_MIN_PROBABLE_BYTES,
+        WKB_MIN_PROBABLE_BYTES, write_wkb_coord_trait, write_wkb_multipoint_header,
+        write_wkb_point_header,
     },
 };
 use sedona_schema::{
@@ -320,7 +320,9 @@ mod tests {
                 Some("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 3 1, 1 3, 1 1))"),
                 Some("MULTIPOINT (1 2, 3 4, 5 6, 7 8)"),
                 Some("MULTILINESTRING ((1 2, 3 4), EMPTY, (5 6, 7 8))"),
-                Some("MULTIPOLYGON (((0 0, 10 0, 10 10, 0 10, 0 0)), EMPTY, ((0 0, 5 0, 0 5, 0 0), (1 1, 3 1, 1 3, 1 1)))"),
+                Some(
+                    "MULTIPOLYGON (((0 0, 10 0, 10 10, 0 10, 0 0)), EMPTY, ((0 0, 5 0, 0 5, 0 0), (1 1, 3 1, 1 3, 1 1)))",
+                ),
                 Some("GEOMETRYCOLLECTION (POINT (1 2), LINESTRING EMPTY, LINESTRING (3 4, 5 6))"),
                 // 3d and 4d
                 Some("LINESTRING Z (1 2 3, 4 5 6, 7 8 9)"),
@@ -348,7 +350,9 @@ mod tests {
                 Some("MULTIPOINT (0 0, 10 0, 10 10, 0 10, 0 0, 1 1, 3 1, 1 3, 1 1)"),
                 Some("MULTIPOINT (1 2, 3 4, 5 6, 7 8)"),
                 Some("MULTIPOINT (1 2, 3 4, 5 6, 7 8)"),
-                Some("MULTIPOINT (0 0, 10 0, 10 10, 0 10, 0 0, 0 0, 5 0, 0 5, 0 0, 1 1, 3 1, 1 3, 1 1)"),
+                Some(
+                    "MULTIPOINT (0 0, 10 0, 10 10, 0 10, 0 0, 0 0, 5 0, 0 5, 0 0, 1 1, 3 1, 1 3, 1 1)",
+                ),
                 Some("MULTIPOINT (1 2, 3 4, 5 6)"),
                 // 3d and 4d
                 Some("MULTIPOINT Z (1 2 3, 4 5 6, 7 8 9)"),

--- a/rust/sedona-functions/src/st_pointzm.rs
+++ b/rust/sedona-functions/src/st_pointzm.rs
@@ -20,12 +20,12 @@ use std::{
     vec,
 };
 
-use arrow_array::{builder::BinaryBuilder, Array};
+use arrow_array::{Array, builder::BinaryBuilder};
 use arrow_schema::DataType;
+use datafusion_common::DataFusionError;
 use datafusion_common::cast::as_float64_array;
 use datafusion_common::error::Result;
 use datafusion_common::scalar::ScalarValue;
-use datafusion_common::DataFusionError;
 use datafusion_expr::{ColumnarValue, Volatility};
 use geo_traits::Dimensions;
 use sedona_common::{sedona_internal_datafusion_err, sedona_internal_err};
@@ -210,7 +210,7 @@ fn write_wkb_pointzm(
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::{create_array, ArrayRef};
+    use arrow_array::{ArrayRef, create_array};
     use arrow_schema::DataType;
     use datafusion_expr::ScalarUDF;
     use rstest::rstest;

--- a/rust/sedona-functions/src/st_reverse.rs
+++ b/rust/sedona-functions/src/st_reverse.rs
@@ -19,7 +19,7 @@ use std::io::Write;
 use std::sync::Arc;
 
 use arrow_array::builder::BinaryBuilder;
-use datafusion_common::{exec_datafusion_err, Result};
+use datafusion_common::{Result, exec_datafusion_err};
 use datafusion_expr::ColumnarValue;
 use datafusion_expr::Volatility;
 use geo_traits::Dimensions;
@@ -32,17 +32,17 @@ use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_geometry::{
     error::SedonaGeometryError,
     wkb_factory::{
-        write_wkb_geometrycollection_header, write_wkb_linestring_header,
+        WKB_MIN_PROBABLE_BYTES, write_wkb_geometrycollection_header, write_wkb_linestring_header,
         write_wkb_multilinestring_header, write_wkb_multipolygon_header, write_wkb_polygon_header,
-        write_wkb_polygon_ring_header, WKB_MIN_PROBABLE_BYTES,
+        write_wkb_polygon_ring_header,
     },
 };
 use sedona_schema::{
     datatypes::{SedonaType, WKB_GEOGRAPHY, WKB_GEOMETRY},
     matchers::ArgMatcher,
 };
-use wkb::reader::Wkb;
 use wkb::Endianness;
+use wkb::reader::Wkb;
 
 use crate::executor::WkbExecutor;
 
@@ -451,7 +451,9 @@ mod tests {
                 Some("MULTIPOLYGON ZM (((0 0 0 0, 1 0 0 0, 1 1 0 0, 0 1 0 0, 0 0 0 0)))"),
                 // GEOMETRYCOLLECTION types (each member geometry reversed)
                 Some("GEOMETRYCOLLECTION EMPTY"),
-                Some("GEOMETRYCOLLECTION (MULTIPOINT((3 4),(1 2),(7 8),(5 6)), LINESTRING (1 2, 1 10))"),
+                Some(
+                    "GEOMETRYCOLLECTION (MULTIPOINT((3 4),(1 2),(7 8),(5 6)), LINESTRING (1 2, 1 10))",
+                ),
                 Some("GEOMETRYCOLLECTION (POINT Z (1 2 3), LINESTRING Z (4 5 6, 1 2 3))"),
                 Some("GEOMETRYCOLLECTION (POINT M (1 2 3), LINESTRING M (4 5 6, 1 2 3))"),
                 Some("GEOMETRYCOLLECTION (POINT ZM (1 2 3 4), LINESTRING ZM (5 6 7 8, 1 2 3 4))"),

--- a/rust/sedona-functions/src/st_rotate.rs
+++ b/rust/sedona-functions/src/st_rotate.rs
@@ -16,7 +16,7 @@
 // under the License.
 use arrow_array::builder::BinaryBuilder;
 use arrow_schema::DataType;
-use datafusion_common::{error::Result, DataFusionError};
+use datafusion_common::{DataFusionError, error::Result};
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_expr::{
     item_crs::ItemCrsKernel,

--- a/rust/sedona-functions/src/st_scale.rs
+++ b/rust/sedona-functions/src/st_scale.rs
@@ -14,9 +14,9 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-use arrow_array::{builder::BinaryBuilder, Array};
+use arrow_array::{Array, builder::BinaryBuilder};
 use arrow_schema::DataType;
-use datafusion_common::{error::Result, DataFusionError};
+use datafusion_common::{DataFusionError, error::Result};
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_expr::{
     item_crs::ItemCrsKernel,

--- a/rust/sedona-functions/src/st_segmentize.rs
+++ b/rust/sedona-functions/src/st_segmentize.rs
@@ -17,9 +17,9 @@
 
 use std::{io::Write, sync::Arc};
 
-use arrow_array::{builder::BinaryBuilder, Array};
+use arrow_array::{Array, builder::BinaryBuilder};
 use arrow_schema::DataType;
-use datafusion_common::{cast::as_float64_array, exec_datafusion_err, exec_err, Result};
+use datafusion_common::{Result, cast::as_float64_array, exec_datafusion_err, exec_err};
 use datafusion_expr::{ColumnarValue, Volatility};
 use geo_traits::{
     CoordTrait, Dimensions, GeometryCollectionTrait, GeometryTrait, LineStringTrait,
@@ -33,9 +33,9 @@ use sedona_geometry::{
     error::SedonaGeometryError,
     interpolate::lerp,
     wkb_factory::{
-        write_wkb_coord_trait, write_wkb_geometrycollection_header, write_wkb_linestring_header,
-        write_wkb_multilinestring_header, write_wkb_multipolygon_header, write_wkb_polygon_header,
-        write_wkb_polygon_ring_header, WKB_MIN_PROBABLE_BYTES,
+        WKB_MIN_PROBABLE_BYTES, write_wkb_coord_trait, write_wkb_geometrycollection_header,
+        write_wkb_linestring_header, write_wkb_multilinestring_header,
+        write_wkb_multipolygon_header, write_wkb_polygon_header, write_wkb_polygon_ring_header,
     },
 };
 use sedona_schema::{

--- a/rust/sedona-functions/src/st_setsrid.rs
+++ b/rust/sedona-functions/src/st_setsrid.rs
@@ -17,15 +17,17 @@
 use std::sync::{Arc, OnceLock};
 
 use arrow_array::{
+    Array, ArrayRef, StringViewArray,
     builder::{BinaryBuilder, NullBufferBuilder, StringViewBuilder},
-    new_null_array, Array, ArrayRef, StringViewArray,
+    new_null_array,
 };
 use arrow_buffer::NullBuffer;
 use arrow_schema::DataType;
 use datafusion_common::{
+    DataFusionError, ScalarValue,
     cast::{as_int64_array, as_string_view_array},
     error::Result,
-    exec_err, DataFusionError, ScalarValue,
+    exec_err,
 };
 use datafusion_common::{config::ConfigOptions, plan_err};
 use datafusion_expr::{ColumnarValue, Volatility};
@@ -40,7 +42,7 @@ use sedona_expr::{
 use sedona_geometry::transform::CrsEngine;
 use sedona_geometry::types::Edges;
 use sedona_schema::{
-    crs::{deserialize_crs, normalize_crs, CachedSRIDToCrs, Crs},
+    crs::{CachedSRIDToCrs, Crs, deserialize_crs, normalize_crs},
     datatypes::SedonaType,
     matchers::ArgMatcher,
 };
@@ -334,7 +336,7 @@ impl SedonaScalarKernel for SRIDifiedKernel {
                 }
                 Ok(ScalarValue::Utf8(None)) => None,
                 Ok(_) | Err(_) => {
-                    return sedona_internal_err!("Can't cast Crs {scalar_crs:?} to Utf8")
+                    return sedona_internal_err!("Can't cast Crs {scalar_crs:?} to Utf8");
                 }
             };
 
@@ -560,14 +562,11 @@ pub fn validate_crs_for_type(crs: &Crs, sedona_type: &SedonaType) -> Result<()> 
     };
 
     // For geography, ensure the CRS is geographical if present
-    if !matches!(edges, Edges::Planar) {
-        if let Some(crs) = crs {
-            if crs.geographic_params()?.is_none() {
-                return plan_err!(
-                    "Can't assign non-geographic CRS {crs} to column of type {sedona_type}"
-                );
-            }
-        }
+    if !matches!(edges, Edges::Planar)
+        && let Some(crs) = crs
+        && crs.geographic_params()?.is_none()
+    {
+        return plan_err!("Can't assign non-geographic CRS {crs} to column of type {sedona_type}");
     }
 
     Ok(())
@@ -591,12 +590,12 @@ pub fn validate_crs_array_for_type(crs_array: &ArrayRef, sedona_type: &SedonaTyp
     if !matches!(edges, Edges::Planar) {
         let crs_array_stringview = as_string_view_array(crs_array)?;
         for item in crs_array_stringview.iter().flatten() {
-            if let Some(crs) = deserialize_crs(item)? {
-                if crs.geographic_params()?.is_none() {
-                    return exec_err!(
-                        "Can't assign non-geographic CRS item {item} to column of type {sedona_type}"
-                    );
-                }
+            if let Some(crs) = deserialize_crs(item)?
+                && crs.geographic_params()?.is_none()
+            {
+                return exec_err!(
+                    "Can't assign non-geographic CRS item {item} to column of type {sedona_type}"
+                );
             }
         }
     }
@@ -608,7 +607,7 @@ pub fn validate_crs_array_for_type(crs_array: &ArrayRef, sedona_type: &SedonaTyp
 mod test {
     use std::rc::Rc;
 
-    use arrow_array::{create_array, ArrayRef};
+    use arrow_array::{ArrayRef, create_array};
     use arrow_schema::Field;
     use datafusion_common::config::ConfigOptions;
     use datafusion_expr::{ReturnFieldArgs, ScalarFunctionArgs, ScalarUDF};

--- a/rust/sedona-functions/src/st_srid.rs
+++ b/rust/sedona-functions/src/st_srid.rs
@@ -17,13 +17,13 @@
 
 use crate::executor::WkbExecutor;
 use arrow_array::{
-    builder::{StringViewBuilder, UInt32Builder},
     Array,
+    builder::{StringViewBuilder, UInt32Builder},
 };
 use arrow_schema::DataType;
 use datafusion_common::{
-    cast::{as_string_view_array, as_struct_array},
     DataFusionError, Result, ScalarValue,
+    cast::{as_string_view_array, as_struct_array},
 };
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_common::sedona_internal_err;
@@ -272,7 +272,7 @@ impl SedonaScalarKernel for StCrsItemCrs {
 #[cfg(test)]
 mod test {
     use super::*;
-    use arrow_array::{create_array, ArrayRef};
+    use arrow_array::{ArrayRef, create_array};
     use arrow_schema::Field;
     use datafusion_common::ScalarValue;
     use datafusion_expr::ScalarUDF;

--- a/rust/sedona-functions/src/st_start_point.rs
+++ b/rust/sedona-functions/src/st_start_point.rs
@@ -28,7 +28,7 @@ use sedona_expr::{
 };
 use sedona_geometry::{
     error::SedonaGeometryError,
-    wkb_factory::{write_wkb_coord_trait, write_wkb_point_header, WKB_MIN_PROBABLE_BYTES},
+    wkb_factory::{WKB_MIN_PROBABLE_BYTES, write_wkb_coord_trait, write_wkb_point_header},
 };
 use sedona_schema::{
     datatypes::{SedonaType, WKB_GEOGRAPHY, WKB_GEOMETRY},
@@ -101,14 +101,14 @@ impl SedonaScalarKernel for STStartOrEndPoint {
         );
 
         executor.execute_wkb_void(|maybe_wkb| {
-            if let Some(wkb) = maybe_wkb {
-                if let Some(coord) = extract_start_or_end_coord(wkb, self.from_start) {
-                    if write_wkb_point_from_coord(&mut builder, coord).is_err() {
-                        return sedona_internal_err!("Failed to write WKB point header");
-                    };
-                    builder.append_value([]);
-                    return Ok(());
-                }
+            if let Some(wkb) = maybe_wkb
+                && let Some(coord) = extract_start_or_end_coord(wkb, self.from_start)
+            {
+                if write_wkb_point_from_coord(&mut builder, coord).is_err() {
+                    return sedona_internal_err!("Failed to write WKB point header");
+                };
+                builder.append_value([]);
+                return Ok(());
             }
 
             builder.append_null();

--- a/rust/sedona-functions/src/st_togeomgeog.rs
+++ b/rust/sedona-functions/src/st_togeomgeog.rs
@@ -17,7 +17,7 @@
 
 use std::sync::Arc;
 
-use datafusion_common::{config::ConfigOptions, Result};
+use datafusion_common::{Result, config::ConfigOptions};
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_common::sedona_internal_err;
 use sedona_expr::{

--- a/rust/sedona-functions/src/st_transform.rs
+++ b/rust/sedona-functions/src/st_transform.rs
@@ -15,21 +15,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow_array::builder::{BinaryBuilder, StringViewBuilder};
 use arrow_array::ArrayRef;
+use arrow_array::builder::{BinaryBuilder, StringViewBuilder};
 use arrow_schema::DataType;
 use datafusion_common::cast::{as_string_view_array, as_struct_array};
 use datafusion_common::config::ConfigOptions;
-use datafusion_common::{exec_err, DataFusionError, Result, ScalarValue};
+use datafusion_common::{DataFusionError, Result, ScalarValue, exec_err};
 use datafusion_expr::ColumnarValue;
 use sedona_common::option::with_crs_engine;
 use sedona_common::sedona_internal_err;
 use sedona_expr::item_crs::{make_item_crs, parse_item_crs_arg_type};
 use sedona_expr::scalar_udf::{ScalarKernelRef, SedonaScalarKernel, SedonaScalarUDF};
-use sedona_geometry::transform::{transform, CrsTransform};
+use sedona_geometry::transform::{CrsTransform, transform};
 use sedona_geometry::types::Edges;
 use sedona_geometry::wkb_factory::WKB_MIN_PROBABLE_BYTES;
-use sedona_schema::crs::{deserialize_crs, Crs};
+use sedona_schema::crs::{Crs, deserialize_crs};
 use sedona_schema::datatypes::SedonaType;
 use sedona_schema::matchers::ArgMatcher;
 use std::io::Write;
@@ -354,10 +354,9 @@ impl<'a> ArgInput<'a> {
 
         if let Ok((SedonaType::Wkb(edges, _) | SedonaType::WkbView(edges, _), maybe_crs_type)) =
             parse_item_crs_arg_type(arg_type)
+            && maybe_crs_type.is_some()
         {
-            if maybe_crs_type.is_some() {
-                return Self::ItemCrs(edges);
-            }
+            return Self::ItemCrs(edges);
         }
 
         if ArgMatcher::is_numeric().match_type(arg_type)
@@ -381,10 +380,9 @@ impl<'a> ArgInput<'a> {
     fn from_arg(arg_type: &'a SedonaType, arg: &'a ColumnarValue) -> Self {
         if let Ok((SedonaType::Wkb(edges, _) | SedonaType::WkbView(edges, _), maybe_crs_type)) =
             parse_item_crs_arg_type(arg_type)
+            && maybe_crs_type.is_some()
         {
-            if maybe_crs_type.is_some() {
-                return Self::ItemCrs(edges);
-            }
+            return Self::ItemCrs(edges);
         }
 
         if ArgMatcher::is_numeric().match_type(arg_type)
@@ -444,13 +442,13 @@ impl<'a> ArgInput<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_array::create_array;
     use arrow_array::ArrayRef;
+    use arrow_array::create_array;
     use arrow_schema::DataType;
     use rstest::rstest;
     use sedona_expr::scalar_udf::SedonaScalarUDF;
-    use sedona_schema::crs::lnglat;
     use sedona_schema::crs::Crs;
+    use sedona_schema::crs::lnglat;
     use sedona_schema::datatypes::{
         WKB_GEOGRAPHY, WKB_GEOGRAPHY_ITEM_CRS, WKB_GEOMETRY, WKB_GEOMETRY_ITEM_CRS,
     };

--- a/rust/sedona-functions/src/st_translate.rs
+++ b/rust/sedona-functions/src/st_translate.rs
@@ -14,9 +14,9 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-use arrow_array::{builder::BinaryBuilder, types::Float64Type, Array, PrimitiveArray};
+use arrow_array::{Array, PrimitiveArray, builder::BinaryBuilder, types::Float64Type};
 use arrow_schema::DataType;
-use datafusion_common::{cast::as_float64_array, error::Result, DataFusionError};
+use datafusion_common::{DataFusionError, cast::as_float64_array, error::Result};
 use datafusion_expr::{ColumnarValue, Volatility};
 use geo_traits::Dimensions;
 
@@ -27,7 +27,7 @@ use sedona_expr::{
 };
 use sedona_geometry::{
     error::SedonaGeometryError,
-    transform::{transform, CrsTransform},
+    transform::{CrsTransform, transform},
     wkb_factory::WKB_MIN_PROBABLE_BYTES,
 };
 use sedona_schema::{

--- a/rust/sedona-functions/src/st_xyzm.rs
+++ b/rust/sedona-functions/src/st_xyzm.rs
@@ -239,7 +239,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_array::{create_array, ArrayRef};
+    use arrow_array::{ArrayRef, create_array};
     use datafusion_common::ScalarValue;
     use datafusion_expr::ScalarUDF;
     use rstest::rstest;

--- a/rust/sedona-functions/src/st_xyzm_minmax.rs
+++ b/rust/sedona-functions/src/st_xyzm_minmax.rs
@@ -16,7 +16,7 @@
 // under the License.
 use std::sync::Arc;
 
-use crate::executor::{bounder_for_arg_type, WkbBytesExecutor, WkbExecutor};
+use crate::executor::{WkbBytesExecutor, WkbExecutor, bounder_for_arg_type};
 use arrow_array::builder::Float64Builder;
 use arrow_schema::DataType;
 use datafusion_common::config::ConfigOptions;
@@ -29,7 +29,7 @@ use sedona_expr::{
     scalar_udf::{SedonaScalarKernel, SedonaScalarUDF},
 };
 use sedona_geometry::{
-    bounds::{geo_traits_bounds_m, geo_traits_bounds_xy, geo_traits_bounds_z, WkbBounder2D},
+    bounds::{WkbBounder2D, geo_traits_bounds_m, geo_traits_bounds_xy, geo_traits_bounds_z},
     interval::{Interval, IntervalTrait},
 };
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
@@ -258,16 +258,10 @@ fn invoke_scalar(
                 .map_err(|e| sedona_internal_datafusion_err!("Error updating bounds: {e}"))?;
             *xy_bounds.y()
         }
-        "z" => {
-            let z_bounds = geo_traits_bounds_z(item)
-                .map_err(|e| sedona_internal_datafusion_err!("Error updating bounds: {e}"))?;
-            z_bounds
-        }
-        "m" => {
-            let m_bounds = geo_traits_bounds_m(item)
-                .map_err(|e| sedona_internal_datafusion_err!("Error updating bounds: {e}"))?;
-            m_bounds
-        }
+        "z" => geo_traits_bounds_z(item)
+            .map_err(|e| sedona_internal_datafusion_err!("Error updating bounds: {e}"))?,
+        "m" => geo_traits_bounds_m(item)
+            .map_err(|e| sedona_internal_datafusion_err!("Error updating bounds: {e}"))?,
         _ => sedona_internal_err!("unexpected dim index")?,
     };
 
@@ -279,7 +273,7 @@ fn invoke_scalar(
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::{create_array as arrow_array, ArrayRef};
+    use arrow_array::{ArrayRef, create_array as arrow_array};
     use datafusion_common::ScalarValue;
     use datafusion_expr::ScalarUDF;
     use rstest::rstest;

--- a/rust/sedona-functions/src/st_zmflag.rs
+++ b/rust/sedona-functions/src/st_zmflag.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use crate::executor::WkbBytesExecutor;
 use arrow_array::builder::Int8Builder;
 use arrow_schema::DataType;
-use datafusion_common::{error::Result, DataFusionError};
+use datafusion_common::{DataFusionError, error::Result};
 use datafusion_expr::{ColumnarValue, Volatility};
 use geo_traits::Dimensions;
 use sedona_common::sedona_internal_err;


### PR DESCRIPTION
Migrates sedona-functions independently to Rust 2024 as part of #258. Applies standard formatting, explicit unsafe scopes, and Rust 2024 let chains. Validated with 560 package tests, all-target checks, and Clippy with warnings denied.