### PR TITLE
chore(rust/sedona-geo): migrate to Rust 2024 edition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
       - id: fmt
         name: rustfmt
         args: ["--all", "--"]
+        pass_filenames: false
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13

--- a/rust/sedona-geo/Cargo.toml
+++ b/rust/sedona-geo/Cargo.toml
@@ -24,7 +24,7 @@ homepage.workspace = true
 repository.workspace = true
 description.workspace = true
 readme.workspace = true
-edition.workspace = true
+edition = "2024"
 rust-version.workspace = true
 
 [lints.clippy]

--- a/rust/sedona-geo/benches/geo-functions.rs
+++ b/rust/sedona-geo/benches/geo-functions.rs
@@ -14,9 +14,9 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use sedona_expr::function_set::FunctionSet;
-use sedona_testing::benchmark_util::{benchmark, BenchmarkArgSpec::*, BenchmarkArgs::*};
+use sedona_testing::benchmark_util::{BenchmarkArgSpec::*, BenchmarkArgs::*, benchmark};
 
 fn criterion_benchmark(c: &mut Criterion) {
     let mut f = FunctionSet::new();

--- a/rust/sedona-geo/src/centroid.rs
+++ b/rust/sedona-geo/src/centroid.rs
@@ -16,7 +16,7 @@
 // under the License.
 //! Centroid extraction functionality for WKB geometries
 
-use datafusion_common::{exec_err, Result};
+use datafusion_common::{Result, exec_err};
 use geo_traits::CoordTrait;
 use geo_traits::GeometryTrait;
 use geo_traits::PointTrait;

--- a/rust/sedona-geo/src/st_area.rs
+++ b/rust/sedona-geo/src/st_area.rs
@@ -75,7 +75,7 @@ fn invoke_scalar(wkb: &Wkb) -> Result<f64> {
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::{create_array, ArrayRef};
+    use arrow_array::{ArrayRef, create_array};
     use datafusion_common::scalar::ScalarValue;
     use rstest::rstest;
     use sedona_expr::scalar_udf::SedonaScalarUDF;

--- a/rust/sedona-geo/src/st_buffer.rs
+++ b/rust/sedona-geo/src/st_buffer.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use arrow_array::builder::BinaryBuilder;
 use arrow_schema::DataType;
-use datafusion_common::{cast::as_float64_array, error::Result, DataFusionError};
+use datafusion_common::{DataFusionError, cast::as_float64_array, error::Result};
 use datafusion_expr::ColumnarValue;
 use geo::algorithm::buffer::{Buffer, BufferStyle};
 use geo_types::Polygon;
@@ -35,9 +35,9 @@ use sedona_schema::{
     matchers::ArgMatcher,
 };
 use wkb::{
-    reader::Wkb,
-    writer::{write_geometry, WriteOptions},
     Endianness,
+    reader::Wkb,
+    writer::{WriteOptions, write_geometry},
 };
 
 use crate::to_geo::item_to_geometry;

--- a/rust/sedona-geo/src/st_concavehull.rs
+++ b/rust/sedona-geo/src/st_concavehull.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use arrow_array::builder::BinaryBuilder;
 use datafusion_common::error::Result;
-use datafusion_common::{cast::as_float64_array, DataFusionError};
+use datafusion_common::{DataFusionError, cast::as_float64_array};
 use datafusion_expr::ColumnarValue;
 use geo::{ConcaveHull, CoordsIter, Geometry, GeometryCollection, Point, Polygon};
 use geo_traits::to_geo::{ToGeoGeometry, ToGeoPoint};
@@ -32,7 +32,7 @@ use sedona_geometry::wkb_factory::WKB_MIN_PROBABLE_BYTES;
 use sedona_schema::datatypes::SedonaType;
 use sedona_schema::{datatypes::WKB_GEOMETRY, matchers::ArgMatcher};
 use wkb::reader::Wkb;
-use wkb::writer::{write_geometry, WriteOptions};
+use wkb::writer::{WriteOptions, write_geometry};
 
 use crate::to_geo::item_to_geometry;
 
@@ -201,7 +201,7 @@ fn compute_and_write_hull(
         _ => {
             return Err(DataFusionError::Execution(
                 "Unsupported geometry type for concave hull".to_string(),
-            ))
+            ));
         }
     }
 
@@ -430,13 +430,13 @@ mod tests {
                 "MULTIPOLYGON (((26 125, 26 200, 126 200, 126 125, 26 125 ),\
                     ( 51 150, 101 150, 76 175, 51 150 )), (( 151 100, 151 200, 176 175, 151 100 )))",
                 0.1,
-                "POLYGON ((151 100, 176 175, 151 200, 126 200, 26 200, 26 125, 126 125, 151 100))"
+                "POLYGON ((151 100, 176 175, 151 200, 126 200, 26 200, 26 125, 126 125, 151 100))",
             ),
             (
                 "MULTIPOLYGON (((26 125, 26 200, 126 200, 126 125, 26 125 ),\
                     ( 51 150, 101 150, 76 175, 51 150 )), (( 151 100, 151 200, 176 175, 151 100 )))",
                 0.4,
-                "POLYGON((151 100,176 175,151 200,26 200,26 125,151 100))"
+                "POLYGON((151 100,176 175,151 200,26 200,26 125,151 100))",
             ),
             // Test GEOMETRYCOLLECTION with different pctconvex values
             (
@@ -444,14 +444,14 @@ mod tests {
                     GEOMETRYCOLLECTION(POLYGON((3 3,4 4,5 5,3 3)), \
                     GEOMETRYCOLLECTION(LINESTRING(6 6,7 7), POLYGON((8 8,9 9,10 10,8 8)))))",
                 0.1,
-                "POLYGON ((10 10, 1 1, 3 3, 3 3, 4 4, 5 5, 8 8, 9 9, 10 10))"
+                "POLYGON ((10 10, 1 1, 3 3, 3 3, 4 4, 5 5, 8 8, 9 9, 10 10))",
             ),
             (
                 "GEOMETRYCOLLECTION(LINESTRING(1 1,2 2), \
                     GEOMETRYCOLLECTION(POLYGON((3 3,4 4,5 5,3 3)), \
                     GEOMETRYCOLLECTION(LINESTRING(6 6,7 7), POLYGON((8 8,9 9,10 10,8 8)))))",
                 0.6,
-                "POLYGON ((10 10, 1 1, 3 3, 3 3, 4 4, 5 5, 8 8, 9 9, 10 10))"
+                "POLYGON ((10 10, 1 1, 3 3, 3 3, 4 4, 5 5, 8 8, 9 9, 10 10))",
             ),
         ];
 

--- a/rust/sedona-geo/src/st_convexhull_agg.rs
+++ b/rust/sedona-geo/src/st_convexhull_agg.rs
@@ -20,9 +20,9 @@ use std::sync::Arc;
 use arrow_array::builder::BinaryBuilder;
 use arrow_array::{Array, ArrayRef, BooleanArray};
 use arrow_schema::FieldRef;
-use datafusion_common::{cast::as_binary_array, error::Result, DataFusionError, ScalarValue};
+use datafusion_common::{DataFusionError, ScalarValue, cast::as_binary_array, error::Result};
 use datafusion_expr::{Accumulator, ColumnarValue, EmitTo, GroupsAccumulator};
-use geo::{algorithm::convex_hull::quick_hull, Coord};
+use geo::{Coord, algorithm::convex_hull::quick_hull};
 use geo_traits::{Dimensions, GeometryTrait};
 use sedona_common::sedona_internal_err;
 use sedona_expr::{
@@ -89,11 +89,7 @@ fn filter_keep(filter: Option<&BooleanArray>, i: usize) -> bool {
 }
 
 fn normalize_zero(v: f64) -> f64 {
-    if v == 0.0 {
-        0.0
-    } else {
-        v
-    }
+    if v == 0.0 { 0.0 } else { v }
 }
 
 fn coord_cmp(a: &Coord, b: &Coord) -> std::cmp::Ordering {
@@ -284,11 +280,9 @@ impl ConvexHullGroupsAccumulator {
             let group_id = group_indices[i];
             i += 1;
 
-            if keep {
-                if let Some(item) = maybe_item {
-                    self.has_input[group_id] = true;
-                    push_hull_coords(item, &mut self.coords[group_id])?;
-                }
+            if keep && let Some(item) = maybe_item {
+                self.has_input[group_id] = true;
+                push_hull_coords(item, &mut self.coords[group_id])?;
             }
 
             Ok(())

--- a/rust/sedona-geo/src/st_dwithin.rs
+++ b/rust/sedona-geo/src/st_dwithin.rs
@@ -80,7 +80,7 @@ impl SedonaScalarKernel for STDWithin {
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::{create_array as arrow_array, ArrayRef};
+    use arrow_array::{ArrayRef, create_array as arrow_array};
     use datafusion_common::scalar::ScalarValue;
     use rstest::rstest;
     use sedona_expr::scalar_udf::SedonaScalarUDF;

--- a/rust/sedona-geo/src/st_intersection_agg.rs
+++ b/rust/sedona-geo/src/st_intersection_agg.rs
@@ -18,7 +18,7 @@ use std::{sync::Arc, vec};
 
 use arrow_array::ArrayRef;
 use arrow_schema::FieldRef;
-use datafusion_common::{error::Result, exec_err, ScalarValue};
+use datafusion_common::{ScalarValue, error::Result, exec_err};
 use datafusion_expr::{Accumulator, ColumnarValue};
 use geo::{BooleanOps, Intersects};
 use geo_traits::to_geo::ToGeoGeometry;
@@ -32,8 +32,8 @@ use sedona_schema::{
     datatypes::{SedonaType, WKB_GEOMETRY},
     matchers::ArgMatcher,
 };
-use wkb::writer::write_geometry;
 use wkb::Endianness;
+use wkb::writer::write_geometry;
 use wkb::{reader::Wkb, writer::WriteOptions};
 
 /// ST_Intersection_Agg() implementation

--- a/rust/sedona-geo/src/st_intersects.rs
+++ b/rust/sedona-geo/src/st_intersects.rs
@@ -75,7 +75,7 @@ fn invoke_scalar(item_a: &Wkb, geom_b: &Wkb) -> Result<bool> {
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::{create_array, ArrayRef};
+    use arrow_array::{ArrayRef, create_array};
     use datafusion_common::scalar::ScalarValue;
     use sedona_expr::scalar_udf::SedonaScalarUDF;
     use sedona_schema::datatypes::WKB_GEOMETRY;

--- a/rust/sedona-geo/src/st_length.rs
+++ b/rust/sedona-geo/src/st_length.rs
@@ -26,7 +26,7 @@ use sedona_expr::{
     scalar_udf::{ScalarKernelRef, SedonaScalarKernel},
 };
 use sedona_functions::executor::WkbExecutor;
-use sedona_geo_generic_alg::algorithm::{line_measures::Euclidean, LengthMeasurableExt};
+use sedona_geo_generic_alg::algorithm::{LengthMeasurableExt, line_measures::Euclidean};
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
 use wkb::reader::Wkb;
 
@@ -76,7 +76,7 @@ fn invoke_scalar(wkb: &Wkb) -> Result<f64> {
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::{create_array, ArrayRef};
+    use arrow_array::{ArrayRef, create_array};
     use datafusion_common::scalar::ScalarValue;
     use rstest::rstest;
     use sedona_expr::scalar_udf::SedonaScalarUDF;

--- a/rust/sedona-geo/src/st_line_interpolate_point.rs
+++ b/rust/sedona-geo/src/st_line_interpolate_point.rs
@@ -19,10 +19,10 @@ use std::sync::Arc;
 use arrow_array::builder::BinaryBuilder;
 use arrow_schema::DataType;
 use datafusion_common::{
-    cast::as_float64_array, error::Result, exec_datafusion_err, DataFusionError,
+    DataFusionError, cast::as_float64_array, error::Result, exec_datafusion_err,
 };
 use datafusion_expr::ColumnarValue;
-use geo::{algorithm::line_measures::InterpolatableLine, Euclidean};
+use geo::{Euclidean, algorithm::line_measures::InterpolatableLine};
 use geo_traits::GeometryTrait;
 use sedona_expr::{
     item_crs::ItemCrsKernel,

--- a/rust/sedona-geo/src/st_perimeter.rs
+++ b/rust/sedona-geo/src/st_perimeter.rs
@@ -26,7 +26,7 @@ use sedona_expr::{
     scalar_udf::{ScalarKernelRef, SedonaScalarKernel},
 };
 use sedona_functions::executor::WkbExecutor;
-use sedona_geo_generic_alg::algorithm::{line_measures::Euclidean, LengthMeasurableExt};
+use sedona_geo_generic_alg::algorithm::{LengthMeasurableExt, line_measures::Euclidean};
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
 use wkb::reader::Wkb;
 
@@ -76,7 +76,7 @@ fn invoke_scalar(wkb: &Wkb) -> Result<f64> {
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::{create_array, ArrayRef};
+    use arrow_array::{ArrayRef, create_array};
     use datafusion_common::scalar::ScalarValue;
     use rstest::rstest;
     use sedona_expr::scalar_udf::SedonaScalarUDF;

--- a/rust/sedona-geo/src/st_union_agg.rs
+++ b/rust/sedona-geo/src/st_union_agg.rs
@@ -18,7 +18,7 @@ use std::{sync::Arc, vec};
 
 use arrow_array::ArrayRef;
 use arrow_schema::FieldRef;
-use datafusion_common::{error::Result, exec_err, ScalarValue};
+use datafusion_common::{ScalarValue, error::Result, exec_err};
 use datafusion_expr::{Accumulator, ColumnarValue};
 use geo::BooleanOps;
 use geo_traits::to_geo::ToGeoGeometry;
@@ -32,8 +32,8 @@ use sedona_schema::{
     datatypes::{SedonaType, WKB_GEOMETRY},
     matchers::ArgMatcher,
 };
-use wkb::writer::write_geometry;
 use wkb::Endianness;
+use wkb::writer::write_geometry;
 use wkb::{reader::Wkb, writer::WriteOptions};
 
 /// ST_Union_Agg() implementation
@@ -303,7 +303,9 @@ mod test {
         ];
         assert_scalar_equal_wkb_geometry_topologically(
             &tester.aggregate_wkt(poly_and_nonoverlap_multi).unwrap(),
-            Some("MULTIPOLYGON(((0 0, 1 0, 1 1, 0 1, 0 0)),((2 2, 3 2, 3 3, 2 3, 2 2)),((4 4, 5 4, 5 5, 4 5, 4 4)))"),
+            Some(
+                "MULTIPOLYGON(((0 0, 1 0, 1 1, 0 1, 0 0)),((2 2, 3 2, 3 3, 2 3, 2 2)),((4 4, 5 4, 5 5, 4 5, 4 4)))",
+            ),
         );
 
         // MultiPolygon with MultiPolygon (should return union of all)
@@ -317,7 +319,9 @@ mod test {
         ];
         assert_scalar_equal_wkb_geometry_topologically(
             &tester.aggregate_wkt(multi_and_multi).unwrap(),
-            Some("MULTIPOLYGON(((0 0, 3 0, 3 3, 0 3, 0 0)),((10 10, 12 10, 12 11, 13 11, 13 13, 11 13, 11 12, 10 12, 10 10)))"),
+            Some(
+                "MULTIPOLYGON(((0 0, 3 0, 3 3, 0 3, 0 0)),((10 10, 12 10, 12 11, 13 11, 13 13, 11 13, 11 12, 10 12, 10 10)))",
+            ),
         );
     }
 
@@ -340,7 +344,9 @@ mod test {
         ];
         assert_scalar_equal_wkb_geometry_topologically(
             &tester.aggregate_wkt(multi_multi_case1).unwrap(),
-            Some("MULTIPOLYGON(((0 0, 3 0, 3 2, 5 2, 5 5, 2 5, 2 3, 0 3, 0 0)),((5 5, 8 5, 8 7, 10 7, 10 10, 7 10, 7 8, 5 8, 5 5)))"),
+            Some(
+                "MULTIPOLYGON(((0 0, 3 0, 3 2, 5 2, 5 5, 2 5, 2 3, 0 3, 0 0)),((5 5, 8 5, 8 7, 10 7, 10 10, 7 10, 7 8, 5 8, 5 5)))",
+            ),
         );
 
         // Test case 2: MultiPolygons with non-intersecting polygons
@@ -354,18 +360,28 @@ mod test {
         ];
         assert_scalar_equal_wkb_geometry_topologically(
             &tester.aggregate_wkt(multi_multi_case2).unwrap(),
-            Some("MULTIPOLYGON(((0 0,1 0,1 1,0 1,0 0)),((2 2,3 2,3 3,2 3,2 2)),((5 5,6 5,6 6,5 6,5 5)),((7 7,8 7,8 8,7 8,7 7)))"),
+            Some(
+                "MULTIPOLYGON(((0 0,1 0,1 1,0 1,0 0)),((2 2,3 2,3 3,2 3,2 2)),((5 5,6 5,6 6,5 6,5 5)),((7 7,8 7,8 8,7 8,7 7)))",
+            ),
         );
 
         // Test case 3: Three MultiPolygons with some overlap
         let multi_multi_case3 = vec![
-            vec![Some("MULTIPOLYGON(((0 0, 4 0, 4 4, 0 4, 0 0)), ((10 10, 14 10, 14 14, 10 14, 10 10)))")],
-            vec![Some("MULTIPOLYGON(((3 3, 7 3, 7 7, 3 7, 3 3)), ((13 13, 17 13, 17 17, 13 17, 13 13)))")],
-            vec![Some("MULTIPOLYGON(((6 6, 10 6, 10 10, 6 10, 6 6)), ((16 16, 20 16, 20 20, 16 20, 16 16)))")],
+            vec![Some(
+                "MULTIPOLYGON(((0 0, 4 0, 4 4, 0 4, 0 0)), ((10 10, 14 10, 14 14, 10 14, 10 10)))",
+            )],
+            vec![Some(
+                "MULTIPOLYGON(((3 3, 7 3, 7 7, 3 7, 3 3)), ((13 13, 17 13, 17 17, 13 17, 13 13)))",
+            )],
+            vec![Some(
+                "MULTIPOLYGON(((6 6, 10 6, 10 10, 6 10, 6 6)), ((16 16, 20 16, 20 20, 16 20, 16 16)))",
+            )],
         ];
         assert_scalar_equal_wkb_geometry_topologically(
             &tester.aggregate_wkt(multi_multi_case3).unwrap(),
-            Some("MULTIPOLYGON(((0 0, 4 0, 4 3, 7 3, 7 6, 10 6, 10 10, 6 10, 6 7, 3 7, 3 4, 0 4, 0 0)),((10 10, 14 10, 14 13, 17 13, 17 16, 20 16, 20 20, 16 20, 16 17, 13 17, 13 14, 10 14, 10 10)))"),
+            Some(
+                "MULTIPOLYGON(((0 0, 4 0, 4 3, 7 3, 7 6, 10 6, 10 10, 6 10, 6 7, 3 7, 3 4, 0 4, 0 0)),((10 10, 14 10, 14 13, 17 13, 17 16, 20 16, 20 20, 16 20, 16 17, 13 17, 13 14, 10 14, 10 10)))",
+            ),
         );
     }
 

--- a/rust/sedona-geo/src/to_geo.rs
+++ b/rust/sedona-geo/src/to_geo.rs
@@ -14,14 +14,14 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-use datafusion_common::{error::Result, not_impl_err, DataFusionError};
+use datafusion_common::{DataFusionError, error::Result, not_impl_err};
 use geo_traits::{
+    GeometryCollectionTrait, GeometryTrait,
+    GeometryType::*,
     to_geo::{
         ToGeoLineString, ToGeoMultiLineString, ToGeoMultiPoint, ToGeoMultiPolygon, ToGeoPoint,
         ToGeoPolygon,
     },
-    GeometryCollectionTrait, GeometryTrait,
-    GeometryType::*,
 };
 use geo_types::Geometry;
 use sedona_functions::executor::{GenericExecutor, GeometryFactory};


### PR DESCRIPTION
Migrates sedona-geo independently to Rust 2024 as part of #258. Applies standard formatter output and a Rust 2024 let chain. Validated with 160 package tests, all-target checks, and Clippy with warnings denied.