### PR TITLE
chore(rust/sedona-geoparquet): migrate to Rust 2024 edition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
       - id: fmt
         name: rustfmt
         args: ["--all", "--"]
+        pass_filenames: false
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13

--- a/rust/sedona-geoparquet/Cargo.toml
+++ b/rust/sedona-geoparquet/Cargo.toml
@@ -24,7 +24,7 @@ homepage.workspace = true
 repository.workspace = true
 description.workspace = true
 readme.workspace = true
-edition.workspace = true
+edition = "2024"
 rust-version.workspace = true
 
 [lints.clippy]
@@ -40,6 +40,7 @@ default = []
 s2geography_tests = ["dep:sedona-s2geography"]
 
 [dev-dependencies]
+datafusion = { workspace = true, features = ["sql"] }
 sedona-testing = { workspace = true }
 url = { workspace = true }
 rstest = { workspace = true }

--- a/rust/sedona-geoparquet/src/file_opener.rs
+++ b/rust/sedona-geoparquet/src/file_opener.rs
@@ -20,8 +20,9 @@ use arrow_array::{Array, RecordBatch};
 use arrow_schema::{DataType, SchemaRef};
 use datafusion::datasource::{listing::PartitionedFile, physical_plan::parquet::ParquetAccessPlan};
 use datafusion_common::{
+    Result,
     cast::{as_binary_array, as_binary_view_array, as_large_binary_array},
-    exec_err, Result,
+    exec_err,
 };
 use datafusion_datasource::morsel::{Morsel, MorselPlan, MorselPlanner, Morselizer};
 use datafusion_datasource_parquet::metadata::DFParquetMetadata;
@@ -180,36 +181,35 @@ impl MorselPlanner for GeoParquetMetadataPlanner {
                 self.options.geometry_columns.inner(),
             )?;
 
-            if self.enable_pruning {
-                if let (Some(predicate), Some(metadata)) =
+            if self.enable_pruning
+                && let (Some(predicate), Some(metadata)) =
                     (self.predicate.as_ref(), metadata.as_ref())
-                {
-                    let spatial_filter = SpatialFilterFactory::default()
-                        .with_bounder_factory(self.bounder_factory.clone())
-                        .try_from_expr(predicate)?;
-                    filter_access_plan_using_geoparquet_file_metadata(
-                        &self.file_schema,
-                        &mut access_plan,
-                        &spatial_filter,
-                        metadata,
-                        &self.metrics,
-                    )?;
-                    filter_access_plan_using_geoparquet_covering(
-                        &self.file_schema,
-                        &mut access_plan,
-                        &spatial_filter,
-                        metadata,
-                        &parquet_metadata,
-                        &self.metrics,
-                    )?;
-                    filter_access_plan_using_native_geostats(
-                        &self.file_schema,
-                        &mut access_plan,
-                        &spatial_filter,
-                        &parquet_metadata,
-                        &self.metrics,
-                    )?;
-                }
+            {
+                let spatial_filter = SpatialFilterFactory::default()
+                    .with_bounder_factory(self.bounder_factory.clone())
+                    .try_from_expr(predicate)?;
+                filter_access_plan_using_geoparquet_file_metadata(
+                    &self.file_schema,
+                    &mut access_plan,
+                    &spatial_filter,
+                    metadata,
+                    &self.metrics,
+                )?;
+                filter_access_plan_using_geoparquet_covering(
+                    &self.file_schema,
+                    &mut access_plan,
+                    &spatial_filter,
+                    metadata,
+                    &parquet_metadata,
+                    &self.metrics,
+                )?;
+                filter_access_plan_using_native_geostats(
+                    &self.file_schema,
+                    &mut access_plan,
+                    &spatial_filter,
+                    &parquet_metadata,
+                    &self.metrics,
+                )?;
             }
 
             let validation_columns = if self.options.validate {
@@ -373,15 +373,15 @@ fn validate_wkb_values<'a>(
     column_name: &str,
 ) -> Result<()> {
     for (row_index, maybe_wkb) in values.into_iter().enumerate() {
-        if let Some(wkb_bytes) = maybe_wkb {
-            if let Err(e) = wkb::reader::read_wkb(wkb_bytes) {
-                return exec_err!(
-                    "WKB validation failed for column '{}' at row {}: {}",
-                    column_name,
-                    row_index,
-                    e
-                );
-            }
+        if let Some(wkb_bytes) = maybe_wkb
+            && let Err(e) = wkb::reader::read_wkb(wkb_bytes)
+        {
+            return exec_err!(
+                "WKB validation failed for column '{}' at row {}: {}",
+                column_name,
+                row_index,
+                e
+            );
         }
     }
 

--- a/rust/sedona-geoparquet/src/format.rs
+++ b/rust/sedona-geoparquet/src/format.rs
@@ -26,9 +26,9 @@ use datafusion::{
     config::{ConfigField, ConfigOptions},
     datasource::{
         file_format::{
+            FileFormat, FileFormatFactory,
             file_compression_type::FileCompressionType,
             parquet::{ParquetFormat, ParquetFormatFactory},
-            FileFormat, FileFormatFactory,
         },
         physical_plan::{
             FileOpener, FileScanConfig, FileScanConfigBuilder, FileSinkConfig, FileSource,
@@ -36,33 +36,33 @@ use datafusion::{
         table_schema::TableSchema,
     },
 };
-use datafusion_catalog::{memory::DataSourceExec, Session};
-use datafusion_common::{plan_err, GetExt, Result, Statistics};
+use datafusion_catalog::{Session, memory::DataSourceExec};
 use datafusion_common::{
-    tree_node::{Transformed, TreeNode, TreeNodeRecursion},
     DataFusionError,
+    tree_node::{Transformed, TreeNode, TreeNodeRecursion},
 };
+use datafusion_common::{GetExt, Result, Statistics, plan_err};
 use datafusion_datasource::morsel::Morselizer;
 use datafusion_datasource_parquet::metadata::DFParquetMetadata;
 use datafusion_datasource_parquet::{CachedParquetFileReaderFactory, ParquetFileReaderFactory};
 use datafusion_execution::cache::cache_manager::FileMetadataCache;
 use datafusion_physical_expr::{
-    expressions::Column, projection::ProjectionExprs, LexRequirement, PhysicalExpr,
+    LexRequirement, PhysicalExpr, expressions::Column, projection::ProjectionExprs,
 };
 use datafusion_physical_plan::{
-    filter_pushdown::FilterPushdownPropagation, metrics::ExecutionPlanMetricsSet, ExecutionPlan,
+    ExecutionPlan, filter_pushdown::FilterPushdownPropagation, metrics::ExecutionPlanMetricsSet,
 };
 use futures::{StreamExt, TryStreamExt};
 use object_store::{ObjectMeta, ObjectStore};
 
-use sedona_common::{sedona_internal_datafusion_err, sedona_internal_err, SedonaOptions};
+use sedona_common::{SedonaOptions, sedona_internal_datafusion_err, sedona_internal_err};
 
 use sedona_expr::metadata_preserving_column::MetadataPreservingColumn;
 use sedona_geometry::bounds::WkbBounder2DFactory;
 use sedona_schema::extension_type::ExtensionType;
 
 use crate::{
-    file_opener::{storage_schema_contains_geo, GeoParquetFileOpenerMetrics, GeoParquetMorselizer},
+    file_opener::{GeoParquetFileOpenerMetrics, GeoParquetMorselizer, storage_schema_contains_geo},
     metadata::{GeoParquetColumnEncoding, GeoParquetMetadata},
     options::TableGeoParquetOptions,
     writer::create_geoparquet_writer_physical_plan,
@@ -512,7 +512,9 @@ impl GeoParquetFileSource {
                     if Arc::ptr_eq(&inner_predicate, &specified_predicate) {
                         Some(inner_predicate)
                     } else {
-                        return sedona_internal_err!("Inner predicate should be equivalent to the predicate in `GeoParquetFileSource`");
+                        return sedona_internal_err!(
+                            "Inner predicate should be equivalent to the predicate in `GeoParquetFileSource`"
+                        );
                     }
                 }
             };
@@ -769,12 +771,12 @@ mod test {
     use datafusion::execution::object_store::ObjectStoreUrl;
     use datafusion::{
         execution::SessionStateBuilder,
-        prelude::{col, ParquetReadOptions, SessionContext},
+        prelude::{ParquetReadOptions, SessionContext, col},
     };
     use datafusion_common::ScalarValue;
     use datafusion_expr::{Expr, Operator, ScalarUDF, Signature, SimpleScalarUDF, Volatility};
-    use datafusion_physical_expr::expressions::{BinaryExpr, Column, Literal};
     use datafusion_physical_expr::PhysicalExpr;
+    use datafusion_physical_expr::expressions::{BinaryExpr, Column, Literal};
 
     use rstest::rstest;
     use sedona_geometry::types::Edges;
@@ -1069,9 +1071,9 @@ mod test {
         // factory so that per-query metadata reads are cached.
         let ctx = setup_context();
         let format = GeoParquetFormat::new(TableGeoParquetOptions::default());
-        let schema = Arc::new(Schema::new(vec![WKB_GEOMETRY
-            .to_storage_field("geometry", true)
-            .unwrap()]));
+        let schema = Arc::new(Schema::new(vec![
+            WKB_GEOMETRY.to_storage_field("geometry", true).unwrap(),
+        ]));
         let table_schema = TableSchema::new(schema, vec![]);
         let file_source = format.file_source(table_schema);
         let conf =
@@ -1132,7 +1134,7 @@ mod test {
             "geoarrow.wkb".to_string(),
         );
         let file_schema = Schema::new(vec![
-            Field::new("geometry", DataType::Binary, true).with_metadata(metadata)
+            Field::new("geometry", DataType::Binary, true).with_metadata(metadata),
         ]);
 
         // Column expression for the geometry column (index 0 in file schema)

--- a/rust/sedona-geoparquet/src/metadata.rs
+++ b/rust/sedona-geoparquet/src/metadata.rs
@@ -21,7 +21,7 @@
 /// to remove the dependency on GeoArrow since we mostly don't need that here yet).
 /// This should be synchronized with that crate when possible.
 /// https://github.com/geoarrow/geoarrow-rs/blob/ad2d29ef90050c5cfcfa7dfc0b4a3e5d12e51bbe/rust/geoarrow-geoparquet/src/metadata.rs
-use datafusion_common::{plan_err, Result};
+use datafusion_common::{Result, plan_err};
 use parquet::basic::{EdgeInterpolationAlgorithm, LogicalType};
 use parquet::file::metadata::{KeyValue, ParquetMetaData};
 use sedona_expr::statistics::GeoStatistics;
@@ -666,7 +666,7 @@ fn column_from_logical_type(
                     Some(_) => {
                         return plan_err!(
                             "Unsupported edge interpolation algorithm in Parquet schema"
-                        )
+                        );
                     }
                 };
                 column_metadata.edges = Some(edges.to_string());
@@ -702,10 +702,10 @@ fn geoparquet_crs_from_logical_type(
         // Resolve projjson:some_key if possible. If this is not possible, the value that
         // will be passed on to the GeoParquet column metadata is the full string
         // "projjson:some_key".
-        if let Some(crs_kv_key) = crs_str.strip_prefix("projjson:") {
-            if let Some(crs_from_kv) = get_parquet_key_value(crs_kv_key, kv_metadata) {
-                return Some(Value::String(crs_from_kv.to_string()));
-            }
+        if let Some(crs_kv_key) = crs_str.strip_prefix("projjson:")
+            && let Some(crs_from_kv) = get_parquet_key_value(crs_kv_key, kv_metadata)
+        {
+            return Some(Value::String(crs_from_kv.to_string()));
         }
 
         // Resolve srid:<int value> to "<int value>", which is accepted by SedonaDB internals
@@ -731,10 +731,10 @@ fn geoparquet_crs_from_logical_type(
 fn get_parquet_key_value(key: &str, kv_metadata: Option<&Vec<KeyValue>>) -> Option<String> {
     if let Some(kv_metadata) = kv_metadata {
         for kv in kv_metadata {
-            if kv.key == key {
-                if let Some(value) = &kv.value {
-                    return Some(value.to_string());
-                }
+            if kv.key == key
+                && let Some(value) = &kv.value
+            {
+                return Some(value.to_string());
             }
         }
     }

--- a/rust/sedona-geoparquet/src/options.rs
+++ b/rust/sedona-geoparquet/src/options.rs
@@ -18,7 +18,7 @@
 use std::{collections::HashMap, str::FromStr};
 
 use datafusion::config::{ConfigField, TableParquetOptions, Visit};
-use datafusion_common::{plan_err, DataFusionError, Result};
+use datafusion_common::{DataFusionError, Result, plan_err};
 
 use crate::metadata::GeoParquetColumnMetadata;
 

--- a/rust/sedona-geoparquet/src/provider.rs
+++ b/rust/sedona-geoparquet/src/provider.rs
@@ -24,10 +24,10 @@ use datafusion::{
         file_format::parquet::ParquetFormat,
         listing::{ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl},
     },
-    execution::{options::ReadOptions, SessionState},
+    execution::{SessionState, options::ReadOptions},
     prelude::{ParquetReadOptions, SessionConfig, SessionContext},
 };
-use datafusion_common::{exec_err, plan_err, Result};
+use datafusion_common::{Result, exec_err, plan_err};
 
 use crate::{
     format::GeoParquetFormat, metadata::GeoParquetColumnMetadata, options::TableGeoParquetOptions,
@@ -60,8 +60,8 @@ pub async fn geoparquet_listing_table(
         if !path_without_query.ends_with(option_extension.clone().as_str()) && !path.is_collection()
         {
             return exec_err!(
-                    "File path '{file_path}' does not match the expected extension '{option_extension}'"
-                );
+                "File path '{file_path}' does not match the expected extension '{option_extension}'"
+            );
         }
     }
 
@@ -464,9 +464,10 @@ mod test {
         )
         .await
         .unwrap_err();
-        assert!(err
-            .message()
-            .ends_with("does not match the expected extension '.parquet'"));
+        assert!(
+            err.message()
+                .ends_with("does not match the expected extension '.parquet'")
+        );
 
         let err = geoparquet_listing_table(
             &ctx,

--- a/rust/sedona-geoparquet/src/statistics_accumulator.rs
+++ b/rust/sedona-geoparquet/src/statistics_accumulator.rs
@@ -21,8 +21,8 @@ use datafusion_common::Result;
 use parquet::{
     basic::LogicalType,
     geospatial::accumulator::{
-        init_geo_stats_accumulator_factory, GeoStatsAccumulator, GeoStatsAccumulatorFactory,
-        ParquetGeoStatsAccumulator, VoidGeoStatsAccumulator,
+        GeoStatsAccumulator, GeoStatsAccumulatorFactory, ParquetGeoStatsAccumulator,
+        VoidGeoStatsAccumulator, init_geo_stats_accumulator_factory,
     },
     schema::types::ColumnDescPtr,
 };
@@ -74,10 +74,9 @@ impl GeoStatsAccumulatorFactory for SedonaGeoStatsAccumulatorFactory {
             crs: _,
             algorithm: None | Some(parquet::basic::EdgeInterpolationAlgorithm::SPHERICAL),
         }) = descr.logical_type_ref()
+            && let Some(bounder) = self.bounder_factory.bounder_for_edge_type(Edges::Spherical)
         {
-            if let Some(bounder) = self.bounder_factory.bounder_for_edge_type(Edges::Spherical) {
-                return Box::new(GeographyGeoStatsAccumulator::new(bounder));
-            }
+            return Box::new(GeographyGeoStatsAccumulator::new(bounder));
         }
 
         Box::new(VoidGeoStatsAccumulator::default())
@@ -179,7 +178,6 @@ impl GeoStatsAccumulator for GeographyGeoStatsAccumulator {
 
 #[cfg(test)]
 mod test {
-    use super::*;
 
     #[cfg(feature = "s2geography_tests")]
     use parquet::geospatial::bounding_box::BoundingBox;

--- a/rust/sedona-geoparquet/src/statistics_accumulator.rs
+++ b/rust/sedona-geoparquet/src/statistics_accumulator.rs
@@ -178,6 +178,11 @@ impl GeoStatsAccumulator for GeographyGeoStatsAccumulator {
 
 #[cfg(test)]
 mod test {
+    #[cfg(feature = "s2geography_tests")]
+    use super::GeographyGeoStatsAccumulator;
+
+    #[cfg(feature = "s2geography_tests")]
+    use parquet::geospatial::accumulator::GeoStatsAccumulator;
 
     #[cfg(feature = "s2geography_tests")]
     use parquet::geospatial::bounding_box::BoundingBox;

--- a/rust/sedona-geoparquet/src/writer.rs
+++ b/rust/sedona-geoparquet/src/writer.rs
@@ -18,8 +18,8 @@
 use std::{collections::HashMap, sync::Arc};
 
 use arrow_array::{
-    builder::{Float32Builder, NullBufferBuilder},
     ArrayRef, RecordBatch, StructArray,
+    builder::{Float32Builder, NullBufferBuilder},
 };
 use arrow_schema::{DataType, Field, FieldRef, Fields, Schema, SchemaRef};
 use async_trait::async_trait;
@@ -32,22 +32,22 @@ use datafusion::{
     },
 };
 use datafusion_common::{
-    config::ConfigOptions, exec_datafusion_err, exec_err, not_impl_err, DataFusionError, Result,
+    DataFusionError, Result, config::ConfigOptions, exec_datafusion_err, exec_err, not_impl_err,
 };
 use datafusion_execution::{SendableRecordBatchStream, TaskContext};
 use datafusion_expr::{
-    dml::InsertOp, ColumnarValue, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+    ColumnarValue, ScalarUDF, ScalarUDFImpl, Signature, Volatility, dml::InsertOp,
 };
 use datafusion_physical_expr::{
-    expressions::Column, LexRequirement, PhysicalExpr, ScalarFunctionExpr,
+    LexRequirement, PhysicalExpr, ScalarFunctionExpr, expressions::Column,
 };
 use datafusion_physical_plan::{
-    stream::RecordBatchStreamAdapter, DisplayAs, DisplayFormatType, ExecutionPlan,
+    DisplayAs, DisplayFormatType, ExecutionPlan, stream::RecordBatchStreamAdapter,
 };
 use float_next_after::NextAfter;
 use futures::StreamExt;
 use geo_traits::GeometryTrait;
-use sedona_common::{sedona_internal_err, SedonaOptions, SedonaRuntime};
+use sedona_common::{SedonaOptions, SedonaRuntime, sedona_internal_err};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_functions::executor::WkbExecutor;
 use sedona_geometry::types::Edges;
@@ -56,7 +56,7 @@ use sedona_geometry::{
     interval::{Interval, IntervalTrait},
 };
 use sedona_schema::{
-    crs::{deserialize_crs_from_obj, lnglat, Crs},
+    crs::{Crs, deserialize_crs_from_obj, lnglat},
     datatypes::SedonaType,
     matchers::ArgMatcher,
     schema::SedonaSchema,
@@ -751,15 +751,15 @@ mod test {
     use std::iter::zip;
     use std::path::Path;
 
-    use arrow_array::{create_array, Array, RecordBatch};
+    use arrow_array::{Array, RecordBatch, create_array};
     use datafusion::datasource::file_format::format_as_file_type;
     use datafusion::prelude::DataFrame;
     use datafusion::{
         execution::SessionStateBuilder,
-        prelude::{col, lit, SessionContext},
+        prelude::{SessionContext, col, lit},
     };
-    use datafusion_common::cast::{as_float32_array, as_struct_array};
     use datafusion_common::ScalarValue;
+    use datafusion_common::cast::{as_float32_array, as_struct_array};
     use datafusion_expr::{Cast, Expr, LogicalPlanBuilder};
     use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
     use parquet::basic::{EdgeInterpolationAlgorithm, LogicalType};
@@ -1099,9 +1099,10 @@ mod test {
         )
         .await
         .unwrap_err();
-        assert!(err
-            .message()
-            .starts_with("Can't overwrite GeoParquet 1.1 bbox column 'bbox'"));
+        assert!(
+            err.message()
+                .starts_with("Can't overwrite GeoParquet 1.1 bbox column 'bbox'")
+        );
 
         options.overwrite_bbox_columns = true;
         test_write_dataframe(&ctx, df, df_batches_with_bbox, options, vec![])


### PR DESCRIPTION
Migrates sedona-geoparquet independently to Rust 2024 as part of #258. Declares the DataFusion SQL test feature locally, eliminating reliance on workspace feature unification. Applies standard formatting and let chains. Validated with 65 tests, all-target checks, and strict Clippy.