### PR TITLE
chore(rust/sedona-raster-functions): migrate to Rust 2024 edition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
       - id: fmt
         name: rustfmt
         args: ["--all", "--"]
+        pass_filenames: false
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13

--- a/rust/sedona-raster-functions/Cargo.toml
+++ b/rust/sedona-raster-functions/Cargo.toml
@@ -24,7 +24,7 @@ homepage.workspace = true
 repository.workspace = true
 description.workspace = true
 readme.workspace = true
-edition.workspace = true
+edition = "2024"
 rust-version.workspace = true
 
 [lints.clippy]

--- a/rust/sedona-raster-functions/benches/native-raster-functions.rs
+++ b/rust/sedona-raster-functions/benches/native-raster-functions.rs
@@ -16,15 +16,15 @@
 // under the License.
 use std::sync::Arc;
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use datafusion_common::error::Result;
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_schema::{
-    crs::{lnglat, Crs},
+    crs::{Crs, lnglat},
     datatypes::SedonaType,
 };
-use sedona_testing::benchmark_util::{benchmark, BenchmarkArgSpec::*, BenchmarkArgs};
+use sedona_testing::benchmark_util::{BenchmarkArgSpec::*, BenchmarkArgs, benchmark};
 
 fn sd_apply_default_crs_udf() -> SedonaScalarUDF {
     SedonaScalarUDF::new(

--- a/rust/sedona-raster-functions/src/crs_utils.rs
+++ b/rust/sedona-raster-functions/src/crs_utils.rs
@@ -18,10 +18,10 @@
 use std::borrow::Cow;
 
 use datafusion_common::config::ConfigOptions;
-use datafusion_common::{exec_err, DataFusionError, Result};
-use sedona_geometry::transform::{transform, CrsEngine};
+use datafusion_common::{DataFusionError, Result, exec_err};
+use sedona_geometry::transform::{CrsEngine, transform};
 use sedona_raster::error::RasterResultExt;
-use sedona_schema::crs::{deserialize_crs, CoordinateReferenceSystem, Crs, CrsRef};
+use sedona_schema::crs::{CoordinateReferenceSystem, Crs, CrsRef, deserialize_crs};
 use wkb::reader::read_wkb;
 
 /// Run `f` with the session's CRS engine: the `SedonaOptions` runtime engine
@@ -203,28 +203,32 @@ mod tests {
         let wkb = sample_wkb();
         with_global_proj_engine(|engine| {
             let crs = resolve_crs(Some("EPSG:4326")).unwrap();
-            assert!(align_wkb_to_crs(
-                &wkb,
-                crs.as_deref(),
-                None,
-                "geometry",
-                "reference raster",
-                engine,
-            )
-            .unwrap_err()
-            .to_string()
-            .contains("geometry has a CRS but the reference raster does not"));
-            assert!(align_wkb_to_crs(
-                &wkb,
-                None,
-                crs.as_deref(),
-                "geometry",
-                "reference raster",
-                engine,
-            )
-            .unwrap_err()
-            .to_string()
-            .contains("reference raster has a CRS but the geometry does not"));
+            assert!(
+                align_wkb_to_crs(
+                    &wkb,
+                    crs.as_deref(),
+                    None,
+                    "geometry",
+                    "reference raster",
+                    engine,
+                )
+                .unwrap_err()
+                .to_string()
+                .contains("geometry has a CRS but the reference raster does not")
+            );
+            assert!(
+                align_wkb_to_crs(
+                    &wkb,
+                    None,
+                    crs.as_deref(),
+                    "geometry",
+                    "reference raster",
+                    engine,
+                )
+                .unwrap_err()
+                .to_string()
+                .contains("reference raster has a CRS but the geometry does not")
+            );
             Ok(())
         })
         .unwrap();

--- a/rust/sedona-raster-functions/src/executor.rs
+++ b/rust/sedona-raster-functions/src/executor.rs
@@ -21,13 +21,13 @@ use datafusion_common::cast::{
     as_binary_array, as_binary_view_array, as_string_view_array, as_struct_array,
 };
 use datafusion_common::error::Result;
-use datafusion_common::{exec_err, ScalarValue};
+use datafusion_common::{ScalarValue, exec_err};
 use datafusion_expr::ColumnarValue;
 use sedona_common::{sedona_internal_datafusion_err, sedona_internal_err};
 use sedona_raster::array::{RasterRefImpl, RasterStructArray};
-use sedona_schema::crs::{deserialize_crs, Crs, CrsRef};
-use sedona_schema::datatypes::SedonaType;
+use sedona_schema::crs::{Crs, CrsRef, deserialize_crs};
 use sedona_schema::datatypes::RASTER;
+use sedona_schema::datatypes::SedonaType;
 
 /// Helper for writing raster kernel implementations
 ///
@@ -648,7 +648,7 @@ impl<'a, 'b> RasterExecutor<'a, 'b> {
                         other => {
                             return sedona_internal_err!(
                                 "Unsupported geometry scalar type: {other:?}"
-                            )
+                            );
                         }
                     };
                     Ok(GeomWkbCrsAccessor::WkbScalar {
@@ -714,8 +714,8 @@ impl<'a, 'b> RasterExecutor<'a, 'b> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_array::builder::Int64Builder;
     use arrow_array::Int64Array;
+    use arrow_array::builder::Int64Builder;
     use arrow_schema::Field;
     use sedona_geometry::types::Edges;
     use sedona_raster::traits::RasterRef;

--- a/rust/sedona-raster-functions/src/rs_bandpath.rs
+++ b/rust/sedona-raster-functions/src/rs_bandpath.rs
@@ -151,13 +151,13 @@ fn get_band_path(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_array::{create_array, Array, ArrayRef, Int32Array, Int64Array, StringArray};
+    use arrow_array::{Array, ArrayRef, Int32Array, Int64Array, StringArray, create_array};
     use datafusion_common::ScalarValue;
     use datafusion_expr::ScalarUDF;
     use sedona_schema::datatypes::RASTER;
     use sedona_schema::raster::BandDataType;
     use sedona_testing::compare::assert_array_equal;
-    use sedona_testing::raster_spec::{raster_array, RasterSpec};
+    use sedona_testing::raster_spec::{RasterSpec, raster_array};
     use sedona_testing::rasters::generate_test_rasters;
     use sedona_testing::testers::ScalarUdfTester;
 

--- a/rust/sedona-raster-functions/src/rs_dim_band.rs
+++ b/rust/sedona-raster-functions/src/rs_dim_band.rs
@@ -300,7 +300,7 @@ mod tests {
     use sedona_raster::traits::RasterRef;
     use sedona_schema::datatypes::RASTER;
     use sedona_schema::raster::BandDataType;
-    use sedona_testing::raster_spec::{assert_rasters_equal, RasterSpec};
+    use sedona_testing::raster_spec::{RasterSpec, assert_rasters_equal};
     use sedona_testing::rasters::generate_test_rasters;
     use sedona_testing::testers::ScalarUdfTester;
 

--- a/rust/sedona-raster-functions/src/rs_ensure_loaded.rs
+++ b/rust/sedona-raster-functions/src/rs_ensure_loaded.rs
@@ -33,7 +33,7 @@ use arrow_array::{Array, ArrayRef, StructArray};
 use arrow_schema::{DataType, FieldRef};
 use async_trait::async_trait;
 use datafusion_common::config::ConfigOptions;
-use datafusion_common::{plan_err, Result};
+use datafusion_common::{Result, plan_err};
 use datafusion_expr::async_udf::AsyncScalarUDFImpl;
 use datafusion_expr::{
     ColumnarValue, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,

--- a/rust/sedona-raster-functions/src/rs_example.rs
+++ b/rust/sedona-raster-functions/src/rs_example.rs
@@ -79,7 +79,7 @@ impl SedonaScalarKernel for RsExample {
 mod tests {
     use super::*;
     use datafusion_expr::ScalarUDF;
-    use sedona_testing::raster_spec::{assert_raster_scalar_equals, RasterSpec};
+    use sedona_testing::raster_spec::{RasterSpec, assert_raster_scalar_equals};
 
     #[test]
     fn udf_size() {

--- a/rust/sedona-raster-functions/src/rs_georeference.rs
+++ b/rust/sedona-raster-functions/src/rs_georeference.rs
@@ -17,12 +17,12 @@
 use std::{sync::Arc, vec};
 
 use crate::executor::RasterExecutor;
+use arrow_array::Array;
 use arrow_array::builder::StringBuilder;
 use arrow_array::cast::AsArray;
-use arrow_array::Array;
 use arrow_schema::DataType;
-use datafusion_common::error::Result;
 use datafusion_common::DataFusionError;
+use datafusion_common::error::Result;
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_raster::geo_transform::GeoTransformEx;
@@ -234,9 +234,13 @@ mod tests {
         let result = tester.invoke_array(Arc::new(rasters.clone())).unwrap();
 
         let expected: Arc<dyn Array> = Arc::new(StringArray::from(vec![
-            Some("0.1000000000\n0.0000000000\n0.0000000000\n-0.2000000000\n1.0000000000\n2.0000000000"),
+            Some(
+                "0.1000000000\n0.0000000000\n0.0000000000\n-0.2000000000\n1.0000000000\n2.0000000000",
+            ),
             None,
-            Some("0.2000000000\n0.0800000000\n0.0600000000\n-0.4000000000\n3.0000000000\n4.0000000000"),
+            Some(
+                "0.2000000000\n0.0800000000\n0.0600000000\n-0.4000000000\n3.0000000000\n4.0000000000",
+            ),
         ]));
         assert_array_equal(&result, &expected);
 
@@ -260,9 +264,13 @@ mod tests {
         // its center shift includes the skew halves: dx = (0.2 + 0.06) * 0.5,
         // dy = (0.08 - 0.4) * 0.5.
         let expected: Arc<dyn Array> = Arc::new(StringArray::from(vec![
-            Some("0.1000000000\n0.0000000000\n0.0000000000\n-0.2000000000\n1.0500000000\n1.9000000000"),
+            Some(
+                "0.1000000000\n0.0000000000\n0.0000000000\n-0.2000000000\n1.0500000000\n1.9000000000",
+            ),
             None,
-            Some("0.2000000000\n0.0800000000\n0.0600000000\n-0.4000000000\n3.1300000000\n3.8400000000"),
+            Some(
+                "0.2000000000\n0.0800000000\n0.0600000000\n-0.4000000000\n3.1300000000\n3.8400000000",
+            ),
         ]));
 
         for format in ["ESRI", "esri", "NODE", "node"] {
@@ -301,15 +309,19 @@ mod tests {
             .invoke_arrays(vec![Arc::new(rasters), formats])
             .unwrap();
         let expected: Arc<dyn Array> = Arc::new(StringArray::from(vec![
-                // explicit GDAL
-                Some("0.1000000000\n0.0000000000\n0.0000000000\n-0.2000000000\n1.0000000000\n2.0000000000"),
-                // null raster
-                None,
-                // null format -> NULL output
-                None,
-                // explicit ESRI on a skewed raster: the center shift uses the
-                // full affine, dx = (0.3 + 0.09) * 0.5, dy = (0.12 - 0.6) * 0.5
-                Some("0.3000000000\n0.1200000000\n0.0900000000\n-0.6000000000\n4.1950000000\n4.7600000000"),
+            // explicit GDAL
+            Some(
+                "0.1000000000\n0.0000000000\n0.0000000000\n-0.2000000000\n1.0000000000\n2.0000000000",
+            ),
+            // null raster
+            None,
+            // null format -> NULL output
+            None,
+            // explicit ESRI on a skewed raster: the center shift uses the
+            // full affine, dx = (0.3 + 0.09) * 0.5, dy = (0.12 - 0.6) * 0.5
+            Some(
+                "0.3000000000\n0.1200000000\n0.0900000000\n-0.6000000000\n4.1950000000\n4.7600000000",
+            ),
         ]));
         assert_array_equal(&result, &expected);
     }

--- a/rust/sedona-raster-functions/src/rs_pixel_functions.rs
+++ b/rust/sedona-raster-functions/src/rs_pixel_functions.rs
@@ -27,7 +27,7 @@ use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_expr::item_crs::make_item_crs;
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_geometry::types::Edges;
-use sedona_geometry::wkb_factory::{write_wkb_point, write_wkb_polygon, WKB_MIN_PROBABLE_BYTES};
+use sedona_geometry::wkb_factory::{WKB_MIN_PROBABLE_BYTES, write_wkb_point, write_wkb_polygon};
 use sedona_raster::affine_transformation::to_world_coordinate;
 use sedona_raster::geo_transform::GeoTransformEx;
 use sedona_raster::traits::RasterRef;

--- a/rust/sedona-raster-functions/src/rs_rastercoordinate.rs
+++ b/rust/sedona-raster-functions/src/rs_rastercoordinate.rs
@@ -245,11 +245,13 @@ mod tests {
         let result_err =
             tester.invoke_array_scalar_scalar(Arc::new(noninvertible_rasters), 2.0_f64, 3.0_f64);
         assert!(result_err.is_err());
-        assert!(result_err
-            .err()
-            .unwrap()
-            .to_string()
-            .contains("determinant is zero"));
+        assert!(
+            result_err
+                .err()
+                .unwrap()
+                .to_string()
+                .contains("determinant is zero")
+        );
     }
 
     #[rstest]
@@ -277,11 +279,13 @@ mod tests {
         let result_err =
             tester.invoke_array_scalar_scalar(Arc::new(noninvertible_rasters), 2.0_f64, 3.0_f64);
         assert!(result_err.is_err());
-        assert!(result_err
-            .err()
-            .unwrap()
-            .to_string()
-            .contains("determinant is zero"));
+        assert!(
+            result_err
+                .err()
+                .unwrap()
+                .to_string()
+                .contains("determinant is zero")
+        );
     }
 
     #[rstest]

--- a/rust/sedona-raster-functions/src/rs_set_band_nodata.rs
+++ b/rust/sedona-raster-functions/src/rs_set_band_nodata.rs
@@ -42,16 +42,16 @@
 
 use std::sync::Arc;
 
+use arrow_array::Array;
 use arrow_array::cast::AsArray;
 use arrow_array::types::{Float64Type, Int64Type};
-use arrow_array::Array;
 use arrow_schema::DataType;
 use datafusion_common::error::Result;
 use datafusion_common::exec_err;
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_raster::builder::{RasterBuilder, RasterOverrides};
-use sedona_raster::traits::{nodata_f64_to_bytes, BandOverrides, Override, RasterRef};
+use sedona_raster::traits::{BandOverrides, Override, RasterRef, nodata_f64_to_bytes};
 use sedona_schema::datatypes::SedonaType;
 use sedona_schema::matchers::ArgMatcher;
 
@@ -170,7 +170,7 @@ fn set_band_nodata(
             return exec_err!(
                 "RS_SetBandNoDataValue: raster has {num_bands} bands; specify which band to set \
                  (the 2-argument form is only allowed for a single-band raster)"
-            )
+            );
         }
     };
     if band < 1 || band as usize > num_bands {
@@ -224,7 +224,7 @@ mod tests {
     use datafusion_common::ScalarValue;
     use datafusion_expr::ScalarUDF;
     use sedona_schema::datatypes::RASTER;
-    use sedona_testing::raster_spec::{assert_rasters_equal, RasterSpec};
+    use sedona_testing::raster_spec::{RasterSpec, assert_rasters_equal};
     use sedona_testing::rasters::generate_test_rasters;
     use sedona_testing::testers::ScalarUdfTester;
 

--- a/rust/sedona-raster-functions/src/rs_set_georeference.rs
+++ b/rust/sedona-raster-functions/src/rs_set_georeference.rs
@@ -48,7 +48,7 @@ use datafusion_common::{exec_datafusion_err, exec_err};
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_common::{sedona_internal_datafusion_err, sedona_internal_err};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
-use sedona_raster::array::{with_column_overrides, RasterColumnOverrides};
+use sedona_raster::array::{RasterColumnOverrides, with_column_overrides};
 use sedona_raster::traits::Override;
 use sedona_schema::datatypes::SedonaType;
 use sedona_schema::matchers::ArgMatcher;
@@ -215,7 +215,14 @@ fn parse_georeference(georef: &str, format: GeoReferenceFormat) -> Result<[f64; 
         );
     }
 
-    let [scale_x, skew_y, skew_x, scale_y, mut upper_left_x, mut upper_left_y] = [
+    let [
+        scale_x,
+        skew_y,
+        skew_x,
+        scale_y,
+        mut upper_left_x,
+        mut upper_left_y,
+    ] = [
         values[0], values[1], values[2], values[3], values[4], values[5],
     ];
 
@@ -238,7 +245,7 @@ mod tests {
     use datafusion_common::ScalarValue;
     use datafusion_expr::ScalarUDF;
     use sedona_schema::datatypes::RASTER;
-    use sedona_testing::raster_spec::{assert_rasters_equal, raster_array, RasterSpec};
+    use sedona_testing::raster_spec::{RasterSpec, assert_rasters_equal, raster_array};
     use sedona_testing::testers::ScalarUdfTester;
 
     /// A 2x2 raster with a CRS and a named band — so the comparisons confirm

--- a/rust/sedona-raster-functions/src/rs_setsrid.rs
+++ b/rust/sedona-raster-functions/src/rs_setsrid.rs
@@ -28,9 +28,9 @@ use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_common::{sedona_internal_datafusion_err, sedona_internal_err};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_geometry::transform::CrsEngine;
-use sedona_raster::array::{with_column_overrides, RasterColumnOverrides};
+use sedona_raster::array::{RasterColumnOverrides, with_column_overrides};
 use sedona_raster::traits::Override;
-use sedona_schema::crs::{normalize_crs, CachedSRIDToCrs};
+use sedona_schema::crs::{CachedSRIDToCrs, normalize_crs};
 use sedona_schema::datatypes::SedonaType;
 use sedona_schema::matchers::ArgMatcher;
 

--- a/rust/sedona-raster-functions/src/rs_slice.rs
+++ b/rust/sedona-raster-functions/src/rs_slice.rs
@@ -381,7 +381,7 @@ mod tests {
     use datafusion_expr::ScalarUDF;
     use sedona_schema::datatypes::RASTER;
     use sedona_schema::raster::BandDataType;
-    use sedona_testing::raster_spec::{assert_rasters_equal, RasterSpec};
+    use sedona_testing::raster_spec::{RasterSpec, assert_rasters_equal};
     use sedona_testing::rasters::generate_test_rasters;
     use sedona_testing::testers::ScalarUdfTester;
 

--- a/rust/sedona-raster-functions/src/rs_spatial_predicates.rs
+++ b/rust/sedona-raster-functions/src/rs_spatial_predicates.rs
@@ -38,15 +38,15 @@ use crate::executor::RasterExecutor;
 use crate::footprint::write_convexhull_wkb;
 use arrow_array::builder::BooleanBuilder;
 use arrow_schema::DataType;
+use datafusion_common::Result;
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::exec_err;
-use datafusion_common::Result;
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_geometry::transform::CrsEngine;
 use sedona_raster::error::RasterResultExt;
 use sedona_raster::traits::RasterRef;
-use sedona_schema::crs::{lnglat, CrsRef};
+use sedona_schema::crs::{CrsRef, lnglat};
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
 use sedona_tg::tg;
 
@@ -345,13 +345,13 @@ fn evaluate_predicate_with_crs<Op: tg::BinaryPredicate>(
             return exec_err!(
                 "Cannot evaluate spatial predicate: \
                 left geometry has CRS but right geometry does not"
-            )
+            );
         }
         (None, Some(_)) => {
             return exec_err!(
                 "Cannot evaluate spatial predicate: \
                 right geometry has CRS but left geometry does not"
-            )
+            );
         }
     };
 
@@ -411,16 +411,16 @@ pub fn raster_intersects_geom_wkb(raster: &dyn RasterRef, geom_wkb: &[u8]) -> Re
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_array::{create_array, ArrayRef};
+    use arrow_array::{ArrayRef, create_array};
     use datafusion_common::DataFusionError;
     use datafusion_expr::ScalarUDF;
     use rstest::rstest;
     use sedona_geometry::types::Edges;
     use sedona_proj::error::SedonaProjError;
-    use sedona_proj::transform::{with_global_proj_engine, LazyProjEngine};
+    use sedona_proj::transform::{LazyProjEngine, with_global_proj_engine};
     use sedona_raster::builder::RasterBuilder;
-    use sedona_schema::crs::deserialize_crs;
     use sedona_schema::crs::OGC_CRS84_PROJJSON;
+    use sedona_schema::crs::deserialize_crs;
     use sedona_schema::datatypes::RASTER;
     use sedona_schema::datatypes::WKB_GEOMETRY;
     use sedona_schema::raster::BandDataType;

--- a/rust/sedona-raster-functions/src/rs_value.rs
+++ b/rust/sedona-raster-functions/src/rs_value.rs
@@ -34,11 +34,11 @@
 
 use std::sync::Arc;
 
-use arrow_array::{builder::Float64Builder, Array, ArrayRef, Float64Array, StructArray};
+use arrow_array::{Array, ArrayRef, Float64Array, StructArray, builder::Float64Builder};
 use arrow_schema::DataType;
 use datafusion_common::cast::as_int32_array;
 use datafusion_common::config::ConfigOptions;
-use datafusion_common::{exec_err, Result, ScalarValue};
+use datafusion_common::{Result, ScalarValue, exec_err};
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_geometry::transform::CrsTransform;
@@ -921,13 +921,10 @@ mod tests {
         let raster_crs = resolve_crs(rasters.get(0).unwrap().crs()).unwrap();
         let point_type = SedonaType::Wkb(Edges::Planar, lnglat());
         with_global_proj_engine(|engine| {
-            assert!(column_point_crs_transform(
-                "RS_Value",
-                &point_type,
-                raster_crs.as_deref(),
-                engine
-            )
-            .is_err());
+            assert!(
+                column_point_crs_transform("RS_Value", &point_type, raster_crs.as_deref(), engine)
+                    .is_err()
+            );
             Ok(())
         })
         .unwrap();

--- a/rust/sedona-raster-functions/src/rs_values.rs
+++ b/rust/sedona-raster-functions/src/rs_values.rs
@@ -44,7 +44,7 @@ use arrow_array::{Array, ArrayRef, StructArray};
 use arrow_schema::DataType;
 use datafusion_common::cast::as_int32_array;
 use datafusion_common::config::ConfigOptions;
-use datafusion_common::{exec_err, Result, ScalarValue};
+use datafusion_common::{Result, ScalarValue, exec_err};
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_raster::array::RasterStructArray;

--- a/rust/sedona-raster-functions/src/sampling.rs
+++ b/rust/sedona-raster-functions/src/sampling.rs
@@ -29,13 +29,13 @@ use std::rc::Rc;
 
 use arrow_array::ArrayRef;
 use arrow_schema::DataType;
-use datafusion_common::{exec_datafusion_err, exec_err, DataFusionError, Result};
+use datafusion_common::{DataFusionError, Result, exec_datafusion_err, exec_err};
 use datafusion_expr::ColumnarValue;
 use sedona_geometry::error::SedonaGeometryError;
-use sedona_geometry::transform::{visit_point_coords, CrsEngine, CrsTransform};
+use sedona_geometry::transform::{CrsEngine, CrsTransform, visit_point_coords};
 use sedona_raster::error::RasterResultExt;
 use sedona_raster::geo_transform::GeoTransformEx;
-use sedona_raster::traits::{nodata_bytes_to_f64_lossless, BandRef, NdBuffer, RasterRef};
+use sedona_raster::traits::{BandRef, NdBuffer, RasterRef, nodata_bytes_to_f64_lossless};
 use sedona_schema::crs::CrsRef;
 use sedona_schema::datatypes::SedonaType;
 use wkb::reader::read_wkb;
@@ -272,10 +272,10 @@ pub(crate) fn read_pixel(
     // be represented faithfully; failing loudly is preferred over a wrong value.
     let value = nodata_bytes_to_f64_lossless(bytes, &buffer.data_type).context(func)?;
 
-    if let Some(nodata) = nodata {
-        if value == nodata || (value.is_nan() && nodata.is_nan()) {
-            return Ok(None);
-        }
+    if let Some(nodata) = nodata
+        && (value == nodata || (value.is_nan() && nodata.is_nan()))
+    {
+        return Ok(None);
     }
 
     Ok(Some(value))


### PR DESCRIPTION
Migrates sedona-raster-functions independently to Rust 2024 as part of #258. Applies standard formatter output and a Rust 2024 let chain. Validated with 269 package tests, all-target checks, and Clippy with warnings denied.