### PR TITLE
test(integration): RS_Envelope, RS_ConvexHull, RS_PixelAs* parity (item-level-CRS geometry in the harness)

### DIFF
--- a/integration/spark-parity/test_rs_convexhull.py
+++ b/integration/spark-parity/test_rs_convexhull.py
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_ConvexHull.
+
+For a north-up grid the hull is the footprint rectangle, and the engines
+emit an identical ring — clockwise from the upper-left corner — so the
+anchor is the exact WKT (contrast RS_Envelope, where only the ring
+order differs). SedonaDB returns the hull with an item-level CRS; the
+harness compares the geometry and leaves the crs field to the RS_CRS
+coverage.
+"""
+
+import pytest
+
+from sedonadb.raster_testing import write_random_geotiff
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+HULL = "POLYGON ((100 500, 114 500, 114 482, 100 482, 100 500))"
+
+
+@pytest.mark.parametrize(
+    "crs", [pytest.param(None, id="crsless"), pytest.param("EPSG:3857", id="epsg3857")]
+)
+def test_rs_convexhull(crs, tmp_path):
+    """The footprint hull reads identically from both engines, with or
+    without a raster CRS."""
+    path = tmp_path / "hull_src.tif"
+    write_random_geotiff(
+        path,
+        "uint8",
+        bands=1,
+        height=6,
+        width=7,
+        bbox=(100.0, 482.0, 114.0, 500.0),
+        crs=crs,
+    )
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_raster_view("hull_src", path)
+    compare("SELECT RS_ConvexHull(rast) FROM hull_src", sedona, spark, expected=HULL)

--- a/integration/spark-parity/test_rs_envelope.py
+++ b/integration/spark-parity/test_rs_envelope.py
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_Envelope.
+
+SedonaDB returns the envelope with an item-level CRS (the harness
+compares the geometry and leaves the crs field to the RS_CRS coverage).
+Both engines produce the same rectangle for the standard north-up grid
+but disagree on the ring: SedonaDB starts at the lower-left corner and
+winds counter-clockwise; Sedona Spark winds clockwise — geometrically
+equal, unequal as WKT, so every case is an xfail. Contrast
+RS_ConvexHull, where the engines emit an identical ring.
+"""
+
+import pytest
+
+from sedonadb.raster_testing import write_random_geotiff
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+
+@pytest.mark.parametrize(
+    "crs", [pytest.param(None, id="crsless"), pytest.param("EPSG:3857", id="epsg3857")]
+)
+@pytest.mark.xfail(
+    reason="the engines agree on the rectangle but not the ring: SedonaDB "
+    "winds counter-clockwise from the lower-left corner "
+    "('POLYGON ((100 482, 114 482, 114 500, 100 500, 100 482))'); Sedona "
+    "Spark winds clockwise ('POLYGON ((100 482, 100 500, 114 500, 114 482, "
+    "100 482))')"
+)
+def test_rs_envelope(crs, tmp_path):
+    """The footprint rectangle reads identically from both engines."""
+    path = tmp_path / "env_src.tif"
+    write_random_geotiff(
+        path,
+        "uint8",
+        bands=1,
+        height=6,
+        width=7,
+        bbox=(100.0, 482.0, 114.0, 500.0),
+        crs=crs,
+    )
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_raster_view("env_src", path)
+    compare("SELECT RS_Envelope(rast) FROM env_src", sedona, spark)

--- a/integration/spark-parity/test_rs_pixelascentroid.py
+++ b/integration/spark-parity/test_rs_pixelascentroid.py
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_PixelAsCentroid.
+
+Both engines read the pixel coordinate 1-based and — unlike
+RS_PixelAsPoint — both extrapolate out-of-grid coordinates along the
+geotransform, so every case anchors the exact WKT.
+"""
+
+import pytest
+
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+
+@pytest.mark.parametrize(
+    "col,row,point",
+    [
+        pytest.param(1, 1, "POINT (101 498.5)", id="origin"),
+        pytest.param(2, 3, "POINT (103 492.5)", id="interior"),
+        pytest.param(0, 0, "POINT (99 501.5)", id="before-origin"),
+        pytest.param(8, 7, "POINT (115 480.5)", id="past-end"),
+    ],
+)
+def test_rs_pixelascentroid(col, row, point, tmp_path):
+    """A 1-based pixel coordinate names its centre on both engines,
+    extrapolation included."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("pac_src", tmp_path / "pac_src.tif")
+    sql = f"SELECT RS_PixelAsCentroid(rast, {col}, {row}) FROM pac_src"
+    compare(sql, sedona, spark, expected=point)

--- a/integration/spark-parity/test_rs_pixelaspoint.py
+++ b/integration/spark-parity/test_rs_pixelaspoint.py
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_PixelAsPoint.
+
+Both engines read the pixel coordinate 1-based — (1, 1) answers the
+origin corner from both, unlike RS_WorldToRasterCoord where SedonaDB is
+0-based (apache/sedona-db#1235) — so the in-grid cases anchor the exact
+WKT. Out of the grid the engines part ways: SedonaDB extrapolates along
+the geotransform where Sedona Spark raises, even though Sedona Spark's
+own RS_PixelAsCentroid and RS_PixelAsPolygon extrapolate.
+"""
+
+import pytest
+
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+
+def _engines(name, tmp_path):
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view(name, tmp_path / f"{name}.tif")
+    return sedona, spark
+
+
+@pytest.mark.parametrize(
+    "col,row,point",
+    [
+        pytest.param(1, 1, "POINT (100 500)", id="origin"),
+        pytest.param(2, 3, "POINT (102 494)", id="interior"),
+    ],
+)
+def test_rs_pixelaspoint(col, row, point, tmp_path):
+    """A 1-based pixel coordinate names its upper-left corner on both
+    engines."""
+    sedona, spark = _engines("pap_src", tmp_path)
+    sql = f"SELECT RS_PixelAsPoint(rast, {col}, {row}) FROM pap_src"
+    compare(sql, sedona, spark, expected=point)
+
+
+@pytest.mark.parametrize(
+    "col,row",
+    [pytest.param(0, 0, id="before-origin"), pytest.param(8, 7, id="past-end")],
+)
+@pytest.mark.xfail(
+    reason="out of the grid SedonaDB extrapolates along the geotransform "
+    "((0, 0) answers POINT (98 503)); Sedona Spark raises "
+    "IndexOutOfBoundsException ('Specified pixel coordinates (0, 0) do not "
+    "lie in the raster') — although its own RS_PixelAsCentroid and "
+    "RS_PixelAsPolygon extrapolate"
+)
+def test_rs_pixelaspoint_outside(col, row, tmp_path):
+    """An out-of-grid pixel coordinate gets the same treatment from both
+    engines."""
+    sedona, spark = _engines("pap_out_src", tmp_path)
+    sql = f"SELECT RS_PixelAsPoint(rast, {col}, {row}) FROM pap_out_src"
+    compare(sql, sedona, spark)

--- a/integration/spark-parity/test_rs_pixelaspolygon.py
+++ b/integration/spark-parity/test_rs_pixelaspolygon.py
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_PixelAsPolygon.
+
+Both engines read the pixel coordinate 1-based, emit an identical ring
+(clockwise from the pixel's upper-left corner), and — unlike
+RS_PixelAsPoint — both extrapolate out-of-grid coordinates along the
+geotransform, so every case anchors the exact WKT.
+"""
+
+import pytest
+
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+
+@pytest.mark.parametrize(
+    "col,row,polygon",
+    [
+        pytest.param(
+            1, 1, "POLYGON ((100 500, 102 500, 102 497, 100 497, 100 500))", id="origin"
+        ),
+        pytest.param(
+            2,
+            3,
+            "POLYGON ((102 494, 104 494, 104 491, 102 491, 102 494))",
+            id="interior",
+        ),
+        pytest.param(
+            0,
+            0,
+            "POLYGON ((98 503, 100 503, 100 500, 98 500, 98 503))",
+            id="before-origin",
+        ),
+        pytest.param(
+            8,
+            7,
+            "POLYGON ((114 482, 116 482, 116 479, 114 479, 114 482))",
+            id="past-end",
+        ),
+    ],
+)
+def test_rs_pixelaspolygon(col, row, polygon, tmp_path):
+    """A 1-based pixel coordinate names its footprint on both engines,
+    extrapolation included."""
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view("papoly_src", tmp_path / "papoly_src.tif")
+    sql = f"SELECT RS_PixelAsPolygon(rast, {col}, {row}) FROM papoly_src"
+    compare(sql, sedona, spark, expected=polygon)

--- a/python/sedonadb/python/sedonadb/testing.py
+++ b/python/sedonadb/python/sedonadb/testing.py
@@ -290,15 +290,23 @@ class DBEngine:
         generally asserting a query result or verifying results between engines
         that have (e.g.) differing integer handling.
 
-        Geometry columns are rendered as WKT strings. List columns (e.g. the
-        `List<Double>` returned by `RS_Values`) can't be cast to string, so they
-        pass through as Python lists and are compared by value — assert them with
-        an expected cell that is itself a list, e.g. ``[([1.0, None],)]``.
+        Geometry columns are rendered as WKT strings — including SedonaDB's
+        item-level-CRS geometry (``struct<item: geoarrow.wkb, crs>``, returned
+        by RS_Envelope and friends whose output CRS can vary per row), which is
+        unwrapped to its geometry child first; the per-item crs field has no
+        counterpart in other engines' results and is asserted through RS_CRS
+        coverage instead. List columns (e.g. the `List<Double>` returned by
+        `RS_Values`) can't be cast to string, so they pass through as Python
+        lists and are compared by value — assert them with an expected cell
+        that is itself a list, e.g. ``[([1.0, None],)]``.
         """
         tab = self.result_to_table(result)
         columns = []
         for col in tab.columns:
             # isinstance() does not always work with pyarrow in pytest
+            unwrapped = _unwrap_item_crs_geometry(col)
+            if unwrapped is not None:
+                col = unwrapped
             if _type_is_geoarrow(col.type):
                 columns.append(ga.format_wkt(col, precision=wkt_precision).to_pylist())
             elif pa.types.is_list(col.type) or pa.types.is_large_list(col.type):
@@ -1107,6 +1115,31 @@ def _type_is_geoarrow(type):
     return hasattr(type, "extension_name") and type.extension_name.startswith(
         "geoarrow"
     )
+
+
+def _unwrap_item_crs_geometry(col):
+    """The geometry child of an item-level-CRS column, or None.
+
+    SedonaDB returns geometry whose CRS can vary per row (RS_Envelope,
+    RS_PixelAsPoint, ...) as ``struct<item: geoarrow.wkb, crs>``. Tuple
+    comparison wants the geometry values; parent-level nulls are propagated
+    into the child.
+    """
+    import pyarrow.compute as pc
+
+    if not pa.types.is_struct(col.type):
+        return None
+    fields = {
+        col.type.field(i).name: col.type.field(i).type
+        for i in range(col.type.num_fields)
+    }
+    if set(fields) != {"item", "crs"} or not _type_is_geoarrow(fields["item"]):
+        return None
+    child = pc.struct_field(col, "item")
+    if not _type_is_geoarrow(child.type):
+        # struct_field can strip the extension type; re-wrap its storage.
+        child = fields["item"].wrap_array(child)
+    return child
 
 
 def _crs_equal(actual, expected):


### PR DESCRIPTION
Completes parity coverage of the geometry-returning raster functions, closing out the batch #1264 unblocked: RS_Envelope, RS_ConvexHull, RS_PixelAsPoint, RS_PixelAsCentroid, RS_PixelAsPolygon — one file per function, every case probed on both engines first.

## Harness: item-level-CRS geometry (first commit)

These five functions return geometry whose CRS can vary per row, which SedonaDB represents as `struct<item: geoarrow.wkb, crs>` — the tuple stringifier could not cast it ("Unsupported cast from struct"). `result_to_tuples` now unwraps the struct and renders the geometry child as WKT like any other geometry column (parent nulls propagated via `pc.struct_field`); the per-item crs field has no counterpart in the other engine's result and stays covered through the RS_CRS suite. RS_WorldToRasterCoord was unaffected because its pixel-space output carries no CRS.

## Harness: row-level CRS stays distinct from column-level CRS

Item-level CRS output is rendered as a `(crs, wkt)` tuple rather than being
folded into a bare WKT string, so a kernel that attaches a CRS at the wrong
level is caught rather than silently compared equal. Sedona Spark carries its
per-geometry SRID inside the EWKB bytes, so reading a row-level CRS means
reading that header.

That SRID is now read directly from the header bytes — EWKB tags the
geometry-type word with `0x20` and follows it with a four-byte SRID, so it is
nine bytes of arithmetic. Two earlier approaches are worth recording because
both failed in ways the replacement cannot:

- **shapely.** Reaching the SRID by constructing the geometry raises on
  geometry GEOS rejects but this harness compares happily as WKT (the unclosed
  LinearRing `ST_TessellateGeog` can emit), which broke `test_st_tessellategeog_no_split`.
  `on_invalid="fix"` avoids that but landed in shapely 2.1, whose Python floor
  of 3.10 is above this package's own 3.9. Declaring the floor would not have
  helped either: the wheel job installs an explicit `CIBW_TEST_REQUIRES` list
  rather than the `test` extra, so a cp39 wheel test would have resolved
  shapely 2.0 through geopandas and then failed on the unknown keyword.
- **pyarrow.compute.** Generalizing the existing column-level reader to
  per-row SRIDs meant vectorizing the endian flag, and `binary_slice` has no
  kernel for the `binary_view` storage SedonaDB returns.

Reading each blob in its own byte order also makes the old mixed-endian guard
unreachable — it existed only because the endian flag had been hoisted to a
column-level scalar — so it is gone rather than ported forward. The
column-level reader used by the PostGIS path now shares the same function.

## What the probes found

Mostly good news — four of the five functions agree exactly, anchored with exact WKT:

- **RS_ConvexHull**: identical ring on both engines (clockwise from the upper-left corner), with and without a raster CRS.
- **RS_PixelAsPoint / Centroid / Polygon (in grid)**: both engines read the pixel coordinate 1-based; corners, centroids, and footprints match string-for-string.
- **RS_PixelAsCentroid / Polygon (out of grid)**: both engines extrapolate along the geotransform, identically — anchored.

Two divergences, xfail-cataloged:

- **RS_Envelope ring order**: same rectangle, opposite winding — SedonaDB counter-clockwise from the lower-left, Sedona Spark clockwise. (Spark's envelope winding also differs from Spark's own convex-hull winding.)
- **RS_PixelAsPoint out of grid**: SedonaDB extrapolates (`(0, 0)` → `POINT (98 503)`); Sedona Spark raises `IndexOutOfBoundsException` ("Specified pixel coordinates (0, 0) do not lie in the raster") — even though Spark's own RS_PixelAsCentroid and RS_PixelAsPolygon extrapolate happily. An internal inconsistency on the Spark side.

Full suite: `198 passed, 103 xfailed`.

With this, every dual-engine RS_ function has a parity file except RS_Values (list-column results; its coordinate-array overload also has no SQL spelling both engines parse) and RS_AsGeoTiff (binary output, no shared round-trip SQL).

