### PR TITLE
chore(rust/sedona-raster-gdal): migrate to Rust 2024 edition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
       - id: fmt
         name: rustfmt
         args: ["--all", "--"]
+        pass_filenames: false
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13

--- a/rust/sedona-raster-gdal/Cargo.toml
+++ b/rust/sedona-raster-gdal/Cargo.toml
@@ -24,7 +24,7 @@ homepage.workspace = true
 repository.workspace = true
 description = "GDAL integration for Apache SedonaDB raster types"
 readme.workspace = true
-edition.workspace = true
+edition = "2024"
 rust-version.workspace = true
 
 [lints.clippy]

--- a/rust/sedona-raster-gdal/benches/rs_as_geotiff.rs
+++ b/rust/sedona-raster-gdal/benches/rs_as_geotiff.rs
@@ -25,10 +25,10 @@ use std::sync::Arc;
 
 use arrow_array::ArrayRef;
 use arrow_schema::DataType;
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use datafusion_common::ScalarValue;
 use datafusion_expr::{ColumnarValue, ScalarUDF};
-use sedona_schema::datatypes::{SedonaType, RASTER};
+use sedona_schema::datatypes::{RASTER, SedonaType};
 use sedona_schema::raster::BandDataType;
 use sedona_testing::raster_spec::RasterSpec;
 use sedona_testing::testers::ScalarUdfTester;

--- a/rust/sedona-raster-gdal/benches/rs_as_raster.rs
+++ b/rust/sedona-raster-gdal/benches/rs_as_raster.rs
@@ -21,13 +21,13 @@ use std::{hint::black_box, sync::Arc};
 
 use arrow_array::{ArrayRef, BooleanArray, Float64Array, StringArray};
 use arrow_schema::DataType;
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use datafusion_expr::ScalarUDF;
 use sedona_schema::crs::deserialize_crs;
-use sedona_schema::datatypes::{Edges, SedonaType, RASTER};
+use sedona_schema::datatypes::{Edges, RASTER, SedonaType};
 use sedona_testing::{
     create::create_array,
-    raster_spec::{raster_array as build_raster_array, RasterSpec},
+    raster_spec::{RasterSpec, raster_array as build_raster_array},
     testers::ScalarUdfTester,
 };
 

--- a/rust/sedona-raster-gdal/benches/rs_clip.rs
+++ b/rust/sedona-raster-gdal/benches/rs_clip.rs
@@ -41,9 +41,9 @@ use std::sync::Arc;
 
 use arrow_array::{ArrayRef, BinaryArray, BooleanArray, Int32Array};
 use arrow_schema::DataType;
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use datafusion_expr::ScalarUDF;
-use sedona_schema::datatypes::{SedonaType, RASTER, WKB_GEOMETRY};
+use sedona_schema::datatypes::{RASTER, SedonaType, WKB_GEOMETRY};
 use sedona_testing::{
     benchmark_util::BenchmarkArgSpec, create::make_wkb, raster_spec::RasterSpec,
     testers::ScalarUdfTester,

--- a/rust/sedona-raster-gdal/benches/rs_from_gdal_raster.rs
+++ b/rust/sedona-raster-gdal/benches/rs_from_gdal_raster.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 
 use arrow_array::{ArrayRef, BinaryArray};
 use arrow_schema::DataType;
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use datafusion_expr::ScalarUDF;
 use sedona_schema::datatypes::SedonaType;
 use sedona_testing::{data::test_raster, testers::ScalarUdfTester};

--- a/rust/sedona-raster-gdal/benches/rs_frompath.rs
+++ b/rust/sedona-raster-gdal/benches/rs_frompath.rs
@@ -24,7 +24,7 @@ use std::{hint::black_box, sync::Arc};
 
 use arrow_array::{ArrayRef, StringArray};
 use arrow_schema::DataType;
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use datafusion_expr::ScalarUDF;
 use sedona_schema::datatypes::SedonaType;
 use sedona_testing::{data::test_raster, testers::ScalarUdfTester};

--- a/rust/sedona-raster-gdal/benches/rs_metadata.rs
+++ b/rust/sedona-raster-gdal/benches/rs_metadata.rs
@@ -21,9 +21,9 @@ use std::{hint::black_box, sync::Arc};
 
 use arrow_array::{ArrayRef, StringArray};
 use arrow_schema::DataType;
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use datafusion_expr::ScalarUDF;
-use sedona_schema::datatypes::{SedonaType, RASTER};
+use sedona_schema::datatypes::{RASTER, SedonaType};
 use sedona_testing::{data::test_raster, testers::ScalarUdfTester};
 
 const SMALL_RASTER_FIXTURES: &[&str] = &[

--- a/rust/sedona-raster-gdal/benches/rs_polygonize.rs
+++ b/rust/sedona-raster-gdal/benches/rs_polygonize.rs
@@ -21,10 +21,10 @@ use std::{hint::black_box, sync::Arc};
 
 use arrow_array::{ArrayRef, Int32Array};
 use arrow_schema::DataType;
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use datafusion_expr::ColumnarValue;
 use datafusion_expr::ScalarUDF;
-use sedona_schema::datatypes::{SedonaType, RASTER};
+use sedona_schema::datatypes::{RASTER, SedonaType};
 use sedona_testing::testers::ScalarUdfTester;
 
 fn raster_array(rows: usize) -> ArrayRef {

--- a/rust/sedona-raster-gdal/benches/rs_resample.rs
+++ b/rust/sedona-raster-gdal/benches/rs_resample.rs
@@ -37,9 +37,9 @@ use std::sync::Arc;
 
 use arrow_array::{ArrayRef, BooleanArray, Float64Array, StringArray};
 use arrow_schema::DataType;
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use datafusion_expr::ScalarUDF;
-use sedona_schema::datatypes::{SedonaType, RASTER};
+use sedona_schema::datatypes::{RASTER, SedonaType};
 use sedona_testing::{raster_spec::RasterSpec, testers::ScalarUdfTester};
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/rust/sedona-raster-gdal/benches/rs_tile.rs
+++ b/rust/sedona-raster-gdal/benches/rs_tile.rs
@@ -36,9 +36,9 @@ use std::sync::Arc;
 
 use arrow_array::{ArrayRef, BooleanArray, Float64Array, Int32Array};
 use arrow_schema::DataType;
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use datafusion_expr::ScalarUDF;
-use sedona_schema::datatypes::{SedonaType, RASTER};
+use sedona_schema::datatypes::{RASTER, SedonaType};
 use sedona_testing::{raster_spec::RasterSpec, testers::ScalarUdfTester};
 
 fn udf() -> ScalarUDF {

--- a/rust/sedona-raster-gdal/benches/rs_zonalstats.rs
+++ b/rust/sedona-raster-gdal/benches/rs_zonalstats.rs
@@ -43,9 +43,9 @@
 use std::sync::Arc;
 
 use arrow_array::{ArrayRef, BinaryArray, BooleanArray, Int64Array, StringArray};
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use datafusion_expr::ScalarUDF;
-use sedona_schema::datatypes::{SedonaType, RASTER, WKB_GEOMETRY};
+use sedona_schema::datatypes::{RASTER, SedonaType, WKB_GEOMETRY};
 use sedona_testing::{
     benchmark_util::BenchmarkArgSpec, create::make_wkb, raster_spec::RasterSpec,
     testers::ScalarUdfTester,

--- a/rust/sedona-raster-gdal/src/gdal_common.rs
+++ b/rust/sedona-raster-gdal/src/gdal_common.rs
@@ -25,10 +25,10 @@ use sedona_gdal::raster::types::DatasetOptions;
 use sedona_gdal::raster::types::GdalDataType;
 use sedona_raster::geo_transform::GeoTransform;
 
-use sedona_raster::traits::{is_spatial_dim_pair, RasterRef};
+use sedona_raster::traits::{RasterRef, is_spatial_dim_pair};
 use sedona_schema::raster::BandDataType;
 
-use datafusion_common::{exec_datafusion_err, exec_err, DataFusionError, Result};
+use datafusion_common::{DataFusionError, Result, exec_datafusion_err, exec_err};
 
 /// Execute a closure with a reference to the global [`Gdal`] handle,
 /// converting initialization errors to [`DataFusionError`].
@@ -583,7 +583,7 @@ mod tests {
     use crate::utils::Grid;
     use sedona_raster::array::RasterStructArray;
     use sedona_raster::builder::{RasterBuilder, StartBandArgs};
-    use sedona_testing::rasters::{build_in_db_raster, InDbTestBand};
+    use sedona_testing::rasters::{InDbTestBand, build_in_db_raster};
 
     fn single_raster<'a>(
         raster_array: &'a arrow_array::StructArray,
@@ -607,9 +607,11 @@ mod tests {
     }
 
     fn assert_wgs84_projection(dataset: &Dataset) {
-        assert!(dataset
-            .projection()
-            .contains("AUTHORITY[\"EPSG\",\"4326\"]"));
+        assert!(
+            dataset
+                .projection()
+                .contains("AUTHORITY[\"EPSG\",\"4326\"]")
+        );
     }
 
     #[test]
@@ -711,9 +713,11 @@ mod tests {
         let err = bytes_to_f64(&val.to_le_bytes(), &BandDataType::Int64)
             .err()
             .unwrap();
-        assert!(err
-            .to_string()
-            .contains("Cannot convert Int64 nodata value to f64 without potential precision loss"));
+        assert!(
+            err.to_string().contains(
+                "Cannot convert Int64 nodata value to f64 without potential precision loss"
+            )
+        );
 
         // Float32
         let val: f32 = -9999.0;

--- a/rust/sedona-raster-gdal/src/gdal_dataset_provider.rs
+++ b/rust/sedona-raster-gdal/src/gdal_dataset_provider.rs
@@ -19,7 +19,7 @@ use std::convert::TryInto;
 use std::{cell::RefCell, marker::PhantomData, num::NonZeroUsize, rc::Rc};
 
 use datafusion_common::config::ConfigOptions;
-use datafusion_common::{exec_datafusion_err, exec_err, DataFusionError, Result};
+use datafusion_common::{DataFusionError, Result, exec_datafusion_err, exec_err};
 
 use sedona_gdal::dataset::Dataset;
 use sedona_gdal::gdal::Gdal;
@@ -28,7 +28,7 @@ use sedona_raster::error::RasterResultExt;
 use sedona_raster::geo_transform::{GeoTransform, GeoTransformEx};
 
 use sedona_common::SedonaOptions;
-use sedona_raster::traits::{split_outdb_band_fragment, RasterRef};
+use sedona_raster::traits::{RasterRef, split_outdb_band_fragment};
 use sedona_schema::raster::BandDataType;
 
 use crate::gdal_common::{
@@ -556,7 +556,8 @@ fn compute_vrt_simple_source_windows(
     {
         return exec_err!(
             "Out-db raster is not aligned with target raster (geotransform mismatch): dst={:?} src={:?}",
-            dst_gt, src_gt
+            dst_gt,
+            src_gt
         );
     }
 
@@ -613,7 +614,7 @@ mod tests {
     use sedona_raster::array::RasterStructArray;
     use sedona_raster::builder::{RasterBuilder, StartBandArgs};
     use sedona_schema::raster::BandDataType;
-    use sedona_testing::rasters::{build_in_db_raster, InDbTestBand};
+    use sedona_testing::rasters::{InDbTestBand, build_in_db_raster};
     use tempfile::TempDir;
 
     use crate::gdal_common::with_gdal;

--- a/rust/sedona-raster-gdal/src/lib.rs
+++ b/rust/sedona-raster-gdal/src/lib.rs
@@ -49,10 +49,10 @@ mod utils;
 
 // Re-export main dataset conversion functions
 pub use gdal_common::{
-    band_data_type_to_gdal, bytes_to_f64, gdal_to_band_data_type, gdal_type_byte_size,
-    nodata_bytes_to_f64, nodata_f64_to_bytes, GdalBandLayout, GdalBandPlan,
+    GdalBandLayout, GdalBandPlan, band_data_type_to_gdal, bytes_to_f64, gdal_to_band_data_type,
+    gdal_type_byte_size, nodata_bytes_to_f64, nodata_f64_to_bytes,
 };
-pub use raster_loader::{GdalLoader, GDAL_FORMAT};
+pub use raster_loader::{GDAL_FORMAT, GdalLoader};
 pub use rs_as_geotiff::rs_as_geotiff_udf;
 pub use rs_as_raster::rs_as_raster_udf;
 pub use rs_clip::rs_clip_udf;

--- a/rust/sedona-raster-gdal/src/raster_loader.rs
+++ b/rust/sedona-raster-gdal/src/raster_loader.rs
@@ -58,8 +58,8 @@
 //! it during session bootstrap.
 
 use std::iter::zip;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use arrow_buffer::Buffer;
 use arrow_schema::ArrowError;

--- a/rust/sedona-raster-gdal/src/rs_as_geotiff.rs
+++ b/rust/sedona-raster-gdal/src/rs_as_geotiff.rs
@@ -25,8 +25,8 @@
 //! - RS_AsGeoTiff(raster, compressionType, imageQuality, tileWidth, tileHeight)
 
 use std::ptr::NonNull;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::gdal_common::with_gdal;
 use arrow_array::builder::BinaryViewBuilder;
@@ -35,7 +35,7 @@ use arrow_schema::DataType;
 use datafusion_common::cast::{as_float64_array, as_string_array, as_uint32_array};
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::error::Result;
-use datafusion_common::{exec_datafusion_err, exec_err, ScalarValue};
+use datafusion_common::{ScalarValue, exec_datafusion_err, exec_err};
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_gdal::vsi::VSIBuffer;
@@ -49,7 +49,7 @@ use sedona_schema::raster::BandDataType;
 
 // Use thread-local provider to create GDAL datasets from `RasterRef`.
 use crate::gdal_dataset_provider::{
-    configure_thread_local_options, thread_local_provider, GDALDatasetProvider,
+    GDALDatasetProvider, configure_thread_local_options, thread_local_provider,
 };
 
 /// Counter for generating unique VSI memory file names
@@ -171,10 +171,10 @@ impl RsAsGeoTiff {
             options_list.push(format!("COMPRESS={}", comp.gdal_value()));
 
             // Add quality for JPEG
-            if comp == CompressionType::Jpeg {
-                if let Some(q) = jpeg_quality {
-                    options_list.push(format!("JPEG_QUALITY={}", q));
-                }
+            if comp == CompressionType::Jpeg
+                && let Some(q) = jpeg_quality
+            {
+                options_list.push(format!("JPEG_QUALITY={}", q));
             }
 
             // Add a predictor for Deflate/LZW (improves compression): horizontal

--- a/rust/sedona-raster-gdal/src/rs_as_raster.rs
+++ b/rust/sedona-raster-gdal/src/rs_as_raster.rs
@@ -24,7 +24,7 @@ use arrow_schema::DataType;
 use datafusion_common::cast::{as_boolean_array, as_float64_array, as_string_array};
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::error::Result;
-use datafusion_common::{exec_datafusion_err, exec_err, ScalarValue};
+use datafusion_common::{ScalarValue, exec_datafusion_err, exec_err};
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_common::SedonaOptions;
 use sedona_expr::{
@@ -40,10 +40,10 @@ use sedona_raster::builder::RasterBuilder;
 use sedona_raster::error::RasterResultExt;
 use sedona_raster::traits::RasterRef;
 use sedona_raster_functions::{
-    crs_utils::{align_wkb_to_crs, resolve_crs},
     RasterExecutor,
+    crs_utils::{align_wkb_to_crs, resolve_crs},
 };
-use sedona_schema::datatypes::{SedonaType, RASTER};
+use sedona_schema::datatypes::{RASTER, SedonaType};
 use sedona_schema::matchers::ArgMatcher;
 use sedona_schema::raster::BandDataType;
 
@@ -638,7 +638,7 @@ mod tests {
     use sedona_schema::datatypes::RASTER;
     use sedona_schema::datatypes::WKB_GEOMETRY;
     use sedona_schema::raster::BandDataType;
-    use sedona_testing::raster_spec::{assert_rasters_equal, RasterSpec};
+    use sedona_testing::raster_spec::{RasterSpec, assert_rasters_equal};
     use sedona_testing::{
         create::{create_array, create_array_item_crs, make_wkb},
         testers::ScalarUdfTester,

--- a/rust/sedona-raster-gdal/src/rs_clip.rs
+++ b/rust/sedona-raster-gdal/src/rs_clip.rs
@@ -25,11 +25,11 @@
 use std::sync::Arc;
 
 use arrow_array::ArrayRef;
+use datafusion_common::ScalarValue;
 use datafusion_common::cast::{as_boolean_array, as_float64_array, as_int32_array};
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::error::Result;
 use datafusion_common::exec_err;
-use datafusion_common::ScalarValue;
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_common::sedona_internal_err;
 use sedona_gdal::gdal::Gdal;
@@ -39,20 +39,20 @@ use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_raster::array::RasterRefImpl;
 use sedona_raster::builder::RasterBuilder;
 use sedona_raster::error::RasterResultExt;
-use sedona_raster::traits::{is_spatial_dim_pair, RasterRef};
+use sedona_raster::traits::{RasterRef, is_spatial_dim_pair};
+use sedona_raster_functions::RasterExecutor;
 use sedona_raster_functions::crs_utils::{crs_transform_wkb, resolve_crs, with_crs_engine};
 use sedona_raster_functions::rs_ensure_loaded::{
     NEEDS_PIXELS_METADATA_KEY, RETURNS_BYTES_METADATA_KEY,
 };
-use sedona_raster_functions::RasterExecutor;
-use sedona_schema::datatypes::{SedonaType, RASTER};
+use sedona_schema::datatypes::{RASTER, SedonaType};
 use sedona_schema::matchers::ArgMatcher;
 use sedona_schema::raster::BandDataType;
 
 use crate::gdal_common::{raster_geo_transform, with_gdal};
 use crate::gdal_dataset_provider::configure_thread_local_options;
-use crate::mask::{envelope_window, rasterize_geometry_mask, PixelWindow};
-use crate::utils::{append_band_from_buffer, BandHeader};
+use crate::mask::{PixelWindow, envelope_window, rasterize_geometry_mask};
+use crate::utils::{BandHeader, append_band_from_buffer};
 use sedona_raster::traits::nodata_f64_to_bytes;
 
 /// RS_Clip() scalar UDF implementation
@@ -747,16 +747,16 @@ fn build_clipped_raster(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_array::{cast::AsArray, StructArray};
+    use arrow_array::{StructArray, cast::AsArray};
     use sedona_expr::scalar_udf::SedonaScalarKernel;
     use sedona_proj::error::SedonaProjError;
-    use sedona_proj::transform::{with_global_proj_engine, LazyProjEngine};
+    use sedona_proj::transform::{LazyProjEngine, with_global_proj_engine};
     use sedona_raster::array::RasterStructArray;
     use sedona_schema::crs::deserialize_crs;
     use sedona_schema::datatypes::Edges;
     use sedona_testing::create::make_wkb;
     use sedona_testing::raster_spec::{
-        assert_raster_scalar_equals, assert_rasters_equal, raster_array, RasterSpec,
+        RasterSpec, assert_raster_scalar_equals, assert_rasters_equal, raster_array,
     };
     use sedona_testing::testers::ScalarUdfTester;
 

--- a/rust/sedona-raster-gdal/src/rs_from_gdal_raster.rs
+++ b/rust/sedona-raster-gdal/src/rs_from_gdal_raster.rs
@@ -20,14 +20,14 @@
 //! Similar to PostGIS's ST_FromGDALRaster. Parses binary content using GDAL driver
 //! and loads it as an in-db raster with all band data stored inline.
 
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
-use arrow_array::{cast::AsArray, Array};
+use arrow_array::{Array, cast::AsArray};
 use arrow_schema::DataType;
+use datafusion_common::ScalarValue;
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::error::Result;
-use datafusion_common::ScalarValue;
 use datafusion_expr::{ColumnarValue, Volatility};
 use sedona_common::sedona_internal_err;
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
@@ -37,7 +37,7 @@ use sedona_gdal::raster::types::DatasetOptions;
 use sedona_raster::builder::RasterBuilder;
 use sedona_raster::error::RasterResultExt;
 use sedona_raster_functions::rs_ensure_loaded::RETURNS_BYTES_METADATA_KEY;
-use sedona_schema::datatypes::{SedonaType, RASTER};
+use sedona_schema::datatypes::{RASTER, SedonaType};
 use sedona_schema::matchers::ArgMatcher;
 
 use crate::gdal_common::{convert_gdal_err, with_gdal};
@@ -182,7 +182,7 @@ impl SedonaScalarKernel for RsFromGDALRaster {
                 other => {
                     return sedona_internal_err!(
                         "RS_FromGDALRaster expected Binary or BinaryView content, got {other:?}"
-                    )
+                    );
                 }
             }
             let result = builder.finish().context("Failed to build raster")?;
@@ -205,7 +205,7 @@ mod tests {
     use sedona_raster::array::RasterStructArray;
     use sedona_schema::datatypes::RASTER;
     use sedona_testing::raster_spec::{
-        assert_raster_scalar_equals, assert_rasters_equal, RasterSpec,
+        RasterSpec, assert_raster_scalar_equals, assert_rasters_equal,
     };
     use sedona_testing::testers::ScalarUdfTester;
 

--- a/rust/sedona-raster-gdal/src/rs_frompath.rs
+++ b/rust/sedona-raster-gdal/src/rs_frompath.rs
@@ -29,7 +29,7 @@ use sedona_common::sedona_internal_err;
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_functions::executor::WkbBytesExecutor;
 use sedona_raster::builder::RasterBuilder;
-use sedona_schema::datatypes::{SedonaType, RASTER};
+use sedona_schema::datatypes::{RASTER, SedonaType};
 use sedona_schema::matchers::ArgMatcher;
 
 use crate::gdal_common::with_gdal;
@@ -96,8 +96,8 @@ impl SedonaScalarKernel for RsFromPath {
 mod tests {
     use super::*;
     use arrow_array::{StringArray, StructArray};
-    use datafusion_common::cast::as_struct_array;
     use datafusion_common::ScalarValue;
+    use datafusion_common::cast::as_struct_array;
     use datafusion_expr::ScalarUDFImpl;
     use sedona_raster::array::RasterStructArray;
     use sedona_raster::traits::RasterRef;

--- a/rust/sedona-raster-gdal/src/rs_metadata.rs
+++ b/rust/sedona-raster-gdal/src/rs_metadata.rs
@@ -17,10 +17,10 @@
 
 use std::sync::Arc;
 
+use arrow_array::StructArray;
 use arrow_array::builder::{
     Float64Builder, Int32Builder, Int64Builder, UInt32Builder, UInt64Builder,
 };
-use arrow_array::StructArray;
 use arrow_buffer::NullBufferBuilder;
 use arrow_schema::{DataType, Field, Fields};
 use datafusion_common::config::ConfigOptions;
@@ -205,8 +205,8 @@ impl SedonaScalarKernel for RsMetaData {
 mod tests {
     use super::*;
     use arrow_array::{
-        cast::AsArray, types::Float64Type, types::Int32Type, types::Int64Type, types::UInt32Type,
-        types::UInt64Type, Array,
+        Array, cast::AsArray, types::Float64Type, types::Int32Type, types::Int64Type,
+        types::UInt32Type, types::UInt64Type,
     };
     use datafusion_common::ScalarValue;
     use datafusion_expr::ScalarUDF;
@@ -215,7 +215,7 @@ mod tests {
     use sedona_schema::datatypes::RASTER;
     use sedona_schema::raster::BandDataType;
     use sedona_testing::{
-        rasters::{build_in_db_raster, generate_multi_band_raster, InDbTestBand},
+        rasters::{InDbTestBand, build_in_db_raster, generate_multi_band_raster},
         testers::ScalarUdfTester,
     };
     use tempfile::TempDir;

--- a/rust/sedona-raster-gdal/src/rs_polygonize.rs
+++ b/rust/sedona-raster-gdal/src/rs_polygonize.rs
@@ -43,7 +43,7 @@ use sedona_schema::matchers::ArgMatcher;
 
 use crate::gdal_common::with_gdal;
 use crate::gdal_dataset_provider::{
-    configure_thread_local_options, thread_local_provider, RasterDataset,
+    RasterDataset, configure_thread_local_options, thread_local_provider,
 };
 
 pub fn rs_polygonize_udf() -> SedonaScalarUDF {
@@ -302,15 +302,15 @@ mod tests {
     use super::*;
 
     use arrow_array::Array;
+    use datafusion_common::ScalarValue;
     use datafusion_common::cast::{
         as_float64_array, as_list_array, as_string_view_array, as_struct_array,
     };
-    use datafusion_common::ScalarValue;
     use datafusion_expr::{ScalarUDF, ScalarUDFImpl};
     use sedona_gdal::raster::types::Buffer;
     use sedona_raster::array::RasterStructArray;
     use sedona_schema::datatypes::RASTER;
-    use sedona_testing::raster_spec::{raster_array, RasterSpec};
+    use sedona_testing::raster_spec::{RasterSpec, raster_array};
     use sedona_testing::testers::ScalarUdfTester;
     use tempfile::tempdir;
 

--- a/rust/sedona-raster-gdal/src/rs_reproject_match.rs
+++ b/rust/sedona-raster-gdal/src/rs_reproject_match.rs
@@ -39,28 +39,28 @@ use arrow_schema::DataType;
 use datafusion_common::cast::as_string_view_array;
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::error::Result;
-use datafusion_common::{exec_err, ScalarValue};
+use datafusion_common::{ScalarValue, exec_err};
 use datafusion_expr::{ColumnarValue, Volatility};
 
-use sedona_common::{sedona_internal_err, SedonaOptions};
+use sedona_common::{SedonaOptions, sedona_internal_err};
 use sedona_expr::scalar_udf::{SedonaScalarKernel, SedonaScalarUDF};
 use sedona_gdal::raster::types::ResampleAlg;
 use sedona_raster::array::RasterRefImpl;
 use sedona_raster::builder::RasterBuilder;
 use sedona_raster::geo_transform::GeoTransform;
 use sedona_raster::traits::RasterRef;
+use sedona_raster_functions::RasterExecutor;
 use sedona_raster_functions::rs_ensure_loaded::{
     NEEDS_PIXELS_METADATA_KEY, RETURNS_BYTES_METADATA_KEY,
 };
-use sedona_raster_functions::RasterExecutor;
-use sedona_schema::datatypes::{SedonaType, RASTER};
+use sedona_schema::datatypes::{RASTER, SedonaType};
 use sedona_schema::matchers::ArgMatcher;
 
-use crate::gdal_common::{raster_ref_to_gdal_mem, with_gdal, GdalBandLayout};
+use crate::gdal_common::{GdalBandLayout, raster_ref_to_gdal_mem, with_gdal};
 use crate::gdal_dataset_provider::configure_thread_local_options;
 use crate::utils::{
-    append_warped_nd_from_dataset, parse_resample_algorithm, reject_lossy_resample_dtypes, Grid,
-    OutputGrid,
+    Grid, OutputGrid, append_warped_nd_from_dataset, parse_resample_algorithm,
+    reject_lossy_resample_dtypes,
 };
 
 /// RS_ReprojectMatch() scalar UDF implementation.
@@ -293,7 +293,7 @@ fn reproject_match(
 mod tests {
     use super::*;
     use sedona_testing::raster_spec::{
-        assert_raster_scalar_equals, assert_rasters_equal, raster_array, RasterSpec,
+        RasterSpec, assert_raster_scalar_equals, assert_rasters_equal, raster_array,
     };
     use sedona_testing::testers::ScalarUdfTester;
 

--- a/rust/sedona-raster-gdal/src/rs_resample.rs
+++ b/rust/sedona-raster-gdal/src/rs_resample.rs
@@ -57,19 +57,19 @@ use sedona_raster::array::RasterRefImpl;
 use sedona_raster::builder::RasterBuilder;
 use sedona_raster::geo_transform::{GeoTransform, GeoTransformEx};
 use sedona_raster::traits::RasterRef;
+use sedona_raster_functions::RasterExecutor;
 use sedona_raster_functions::crs_utils::{crs_transform_required, resolve_crs};
 use sedona_raster_functions::rs_ensure_loaded::{
     NEEDS_PIXELS_METADATA_KEY, RETURNS_BYTES_METADATA_KEY,
 };
-use sedona_raster_functions::RasterExecutor;
-use sedona_schema::datatypes::{SedonaType, RASTER};
+use sedona_schema::datatypes::{RASTER, SedonaType};
 use sedona_schema::matchers::ArgMatcher;
 
-use crate::gdal_common::{raster_ref_to_gdal_mem, with_gdal, GdalBandLayout};
+use crate::gdal_common::{GdalBandLayout, raster_ref_to_gdal_mem, with_gdal};
 use crate::gdal_dataset_provider::configure_thread_local_options;
 use crate::utils::{
-    append_resampled_nd_from_dataset, append_warped_nd_from_dataset, parse_resample_algorithm,
-    reject_lossy_resample_dtypes, Grid, OutputGrid,
+    Grid, OutputGrid, append_resampled_nd_from_dataset, append_warped_nd_from_dataset,
+    parse_resample_algorithm, reject_lossy_resample_dtypes,
 };
 
 /// RS_Resample() scalar UDF implementation.
@@ -670,7 +670,7 @@ mod tests {
     use datafusion_common::ScalarValue;
     use sedona_raster::array::RasterStructArray;
     use sedona_testing::raster_spec::{
-        assert_raster_scalar_equals, assert_rasters_equal, raster_array, RasterSpec,
+        RasterSpec, assert_raster_scalar_equals, assert_rasters_equal, raster_array,
     };
     use sedona_testing::testers::ScalarUdfTester;
 

--- a/rust/sedona-raster-gdal/src/rs_tile.rs
+++ b/rust/sedona-raster-gdal/src/rs_tile.rs
@@ -36,7 +36,7 @@ use arrow_schema::{DataType, Field, Fields};
 use datafusion_common::cast::{as_boolean_array, as_float64_array, as_int64_array, as_list_array};
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::error::Result;
-use datafusion_common::{exec_datafusion_err, exec_err, ScalarValue};
+use datafusion_common::{ScalarValue, exec_datafusion_err, exec_err};
 use datafusion_expr::{ColumnarValue, Volatility};
 
 use sedona_common::sedona_internal_err;
@@ -45,12 +45,12 @@ use sedona_raster::array::RasterRefImpl;
 use sedona_raster::builder::RasterBuilder;
 use sedona_raster::error::RasterResultExt;
 use sedona_raster::geo_transform::{GeoTransform, GeoTransformEx};
-use sedona_raster::traits::{is_spatial_dim_pair, nodata_f64_to_bytes, RasterRef};
-use sedona_raster_functions::rs_ensure_loaded::NEEDS_PIXELS_METADATA_KEY;
+use sedona_raster::traits::{RasterRef, is_spatial_dim_pair, nodata_f64_to_bytes};
 use sedona_raster_functions::RasterExecutor;
+use sedona_raster_functions::rs_ensure_loaded::NEEDS_PIXELS_METADATA_KEY;
 
-use crate::utils::{append_stacked_band, BandHeader};
-use sedona_schema::datatypes::{SedonaType, RASTER};
+use crate::utils::{BandHeader, append_stacked_band};
+use sedona_schema::datatypes::{RASTER, SedonaType};
 use sedona_schema::matchers::{ArgMatcher, TypeMatcher};
 
 /// RS_Tile() scalar UDF implementation.
@@ -779,7 +779,7 @@ mod tests {
     use datafusion_expr::ScalarUDF;
     use sedona_raster::array::RasterStructArray;
     use sedona_schema::datatypes::RASTER;
-    use sedona_testing::raster_spec::{assert_rasters_equal, raster_array, RasterSpec};
+    use sedona_testing::raster_spec::{RasterSpec, assert_rasters_equal, raster_array};
     use sedona_testing::testers::ScalarUdfTester;
 
     /// The optional tiling parameters for the core-tiling helper tests.

--- a/rust/sedona-raster-gdal/src/rs_zonal_stats.rs
+++ b/rust/sedona-raster-gdal/src/rs_zonal_stats.rs
@@ -57,7 +57,7 @@ use arrow_schema::{DataType, Field, Fields};
 use datafusion_common::cast::{as_boolean_array, as_int64_array, as_string_array};
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::error::Result;
-use datafusion_common::{exec_datafusion_err, exec_err, ScalarValue};
+use datafusion_common::{ScalarValue, exec_datafusion_err, exec_err};
 use datafusion_expr::{ColumnarValue, Volatility};
 
 use sedona_common::sedona_internal_err;
@@ -66,17 +66,17 @@ use sedona_gdal::gdal::Gdal;
 use sedona_raster::array::RasterRefImpl;
 use sedona_raster::error::RasterResultExt;
 use sedona_raster::traits::RasterRef;
+use sedona_raster_functions::RasterExecutor;
 use sedona_raster_functions::crs_utils::{align_wkb_to_crs, resolve_crs, with_crs_engine};
 use sedona_raster_functions::rs_ensure_loaded::NEEDS_PIXELS_METADATA_KEY;
 use sedona_raster_functions::rs_spatial_predicates::raster_intersects_geom_wkb;
-use sedona_raster_functions::RasterExecutor;
 use sedona_schema::datatypes::SedonaType;
 use sedona_schema::matchers::ArgMatcher;
 use sedona_schema::raster::BandDataType;
 
 use crate::gdal_common::{raster_geo_transform, with_gdal};
 use crate::gdal_dataset_provider::configure_thread_local_options;
-use crate::mask::{envelope_window, rasterize_geometry_mask, PixelWindow};
+use crate::mask::{PixelWindow, envelope_window, rasterize_geometry_mask};
 
 /// The statistics RS_ZonalStatsAll returns, in the order Sedona Spark reports
 /// them. RS_ZonalStats selects one of these by name.
@@ -745,13 +745,13 @@ fn collect_zonal_values(
     } else {
         None
     };
-    if let Some(nd) = nodata {
-        if nd.len() != byte_size {
-            return sedona_internal_err!(
-                "RS_ZonalStats: band {band_num} nodata is {} bytes, expected {byte_size} for {data_type:?}",
-                nd.len()
-            );
-        }
+    if let Some(nd) = nodata
+        && nd.len() != byte_size
+    {
+        return sedona_internal_err!(
+            "RS_ZonalStats: band {band_num} nodata is {} bytes, expected {byte_size} for {data_type:?}",
+            nd.len()
+        );
     }
 
     scratch.clear();
@@ -1139,14 +1139,18 @@ mod tests {
         assert!(err.contains("has 3 bands"), "{err}");
         // Explicit band is range-checked (1-based).
         assert_eq!(resolve_band(Some(2), 3).unwrap(), 2);
-        assert!(resolve_band(Some(0), 3)
-            .unwrap_err()
-            .to_string()
-            .contains(">= 1"));
-        assert!(resolve_band(Some(4), 3)
-            .unwrap_err()
-            .to_string()
-            .contains("out of range"));
+        assert!(
+            resolve_band(Some(0), 3)
+                .unwrap_err()
+                .to_string()
+                .contains(">= 1")
+        );
+        assert!(
+            resolve_band(Some(4), 3)
+                .unwrap_err()
+                .to_string()
+                .contains("out of range")
+        );
     }
 
     #[test]
@@ -1276,7 +1280,7 @@ mod udf_tests {
     use arrow_array::{Array, StructArray};
     use datafusion_expr::ScalarUDF;
     use sedona_proj::error::SedonaProjError;
-    use sedona_proj::transform::{with_global_proj_engine, LazyProjEngine};
+    use sedona_proj::transform::{LazyProjEngine, with_global_proj_engine};
     use sedona_raster_functions::crs_utils::crs_transform_wkb;
     use sedona_schema::crs::deserialize_crs;
     use sedona_schema::datatypes::{Edges, RASTER};

--- a/rust/sedona-raster-gdal/src/utils.rs
+++ b/rust/sedona-raster-gdal/src/utils.rs
@@ -39,8 +39,8 @@ use sedona_raster::traits::RasterRef;
 use sedona_schema::raster::BandDataType;
 
 use crate::gdal_common::{
-    add_layout_datapointer_bands, band_nodata_to_bytes, convert_gdal_err, gdal_to_band_data_type,
-    normalize_outdb_source_path, set_band_nodata_from_bytes, GdalBandLayout,
+    GdalBandLayout, add_layout_datapointer_bands, band_nodata_to_bytes, convert_gdal_err,
+    gdal_to_band_data_type, normalize_outdb_source_path, set_band_nodata_from_bytes,
 };
 
 /// Append a GDAL dataset as a single in-db raster to the provided [`RasterBuilder`].
@@ -737,8 +737,8 @@ pub fn gdal_dataset_to_nd_raster(
 #[cfg(test)]
 mod tests {
     use super::{
-        append_as_indb_raster, append_as_outdb_raster, append_stacked_band, dataset_to_indb_raster,
-        BandHeader,
+        BandHeader, append_as_indb_raster, append_as_outdb_raster, append_stacked_band,
+        dataset_to_indb_raster,
     };
 
     use arrow_array::StructArray;


### PR DESCRIPTION
Migrates sedona-raster-gdal independently to Rust 2024 as part of #258. Applies standard formatter output and Rust 2024 let chains. Validated with 201 package tests, all-target checks, and Clippy with warnings denied.