### PR TITLE
chore(rust/sedona-raster-zarr): migrate to Rust 2024 edition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
       - id: fmt
         name: rustfmt
         args: ["--all", "--"]
+        pass_filenames: false
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13

--- a/rust/sedona-raster-zarr/Cargo.toml
+++ b/rust/sedona-raster-zarr/Cargo.toml
@@ -24,7 +24,7 @@ homepage.workspace = true
 repository.workspace = true
 description.workspace = true
 readme.workspace = true
-edition.workspace = true
+edition = "2024"
 rust-version.workspace = true
 
 [lints.clippy]

--- a/rust/sedona-raster-zarr/src/coords.rs
+++ b/rust/sedona-raster-zarr/src/coords.rs
@@ -30,8 +30,8 @@
 use arrow_schema::ArrowError;
 use sedona_common::sedona_internal_datafusion_err;
 use zarrs::array::data_type::{
-    Float32DataType, Float64DataType, Int16DataType, Int32DataType, Int64DataType, Int8DataType,
-    UInt16DataType, UInt32DataType, UInt64DataType, UInt8DataType,
+    Float32DataType, Float64DataType, Int8DataType, Int16DataType, Int32DataType, Int64DataType,
+    UInt8DataType, UInt16DataType, UInt32DataType, UInt64DataType,
 };
 use zarrs::array::{Array, ArraySubset};
 use zarrs::storage::AsyncReadableListableStorage;

--- a/rust/sedona-raster-zarr/src/dtype.rs
+++ b/rust/sedona-raster-zarr/src/dtype.rs
@@ -23,11 +23,11 @@
 
 use arrow_schema::ArrowError;
 use sedona_schema::raster::BandDataType;
-use zarrs::array::data_type::{
-    BoolDataType, Float32DataType, Float64DataType, Int16DataType, Int32DataType, Int64DataType,
-    Int8DataType, UInt16DataType, UInt32DataType, UInt64DataType, UInt8DataType,
-};
 use zarrs::array::DataType as ZarrDataType;
+use zarrs::array::data_type::{
+    BoolDataType, Float32DataType, Float64DataType, Int8DataType, Int16DataType, Int32DataType,
+    Int64DataType, UInt8DataType, UInt16DataType, UInt32DataType, UInt64DataType,
+};
 
 /// Map a Zarr `DataType` to a SedonaDB `BandDataType`.
 ///

--- a/rust/sedona-raster-zarr/src/lib.rs
+++ b/rust/sedona-raster-zarr/src/lib.rs
@@ -35,5 +35,5 @@ mod raster_loader;
 mod source_uri;
 
 pub use loader::ZarrChunkReader;
-pub use raster_loader::{ZarrLoader, ZARR_FORMAT};
+pub use raster_loader::{ZARR_FORMAT, ZarrLoader};
 pub use source_uri::{object_store_for_uri, open_storage_from_uri};

--- a/rust/sedona-raster-zarr/src/loader.rs
+++ b/rust/sedona-raster-zarr/src/loader.rs
@@ -43,7 +43,7 @@ use zarrs::storage::{AsyncReadableListableStorage, AsyncReadableListableStorageT
 
 use crate::coords;
 use crate::dtype::zarr_to_band_data_type;
-use crate::geozarr::{crs_from_cf_attributes, geotransform_from_cf_attributes, GroupGeoMetadata};
+use crate::geozarr::{GroupGeoMetadata, crs_from_cf_attributes, geotransform_from_cf_attributes};
 use crate::source_uri::build_chunk_anchor;
 
 /// Streaming reader over the chunk grid of a Zarr group.
@@ -461,13 +461,13 @@ fn transform_from_bbox(
             // Mirror the coordinate-array path: when the group declares no CRS,
             // infer a geographic one from the spatial dim names (lat/lon).
             // Generic y/x stay CRS-less (attach via RS_SetCRS).
-            if geo.crs.is_none() {
-                if let Some(inferred) = coords::infer_geographic_crs(
+            if geo.crs.is_none()
+                && let Some(inferred) = coords::infer_geographic_crs(
                     &array_infos[0].dim_names[y_axis],
                     &array_infos[0].dim_names[x_axis],
-                ) {
-                    geo.crs = Some(inferred.to_string());
-                }
+                )
+            {
+                geo.crs = Some(inferred.to_string());
             }
             log::debug!(
                 "Zarr group at {group_uri} has no `spatial:transform`; derived a \
@@ -1017,8 +1017,8 @@ mod tests {
     use super::*;
     use std::sync::Arc;
     use tempfile::TempDir;
-    use zarrs::array::data_type;
     use zarrs::array::ArrayBuilder;
+    use zarrs::array::data_type;
     use zarrs_filesystem::FilesystemStore;
 
     /// Direct coverage for `retrieve_chunk_bytes`. The function is the
@@ -1098,7 +1098,7 @@ mod tests {
         // y_axis=0, x_axis=1 → x_off=2*2=4, y_off=1*2=2
         assert_eq!(t[0], 10.0 + 4.0); // origin_x
         assert_eq!(t[3], 20.0 - 2.0); // origin_y after y_off=2 with sy=-1
-                                      // Scale/skew carry through unchanged.
+        // Scale/skew carry through unchanged.
         assert_eq!(t[1], 1.0);
         assert_eq!(t[2], 0.0);
         assert_eq!(t[4], 0.0);

--- a/rust/sedona-raster-zarr/src/raster_loader.rs
+++ b/rust/sedona-raster-zarr/src/raster_loader.rs
@@ -48,7 +48,7 @@ use std::hash::Hash;
 use arrow_buffer::Buffer;
 use arrow_schema::ArrowError;
 use async_trait::async_trait;
-use futures::{stream, StreamExt, TryStreamExt};
+use futures::{StreamExt, TryStreamExt, stream};
 use sedona_common::sedona_internal_datafusion_err;
 use sedona_raster::raster_loader::{AsyncRasterLoader, RasterLoadRequest, RasterLoadResult};
 use zarrs::array::{Array, ArrayBytes};
@@ -302,7 +302,7 @@ mod tests {
     use sedona_schema::raster::BandDataType;
     use tempfile::TempDir;
     use zarrs::array::ArrayBuilder;
-    use zarrs::array::{data_type as zarr_dtype, FillValue};
+    use zarrs::array::{FillValue, data_type as zarr_dtype};
     use zarrs::group::GroupBuilder;
     use zarrs_filesystem::FilesystemStore;
 

--- a/rust/sedona-raster-zarr/src/source_uri.rs
+++ b/rust/sedona-raster-zarr/src/source_uri.rs
@@ -40,9 +40,9 @@
 use std::sync::Arc;
 
 use arrow_schema::ArrowError;
+use object_store::ObjectStore;
 use object_store::path::Path as ObjectPath;
 use object_store::prefix::PrefixStore;
-use object_store::ObjectStore;
 use url::Url;
 use zarrs::storage::AsyncReadableListableStorage;
 use zarrs_object_store::AsyncObjectStore;

--- a/rust/sedona-raster-zarr/tests/cloud.rs
+++ b/rust/sedona-raster-zarr/tests/cloud.rs
@@ -37,11 +37,11 @@
 
 use std::sync::Arc;
 
+use object_store::ObjectStore;
 use object_store::aws::AmazonS3Builder;
 use object_store::http::HttpBuilder;
-use object_store::ObjectStore;
 use sedona_raster::array::RasterStructArray;
-use sedona_raster_zarr::{open_storage_from_uri, ZarrChunkReader};
+use sedona_raster_zarr::{ZarrChunkReader, open_storage_from_uri};
 
 /// NASA MEaSUREs ITS_LIVE global glacier ice-velocity datacubes — public,
 /// anonymous, in `s3://its-live-data/` (us-west-2). Project and data docs:

--- a/rust/sedona-raster-zarr/tests/zarr_roundtrip.rs
+++ b/rust/sedona-raster-zarr/tests/zarr_roundtrip.rs
@@ -25,12 +25,12 @@
 
 use std::sync::Arc;
 
-use arrow_array::cast::AsArray;
 use arrow_array::StructArray;
+use arrow_array::cast::AsArray;
 use arrow_schema::ArrowError;
 use sedona_raster::array::RasterStructArray;
 use sedona_raster::traits::RasterRef;
-use sedona_raster_zarr::{open_storage_from_uri, ZarrChunkReader};
+use sedona_raster_zarr::{ZarrChunkReader, open_storage_from_uri};
 
 /// Drain a `ZarrChunkReader` into a single `StructArray`. Fixtures in
 /// this file are small (≤8 chunk rows) so they fit in one batch with a
@@ -57,8 +57,8 @@ async fn read_all(uri: &str, arrays: Option<&[String]>) -> Result<StructArray, A
 }
 use sedona_schema::raster::BandDataType;
 use tempfile::TempDir;
-use zarrs::array::data_type;
 use zarrs::array::ArrayBuilder;
+use zarrs::array::data_type;
 use zarrs::group::{Group, GroupBuilder};
 use zarrs::metadata_ext::group::consolidated_metadata::{
     ConsolidatedMetadata, ConsolidatedMetadataKind,


### PR DESCRIPTION
Migrates sedona-raster-zarr independently to Rust 2024 as part of #258. Applies standard formatter output and a Rust 2024 let chain. Validated with 91 passing tests, all-target checks, strict Clippy, and expected ignored cloud tests.