### PR TITLE
chore(rust/sedona-spatial-join-geography): migrate to Rust 2024 edition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
       - id: fmt
         name: rustfmt
         args: ["--all", "--"]
+        pass_filenames: false
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13

--- a/rust/sedona-spatial-join-geography/Cargo.toml
+++ b/rust/sedona-spatial-join-geography/Cargo.toml
@@ -24,7 +24,7 @@ homepage.workspace = true
 repository.workspace = true
 description.workspace = true
 readme.workspace = true
-edition.workspace = true
+edition = "2024"
 rust-version.workspace = true
 
 [dependencies]

--- a/rust/sedona-spatial-join-geography/src/join_provider.rs
+++ b/rust/sedona-spatial-join-geography/src/join_provider.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use arrow_array::{ArrayRef, Float64Array};
 use arrow_schema::DataType;
-use datafusion_common::{exec_datafusion_err, JoinType, Result, ScalarValue};
+use datafusion_common::{JoinType, Result, ScalarValue, exec_datafusion_err};
 use datafusion_physical_plan::ColumnarValue;
 use sedona_common::sedona_internal_err;
 use sedona_expr::statistics::GeoStatistics;
@@ -30,14 +30,14 @@ use sedona_s2geography::{
 };
 use sedona_schema::datatypes::SedonaType;
 use sedona_spatial_join::{
+    SpatialJoinOptions, SpatialPredicate,
     index::{
-        default_spatial_index_builder::DefaultSpatialIndexBuilder,
-        spatial_index_builder::SpatialJoinBuildMetrics, SpatialIndexBuilder,
+        SpatialIndexBuilder, default_spatial_index_builder::DefaultSpatialIndexBuilder,
+        spatial_index_builder::SpatialJoinBuildMetrics,
     },
     join_provider::SpatialJoinProvider,
     operand_evaluator::{EvaluatedGeometryArray, EvaluatedGeometryArrayFactory},
     utils::bounds::Bounds2D,
-    SpatialJoinOptions, SpatialPredicate,
 };
 
 use crate::{

--- a/rust/sedona-spatial-join-geography/src/physical_planner.rs
+++ b/rust/sedona-spatial-join-geography/src/physical_planner.rs
@@ -27,8 +27,8 @@ use sedona_query_planner::{
 };
 use sedona_schema::{datatypes::SedonaType, matchers::ArgMatcher};
 use sedona_spatial_join::{
-    physical_planner::{repartition_probe_side, should_swap_join_order},
     SpatialJoinExec,
+    physical_planner::{repartition_probe_side, should_swap_join_order},
 };
 
 use crate::join_provider::GeographyJoinProvider;

--- a/rust/sedona-spatial-join-geography/src/refiner.rs
+++ b/rust/sedona-spatial-join-geography/src/refiner.rs
@@ -21,22 +21,22 @@
 //! using s2geography, rather than the default Cartesian predicates.
 
 use std::sync::{
-    atomic::{AtomicUsize, Ordering},
     Arc,
+    atomic::{AtomicUsize, Ordering},
 };
 
-use datafusion_common::{exec_datafusion_err, Result};
-use sedona_common::{sedona_internal_err, ExecutionMode, SpatialJoinOptions};
+use datafusion_common::{Result, exec_datafusion_err};
+use sedona_common::{ExecutionMode, SpatialJoinOptions, sedona_internal_err};
 use sedona_expr::statistics::GeoStatistics;
 use sedona_s2geography::{
     geography::{Geography, GeographyFactory},
     operator::{Op, OpType},
 };
 use sedona_spatial_join::{
+    IndexQueryResult, IndexQueryResultRefiner, SpatialPredicate,
     refine::IndexQueryResultRefinerFactory,
     spatial_predicate::{RelationPredicate, SpatialRelationType},
     utils::init_once_array::InitOnceArray,
-    IndexQueryResult, IndexQueryResultRefiner, SpatialPredicate,
 };
 use wkb::reader::Wkb;
 
@@ -66,14 +66,14 @@ impl GeographyRefiner {
                 _ => {
                     return sedona_internal_err!(
                         "GeographyRefiner created with unsupported relation type {relation_type}"
-                    )
+                    );
                 }
             },
             SpatialPredicate::Distance(_) => OpType::DWithin,
             _ => {
                 return sedona_internal_err!(
                     "GeographyRefiner created with unsupported predicate {predicate}"
-                )
+                );
             }
         };
 

--- a/rust/sedona-spatial-join-geography/src/spatial_index_builder.rs
+++ b/rust/sedona-spatial-join-geography/src/spatial_index_builder.rs
@@ -28,12 +28,13 @@ use datafusion_common::{JoinType, Result};
 use sedona_common::SpatialJoinOptions;
 use sedona_expr::statistics::GeoStatistics;
 use sedona_spatial_join::{
+    SpatialPredicate,
     evaluated_batch::evaluated_batch_stream::SendableEvaluatedBatchStream,
     index::{
+        SpatialIndexBuilder, SpatialIndexRef,
         default_spatial_index_builder::DefaultSpatialIndexBuilder,
-        spatial_index_builder::SpatialJoinBuildMetrics, SpatialIndexBuilder, SpatialIndexRef,
+        spatial_index_builder::SpatialJoinBuildMetrics,
     },
-    SpatialPredicate,
 };
 
 use crate::refiner::GeographyRefinerFactory;

--- a/rust/sedona-spatial-join-geography/tests/spatial_join_integration.rs
+++ b/rust/sedona-spatial-join-geography/tests/spatial_join_integration.rs
@@ -29,13 +29,13 @@ use datafusion::{
     execution::SessionStateBuilder,
     prelude::{SessionConfig, SessionContext},
 };
-use datafusion_common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion_common::Result;
+use datafusion_common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion_expr::JoinType;
 use geo_types::{Coord, Rect};
 use rstest::rstest;
-use sedona_common::option::SpatialJoinOptions;
 use sedona_common::SedonaOptions;
+use sedona_common::option::SpatialJoinOptions;
 use sedona_geometry::types::GeometryTypeId;
 use sedona_query_planner::{
     optimizer::register_spatial_join_logical_optimizer, query_planner::SedonaQueryPlanner,
@@ -334,9 +334,15 @@ async fn test_geography_join_types(
     let batch_size = 30;
 
     let sql = match join_type {
-        JoinType::Inner => "SELECT L.id l_id, R.id r_id FROM L INNER JOIN R ON ST_Intersects(L.geometry, R.geometry) ORDER BY l_id, r_id",
-        JoinType::Left => "SELECT L.id l_id, R.id r_id FROM L LEFT JOIN R ON ST_Intersects(L.geometry, R.geometry) ORDER BY l_id, r_id",
-        JoinType::Right => "SELECT L.id l_id, R.id r_id FROM L RIGHT JOIN R ON ST_Intersects(L.geometry, R.geometry) ORDER BY l_id, r_id",
+        JoinType::Inner => {
+            "SELECT L.id l_id, R.id r_id FROM L INNER JOIN R ON ST_Intersects(L.geometry, R.geometry) ORDER BY l_id, r_id"
+        }
+        JoinType::Left => {
+            "SELECT L.id l_id, R.id r_id FROM L LEFT JOIN R ON ST_Intersects(L.geometry, R.geometry) ORDER BY l_id, r_id"
+        }
+        JoinType::Right => {
+            "SELECT L.id l_id, R.id r_id FROM L RIGHT JOIN R ON ST_Intersects(L.geometry, R.geometry) ORDER BY l_id, r_id"
+        }
         _ => unreachable!("Only testing Inner, Left, Right join types"),
     };
 
@@ -400,13 +406,23 @@ fn create_corner_case_test_data() -> Result<(TestPartitions, TestPartitions)> {
     // WKT fixtures for edge cases: full-width polygons and polar triangles
     let wkt_fixtures: Vec<Option<&str>> = vec![
         // Full-width polygons (spanning 360 degrees longitude, with intermediate points)
-        Some("POLYGON((-180 -10, -180 10, -90 10, 0 10, 90 10, 180 10, 180 -10, 90 -10, 0 -10, -90 -10, -180 -10))"),
-        Some("POLYGON((-180 20, -180 40, -90 40, 0 40, 90 40, 180 40, 180 20, 90 20, 0 20, -90 20, -180 20))"),
-        Some("POLYGON((-180 -45, -90 -30, 0 -45, 90 -30, 180 -45, 90 -60, 0 -45, -90 -60, -180 -45))"),
+        Some(
+            "POLYGON((-180 -10, -180 10, -90 10, 0 10, 90 10, 180 10, 180 -10, 90 -10, 0 -10, -90 -10, -180 -10))",
+        ),
+        Some(
+            "POLYGON((-180 20, -180 40, -90 40, 0 40, 90 40, 180 40, 180 20, 90 20, 0 20, -90 20, -180 20))",
+        ),
+        Some(
+            "POLYGON((-180 -45, -90 -30, 0 -45, 90 -30, 180 -45, 90 -60, 0 -45, -90 -60, -180 -45))",
+        ),
         // Full width polygon shifted so that it crosses the antimeridian
-        Some("POLYGON((0 -10, 0 10, 90 10, 180 10, 270 10, 360 10, 360 -10, 270 -10, 180 -10, 80 -10, 0 -10))"),
+        Some(
+            "POLYGON((0 -10, 0 10, 90 10, 180 10, 270 10, 360 10, 360 -10, 270 -10, 180 -10, 80 -10, 0 -10))",
+        ),
         // Whole planet
-        Some("POLYGON((-180 -90, 0 -90, 90 -90, 180 -90, 180 0, 180 90, 90 90, 0 90, -90 90, -180 90, -180 0, -180 -90))"),
+        Some(
+            "POLYGON((-180 -90, 0 -90, 90 -90, 180 -90, 180 0, 180 90, 90 90, 0 90, -90 90, -180 90, -180 0, -180 -90))",
+        ),
         // North pole triangles
         Some("POLYGON((0 70, -120 70, 120 70, 0 70))"),
         Some("POLYGON((0 80, 60 80, -60 80, 0 80))"),


### PR DESCRIPTION
Migrates sedona-spatial-join-geography independently to Rust 2024 as part of #258 and applies standard formatter output. Validated with 14 integration tests, all-target checks, and Clippy with warnings denied.