### PR TITLE
chore(rust/sedona-spatial-join-raster): migrate to Rust 2024 edition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
       - id: fmt
         name: rustfmt
         args: ["--all", "--"]
+        pass_filenames: false
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13

--- a/rust/sedona-spatial-join-raster/Cargo.toml
+++ b/rust/sedona-spatial-join-raster/Cargo.toml
@@ -24,7 +24,7 @@ homepage.workspace = true
 repository.workspace = true
 description.workspace = true
 readme.workspace = true
-edition.workspace = true
+edition = "2024"
 rust-version.workspace = true
 
 [dependencies]

--- a/rust/sedona-spatial-join-raster/src/join_provider.rs
+++ b/rust/sedona-spatial-join-raster/src/join_provider.rs
@@ -17,11 +17,11 @@
 
 use std::sync::Arc;
 
-use arrow_array::{builder::BinaryBuilder, Array, ArrayRef, StructArray};
-use datafusion_common::{exec_datafusion_err, exec_err, JoinType, Result};
+use arrow_array::{Array, ArrayRef, StructArray, builder::BinaryBuilder};
+use datafusion_common::{JoinType, Result, exec_datafusion_err, exec_err};
 use datafusion_expr::ColumnarValue;
 use sedona_common::{
-    sedona_internal_datafusion_err, sedona_internal_err, SpatialJoinOptions, SpatialLibrary,
+    SpatialJoinOptions, SpatialLibrary, sedona_internal_datafusion_err, sedona_internal_err,
 };
 use sedona_expr::statistics::GeoStatistics;
 use sedona_geometry::{
@@ -40,11 +40,11 @@ use sedona_schema::{
     datatypes::WKB_GEOMETRY,
 };
 use sedona_spatial_join::{
-    index::{spatial_index_builder::SpatialJoinBuildMetrics, SpatialIndexBuilder},
+    SpatialPredicate,
+    index::{SpatialIndexBuilder, spatial_index_builder::SpatialJoinBuildMetrics},
     join_provider::{DefaultSpatialJoinProvider, SpatialJoinProvider},
     operand_evaluator::{EvaluatedGeometryArray, EvaluatedGeometryArrayFactory},
     utils::bounds::Bounds2D,
-    SpatialPredicate,
 };
 
 /// [`SpatialJoinProvider`] for raster/geometry spatial joins.

--- a/rust/sedona-spatial-join-raster/src/physical_planner.rs
+++ b/rust/sedona-spatial-join-raster/src/physical_planner.rs
@@ -29,7 +29,7 @@ use sedona_query_planner::{
     spatial_predicate::{RelationPredicate, SpatialPredicate, SpatialRelationType},
 };
 use sedona_schema::{crs::Crs, datatypes::SedonaType, matchers::ArgMatcher};
-use sedona_spatial_join::{physical_planner::repartition_probe_side, SpatialJoinExec};
+use sedona_spatial_join::{SpatialJoinExec, physical_planner::repartition_probe_side};
 
 use crate::join_provider::RasterJoinProvider;
 
@@ -238,20 +238,20 @@ mod test {
     use std::sync::Arc;
 
     use arrow_schema::Schema;
-    use datafusion_physical_expr::{expressions::Column, PhysicalExpr};
+    use datafusion_physical_expr::{PhysicalExpr, expressions::Column};
     use sedona_geometry::types::Edges;
     use sedona_query_planner::spatial_predicate::{
         RelationPredicate, SpatialPredicate, SpatialRelationType,
     };
     use sedona_schema::crs::{deserialize_crs, lnglat};
-    use sedona_schema::datatypes::{SedonaType, RASTER, WKB_GEOMETRY};
+    use sedona_schema::datatypes::{RASTER, SedonaType, WKB_GEOMETRY};
 
     use super::{raster_geometry_target_crs, raster_operand_on_left};
 
     fn schema_with(field_name: &str, sedona_type: &SedonaType) -> Arc<Schema> {
-        Arc::new(Schema::new(vec![sedona_type
-            .to_storage_field(field_name, true)
-            .unwrap()]))
+        Arc::new(Schema::new(vec![
+            sedona_type.to_storage_field(field_name, true).unwrap(),
+        ]))
     }
 
     fn col(name: &str) -> Arc<dyn PhysicalExpr> {
@@ -277,20 +277,24 @@ mod test {
         let target = raster_geometry_target_crs(&pred, &raster_schema, &geom_schema)
             .unwrap()
             .expect("raster/geometry should be handled");
-        assert!(target
-            .as_deref()
-            .unwrap()
-            .crs_equals(lnglat().as_deref().unwrap()));
+        assert!(
+            target
+                .as_deref()
+                .unwrap()
+                .crs_equals(lnglat().as_deref().unwrap())
+        );
 
         // (geometry, raster): still resolves to the geometry's CRS.
         let pred = relation(col("geom"), col("raster"), SpatialRelationType::Contains);
         let target = raster_geometry_target_crs(&pred, &geom_schema, &raster_schema)
             .unwrap()
             .expect("geometry/raster should be handled");
-        assert!(target
-            .as_deref()
-            .unwrap()
-            .crs_equals(lnglat().as_deref().unwrap()));
+        assert!(
+            target
+                .as_deref()
+                .unwrap()
+                .crs_equals(lnglat().as_deref().unwrap())
+        );
     }
 
     #[test]
@@ -334,10 +338,12 @@ mod test {
         let target = raster_geometry_target_crs(&pred, &geom_schema, &raster_schema)
             .unwrap()
             .expect("raster/geometry should be handled");
-        assert!(target
-            .as_deref()
-            .unwrap()
-            .crs_equals(deserialize_crs("EPSG:3857").unwrap().as_deref().unwrap()));
+        assert!(
+            target
+                .as_deref()
+                .unwrap()
+                .crs_equals(deserialize_crs("EPSG:3857").unwrap().as_deref().unwrap())
+        );
     }
 
     #[test]

--- a/rust/sedona-spatial-join-raster/tests/spatial_join_integration.rs
+++ b/rust/sedona-spatial-join-raster/tests/spatial_join_integration.rs
@@ -40,28 +40,28 @@ use arrow_schema::{Field, Schema};
 use datafusion::{
     catalog::MemTable,
     execution::SessionStateBuilder,
-    physical_plan::{displayable, ExecutionPlan},
+    physical_plan::{ExecutionPlan, displayable},
     prelude::{SessionConfig, SessionContext},
 };
+use datafusion_common::Result;
 use datafusion_common::cast::as_int32_array;
 use datafusion_common::tree_node::{TreeNode, TreeNodeRecursion};
-use datafusion_common::Result;
 use rstest::rstest;
-use sedona_common::option::SpatialJoinOptions;
 use sedona_common::SedonaOptions;
+use sedona_common::option::SpatialJoinOptions;
 use sedona_geometry::transform::CrsEngine;
 use sedona_geometry::types::Edges;
 use sedona_proj::error::SedonaProjError;
-use sedona_proj::transform::{with_global_proj_engine, LazyProjEngine};
+use sedona_proj::transform::{LazyProjEngine, with_global_proj_engine};
 use sedona_query_planner::{
     optimizer::register_spatial_join_logical_optimizer, query_planner::SedonaQueryPlanner,
 };
 use sedona_raster::affine_transformation::to_world_coordinate;
 use sedona_raster::array::RasterStructArray;
 use sedona_raster::traits::RasterRef;
-use sedona_raster_functions::footprint::{densify_footprint_ring, FOOTPRINT_POINTS_PER_EDGE};
+use sedona_raster_functions::footprint::{FOOTPRINT_POINTS_PER_EDGE, densify_footprint_ring};
 use sedona_schema::crs::lnglat;
-use sedona_schema::datatypes::{SedonaType, RASTER};
+use sedona_schema::datatypes::{RASTER, SedonaType};
 use sedona_schema::raster::BandDataType;
 use sedona_spatial_join::SpatialJoinExec;
 use sedona_spatial_join_raster::physical_planner::RasterSpatialJoinPhysicalPlanner;


### PR DESCRIPTION
Migrates sedona-spatial-join-raster independently to Rust 2024 as part of #258 and applies standard formatter output. Validated with package tests, all-target checks, and Clippy with warnings denied.