### PR TITLE
feat(rust/sedona): Spark's array(...) spelling via datafusion-spark; RS_Values parity catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
  "fastrand",
  "hex",
  "http 1.4.0",
- "sha1",
+ "sha1 0.10.7",
  "time",
  "tokio",
  "tracing",
@@ -2466,6 +2466,35 @@ dependencies = [
  "datafusion-expr",
  "datafusion-physical-plan",
  "parking_lot",
+]
+
+[[package]]
+name = "datafusion-spark"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ccd16a6949503e56c084df1b90c8889db826ec9347d2f0f51a7837d6fa011e"
+dependencies = [
+ "arrow",
+ "bigdecimal",
+ "chrono",
+ "crc32fast",
+ "datafusion-catalog",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-functions-aggregate",
+ "datafusion-functions-aggregate-common",
+ "datafusion-functions-nested",
+ "log",
+ "num-traits",
+ "percent-encoding",
+ "rand 0.9.2",
+ "serde_json",
+ "sha1 0.11.0",
+ "sha2",
+ "twox-hash",
+ "url",
 ]
 
 [[package]]
@@ -5608,6 +5637,7 @@ dependencies = [
  "datafusion-ffi",
  "datafusion-optimizer",
  "datafusion-session",
+ "datafusion-spark",
  "dirs",
  "futures",
  "geo-traits",
@@ -6583,6 +6613,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7189,6 +7230,9 @@ name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+dependencies = [
+ "rand 0.9.2",
+]
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ datafusion-physical-expr = { version = "54.1.0" }
 datafusion-physical-plan = { version = "54.1.0" }
 datafusion-pruning = { version = "54.1.0" }
 datafusion-session = { version = "54.1.0" }
+datafusion-spark = { version = "54.1.0", default-features = false }
 dirs = "6.0.0"
 env_logger = "0.11"
 fastrand = "2.4"

--- a/integration/spark-parity/test_rs_values.py
+++ b/integration/spark-parity/test_rs_values.py
@@ -1,0 +1,93 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""SedonaDB vs Sedona Spark parity for RS_Values.
+
+A pure divergence catalog today: every spelling of RS_Values is accepted
+by exactly one engine. SedonaDB reads sample locations from a single
+(multi-)geometry; Sedona Spark reads them only from an ARRAY of
+geometries — each rejects the other's spelling — and Sedona Spark
+additionally has a coordinate-array overload SedonaDB lacks, whose
+coordinates it reads 0-based (unlike its own 1-based RS_PixelAs*
+functions). The shared `array(...)` these cases rely on is SedonaDB's
+Spark-compat spelling of make_array, registered from datafusion-spark.
+
+Sample locations on the standard seeded grid: (101 499) is pixel
+(row 0, col 0) = 255 and (103 493) is pixel (row 2, col 1) = 112; the
+coordinate arrays x = [1, 2], y = [1, 1] read 0-based land on 193
+and 255.
+"""
+
+import pytest
+
+from sedonadb.testing import SedonaDB, compare
+from sedonadb.testing_spark import SedonaSpark
+
+GEOM_ARRAY = (
+    "array(ST_GeomFromWKT('POINT (101 499)'), ST_GeomFromWKT('POINT (103 493)'))"
+)
+
+
+def _engines(name, tmp_path):
+    sedona, spark = SedonaDB(), SedonaSpark()
+    for eng in (sedona, spark):
+        eng.create_random_raster_view(name, tmp_path / f"{name}.tif")
+    return sedona, spark
+
+
+@pytest.mark.parametrize(
+    "band", [pytest.param("", id="bandless"), pytest.param(", 1", id="band-1")]
+)
+@pytest.mark.xfail(
+    reason="SedonaDB has no array-of-geometries form of RS_Values (it raises "
+    "'No kernel matching arguments'); Sedona Spark reads sample locations "
+    "only from an array and answers [255.0, 112.0]"
+)
+def test_rs_values_geometry_array(band, tmp_path):
+    """An array of point geometries samples the same values on both
+    engines."""
+    sedona, spark = _engines("vals_arr_src", tmp_path)
+    sql = f"SELECT RS_Values(rast, {GEOM_ARRAY}{band}) FROM vals_arr_src"
+    compare(sql, sedona, spark)
+
+
+@pytest.mark.xfail(
+    reason="SedonaDB samples a bare MULTIPOINT ([255.0, 112.0], one value "
+    "per part); Sedona Spark rejects a non-array geometry argument "
+    "(DATATYPE_MISMATCH — its geometry form takes array<geometry>)"
+)
+def test_rs_values_multipoint(tmp_path):
+    """A bare MULTIPOINT samples the same values on both engines."""
+    sedona, spark = _engines("vals_mp_src", tmp_path)
+    sql = (
+        "SELECT RS_Values(rast, "
+        "ST_GeomFromWKT('MULTIPOINT ((101 499), (103 493))'), 1) FROM vals_mp_src"
+    )
+    compare(sql, sedona, spark)
+
+
+@pytest.mark.xfail(
+    reason="SedonaDB has no coordinate-array overload of RS_Values (it "
+    "raises 'No kernel matching arguments'); Sedona Spark reads the arrays "
+    "0-based — unlike its own 1-based RS_PixelAs* functions — and answers "
+    "[193.0, 255.0]"
+)
+def test_rs_values_coordinate_arrays(tmp_path):
+    """RS_Values(raster, xCoordinates, yCoordinates, band) answers from
+    both engines."""
+    sedona, spark = _engines("vals_xy_src", tmp_path)
+    sql = "SELECT RS_Values(rast, array(1, 2), array(1, 1), 1) FROM vals_xy_src"
+    compare(sql, sedona, spark)

--- a/python/sedonadb/tests/test_context.py
+++ b/python/sedonadb/tests/test_context.py
@@ -56,6 +56,16 @@ def test_options():
     assert "DataFrame object at" not in repr(sd.sql("SELECT 1 as one"))
 
 
+def test_spark_array_spelling():
+    """Spark's array(...) spelling builds the same list as DataFusion's
+    [...] literal and make_array() (registered from datafusion-spark)."""
+    sd = sedonadb.connect()
+    table = sd.sql(
+        "SELECT (array(1, 2) = [1, 2]) AND (array(1, 2) = make_array(1, 2)) AS eq"
+    ).to_arrow_table()
+    assert table.column("eq").to_pylist() == [True]
+
+
 def test_shared_context_and_dataframe_from_threads():
     sd = sedonadb.connect()
     df = sd.sql("SELECT * FROM (VALUES (1), (2), (3)) AS t(x)")

--- a/rust/sedona/Cargo.toml
+++ b/rust/sedona/Cargo.toml
@@ -68,6 +68,7 @@ datafusion-expr = { workspace = true, features = ["sql"] }
 datafusion-ffi = { workspace = true }
 datafusion-optimizer = { workspace = true }
 datafusion-session = { workspace = true }
+datafusion-spark = { workspace = true }
 dirs = { workspace = true }
 futures = { workspace = true }
 geo-traits = { workspace = true }

--- a/rust/sedona/src/context.rs
+++ b/rust/sedona/src/context.rs
@@ -383,6 +383,16 @@ impl SedonaContext {
         // Always register default function set
         out.register_function_set(sedona_functions::register::default_function_set());
 
+        // Spark's array(...) constructor spelling, from DataFusion's Spark
+        // compatibility crate. DataFusion's core renamed array() to
+        // make_array() in apache/datafusion#3122, when sqlparser reserved
+        // the ARRAY keyword; the parser restriction is since gone and the
+        // Spark spelling now lives in datafusion-spark. Registering it lets
+        // Spark SQL that builds arrays run unchanged — DataFusion's own
+        // [...] literals and make_array() are unaffected.
+        out.ctx
+            .register_udf((*datafusion_spark::function::array::array()).clone());
+
         // Register geos scalar kernels if built with geos support
         #[cfg(feature = "geos")]
         out.register_scalar_kernels(sedona_geos::register::scalar_kernels().into_iter())?;
@@ -1019,6 +1029,24 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
+
+    #[tokio::test]
+    async fn spark_array_spelling() {
+        // Spark's array(...) resolves and agrees with DataFusion's own
+        // [...] literal and make_array() spellings.
+        let ctx = SedonaContext::new();
+        let batches = ctx
+            .sql("SELECT (array(1, 2) = [1, 2]) AND (array(1, 2) = make_array(1, 2)) AS eq")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        assert_batches_eq!(
+            ["+------+", "| eq   |", "+------+", "| true |", "+------+",],
+            &batches
+        );
+    }
 
     #[test]
     fn disables_physical_uncorrelated_scalar_subqueries() {


### PR DESCRIPTION
Registers Spark's `array(...)` constructor spelling in SedonaDB, taken from DataFusion's own Spark-compatibility crate, and uses it to open the RS_Values parity catalog — the last RS_ function with no coverage besides RS_AsGeoTiff.

## Why the spelling was missing, and why it's safe to add back

DataFusion's core renamed `array()` to `make_array()` in 2022 (apache/datafusion#3122): sqlparser-rs#566 had reserved the `ARRAY` keyword for Postgres-style `ARRAY[...]` literals, which "makes it impossible to use `array` as a function" — and Postgres itself rejects `array(1, 2)`. That parser restriction is long gone (probing showed `array(1, 2)` reaches DataFusion's *planner* today, failing only on resolution), and upstream now ships Spark's `array` as a UDF in the **datafusion-spark** compatibility crate (apache/datafusion#16932), sqllogictests included, reusing make_array's kernel and coercion.

So rather than hand-rolling an alias, this adds `datafusion-spark` (54.1.0, matching the workspace) as a dependency and registers its `array` UDF in `SedonaContext::finish_new`, where both constructors funnel — every surface gets it. `[...]` literals and `make_array()` are untouched.

## Probed semantics (both engines)

| case | SedonaDB | Sedona Spark |
|---|---|---|
| `array(1, 2, 3)`, `ARRAY(1, 2, 3)` | `[1, 2, 3]` | `[1, 2, 3]` |
| `array(NULL, 1)` | `[None, 1]` | `[None, 1]` |
| `array(array(1), array(2))` | `[[1], [2]]` | `[[1], [2]]` |
| `array(1, 'x')` | cast error | cast error (parity on refusal) |
| `array(1, 2.5)` | `[1.0, 2.5]` (float64) | decimals — Spark types the `2.5` *literal* as DECIMAL; not an array() divergence |
| `array()` | `[]` | computes, but the harness's Arrow transport rejects the null-typed field — untestable cross-engine today |

Tests: a Rust test in `context.rs` and a Python test in `test_context.py`, both asserting `array(1, 2) = [1, 2] = make_array(1, 2)`.

## RS_Values catalog (second commit)

With one shared spelling available, `test_rs_values.py` can finally exist. It is a pure divergence catalog — today every spelling of RS_Values is accepted by exactly one engine:

- **Array of geometries** (`RS_Values(rast, array(ST_GeomFromWKT(...), ...)[, band])`): SedonaDB has no list-of-geometries kernel; Sedona Spark answers `[255.0, 112.0]`.
- **Bare MULTIPOINT**: SedonaDB answers `[255.0, 112.0]` (one value per part); Sedona Spark rejects a non-array geometry argument outright.
- **Coordinate arrays** (`RS_Values(rast, array(1, 2), array(1, 1), 1)`): SedonaDB has no kernel; Sedona Spark answers `[193.0, 255.0]` — and those values pin its coordinate basis as **0-based**, unlike its own 1-based RS_PixelAs* functions.

All anchor values are hand-derivable from the standard seeded grid (stated in the module docstring).

Full spark-parity suite on this branch: `176 passed, 103 xfailed` locally (main plus the four new xfails). Independent of #1286.

