### PR TITLE
test(python): skip st_dump geo-accessor test when sedonadb_expr is absent

### DIFF
--- a/python/sedonadb/tests/test_dataframe.py
+++ b/python/sedonadb/tests/test_dataframe.py
@@ -189,6 +189,9 @@ def test_columns(con):
 
 def test_select_struct_field_after_unnest_st_dump(con):
     # Regression for https://github.com/apache/sedona-db/issues/1232.
+    # The .geo accessor lives in the companion sedonadb-expr package, which
+    # the isolated python-wheels test environment does not install.
+    pytest.importorskip("sedonadb_expr")
     multi = con.sql("SELECT ST_GeomFromText('MULTIPOINT (0 0, 1 1)') AS geometry")
     dumped = multi.select(multi["geometry"].geo.dump().alias("dump")).unnest("dump")
     result = dumped.select(dumped["dump"]["geom"].alias("geometry"))


### PR DESCRIPTION
## What

Guard `test_select_struct_field_after_unnest_st_dump` with `pytest.importorskip("sedonadb_expr")`.

## Why

The `python-wheels` nightly workflow has failed on every main commit since #1226 (last green: #1243, Sep 9). #1226 added this test, which calls the `.geo` accessor — `Expr.geo` does `from sedonadb_expr import GeoMethods` (`python/sedonadb/python/sedonadb/expr/expression.py:230`). `sedonadb-expr` is a separate companion package: the regular `python` workflow installs it explicitly (`.github/workflows/python.yml`), but `python-wheels` runs `pytest {package}/tests` against the built `sedonadb` wheel in isolation via cibuildwheel and never installs it, so the accessor raises `ModuleNotFoundError: No module named 'sedonadb_expr'`.

The guard skips the test in the isolated wheel environment while it keeps running in the full `python` job where `sedonadb-expr` is installed — the same `importorskip` pattern already used for the optional `polars` dependency in this file.

## Verification

- Without `sedonadb_expr`: `1 skipped`.
- With `sedonadb-expr` installed: the test runs and passes.
