### PR TITLE
test(python): fix core wheel ST_Dump regression test

### DIFF
--- a/python/sedonadb/tests/test_dataframe.py
+++ b/python/sedonadb/tests/test_dataframe.py
@@ -190,7 +190,9 @@ def test_columns(con):
 def test_select_struct_field_after_unnest_st_dump(con):
     # Regression for https://github.com/apache/sedona-db/issues/1232.
     multi = con.sql("SELECT ST_GeomFromText('MULTIPOINT (0 0, 1 1)') AS geometry")
-    dumped = multi.select(multi["geometry"].geo.dump().alias("dump")).unnest("dump")
+    dumped = multi.select(multi["geometry"].funcs.st_dump().alias("dump")).unnest(
+        "dump"
+    )
     result = dumped.select(dumped["dump"]["geom"].alias("geometry"))
 
     assert result.to_arrow_table().num_rows == 2


### PR DESCRIPTION
The core wheel tests fail after #1226 added `test_select_struct_field_after_unnest_st_dump`. Its `.geo.dump()` call imports optional `sedonadb_expr`, which the isolated wheel test environment does not install. The failure is visible in [the merge build](https://github.com/apache/sedona-db/actions/runs/34518830194/job/103010939912).

Use the core `.funcs.st_dump()` API instead. This keeps the ST_Dump, unnest, and struct-field projection regression test running in wheel CI, including its two-row assertion.

Related: #1294 addresses the same failure by skipping the test when the optional package is absent.

Validation using the existing local build:

- Reproduced the original `ModuleNotFoundError` with `sedonadb_expr` imports blocked in the test process.
- Updated worktree test passes with those imports blocked and in the normal environment.
- Ruff lint, format check, and `git diff --check` pass.

The full platform wheel matrix has not been rerun.
